### PR TITLE
test(sandbox): container-backed infrastructure regression suite

### DIFF
--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -1,0 +1,51 @@
+# Sandbox — infrastructure regression suite
+
+Runs the real `Memory` engine against **real vector stores in containers**, asserting the
+scoping, filter-translation and deletion behaviour that `audit.md` found broken. Every
+assertion runs against **each** store, so store-to-store divergence shows up as a failure
+rather than as a support ticket.
+
+```bash
+docker compose -f sandbox/docker-compose.yml up -d
+pytest sandbox/
+```
+
+Stores that aren't reachable are skipped, so a partial stack still gives a useful run.
+
+## No LLM, no API keys, no Azure
+
+Nothing here talks to a model provider, by design.
+
+Every bug this suite targets — delete scoping, tenancy isolation, metadata-filter
+translation, `reset()`, entity-id preservation on `update()` — lives **below** the LLM. The
+LLM's only job is deciding which facts to extract from a message; it has no influence on how
+a filter becomes a SQL `WHERE` clause or a Qdrant condition. Pointing a real provider at
+these tests would buy nothing and cost determinism (extraction varies run to run, so
+assertions flake), money per run, a secret that fork PRs can't have, and latency.
+
+So the suite uses:
+
+- **`infer=False`** on every write, which stores the message verbatim and makes zero LLM calls.
+- **`HashEmbedder`** in `conftest.py` — a token-hash embedding that is deterministic, content-sensitive
+  (overlapping text ranks higher, so search-ordering assertions are meaningful) and entirely local.
+
+Real embeddings would only change *semantic relevance quality*, which is a model question,
+not an infrastructure bug. Add an opt-in provider-backed test when someone needs to
+regression-test prompt or extraction changes; that is a different suite from this one.
+
+One wrinkle worth knowing: `audit.md` M-14 is real, so a custom embedder cannot be injected
+through config (the provider allow-lists in `mem0/embeddings/configs.py` are hardcoded
+Pydantic literals that `EmbedderFactory` never consults for registration). The fixture works
+around it by constructing `Memory` normally and swapping `embedding_model` afterwards. The
+dummy `OPENAI_API_KEY` exists purely so the unused default provider can be constructed.
+
+## Known-broken cases
+
+Confirmed defects are marked `xfail` rather than deleted, so the suite is green today and
+flips to `XPASS` the moment someone fixes one:
+
+| Test | Finding |
+|---|---|
+| `test_icontains_is_case_insensitive` | audit O3 — `icontains` maps to a case-sensitive `MatchText` on Qdrant. **Passes on pgvector**, so the two stores disagree. |
+| `test_wildcard_requires_the_field_to_exist` | audit O4 — `*` is a no-op match-all on Qdrant instead of an existence check. **Passes on pgvector**, so the two stores disagree. |
+| `test_or_filter_matches_either_branch_via_get_all` | Found by this suite. `search()` normalises `OR` → `$or` via `_process_filters`; `get_all()` passes filters straight to `vector_store.list()` (`mem0/memory/main.py:1297`) with no normalisation. Qdrant self-normalises and survives; pgvector only recognises `$or`, so the raw `OR` key falls through to an equality comparison and **silently returns zero rows**. The sibling `..._via_search` test passes on both stores, which is the evidence of the asymmetry. |

--- a/sandbox/conftest.py
+++ b/sandbox/conftest.py
@@ -1,0 +1,73 @@
+import copy
+import hashlib
+import os
+import socket
+import uuid
+
+import pytest
+
+from mem0 import Memory
+from mem0.configs.base import MemoryConfig
+from mem0.embeddings.base import EmbeddingBase
+
+EMBED_DIMS = 64
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-sandbox-unused")
+
+STORE_CONFIGS = {
+    "qdrant": {
+        "provider": "qdrant",
+        "config": {
+            "embedding_model_dims": EMBED_DIMS,
+            "host": "localhost",
+            "port": 6333,
+            "path": None,
+        },
+    },
+    "pgvector": {
+        "provider": "pgvector",
+        "config": {
+            "embedding_model_dims": EMBED_DIMS,
+            "dbname": "mem0",
+            "user": "mem0",
+            "password": "mem0",
+            "host": "localhost",
+            "port": 5433,
+        },
+    },
+}
+
+
+class HashEmbedder(EmbeddingBase):
+    """Deterministic token-hash embedding: no network, no API key, stable across runs."""
+
+    def embed(self, text, memory_action=None):
+        vector = [0.0] * EMBED_DIMS
+        for token in str(text).lower().split():
+            digest = hashlib.blake2b(token.encode(), digest_size=8).digest()
+            vector[int.from_bytes(digest, "big") % EMBED_DIMS] += 1.0
+        norm = sum(value * value for value in vector) ** 0.5
+        if norm == 0:
+            return [1.0] + [0.0] * (EMBED_DIMS - 1)
+        return [value / norm for value in vector]
+
+
+def _reachable(host, port):
+    with socket.socket() as sock:
+        sock.settimeout(0.5)
+        return sock.connect_ex((host, port)) == 0
+
+
+@pytest.fixture(params=list(STORE_CONFIGS))
+def memory(request, tmp_path):
+    store = copy.deepcopy(STORE_CONFIGS[request.param])
+    host, port = store["config"]["host"], store["config"]["port"]
+    if not _reachable(host, port):
+        pytest.skip(f"{request.param} unreachable at {host}:{port} — start it with sandbox/docker-compose.yml")
+
+    store["config"]["collection_name"] = f"sandbox_{uuid.uuid4().hex[:12]}"
+    instance = Memory(MemoryConfig(vector_store=store, history_db_path=str(tmp_path / "history.db")))
+    instance.embedding_model = HashEmbedder()
+    yield instance
+    instance.vector_store.delete_col()
+    instance.close()

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  qdrant:
+    image: qdrant/qdrant
+    ports:
+      - "6333:6333"
+
+  pgvector:
+    image: pgvector/pgvector:pg17
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRES_USER: mem0
+      POSTGRES_PASSWORD: mem0
+      POSTGRES_DB: mem0
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mem0"]
+      interval: 2s
+      retries: 15

