### PR TITLE
fix(milvus): omit text field on update for pre-v3 schemas

### DIFF
--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -298,10 +298,15 @@ class MilvusDB(VectorStoreBase):
             if payload is None:
                 payload = existing[0].get("metadata")
 
-        text = ""
-        if payload:
-            text = (payload.get("text_lemmatized") or payload.get("data", ""))[:65535]
-        schema = {"id": vector_id, "vectors": vector, "metadata": payload, "text": text}
+        # Only include the `text` field when the collection's schema has it —
+        # legacy collections created pre-v3 reject unknown top-level fields.
+        # Mirror the guard used by insert().
+        schema = {"id": vector_id, "vectors": vector, "metadata": payload}
+        if self._has_bm25_schema:
+            text = ""
+            if payload:
+                text = (payload.get("text_lemmatized") or payload.get("data", ""))[:65535]
+            schema["text"] = text
         self.client.upsert(collection_name=self.collection_name, data=schema)
 
     def get(self, vector_id) -> Optional[OutputData]:

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -178,6 +178,24 @@ class TestMilvusDB:
         assert call_args[1]['data']['id'] == vector_id
         assert call_args[1]['data']['vectors'] == vector
         assert call_args[1]['data']['metadata'] == payload
+        # Fresh collections get BM25 schema; text is included for sparse search.
+        assert call_args[1]['data']['text'] == "Updated memory"
+
+    def test_update_omits_text_on_legacy_schema(self, milvus_db, mock_milvus_client):
+        """Pre-v3 collections without BM25 must not receive a top-level text field."""
+        milvus_db._has_bm25_schema = False
+        vector_id = "legacy_id"
+        vector = [0.2] * 1536
+        payload = {"user_id": "bob", "data": "Legacy memory"}
+
+        milvus_db.update(vector_id=vector_id, vector=vector, payload=payload)
+
+        mock_milvus_client.upsert.assert_called_once()
+        data = mock_milvus_client.upsert.call_args[1]["data"]
+        assert data["id"] == vector_id
+        assert data["vectors"] == vector
+        assert data["metadata"] == payload
+        assert "text" not in data
 
     def test_delete(self, milvus_db, mock_milvus_client):
         """Test vector deletion."""


### PR DESCRIPTION
## Linked Issue

Closes #5700

## Description

`Milvus.update()` always included a top-level `text` field in the upsert payload. Pre-v3 collections without BM25/`text`+`sparse` fields reject that field, while `insert()` already guards with `_has_bm25_schema`.

This PR mirrors the insert guard on update:
- BM25 schema: still populate `text` from `text_lemmatized` / `data`
- Legacy schema: omit `text` entirely

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

```text
.venv/bin/python -m pytest \
  tests/vector_stores/test_milvus.py::TestMilvusDB::test_update_uses_upsert \
  tests/vector_stores/test_milvus.py::TestMilvusDB::test_update_omits_text_on_legacy_schema \
  tests/vector_stores/test_milvus.py::TestMilvusDB::test_batch_insert -q
# 3 passed
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
