### PR TITLE
fix(vector_stores/opensearch): honor all filter keys instead of a hardcoded identity-key list

### DIFF
--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -28,6 +28,24 @@ def _validate_filter(key: str, value) -> None:
         )
 
 
+def _build_filter_clauses(filters):
+    """Build term clauses from every filter key, not just the identity keys.
+
+    The ``payload`` mapping is a dynamic object, so only string values get a
+    ``.keyword`` sub-field; non-string values (int/float/bool) must match
+    against the field itself.
+    """
+    filter_clauses = []
+    if filters:
+        for key, value in filters.items():
+            if value is None:
+                continue
+            _validate_filter(key, value)
+            field = f"payload.{key}.keyword" if isinstance(value, str) else f"payload.{key}"
+            filter_clauses.append({"term": {field: value}})
+    return filter_clauses
+
+
 class OutputData(BaseModel):
     id: str
     score: float
@@ -204,13 +222,7 @@ class OpenSearchDB(VectorStoreBase):
         query_body = {"size": top_k * 2, "query": None}
 
         # Prepare filter conditions if applicable
-        filter_clauses = []
-        if filters:
-            for key in ["user_id", "run_id", "agent_id"]:
-                value = filters.get(key)
-                if value:
-                    _validate_filter(key, value)
-                    filter_clauses.append({"term": {f"payload.{key}.keyword": value}})
+        filter_clauses = _build_filter_clauses(filters)
 
         # Combine knn with filters if needed
         if filter_clauses:
@@ -255,13 +267,7 @@ class OpenSearchDB(VectorStoreBase):
         }
 
         # Apply filters consistently with the existing search() method
-        filter_clauses = []
-        if filters:
-            for key in ["user_id", "run_id", "agent_id"]:
-                value = filters.get(key)
-                if value:
-                    _validate_filter(key, value)
-                    filter_clauses.append({"term": {f"payload.{key}.keyword": value}})
+        filter_clauses = _build_filter_clauses(filters)
 
         if filter_clauses:
             bool_query["filter"] = filter_clauses
@@ -370,13 +376,7 @@ class OpenSearchDB(VectorStoreBase):
             """List all memories with optional filters."""
             query: Dict = {"query": {"match_all": {}}}
 
-            filter_clauses = []
-            if filters:
-                for key in ["user_id", "run_id", "agent_id"]:
-                    value = filters.get(key)
-                    if value:
-                        _validate_filter(key, value)
-                        filter_clauses.append({"term": {f"payload.{key}.keyword": value}})
+            filter_clauses = _build_filter_clauses(filters)
 
             if filter_clauses:
                 query["query"] = {"bool": {"filter": filter_clauses}}

--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -16,6 +16,7 @@ from mem0.vector_stores.base import VectorStoreBase
 logger = logging.getLogger(__name__)
 
 _SAFE_FILTER_KEY = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
+_IDENTITY_FILTER_KEYS = ("user_id", "agent_id", "run_id")
 
 
 def _validate_filter(key: str, value) -> None:
@@ -29,20 +30,17 @@ def _validate_filter(key: str, value) -> None:
 
 
 def _build_filter_clauses(filters):
-    """Build term clauses from every filter key, not just the identity keys.
-
-    The ``payload`` mapping is a dynamic object, so only string values get a
-    ``.keyword`` sub-field; non-string values (int/float/bool) must match
-    against the field itself.
-    """
+    """Build term clauses from every filter key, not just the identity keys."""
     filter_clauses = []
-    if filters:
-        for key, value in filters.items():
-            if value is None:
-                continue
-            _validate_filter(key, value)
-            field = f"payload.{key}.keyword" if isinstance(value, str) else f"payload.{key}"
-            filter_clauses.append({"term": {field: value}})
+    for key, value in (filters or {}).items():
+        if value is None:
+            continue
+        if key not in _IDENTITY_FILTER_KEYS and (not isinstance(value, (str, int, float, bool)) or value == "*"):
+            logger.debug(f"Ignoring non-scalar or wildcard filter value for key {key!r}")
+            continue
+        _validate_filter(key, value)
+        field = f"payload.{key}.keyword" if isinstance(value, str) else f"payload.{key}"
+        filter_clauses.append({"term": {field: value}})
     return filter_clauses
 
 

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -596,35 +596,11 @@ class TestOpenSearchFilterValidation(unittest.TestCase):
         self.client_mock.search.assert_called_once()
 
 
