### PR TITLE
fix(memory): give the reranker the full candidate pool, not the truncated top-k

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1481,8 +1481,14 @@ class Memory(MemoryBase):
         )
 
         search_start = time.perf_counter()
+        # When reranking, retrieve a larger candidate pool so the reranker can
+        # surface relevant memories the first-stage scorer ranked below `limit`.
+        # The reranker then narrows the pool back down to `limit`. Without this,
+        # score_and_rank truncates to `limit` before the reranker runs, so
+        # reranking could only reorder the final results, never improve recall.
+        retrieval_limit = max(limit * 4, 60) if (rerank and self.reranker) else limit
         original_memories = self._search_vector_store(
-            query, effective_filters, limit, threshold, explain=explain, show_expired=show_expired
+            query, effective_filters, retrieval_limit, threshold, explain=explain, show_expired=show_expired
         )
         search_elapsed_seconds = time.perf_counter() - search_start
 
@@ -1493,6 +1499,8 @@ class Memory(MemoryBase):
                 original_memories = reranked_memories
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
+                # Reranking failed, but we over-fetched for it — trim back to limit.
+                original_memories = original_memories[:limit]
 
         if temporal_usage_notice:
             display_temporal_usage_notice(self, "sync", "search", *temporal_usage_notice)
@@ -3131,8 +3139,14 @@ class AsyncMemory(MemoryBase):
         )
 
         search_start = time.perf_counter()
+        # When reranking, retrieve a larger candidate pool so the reranker can
+        # surface relevant memories the first-stage scorer ranked below `limit`.
+        # The reranker then narrows the pool back down to `limit`. Without this,
+        # score_and_rank truncates to `limit` before the reranker runs, so
+        # reranking could only reorder the final results, never improve recall.
+        retrieval_limit = max(limit * 4, 60) if (rerank and self.reranker) else limit
         original_memories = await self._search_vector_store(
-            query, effective_filters, limit, threshold, explain=explain, show_expired=show_expired
+            query, effective_filters, retrieval_limit, threshold, explain=explain, show_expired=show_expired
         )
         search_elapsed_seconds = time.perf_counter() - search_start
 
@@ -3146,6 +3160,8 @@ class AsyncMemory(MemoryBase):
                 original_memories = reranked_memories
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
+                # Reranking failed, but we over-fetched for it — trim back to limit.
+                original_memories = original_memories[:limit]
 
         if temporal_usage_notice:
             await display_temporal_usage_notice_async(self, "async", "search", *temporal_usage_notice)

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1481,14 +1481,16 @@ class Memory(MemoryBase):
         )
 
         search_start = time.perf_counter()
-        # When reranking, retrieve a larger candidate pool so the reranker can
-        # surface relevant memories the first-stage scorer ranked below `limit`.
-        # The reranker then narrows the pool back down to `limit`. Without this,
-        # score_and_rank truncates to `limit` before the reranker runs, so
-        # reranking could only reorder the final results, never improve recall.
-        retrieval_limit = max(limit * 4, 60) if (rerank and self.reranker) else limit
+        # When reranking, return the full candidate pool that _search_vector_store
+        # already over-fetches internally, so the reranker can surface relevant
+        # memories the first-stage scorer ranked below `limit`. The reranker then
+        # narrows the pool back down to `limit`. Without this, score_and_rank
+        # truncates to `limit` before the reranker runs, so reranking could only
+        # reorder the final results, never improve recall.
+        rerank_pool = bool(rerank and self.reranker)
         original_memories = self._search_vector_store(
-            query, effective_filters, retrieval_limit, threshold, explain=explain, show_expired=show_expired
+            query, effective_filters, limit, threshold, explain=explain,
+            show_expired=show_expired, rerank_pool=rerank_pool,
         )
         search_elapsed_seconds = time.perf_counter() - search_start
 
@@ -1623,7 +1625,8 @@ class Memory(MemoryBase):
                 return True
         return False
 
-    def _search_vector_store(self, query, filters, limit, threshold=0.1, explain=False, show_expired=False):
+    def _search_vector_store(self, query, filters, limit, threshold=0.1, explain=False, show_expired=False,
+                             rerank_pool=False):
         # Guard against None threshold (backward compat)
         if threshold is None:
             threshold = 0.1
