### PR TITLE
Remove redundant check for api_key attribute

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -35,7 +35,7 @@ class LLMBase(ABC):
         if not hasattr(self.config, "model"):
             raise ValueError("Configuration must have a 'model' attribute")
 
-        if not hasattr(self.config, "api_key") and not hasattr(self.config, "api_key"):
+        if not hasattr(self.config, "api_key"):
             # Check if API key is available via environment variable
             # This will be handled by individual providers
             pass

--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -35,11 +35,6 @@ class LLMBase(ABC):
         if not hasattr(self.config, "model"):
             raise ValueError("Configuration must have a 'model' attribute")
 
-        if not hasattr(self.config, "api_key"):
-            # Check if API key is available via environment variable
-            # This will be handled by individual providers
-            pass
-
     def _is_reasoning_model(self, model: str) -> bool:
         """
         Check if the model is a reasoning model or GPT-5 series that doesn't support certain parameters.


### PR DESCRIPTION
## Description

This PR fixes a minor typo in `mem0/llms/base.py`'s `_validate_config` method. The `api_key` attribute was being checked redundantly (`if not hasattr(self.config, "api_key") and not hasattr(self.config, "api_key")`). This has been simplified to a single check, cleaning up the code without altering its behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

This is a trivial typo correction removing a duplicate boolean condition. It does not introduce or alter any functional logic.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
```