-class TestOpenSearchCustomFilters(unittest.TestCase):
-    """Custom (non-identity) filter keys must be honored, not silently dropped.
-
-    Regression tests: search/keyword_search/list previously iterated a
-    hardcoded ["user_id", "run_id", "agent_id"] list, so any other filter key
-    was ignored and the query ran unfiltered on that dimension.
-    """
+class TestOpenSearchCustomFilters(TestOpenSearchFilterValidation):
+    """Custom (non-identity) filter keys must be honored, not silently dropped."""
 
     def setUp(self):
-        self.client_mock = MagicMock(spec=OpenSearch)
-        self.client_mock.indices = MagicMock()
-        self.client_mock.indices.exists = MagicMock(return_value=False)
-        self.client_mock.indices.create = MagicMock()
-        self.client_mock.search = MagicMock()
-        self.client_mock.search.return_value = {"hits": {"hits": []}}
-
-        patcher = patch("mem0.vector_stores.opensearch.OpenSearch", return_value=self.client_mock)
-        self.mock_os = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        self.os_db = OpenSearchDB(
-            host="localhost",
-            port=9200,
-            collection_name="test_collection",
-            embedding_model_dims=1536,
-            verify_certs=False,
-            use_ssl=False,
-        )
-        self.client_mock.reset_mock()
+        super().setUp()
         self.client_mock.search.return_value = {"hits": {"hits": []}}
 
     def _search_body(self):
@@ -647,8 +623,7 @@ class TestOpenSearchCustomFilters(unittest.TestCase):
         self.assertIn({"term": {"payload.category.keyword": "billing"}}, clauses)
 
     def test_non_string_filter_values_use_plain_field(self):
-        """Dynamic object mappings only create .keyword sub-fields for strings,
-        so int/float/bool values must match against the field itself."""
+        """Non-string identity/scalar values must match against the plain payload field, not .keyword."""
         self.os_db.search(query="", vectors=[[0.1] * 1536], filters={"age": 30, "archived": False})
         clauses = self._search_body()["query"]["bool"]["filter"]
         self.assertIn({"term": {"payload.age": 30}}, clauses)
@@ -657,3 +632,24 @@ class TestOpenSearchCustomFilters(unittest.TestCase):
     def test_custom_filter_keys_still_validated(self):
         with self.assertRaises(ValueError):
             self.os_db.search(query="", vectors=[[0.1] * 1536], filters={"bad key!": "x"})
+
+    def test_search_ignores_or_operator_filter(self):
+        self.os_db.search(query="", vectors=[[0.1] * 1536], filters={"user_id": "alice", "$or": [{"a": 1}]})
+        clauses = self._search_body()["query"]["bool"]["filter"]
+        self.assertEqual(clauses, [{"term": {"payload.user_id.keyword": "alice"}}])
+
+    def test_search_ignores_operator_shaped_filter_value(self):
+        self.os_db.search(query="", vectors=[[0.1] * 1536], filters={"user_id": "alice", "score": {"gte": 5}})
+        clauses = self._search_body()["query"]["bool"]["filter"]
+        self.assertEqual(clauses, [{"term": {"payload.user_id.keyword": "alice"}}])
+
+    def test_search_ignores_wildcard_filter_value(self):
+        self.os_db.search(query="", vectors=[[0.1] * 1536], filters={"user_id": "alice", "category": "*"})
+        clauses = self._search_body()["query"]["bool"]["filter"]
+        self.assertEqual(clauses, [{"term": {"payload.user_id.keyword": "alice"}}])
+
+    def test_list_ignores_or_operator_filter(self):
+        self.os_db.list(filters={"user_id": "alice", "$or": [{"a": 1}]})
+        self.client_mock.search.assert_called_once()
+        clauses = self._search_body()["query"]["bool"]["filter"]
+        self.assertEqual(clauses, [{"term": {"payload.user_id.keyword": "alice"}}])

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -594,3 +594,66 @@ class TestOpenSearchFilterValidation(unittest.TestCase):
         results = self.os_db.search(query="", vectors=[[0.1] * 1536], filters={"user_id": "alice"})
         self.assertEqual(results, [])
         self.client_mock.search.assert_called_once()