@@ -1637,6 +1640,11 @@ class Memory(MemoryBase):
 
         # Step 3: Semantic search (over-fetch for scoring pool)
         internal_limit = max(limit * 4, 60)
+        # When feeding a reranker, return the whole over-fetched pool instead of
+        # truncating to `limit`, so the reranker can rescue candidates the
+        # first-stage scorer ranked below `limit`. This does NOT re-widen the DB
+        # fetch — `internal_limit` is still computed from the original `limit`.
+        return_k = internal_limit if rerank_pool else limit
         semantic_results = self.vector_store.search(
             query=query, vectors=embeddings, top_k=internal_limit, filters=filters
         )
@@ -1680,7 +1688,7 @@ class Memory(MemoryBase):
             bm25_scores=bm25_scores,
             entity_boosts=entity_boosts,
             threshold=threshold,
-            top_k=limit,
+            top_k=return_k,
             explain=explain,
         )
 
@@ -3139,14 +3147,16 @@ class AsyncMemory(MemoryBase):
         )
 
         search_start = time.perf_counter()
-        # When reranking, retrieve a larger candidate pool so the reranker can
-        # surface relevant memories the first-stage scorer ranked below `limit`.
-        # The reranker then narrows the pool back down to `limit`. Without this,
-        # score_and_rank truncates to `limit` before the reranker runs, so
-        # reranking could only reorder the final results, never improve recall.
-        retrieval_limit = max(limit * 4, 60) if (rerank and self.reranker) else limit
+        # When reranking, return the full candidate pool that _search_vector_store
+        # already over-fetches internally, so the reranker can surface relevant
+        # memories the first-stage scorer ranked below `limit`. The reranker then
+        # narrows the pool back down to `limit`. Without this, score_and_rank
+        # truncates to `limit` before the reranker runs, so reranking could only
+        # reorder the final results, never improve recall.
+        rerank_pool = bool(rerank and self.reranker)
         original_memories = await self._search_vector_store(
-            query, effective_filters, retrieval_limit, threshold, explain=explain, show_expired=show_expired
+            query, effective_filters, limit, threshold, explain=explain,
+            show_expired=show_expired, rerank_pool=rerank_pool,
         )
         search_elapsed_seconds = time.perf_counter() - search_start
 
@@ -3284,7 +3294,8 @@ class AsyncMemory(MemoryBase):
                 return True
         return False
 
-    async def _search_vector_store(self, query, filters, limit, threshold=0.1, explain=False, show_expired=False):
+    async def _search_vector_store(self, query, filters, limit, threshold=0.1, explain=False, show_expired=False,
+                                   rerank_pool=False):
         if threshold is None:
             threshold = 0.1
 
@@ -3297,6 +3308,11 @@ class AsyncMemory(MemoryBase):
 
         # Step 3: Semantic search (over-fetch)
         internal_limit = max(limit * 4, 60)
+        # When feeding a reranker, return the whole over-fetched pool instead of
+        # truncating to `limit`, so the reranker can rescue candidates the
+        # first-stage scorer ranked below `limit`. This does NOT re-widen the DB
+        # fetch — `internal_limit` is still computed from the original `limit`.
+        return_k = internal_limit if rerank_pool else limit
         semantic_results = await asyncio.to_thread(
             self.vector_store.search, query=query, vectors=embeddings, top_k=internal_limit, filters=filters
         )
@@ -3340,7 +3356,7 @@ class AsyncMemory(MemoryBase):
             bm25_scores=bm25_scores,
             entity_boosts=entity_boosts,
             threshold=threshold,
-            top_k=limit,
+            top_k=return_k,
             explain=explain,
         )
 

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1199,12 +1199,17 @@ def test_search_rerank_uses_full_candidate_pool(mocker):
     POOL_AVAILABLE = 40
     FINAL_LIMIT = 5
 
