### PR TITLE
fix(redis): request and persist updated_at on search paths

### DIFF
--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -126,11 +126,16 @@ class RedisDB(VectorStoreBase):
             # Start with required fields
             created_at_str = payload.get("created_at")
             created_at_ts = int(datetime.fromisoformat(created_at_str).timestamp()) if created_at_str else 0
+            updated_at_str = payload.get("updated_at")
+            updated_at_ts = (
+                int(datetime.fromisoformat(updated_at_str).timestamp()) if updated_at_str else created_at_ts
+            )
             entry = {
                 "memory_id": id,
                 "hash": payload.get("hash", ""),
                 "memory": payload.get("data", ""),
                 "created_at": created_at_ts,
+                "updated_at": updated_at_ts,
                 "embedding": np.array(vector, dtype=np.float32).tobytes(),
             }
 
@@ -155,7 +160,7 @@ class RedisDB(VectorStoreBase):
         v = VectorQuery(
             vector=np.array(vectors, dtype=np.float32).tobytes(),
             vector_field_name="embedding",
-            return_fields=["memory_id", "hash", "agent_id", "run_id", "user_id", "memory", "metadata", "created_at"],
+            return_fields=["memory_id", "hash", "agent_id", "run_id", "user_id", "memory", "metadata", "created_at", "updated_at"],
             filter_expression=filter,
             num_results=top_k,
         )
@@ -209,7 +214,7 @@ class RedisDB(VectorStoreBase):
         t = TextQuery(
             text=query,
             text_field_name="memory",
-            return_fields=["memory_id", "hash", "agent_id", "run_id", "user_id", "memory", "metadata", "created_at"],
+            return_fields=["memory_id", "hash", "agent_id", "run_id", "user_id", "memory", "metadata", "created_at", "updated_at"],
             filter_expression=filter_expression,
             num_results=top_k,
         )

--- a/tests/vector_stores/test_redis.py
+++ b/tests/vector_stores/test_redis.py
@@ -234,6 +234,12 @@ def test_search_and_keyword_search_request_updated_at():
     """search()/keyword_search() must include updated_at in return_fields (#6059)."""
     db, mock_index = _make_redis_db()
 
+    def _capture_query(**kwargs):
+        # Capture constructor kwargs; avoid MagicMock.return_fields being a method.
+        obj = MagicMock(name="Query")
+        obj.return_fields = list(kwargs.get("return_fields") or [])
+        return obj
+
     mock_index.query.return_value = [
         {
             "memory_id": "m1",
@@ -247,10 +253,12 @@ def test_search_and_keyword_search_request_updated_at():
         }
     ]
 
-    results = db.search("q", [0.1, 0.2, 0.3], top_k=1)
+    with patch("mem0.vector_stores.redis.VectorQuery", side_effect=_capture_query) as VQ:
+        results = db.search("q", [0.1, 0.2, 0.3], top_k=1)
+
     assert results[0].payload.get("updated_at") is not None
-    vq = mock_index.query.call_args[0][0]
-    assert "updated_at" in vq.return_fields
+    assert VQ.call_count == 1
+    assert "updated_at" in VQ.call_args.kwargs["return_fields"]
 
     mock_index.query.reset_mock()
     mock_index.query.return_value = [
@@ -265,10 +273,12 @@ def test_search_and_keyword_search_request_updated_at():
             "text_score": 0.9,
         }
     ]
-    results = db.keyword_search("hello", top_k=1)
+    with patch("mem0.vector_stores.redis.TextQuery", side_effect=_capture_query) as TQ:
+        results = db.keyword_search("hello", top_k=1)
+
     assert results[0].payload.get("updated_at") is not None
-    tq = mock_index.query.call_args[0][0]
-    assert "updated_at" in tq.return_fields
+    assert TQ.call_count == 1
+    assert "updated_at" in TQ.call_args.kwargs["return_fields"]
 
 
 def test_insert_persists_updated_at():

--- a/tests/vector_stores/test_redis.py
+++ b/tests/vector_stores/test_redis.py
@@ -228,3 +228,64 @@ def test_update_entity_payload_without_hash_and_timestamps():
     assert data_dict["hash"] == ""
     assert data_dict["created_at"] == 0
     assert data_dict["updated_at"] == 0
+
+
+def test_search_and_keyword_search_request_updated_at():
+    """search()/keyword_search() must include updated_at in return_fields (#6059)."""
+    db, mock_index = _make_redis_db()
+
+    mock_index.query.return_value = [
+        {
+            "memory_id": "m1",
+            "hash": "h1",
+            "memory": "hello",
+            "created_at": "1704067200",
+            "updated_at": "1704153600",
+            "vector_distance": "0.1",
+            "user_id": "u1",
+            "metadata": "{}",
+        }
+    ]
+
+    results = db.search("q", [0.1, 0.2, 0.3], top_k=1)
+    assert results[0].payload.get("updated_at") is not None
+    vq = mock_index.query.call_args[0][0]
+    assert "updated_at" in vq.return_fields
+
+    mock_index.query.reset_mock()
+    mock_index.query.return_value = [
+        {
+            "memory_id": "m1",
+            "hash": "h1",
+            "memory": "hello",
+            "created_at": "1704067200",
+            "updated_at": "1704153600",
+            "user_id": "u1",
+            "metadata": "{}",
+            "text_score": 0.9,
+        }
+    ]
+    results = db.keyword_search("hello", top_k=1)
+    assert results[0].payload.get("updated_at") is not None
+    tq = mock_index.query.call_args[0][0]
+    assert "updated_at" in tq.return_fields
+
+
+def test_insert_persists_updated_at():
+    """insert must write updated_at (defaults to created_at when omitted)."""
+    db, mock_index = _make_redis_db()
+    db.insert(
+        vectors=[[0.1, 0.2, 0.3]],
+        payloads=[
+            {
+                "data": "hello",
+                "hash": "h1",
+                "created_at": "2024-01-01T00:00:00+00:00",
+                "updated_at": "2024-01-02T00:00:00+00:00",
+                "user_id": "u1",
+            }
+        ],
+        ids=["m1"],
+    )
+    data = mock_index.load.call_args[0][0]
+    assert "updated_at" in data[0]


### PR DESCRIPTION
## Summary

Redis `search()` / `keyword_search()` never returned `updated_at` even though `get()` / `list()` and `update()` already do. This PR:

1. Adds `updated_at` to `return_fields` for vector and keyword queries (the original #6059 gap).
2. Persists `updated_at` on `insert()` (defaults to `created_at`) so search can actually surface a value for new memories, not only after an update.

Supersedes the incomplete open salvage #6275 (return_fields only).

Closes #6059

## Motivation

Silent metadata parity gap: updated memories show `updated_at` via `get()`/`list()` but drop it on `search()`/`keyword_search()` because redis-vl never returned the field. Additionally, `insert()` never wrote `updated_at` at all while treating it as an excluded metadata key, so even with return_fields fixed, fresh memories still had no timestamp until an update.

## Verification

- Unit tests in `tests/vector_stores/test_redis.py`:
  - `test_search_and_keyword_search_request_updated_at` asserts both query objects include `updated_at` in `return_fields` and payloads populate it.
  - `test_insert_persists_updated_at` asserts load payload includes `updated_at`.
- Local stub suite over RedisDB (mocked redis-vl) for insert/search/keyword paths: PASS