--- a/sandbox/test_infra.py
+++ b/sandbox/test_infra.py
@@ -1,0 +1,117 @@
+import pytest
+
+
+def add(memory, text, **scope):
+    return memory.add(text, infer=False, **scope)
+
+
+def texts(result):
+    return sorted(row["memory"] for row in result["results"])
+
+
+def test_get_all_is_scoped_to_the_requested_user(memory):
+    add(memory, "alice likes espresso", user_id="alice")
+    add(memory, "bob likes tea", user_id="bob")
+
+    assert texts(memory.get_all(filters={"user_id": "alice"})) == ["alice likes espresso"]
+
+
+def test_search_does_not_leak_across_users(memory):
+    add(memory, "alice likes espresso", user_id="alice")
+    add(memory, "bob likes espresso", user_id="bob")
+
+    result = memory.search("likes espresso", filters={"user_id": "alice"}, threshold=0.0)
+
+    assert texts(result) == ["alice likes espresso"]
+
+
+def test_get_all_is_scoped_to_the_requested_run(memory):
+    add(memory, "session one note", user_id="alice", run_id="r1")
+    add(memory, "session two note", user_id="alice", run_id="r2")
+
+    assert texts(memory.get_all(filters={"user_id": "alice", "run_id": "r1"})) == ["session one note"]
+
+
+def test_delete_all_conjoins_entity_filters(memory):
+    """Audit P1's OSS twin: a run_id matching nothing must not wipe the whole user."""
+    add(memory, "alice note one", user_id="alice")
+    add(memory, "alice note two", user_id="alice")
+
+    memory.delete_all(user_id="alice", run_id="run_that_does_not_exist")
+
+    assert len(memory.get_all(filters={"user_id": "alice"})["results"]) == 2
+
+
+def test_delete_all_removes_only_the_targeted_run(memory):
+    add(memory, "keep this", user_id="alice", run_id="r1")
+    add(memory, "delete this", user_id="alice", run_id="r2")
+
+    memory.delete_all(user_id="alice", run_id="r2")
+
+    assert texts(memory.get_all(filters={"user_id": "alice"})) == ["keep this"]
+
+
+def test_update_metadata_does_not_overwrite_entity_ids(memory):
+    memory_id = add(memory, "alice note", user_id="alice", run_id="r1")["results"][0]["id"]
+
+    memory.update(memory_id, metadata={"user_id": "mallory", "topic": "coffee"})
+
+    assert memory.get(memory_id)["user_id"] == "alice"
+    assert texts(memory.get_all(filters={"user_id": "alice"})) == ["alice note"]
+
+
+def test_reset_clears_every_memory(memory):
+    add(memory, "alice note", user_id="alice")
+
+    memory.reset()
+
+    assert memory.get_all(filters={"user_id": "alice"})["results"] == []
+
+
+def test_metadata_operator_filters_narrow_the_result_set(memory):
+    add(memory, "cheap item", user_id="alice", metadata={"price": 5})
+    add(memory, "pricey item", user_id="alice", metadata={"price": 50})
+
+    assert texts(memory.get_all(filters={"user_id": "alice", "price": {"gte": 40}})) == ["pricey item"]
+
+
+def seed_colors(memory):
+    add(memory, "red note", user_id="alice", metadata={"color": "red"})
+    add(memory, "blue note", user_id="alice", metadata={"color": "blue"})
+    add(memory, "green note", user_id="alice", metadata={"color": "green"})
+    return {"user_id": "alice", "OR": [{"color": "red"}, {"color": "blue"}]}
+
+
+def test_or_filter_matches_either_branch_via_search(memory):
+    filters = seed_colors(memory)
+
+    assert texts(memory.search("note", filters=filters, threshold=0.0)) == ["blue note", "red note"]
+
+
+@pytest.mark.xfail(
+    reason="get_all() hands raw filters to vector_store.list() without the OR->$or normalisation "
+    "search() applies; qdrant self-normalises, pgvector matches nothing"
+)
+def test_or_filter_matches_either_branch_via_get_all(memory):
+    filters = seed_colors(memory)
+
+    assert texts(memory.get_all(filters=filters)) == ["blue note", "red note"]
+
+
+@pytest.mark.xfail(reason="audit O3: icontains maps to a case-sensitive MatchText on qdrant")
+def test_icontains_is_case_insensitive(memory):
+    add(memory, "deadline note", user_id="alice", metadata={"deadline": "today"})
+
+    result = memory.get_all(filters={"user_id": "alice", "deadline": {"icontains": "TODAY"}})
+
+    assert texts(result) == ["deadline note"]
+
+
+@pytest.mark.xfail(reason="audit O4: wildcard is a no-op match-all on qdrant, not an existence check")
+def test_wildcard_requires_the_field_to_exist(memory):
+    add(memory, "has category", user_id="alice", metadata={"category": "work"})
+    add(memory, "no category", user_id="alice")
+
+    result = memory.get_all(filters={"user_id": "alice", "category": "*"})
+
+    assert texts(result) == ["has category"]