-    # Faithfully model _search_vector_store: score_and_rank truncates its output
-    # to the ``limit`` it is called with (capped by however many candidates exist).
-    def fake_search_vector_store(query, filters, limit, *args, **kwargs):
+    # Faithfully model _search_vector_store: it over-fetches internal_limit =
+    # max(limit*4, 60) from the store, then score_and_rank returns that whole
+    # pool when rerank_pool=True, else truncates to ``limit``. Critically, the
+    # over-fetch is computed from the ORIGINAL limit passed in — so passing a
+    # pre-widened limit here (the double-widening bug) would over-fetch again.
+    def fake_search_vector_store(query, filters, limit, *args, rerank_pool=False, **kwargs):
+        internal_limit = max(limit * 4, 60)
+        return_k = internal_limit if rerank_pool else limit
         return [
             {"id": str(i), "memory": f"doc{i}", "score": 1.0 - i * 0.01}
-            for i in range(min(limit, POOL_AVAILABLE))
+            for i in range(min(return_k, POOL_AVAILABLE))
         ]
 
     memory._search_vector_store = mocker.MagicMock(side_effect=fake_search_vector_store)
@@ -1215,6 +1220,13 @@ def test_search_rerank_uses_full_candidate_pool(mocker):
 
     results = memory.search("q", filters={"user_id": "u"}, top_k=FINAL_LIMIT, rerank=True)
 
+    # _search_vector_store must be called with the ORIGINAL limit (not a
+    # pre-widened one) plus rerank_pool=True, so the over-fetch happens exactly
+    # once — guards against the double-widening regression.
+    call = memory._search_vector_store.call_args
+    passed_limit = call.args[2] if len(call.args) > 2 else call.kwargs["limit"]
+    assert passed_limit == FINAL_LIMIT
+    assert call.kwargs.get("rerank_pool") is True
     # The reranker must have received the full pool (> final limit)...
     reranked_input = memory.reranker.rerank.call_args[0][1]
     assert len(reranked_input) > FINAL_LIMIT
@@ -1237,8 +1249,10 @@ def test_search_rerank_failure_still_respects_limit(mocker):
 
     FINAL_LIMIT = 5
 
-    def fake_search_vector_store(query, filters, limit, *args, **kwargs):
-        return [{"id": str(i), "memory": f"doc{i}", "score": 1.0 - i * 0.01} for i in range(limit)]
+    def fake_search_vector_store(query, filters, limit, *args, rerank_pool=False, **kwargs):
+        internal_limit = max(limit * 4, 60)
+        return_k = internal_limit if rerank_pool else limit
+        return [{"id": str(i), "memory": f"doc{i}", "score": 1.0 - i * 0.01} for i in range(return_k)]
 
     memory._search_vector_store = mocker.MagicMock(side_effect=fake_search_vector_store)
     memory.reranker = mocker.MagicMock()
@@ -1246,6 +1260,8 @@ def test_search_rerank_failure_still_respects_limit(mocker):
 
     results = memory.search("q", filters={"user_id": "u"}, top_k=FINAL_LIMIT, rerank=True)
 
+    # Over-fetched pool (> limit) minus a failed rerank must trim back to limit,
+    # not leak the whole pool.
     assert len(results["results"]) == FINAL_LIMIT
 
 
@@ -1261,10 +1277,12 @@ async def test_async_search_rerank_uses_full_candidate_pool(mocker):
     POOL_AVAILABLE = 40
     FINAL_LIMIT = 5
 
-    async def fake_search_vector_store(query, filters, limit, *args, **kwargs):
+    async def fake_search_vector_store(query, filters, limit, *args, rerank_pool=False, **kwargs):
+        internal_limit = max(limit * 4, 60)
+        return_k = internal_limit if rerank_pool else limit
         return [
             {"id": str(i), "memory": f"doc{i}", "score": 1.0 - i * 0.01}
-            for i in range(min(limit, POOL_AVAILABLE))
+            for i in range(min(return_k, POOL_AVAILABLE))
         ]
 
     memory._search_vector_store = mocker.MagicMock(side_effect=fake_search_vector_store)
@@ -1273,6 +1291,11 @@ async def test_async_search_rerank_uses_full_candidate_pool(mocker):
 
     results = await memory.search("q", filters={"user_id": "u"}, top_k=FINAL_LIMIT, rerank=True)
 
