### PR TITLE
docs(vllm): add LMCache integration guide

### DIFF
--- a/docs/components/llms/models/vllm.mdx
+++ b/docs/components/llms/models/vllm.mdx
@@ -1,9 +1,9 @@
 ---
 title: vLLM
-description: "Configure vLLM as an LLM provider in Mem0 for high-performance local inference with GPU-optimized serving."
+description: "Configure vLLM as an LLM provider in Mem0, with optional LMCache-backed KV reuse."
 ---
 
-[vLLM](https://docs.vllm.ai/) is a high-performance inference engine for large language models that provides significant performance improvements for local inference. It's designed to maximize throughput and memory efficiency for serving LLMs.
+[vLLM](https://docs.vllm.ai/) is a high-performance inference engine for serving large language models. Mem0 connects to its OpenAI-compatible API for memory extraction.
 
 ## Prerequisites
 
@@ -16,11 +16,9 @@ description: "Configure vLLM as an LLM provider in Mem0 for high-performance loc
 2. **Start vLLM server**:
 
    ```bash
-   # For testing with a small model
-   vllm serve microsoft/DialoGPT-medium --port 8000
-
-   # For production with a larger model (requires GPU)
-   vllm serve Qwen/Qwen2.5-32B-Instruct --port 8000
+   vllm serve Qwen/Qwen3-8B \
+     --port 8000 \
+     --max-model-len 16384
    ```
 
 ## Usage
@@ -36,8 +34,9 @@ config = {
     "llm": {
         "provider": "vllm",
         "config": {
-            "model": "Qwen/Qwen2.5-32B-Instruct",
+            "model": "Qwen/Qwen3-8B",
             "vllm_base_url": "http://localhost:8000/v1",
+            "api_key": "vllm-api-key",
             "temperature": 0.1,
             "max_tokens": 2000,
         }
@@ -61,7 +60,7 @@ const config = {
   llm: {
     provider: "vllm",
     config: {
-      model: "Qwen/Qwen2.5-32B-Instruct",
+      model: "Qwen/Qwen3-8B",
       baseURL: "http://localhost:8000/v1",
       apiKey: process.env.VLLM_API_KEY || "vllm-api-key",
       temperature: 0.1,
@@ -94,6 +93,61 @@ await memory.add(messages, { userId: "alice", metadata: { category: "movies" } }
 
 </CodeGroup>
 
+## Optional: Reuse KV cache with LMCache
+
+[LMCache](https://docs.lmcache.ai/) adds reusable KV-cache tiers behind vLLM. Mem0 does not need a separate LMCache provider: both the Python and TypeScript configurations above continue to connect to the same vLLM URL.
+
+Mem0's inferred memory writes reuse a large extraction-prompt prefix, so later `add(..., infer=True)` calls can reuse cached prefill work. To enable LMCache in its recommended multiprocess mode:
+
+1. Install LMCache alongside vLLM:
+
+   ```bash
+   pip install lmcache vllm
+   ```
+
+2. Start the LMCache server:
+
+   ```bash
+   lmcache server \
+     --host localhost \
+     --port 5555 \
+     --l1-size-gb 20 \
+     --eviction-policy LRU
+   ```
+
+3. Start vLLM with the LMCache MP connector:
+
+   ```bash
+   vllm serve Qwen/Qwen3-8B \
+     --port 8000 \
+     --max-model-len 16384 \
+     --kv-transfer-config \
+     '{"kv_connector":"LMCacheMPConnector","kv_connector_module_path":"lmcache.integration.vllm.lmcache_mp_connector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.host":"tcp://localhost","lmcache.mp.port":5555}}'
+   ```
+
+   The `kv_connector_module_path` setting selects LMCache's current connector with vLLM 0.20 and later. For older vLLM releases, omit that setting and use the connector bundled with vLLM. See the [LMCache quickstart](https://docs.lmcache.ai/getting_started/quickstart.html) for version-specific details.
+
+4. Run the same Mem0 code from the Usage section, or the repository example:
+
+   ```bash
+   python examples/misc/vllm_example.py
+   ```
+
+The first matching request populates LMCache. After subsequent requests, inspect the token-level lookup counters described in [LMCache's metrics reference](https://docs.lmcache.ai/mp/observability/metrics.html):
+
+```bash
+curl -s http://localhost:8080/metrics | \
+  grep -E 'lmcache_mp_lookup_(requested|hit)_tokens_total'
+```
+
+<Note>
+  LMCache accelerates LLM prefill for repeated prefixes, including inferred memory writes and procedural-memory summarization. Normal `search()` calls, embeddings, vector-store operations, and `add(..., infer=False)` do not use the extraction LLM and are not accelerated by LMCache.
+</Note>
+
+<Note>
+  vLLM also provides GPU-resident automatic prefix caching. Compare LMCache against vLLM with that cache enabled. LMCache is most useful when cached state must outgrow GPU memory, survive a vLLM restart, or be shared by multiple vLLM engines; short or mostly unique prompts may not benefit.
+</Note>
+
 ## Configuration Parameters
 
 | Parameter       | Description                       | Default                       | Environment Variable |
@@ -106,7 +160,7 @@ await memory.add(messages, { userId: "alice", metadata: { category: "movies" } }
 
 ## Environment Variables
 
-You can set these environment variables instead of specifying them in config:
+The repository example reads these environment variables when constructing its vLLM configuration:
 
 ```bash
 export VLLM_BASE_URL="http://localhost:8000/v1"
@@ -116,7 +170,7 @@ export OPENAI_API_KEY="your-openai-api-key"  # for embeddings
 
 ## Benefits
 
-- **High Performance**: 2-24x faster inference than standard implementations
+- **GPU Optimized**: High-throughput inference with continuous batching
 - **Memory Efficient**: Optimized memory usage with PagedAttention
 - **Local Deployment**: Keep your data private and reduce API costs
 - **Easy Integration**: Drop-in replacement for other LLM providers
@@ -138,10 +192,10 @@ export OPENAI_API_KEY="your-openai-api-key"  # for embeddings
 
 3. **Model not found**: Check model name matches server
 
-4. **Out of memory**: Try smaller models or reduce `max_model_len`
+4. **Out of memory**: Try a smaller model or tune vLLM's memory settings. Mem0's extraction prompt can exceed 4,096 tokens, so ensure the server context window can hold the complete prompt and response.
 
    ```bash
-   vllm serve Qwen/Qwen2.5-32B-Instruct --max-model-len 4096
+   vllm serve Qwen/Qwen3-8B --max-model-len 16384
    ```
 
 ## Config

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -445,7 +445,7 @@ Everything below is OSS-only provider configuration. Skip this entire section wh
 - [Ollama](https://docs.mem0.ai/components/llms/models/ollama) [OSS]: Use when the LLM is a local Ollama model.
 - [LM Studio](https://docs.mem0.ai/components/llms/models/lmstudio) [OSS]: Use when the LLM is served from LM Studio.
 - [LiteLLM](https://docs.mem0.ai/components/llms/models/litellm) [OSS]: Use when multiplexing many providers behind LiteLLM.
-- [vLLM](https://docs.mem0.ai/components/llms/models/vllm) [OSS]: Use when self-hosting inference with vLLM.
+- [vLLM](https://docs.mem0.ai/components/llms/models/vllm) [OSS]: Use when self-hosting inference with vLLM or enabling LMCache-backed KV reuse.
 - [LangChain LLM](https://docs.mem0.ai/components/llms/models/langchain) [OSS]: Use when the LLM is wrapped behind a LangChain adapter.
 
 ### Embedding Providers [OSS]

--- a/examples/misc/vllm_example.py
+++ b/examples/misc/vllm_example.py
@@ -1,54 +1,72 @@
-"""
-Example of using vLLM with mem0 for high-performance memory operations.
+"""Example of using vLLM with Mem0 for inferred memory extraction.
 
 SETUP INSTRUCTIONS:
-1. Install vLLM:
+1. Install Mem0 and vLLM:
+   pip install mem0ai
    pip install vllm
 
 2. Start vLLM server (in a separate terminal):
-   vllm serve microsoft/DialoGPT-small --port 8000
+   vllm serve Qwen/Qwen3-8B --port 8000 --max-model-len 16384
 
-   Wait for the message: "Uvicorn running on http://0.0.0.0:8000"
-   (Small model: ~500MB download, much faster!)
+3. Set an OpenAI API key for the embedding model:
+   export OPENAI_API_KEY="your-openai-api-key"
 
-3. Verify server is running:
+4. Verify the vLLM server is running:
    curl http://localhost:8000/health
 
-4. Run this example:
+5. Run this example:
    python examples/misc/vllm_example.py
 
+To enable LMCache, start vLLM with the LMCache MP connector documented at:
+https://docs.mem0.ai/components/llms/models/vllm
+
 Optional environment variables:
+   export VLLM_MODEL="Qwen/Qwen3-8B"
    export VLLM_BASE_URL="http://localhost:8000/v1"
    export VLLM_API_KEY="vllm-api-key"
+   export QDRANT_PATH="/tmp/mem0_vllm_example"
 """
+
+import os
 
 from mem0 import Memory
 
-# Configuration for vLLM integration
+MODEL = os.getenv("VLLM_MODEL", "Qwen/Qwen3-8B")
+BASE_URL = os.getenv("VLLM_BASE_URL", "http://localhost:8000/v1")
+VLLM_API_KEY = os.getenv("VLLM_API_KEY", "vllm-api-key")
+QDRANT_PATH = os.getenv("QDRANT_PATH", "/tmp/mem0_vllm_example")
+USER_ID = "vllm_example_user"
+
+# LMCache is configured on the vLLM server, so this Mem0 configuration works
+# with either native vLLM or an LMCache-backed vLLM server.
 config = {
     "llm": {
         "provider": "vllm",
         "config": {
-            "model": "Qwen/Qwen2.5-32B-Instruct",
-            "vllm_base_url": "http://localhost:8000/v1",
-            "api_key": "vllm-api-key",
-            "temperature": 0.7,
-            "max_tokens": 100,
+            "model": MODEL,
+            "vllm_base_url": BASE_URL,
+            "api_key": VLLM_API_KEY,
+            "temperature": 0.1,
+            "max_tokens": 500,
         },
     },
     "embedder": {"provider": "openai", "config": {"model": "text-embedding-3-small"}},
     "vector_store": {
         "provider": "qdrant",
-        "config": {"collection_name": "vllm_memories", "host": "localhost", "port": 6333},
+        "config": {"collection_name": "vllm_memories", "path": QDRANT_PATH},
     },
+    "history_db_path": ":memory:",
 }
 
 
 def main():
     """
-    Demonstrate vLLM integration with mem0
+    Demonstrate vLLM integration with Mem0.
     """
-    print("--> Initializing mem0 with vLLM...")
+    if not os.getenv("OPENAI_API_KEY"):
+        raise RuntimeError("Set OPENAI_API_KEY for the embedding model before running this example.")
+
+    print(f"--> Initializing Mem0 with vLLM model {MODEL} at {BASE_URL}...")
 
     # Initialize memory with vLLM
     memory = Memory.from_config(config)
@@ -65,7 +83,7 @@ def main():
                     "content": "That's great! Chess is an excellent strategic game that helps improve critical thinking.",
                 },
             ],
-            "user_id": "user_123",
+            "user_id": USER_ID,
         },
         {
             "messages": [
@@ -75,7 +93,7 @@ def main():
                     "content": "Python is a fantastic language for beginners! What specific areas are you focusing on?",
                 },
             ],
-            "user_id": "user_123",
+            "user_id": USER_ID,
         },
         {
             "messages": [
@@ -85,20 +103,21 @@ def main():
                     "content": "Many people find they're more creative and focused during nighttime hours. It's important to maintain a consistent schedule that works for you.",
                 },
             ],
-            "user_id": "user_123",
+            "user_id": USER_ID,
         },
     ]
 
     print("\n--> Adding memories using vLLM...")
 
-    # Add memories - now powered by vLLM's high-performance inference
+    # Inferred adds call vLLM to extract memories. With LMCache enabled on the
+    # server, these calls can reuse the shared extraction-prompt prefix.
     for i, conversation in enumerate(conversations, 1):
         result = memory.add(messages=conversation["messages"], user_id=conversation["user_id"])
         print(f"Memory {i} added: {result}")
 
     print("\n🔍 Searching memories...")
 
-    # Search memories - vLLM will process the search and memory operations
+    # Normal search uses the configured embedder and vector store, not vLLM.
     search_queries = [
         "What does the user like to do on weekends?",
         "What is the user learning?",
@@ -107,24 +126,20 @@ def main():
 
     for query in search_queries:
         print(f"\nQuery: {query}")
-        memories = memory.search(query=query, user_id="user_123")
+        memories = memory.search(query=query, filters={"user_id": USER_ID})["results"]
 
         for memory_item in memories:
             print(f"  - {memory_item['memory']}")
 
     print("\n--> Getting all memories for user...")
-    all_memories = memory.get_all(user_id="user_123")
+    all_memories = memory.get_all(filters={"user_id": USER_ID})["results"]
     print(f"Total memories stored: {len(all_memories)}")
 
     for memory_item in all_memories:
         print(f"  - {memory_item['memory']}")
 
     print("\n--> vLLM integration demo completed successfully!")
-    print("\nBenefits of using vLLM:")
-    print("  -> 2.7x higher throughput compared to standard implementations")
-    print("  -> 5x faster time-per-output-token")
-    print("  -> Efficient memory usage with PagedAttention")
-    print("  -> Simple configuration, same as other providers")
+    print("    LMCache, when enabled on the server, requires no Mem0 code changes.")
 
 
 if __name__ == "__main__":
@@ -133,7 +148,8 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"=> Error: {e}")
         print("\nTroubleshooting:")
-        print("1. Make sure vLLM server is running: vllm serve microsoft/DialoGPT-small --port 8000")
+        print(f"1. Make sure vLLM is serving {MODEL} at {BASE_URL}")
         print("2. Check if the model is downloaded and accessible")
-        print("3. Verify the base URL and port configuration")
-        print("4. Ensure you have the required dependencies installed")
+        print("3. Verify OPENAI_API_KEY is set for embeddings")
+        print("4. Verify the base URL and port configuration")
+        raise SystemExit(1) from e


### PR DESCRIPTION
## Linked Issue

  Closes #6456

  ## Description

  This PR documents how to use LMCache as a transparent KV-cache layer behind Mem0's existing vLLM provider.

  Mem0's inferred memory writes share a large extraction-prompt prefix, making them suitable for KV-cache reuse. The existing documentation did not explain how to configure LMCache or which Mem0 operations benefit from it.

  This PR:

  - Adds the recommended LMCache multiprocess deployment configuration to the vLLM guide.
  - Documents connector version requirements, cache metrics, and native vLLM APC considerations.
  - Clarifies that LMCache accelerates LLM prefill for inferred memory writes and procedural memory, but not normal search, embeddings, vector-store operations, or `infer=False`.
  - Updates the vLLM example to use a consistent configurable model, current `filters` APIs, the current `{"results": [...]}` response format, and local Qdrant storage.
  - Removes unsupported performance claims from the example.
  - Updates `docs/llms.txt` so the LMCache recipe is discoverable.

  LMCache remains entirely behind the vLLM endpoint. This PR adds no new Mem0 provider, runtime dependency, or public API.

  ## Type of Change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Refactor (no functional changes)
  - [x] Documentation update

  ## Breaking Changes

  N/A

  ## Test Coverage

  - [ ] I added/updated unit tests
  - [ ] I added/updated integration tests
  - [x] I tested manually (describe below)
  - [x] No tests needed (no Mem0 runtime behavior was changed)

  Validation performed:

  - `python3 -m py_compile examples/misc/vllm_example.py`
  - `ruff check examples/misc/vllm_example.py`
  - `ruff format --check examples/misc/vllm_example.py`
  - `pytest -q tests/llms/test_vllm.py` — 6 passed
  - `python3 scripts/check-llms-txt-coverage.py`
  - `python3 -m json.tool docs/docs.json`
  - `git diff --check`
  - Mintlify broken-link validation and local rendered preview
  - Ran the example end to end against both native vLLM and LMCache-backed vLLM with Qwen3-8B
  - Confirmed 7,936 shared-prefix tokens were reused and remained available after restarting vLLM

  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [ ] I have added tests that prove my fix/feature works — not applicable because this changes documentation and an example only
  - [x] Relevant existing tests pass locally
  - [x] I have updated documentation if needed