### PR DESCRIPTION
## Description

Adds `sandbox/` — a regression suite that runs the real `Memory` engine against **real vector stores in containers** (Qdrant + pgvector), asserting the scoping, filter-translation and deletion behaviour that `audit.md` found broken.

Every assertion is parametrised across **both** stores, so store-to-store divergence fails loudly here instead of arriving as a support ticket. That is the point of the suite: the existing `tests/` mock the vector client, so none of the 81 Python test files exercise real infrastructure.

```bash
docker compose -f sandbox/docker-compose.yml up -d
pytest sandbox/
```

Unreachable stores are skipped, so a partial stack still gives a useful run.

## Why there is no LLM provider in here

Deliberate. Every bug this suite targets — delete scoping, tenancy isolation, metadata-filter translation, `reset()`, entity-id preservation on `update()` — lives **below** the LLM. The LLM only decides which facts to extract from a message; it has no influence on how a filter becomes a SQL `WHERE` clause or a Qdrant condition.

A real provider would buy nothing and cost determinism (extraction varies run to run, so assertions flake), money per run, a secret that fork PRs cannot have, and latency. So the suite uses `infer=False` (zero LLM calls, message stored verbatim) plus `HashEmbedder`, a deterministic token-hash embedding that is content-sensitive and entirely local.

Real embeddings would only change *semantic relevance quality*, which is a model question, not an infrastructure bug. A provider-backed suite for prompt/extraction changes is a separate thing from this one.

## New finding, caught on the suite's first run

`OR` filters silently return **zero rows** on pgvector via `get_all()`.

`search()` normalises `OR` → `$or` through `_process_filters`. `get_all()` hands `effective_filters` straight to `vector_store.list()` (`mem0/memory/main.py:1297`) with no normalisation. Qdrant self-normalises (`mem0/vector_stores/qdrant.py:361`) and survives; pgvector's `_build_filter_conditions` only recognises `$or`, so the raw `OR` key falls through to the generic equality branch and compares `payload->>'OR'` against the stringified list — matching nothing.

This is audit O2's failure mode (silent zero-results, the worst kind) confirmed on a first-class store, not just FAISS. The sibling `..._via_search` test passes on both stores, which is the executable evidence of the asymmetry.

Not fixed here — keeping this PR purely additive. The fix belongs where `get_all` builds its filters, so both read paths share one normalisation.

## Known defects are xfail, not deleted

The suite is green today and flips to `XPASS` the moment someone fixes one. Current state: **18 passed, 3 xfailed, 3 xpassed**. Each of the three findings is broken on exactly one store and correct on the other:

| Finding | Broken on | Correct on |
|---|---|---|
| audit O3 — `icontains` is case-sensitive | Qdrant | pgvector |
| audit O4 — `*` is match-all, not an existence check | Qdrant | pgvector |
| `OR` via `get_all()` returns nothing (new) | pgvector | Qdrant |

## Note on audit M-14

Confirmed real while building this: a custom embedder cannot be injected through config, because the provider allow-lists in `mem0/embeddings/configs.py` are hardcoded Pydantic literals that `EmbedderFactory` never consults for registration. The fixture works around it by constructing `Memory` normally and swapping `embedding_model` afterwards; the dummy `OPENAI_API_KEY` exists purely so the unused default provider can be constructed. Worth fixing separately.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

N/A — additive only, no existing file touched.

## Test Coverage

- [x] I added/updated integration tests
- [x] I tested manually (ran the full suite against both containers; 18 passed, 3 xfailed, 3 xpassed; `ruff check`/`format` and `isort` clean)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (`sandbox/README.md`)