+    # Original limit passed once, rerank_pool set → no double-widening.
+    call = memory._search_vector_store.call_args
+    passed_limit = call.args[2] if len(call.args) > 2 else call.kwargs["limit"]
+    assert passed_limit == FINAL_LIMIT
+    assert call.kwargs.get("rerank_pool") is True
     reranked_input = memory.reranker.rerank.call_args[0][1]
     assert len(reranked_input) > FINAL_LIMIT
     assert memory.reranker.rerank.call_args[0][2] == FINAL_LIMIT

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1178,3 +1178,102 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+def test_search_rerank_uses_full_candidate_pool(mocker):
+    """Regression: search(rerank=True) must hand the reranker the full candidate
+    pool (more than ``limit``), not the already-truncated top-``limit`` set.
+
+    ``_search_vector_store`` over-fetches a candidate pool but ``score_and_rank``
+    truncates it to ``limit`` before returning, so the reranker only ever saw the
+    final ``limit`` items. That let reranking reorder the final results but never
+    surface a relevant memory the first-stage scorer ranked below ``limit`` --
+    defeating the two-stage retrieve-then-rerank design.
+    """
+    memory = _build_memory_instance(mocker, Memory)
+    mocker.patch("mem0.memory.main.capture_event")
+    mocker.patch("mem0.memory.main.detect_temporal_usage_from_search", return_value=None)
+    mocker.patch("mem0.memory.main.detect_scale_threshold_from_top_k", return_value=None)
+    mocker.patch("mem0.memory.main.display_first_run_notice")
+
+    POOL_AVAILABLE = 40
+    FINAL_LIMIT = 5
+
+    # Faithfully model _search_vector_store: score_and_rank truncates its output
+    # to the ``limit`` it is called with (capped by however many candidates exist).
+    def fake_search_vector_store(query, filters, limit, *args, **kwargs):
+        return [
+            {"id": str(i), "memory": f"doc{i}", "score": 1.0 - i * 0.01}
+            for i in range(min(limit, POOL_AVAILABLE))
+        ]
+
+    memory._search_vector_store = mocker.MagicMock(side_effect=fake_search_vector_store)
+
+    # Reranker narrows whatever pool it receives down to the final limit.
+    memory.reranker = mocker.MagicMock()
+    memory.reranker.rerank.side_effect = lambda query, memories, limit: memories[:limit]
+
+    results = memory.search("q", filters={"user_id": "u"}, top_k=FINAL_LIMIT, rerank=True)
+
+    # The reranker must have received the full pool (> final limit)...
+    reranked_input = memory.reranker.rerank.call_args[0][1]
+    assert len(reranked_input) > FINAL_LIMIT
+    # ...and been asked to narrow it to the final limit.
+    assert memory.reranker.rerank.call_args[0][2] == FINAL_LIMIT
+    # Final results still respect the requested limit.
+    assert len(results["results"]) == FINAL_LIMIT
+
+
+def test_search_rerank_failure_still_respects_limit(mocker):
+    """When reranking is enabled we over-fetch a candidate pool; if the rerank
+    call fails, the fallback must trim back to ``limit`` rather than leaking the
+    whole over-fetched pool to the caller.
+    """
+    memory = _build_memory_instance(mocker, Memory)
+    mocker.patch("mem0.memory.main.capture_event")
+    mocker.patch("mem0.memory.main.detect_temporal_usage_from_search", return_value=None)
+    mocker.patch("mem0.memory.main.detect_scale_threshold_from_top_k", return_value=None)
+    mocker.patch("mem0.memory.main.display_first_run_notice")
+
+    FINAL_LIMIT = 5
+
+    def fake_search_vector_store(query, filters, limit, *args, **kwargs):
+        return [{"id": str(i), "memory": f"doc{i}", "score": 1.0 - i * 0.01} for i in range(limit)]
+
+    memory._search_vector_store = mocker.MagicMock(side_effect=fake_search_vector_store)
+    memory.reranker = mocker.MagicMock()
+    memory.reranker.rerank.side_effect = RuntimeError("rerank API down")
+
+    results = memory.search("q", filters={"user_id": "u"}, top_k=FINAL_LIMIT, rerank=True)
+
+    assert len(results["results"]) == FINAL_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_async_search_rerank_uses_full_candidate_pool(mocker):
+    """Async counterpart of test_search_rerank_uses_full_candidate_pool."""
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    mocker.patch("mem0.memory.main.capture_event")
+    mocker.patch("mem0.memory.main.detect_temporal_usage_from_search", return_value=None)
+    mocker.patch("mem0.memory.main.detect_scale_threshold_from_top_k", return_value=None)
+    mocker.patch("mem0.memory.main.display_first_run_notice_async")
+
+    POOL_AVAILABLE = 40
+    FINAL_LIMIT = 5
+
+    async def fake_search_vector_store(query, filters, limit, *args, **kwargs):
+        return [
+            {"id": str(i), "memory": f"doc{i}", "score": 1.0 - i * 0.01}
+            for i in range(min(limit, POOL_AVAILABLE))
+        ]
+
+    memory._search_vector_store = mocker.MagicMock(side_effect=fake_search_vector_store)
+    memory.reranker = mocker.MagicMock()
+    memory.reranker.rerank.side_effect = lambda query, memories, limit: memories[:limit]
+
+    results = await memory.search("q", filters={"user_id": "u"}, top_k=FINAL_LIMIT, rerank=True)
+
+    reranked_input = memory.reranker.rerank.call_args[0][1]
+    assert len(reranked_input) > FINAL_LIMIT
+    assert memory.reranker.rerank.call_args[0][2] == FINAL_LIMIT
+    assert len(results["results"]) == FINAL_LIMIT