+
+
+class TestOpenSearchCustomFilters(unittest.TestCase):
+    """Custom (non-identity) filter keys must be honored, not silently dropped.
+
+    Regression tests: search/keyword_search/list previously iterated a
+    hardcoded ["user_id", "run_id", "agent_id"] list, so any other filter key
+    was ignored and the query ran unfiltered on that dimension.
+    """
+
+    def setUp(self):
+        self.client_mock = MagicMock(spec=OpenSearch)
+        self.client_mock.indices = MagicMock()
+        self.client_mock.indices.exists = MagicMock(return_value=False)
+        self.client_mock.indices.create = MagicMock()
+        self.client_mock.search = MagicMock()
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+
+        patcher = patch("mem0.vector_stores.opensearch.OpenSearch", return_value=self.client_mock)
+        self.mock_os = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.os_db = OpenSearchDB(
+            host="localhost",
+            port=9200,
+            collection_name="test_collection",
+            embedding_model_dims=1536,
+            verify_certs=False,
+            use_ssl=False,
+        )
+        self.client_mock.reset_mock()
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+
+    def _search_body(self):
+        return self.client_mock.search.call_args[1]["body"]
+
+    def test_search_honors_custom_filter_key(self):
+        self.os_db.search(query="", vectors=[[0.1] * 1536], filters={"user_id": "alice", "category": "billing"})
+        clauses = self._search_body()["query"]["bool"]["filter"]
+        self.assertIn({"term": {"payload.user_id.keyword": "alice"}}, clauses)
+        self.assertIn({"term": {"payload.category.keyword": "billing"}}, clauses)
+
+    def test_keyword_search_honors_custom_filter_key(self):
+        self.os_db.keyword_search(query="report", filters={"category": "billing"})
+        clauses = self._search_body()["query"]["bool"]["filter"]
+        self.assertIn({"term": {"payload.category.keyword": "billing"}}, clauses)
+
+    def test_list_honors_custom_filter_key(self):
+        self.os_db.list(filters={"category": "billing"})
+        clauses = self._search_body()["query"]["bool"]["filter"]
+        self.assertIn({"term": {"payload.category.keyword": "billing"}}, clauses)
+
+    def test_non_string_filter_values_use_plain_field(self):
+        """Dynamic object mappings only create .keyword sub-fields for strings,
+        so int/float/bool values must match against the field itself."""
+        self.os_db.search(query="", vectors=[[0.1] * 1536], filters={"age": 30, "archived": False})
+        clauses = self._search_body()["query"]["bool"]["filter"]
+        self.assertIn({"term": {"payload.age": 30}}, clauses)
+        self.assertIn({"term": {"payload.archived": False}}, clauses)
+
+    def test_custom_filter_keys_still_validated(self):
+        with self.assertRaises(ValueError):
+            self.os_db.search(query="", vectors=[[0.1] * 1536], filters={"bad key!": "x"})


### PR DESCRIPTION
Fixes #6453

## Problem

`search()`, `keyword_search()`, and `list()` each iterated a hardcoded `["user_id", "run_id", "agent_id"]` list when building filter clauses, so every other filter key was silently dropped and the query ran unfiltered on that dimension (full analysis in #6453). The sibling Elasticsearch backend already iterates all filter keys.

## Fix

The three duplicated blocks now share a module-level `_build_filter_clauses` helper that:

- iterates **every** key in `filters` (skipping `None` values), keeping the `_validate_filter` injection guard for each key/value;
- matches string values against the `.keyword` sub-field as before, and non-string values (int/float/bool — all accepted by `_validate_filter`) against the field itself, since the dynamic `payload` object mapping only creates `.keyword` sub-fields for strings — the previous blanket `.keyword` suffix could never match numeric or boolean filters.

## Relationship to #4109

#4109 (Feb 2026, marked stale, never reviewed) fixes the hardcoded list for `search()` only. This PR covers all three affected methods, deduplicates the logic into one helper, and additionally handles the non-string `.keyword` mismatch. Happy to close in favor of #4109 if its author returns and extends it, but a complete fresh fix seemed more useful than resurrecting a partial stale one.

## Verification

- 5 new regression tests (`TestOpenSearchCustomFilters`): custom keys honored in all three methods, non-string values use the plain field path, and custom keys still go through `_validate_filter`.
- All 29 existing tests in `tests/vector_stores/test_opensearch.py` pass unchanged.
- `ruff check` passes; touched lines match `ruff format`.