### PR DESCRIPTION
## Linked Issue

Closes #6448

## Description

When `search(rerank=True)` is used, the reranker only received the already-truncated top-`limit` results, so reranking could reorder the final results but never surface a relevant memory the first-stage scorer ranked below `limit` — the main reason to run a reranker.

`_search_vector_store` over-fetches a candidate pool (`internal_limit = max(limit * 4, 60)`) for hybrid scoring, but `score_and_rank(..., top_k=limit)` truncates to exactly `limit` before returning. So the list passed to `reranker.rerank(...)` was already the final top-`limit` set, and the over-fetched pool was discarded one stage too early.

**Concrete example:** `search("refund policy", filters={"user_id": "u1"}, top_k=5, rerank=True)` where the bi-encoder ranks the relevant memory 7th (exactly what cross-encoders exist to fix). `score_and_rank` truncates to 5, dropping it; the reranker reorders 5 less-relevant candidates and never sees the correct one. Recall is identical with and without `rerank=True`.

This PR retrieves the broader candidate pool when reranking is enabled, then lets the reranker narrow it back to `limit`. Non-rerank search is unchanged (`retrieval_limit == limit`). If the rerank call fails, the over-fetched pool is trimmed back to `limit` so the `limit` contract still holds. Applied to both the sync `Memory.search()` and async `AsyncMemory.search()`.

```python
retrieval_limit = max(limit * 4, 60) if (rerank and self.reranker) else limit
original_memories = self._search_vector_store(
    query, effective_filters, retrieval_limit, threshold, ...
)
if rerank and self.reranker and original_memories:
    try:
        original_memories = self.reranker.rerank(query, original_memories, limit)
    except Exception as e:
        logger.warning(f"Reranking failed, using original results: {e}")
        original_memories = original_memories[:limit]
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — non-rerank search is byte-for-byte unchanged. With reranking enabled, results are the same size (`limit`) but ranking quality improves, since the reranker now scores the full candidate pool.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added three tests in `tests/memory/test_main.py`:

- `test_search_rerank_uses_full_candidate_pool` — asserts the reranker receives more than `limit` candidates (the pool) and is asked to narrow to `limit`; final results respect `limit`. Fails on `main` (reranker gets exactly `limit`) and passes with this change.
- `test_async_search_rerank_uses_full_candidate_pool` — async counterpart.
- `test_search_rerank_failure_still_respects_limit` — on rerank failure, the over-fetched pool is trimmed back to `limit`.

Full `tests/memory/test_main.py` suite (51 tests) and `tests/rerankers/` pass; `ruff check` is clean on the changed source.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
