### PR TITLE
fix(openmemory): unbreak local self-hosted flow (config PUT, Qdrant search, get_all filters, DeepSeek categorization)

### DIFF
--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -177,9 +177,9 @@ async def search_memory(query: str) -> str:
             embeddings = memory_client.embedding_model.embed(query, "search")
 
             hits = memory_client.vector_store.search(
-                query=query, 
-                vectors=embeddings, 
-                limit=10, 
+                query=query,
+                vectors=embeddings,
+                top_k=10,
                 filters=filters,
             )
 

--- a/openmemory/api/app/mcp_server.py
+++ b/openmemory/api/app/mcp_server.py
@@ -244,8 +244,9 @@ async def list_memories() -> str:
             # Get or create user and app
             user, app = get_user_and_app(db, user_id=uid, app_id=client_name)
 
-            # Get all memories
-            memories = memory_client.get_all(user_id=uid)
+            # Get all memories. Memory.get_all() is keyword-only and takes a
+            # filters dict, not a bare user_id kwarg (see mem0/memory/main.py::Memory.get_all).
+            memories = memory_client.get_all(filters={"user_id": uid})
             filtered_memories = []
 
             # Filter memories based on permissions

--- a/openmemory/api/app/routers/config.py
+++ b/openmemory/api/app/routers/config.py
@@ -142,19 +142,26 @@ async def get_configuration(db: Session = Depends(get_db)):
 async def update_configuration(config: ConfigSchema, db: Session = Depends(get_db)):
     """Update the configuration."""
     current_config = get_config_from_db(db)
-    
+
     # Convert to dict for processing
     updated_config = current_config.copy()
-    
+
     # Update openmemory settings if provided
     if config.openmemory is not None:
         if "openmemory" not in updated_config:
             updated_config["openmemory"] = {}
         updated_config["openmemory"].update(config.openmemory.dict(exclude_none=True))
-    
-    # Update mem0 settings
-    updated_config["mem0"] = config.mem0.dict(exclude_none=True)
-    
+
+    # Update mem0 settings if provided
+    if config.mem0 is not None:
+        updated_config["mem0"] = config.mem0.dict(exclude_none=True)
+
+    # Persist and reset in-memory client so new config takes effect
+    save_config_to_db(db, updated_config)
+    reset_memory_client()
+    return updated_config
+
+
 
 @router.patch("/", response_model=ConfigSchema)
 async def patch_configuration(config_update: ConfigSchema, db: Session = Depends(get_db)):

--- a/openmemory/api/app/utils/categorization.py
+++ b/openmemory/api/app/utils/categorization.py
@@ -1,43 +1,94 @@
+import json
 import logging
+import os
 from typing import List
 
 from app.utils.prompts import MEMORY_CATEGORIZATION_PROMPT
 from dotenv import load_dotenv
 from openai import OpenAI
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 load_dotenv()
-openai_client = OpenAI()
+
+# Prefer DEEPSEEK_API_KEY over OPENAI_API_KEY so categorization works without a real
+# OpenAI key. DeepSeek's API is OpenAI-compatible.
+_deepseek_key = os.getenv("DEEPSEEK_API_KEY")
+if _deepseek_key:
+    openai_client = OpenAI(
+        api_key=_deepseek_key,
+        base_url=os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1"),
+    )
+    _CATEGORIZATION_MODEL = "deepseek-chat"
+    _USE_STRUCTURED_OUTPUT = False  # DeepSeek doesn't support beta parse yet
+else:
+    openai_client = OpenAI()
+    _CATEGORIZATION_MODEL = "gpt-4o-mini"
+    _USE_STRUCTURED_OUTPUT = True
 
 
 class MemoryCategories(BaseModel):
     categories: List[str]
 
 
+_JSON_INSTRUCTION = (
+    "\n\nReturn ONLY a compact JSON object with this exact shape and no extra text:\n"
+    '{"categories": ["<category-1>", "<category-2>"]}'
+)
+
+
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=15))
 def get_categories_for_memory(memory: str) -> List[str]:
+    completion = None
     try:
+        if _USE_STRUCTURED_OUTPUT:
+            messages = [
+                {"role": "system", "content": MEMORY_CATEGORIZATION_PROMPT},
+                {"role": "user", "content": memory},
+            ]
+            completion = openai_client.beta.chat.completions.parse(
+                model=_CATEGORIZATION_MODEL,
+                messages=messages,
+                response_format=MemoryCategories,
+                temperature=0,
+            )
+            parsed: MemoryCategories = completion.choices[0].message.parsed
+            return [cat.strip().lower() for cat in parsed.categories]
+
+        # DeepSeek path: use JSON mode + manual parse.
         messages = [
-            {"role": "system", "content": MEMORY_CATEGORIZATION_PROMPT},
-            {"role": "user", "content": memory}
+            {
+                "role": "system",
+                "content": MEMORY_CATEGORIZATION_PROMPT + _JSON_INSTRUCTION,
+            },
+            {"role": "user", "content": memory},
         ]
-
-        # Let OpenAI handle the pydantic parsing directly
-        completion = openai_client.beta.chat.completions.parse(
-            model="gpt-4o-mini",
+        completion = openai_client.chat.completions.create(
+            model=_CATEGORIZATION_MODEL,
             messages=messages,
-            response_format=MemoryCategories,
-            temperature=0
+            response_format={"type": "json_object"},
+            temperature=0,
         )
-
-        parsed: MemoryCategories = completion.choices[0].message.parsed
+        raw = completion.choices[0].message.content or "{}"
+        data = json.loads(raw)
+        parsed = MemoryCategories(**data)
         return [cat.strip().lower() for cat in parsed.categories]
 
+    except (json.JSONDecodeError, ValidationError) as e:
+        logging.error(f"[ERROR] Failed to parse categorization response: {e}")
+        try:
+            logging.debug(
+                f"[DEBUG] Raw response: {completion.choices[0].message.content}"
+            )
+        except Exception as debug_e:
+            logging.debug(f"[DEBUG] Could not extract raw response: {debug_e}")
+        raise
     except Exception as e:
         logging.error(f"[ERROR] Failed to get categories: {e}")
         try:
-            logging.debug(f"[DEBUG] Raw response: {completion.choices[0].message.content}")
+            logging.debug(
+                f"[DEBUG] Raw response: {completion.choices[0].message.content}"
+            )
         except Exception as debug_e:
             logging.debug(f"[DEBUG] Could not extract raw response: {debug_e}")
         raise


### PR DESCRIPTION
## Linked Issue

No existing issue — filing this alongside a report. Willing to open a tracking issue if maintainers prefer.

## Description

Four independent bugs together make a local self-hosted `openmemory` deployment (Ollama embedder + non-OpenAI LLM + Qdrant) unusable out of the box. Because they surface in the same first-run flow (configure → add memory → search → list), I'm sending them as one PR.

### 1. `PUT /api/v1/config/` never persists and never returns

`openmemory/api/app/routers/config.py::update_configuration` mutates a local dict, then falls through — no `save_config_to_db()`, no `reset_memory_client()`, no `return`. FastAPI then raises `ResponseValidationError` (500) because `response_model=ConfigSchema` sees `None`, and the UI Settings page appears to succeed but nothing is written to the database. This is the root cause behind reports of "I saved the embedder in Settings but it keeps using the default."

Fixed by mirroring the pattern already used by sibling endpoints in the same file (`update_llm_configuration`, `update_embedder_configuration`, `update_vector_store_configuration`, `update_openmemory_configuration`): guard `config.mem0` being None, save, reset the memory client, return the merged config.

### 2. MCP `search_memory` passes `limit` to a `top_k` parameter

`openmemory/api/app/mcp_server.py::search_memory` calls:

```python
memory_client.vector_store.search(query=..., vectors=..., limit=10, filters=...)
```

But `mem0/vector_stores/qdrant.py::Qdrant.search` declares:

```python
def search(self, query: str, vectors: list, top_k: int = 5, filters: dict = None) -> list:
```

Every MCP `search_memory` call therefore returns `Error searching memory: Qdrant.search() got an unexpected keyword argument 'limit'`. Renamed `limit` → `top_k` to match the vector store contract.

### 3. MCP `list_memories` passes `user_id` but `get_all` expects `filters` dict

`openmemory/api/app/mcp_server.py::list_memories` calls:

```python
memory_client.get_all(user_id=uid)
```

But `mem0/memory/main.py::Memory.get_all` declares:

```python
def get_all(self, *, filters=None, top_k=20, ...):
    """
    filters (dict): Must contain at least one of: user_id, agent_id, run_id.
    Example: filters={"user_id": "u1"}
    """
```

Because `get_all` is keyword-only after `*`, the bare `user_id=uid` falls into `**kwargs`, gets ignored, and then internal filter validation fails. MCP `list_memories` therefore fails on every call. Fixed by passing the documented shape `filters={"user_id": uid}`.

### 4. Categorization hard-codes OpenAI, breaks any non-OpenAI deployment

`openmemory/api/app/utils/categorization.py` unconditionally constructs `OpenAI()` and calls `gpt-4o-mini`, regardless of what the user configured as their main LLM provider. On any local deployment that uses DeepSeek / Ollama / etc. with `OPENAI_API_KEY` left as the placeholder `sk-xxx`, every `add_memory` triggers **three 401 retries** against `api.openai.com` before failing categorization silently.

Made client selection env-driven:
- If `DEEPSEEK_API_KEY` is set → target DeepSeek's OpenAI-compatible endpoint with `deepseek-chat`.
- Otherwise → keep the original OpenAI + `gpt-4o-mini` path (unchanged behavior for existing users).

DeepSeek doesn't support `openai_client.beta.chat.completions.parse` (returns `This response_format type is unavailable now`), so the DeepSeek branch uses the standard `chat.completions.create` with `response_format={"type": "json_object"}` plus manual `MemoryCategories` Pydantic validation, which DeepSeek does support. The prompt includes the required "json" literal that DeepSeek's JSON mode expects.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Breaking Changes

None. All four changes are strictly additive or bug fixes:
- Existing OpenAI-based categorization keeps its original code path.
- The config `PUT` endpoint moves from "500 + silent no-op" to "200 + actually saves", which is the documented behavior.
- The Qdrant kwarg fix aligns the caller with an already-existing signature.
- The `get_all` filters fix aligns the caller with an already-existing signature.

## How I Reproduced & Verified

Local stack on macOS via `openmemory/docker-compose.yml`:
- `openmemory-mcp` + `qdrant` (mem0_store) + Ollama (host) `nomic-embed-text` (768-dim) + DeepSeek `deepseek-chat`.

**Before the patch** (all four failures observed in the same session):

```
# Bug 1 — PUT config
$ curl -X PUT http://localhost:8765/api/v1/config/ -d '{"mem0": {...}}'
{ "detail": ... }   # 500 ResponseValidationError; DB unchanged
File "app/routers/config.py", line 141, in update_configuration
    PUT /api/v1/config/
fastapi.exceptions.ResponseValidationError: 1 validation error:
  {'type': 'model_attributes_type', 'loc': ('response',), 'msg': 'Input should be a valid dictionary or object to extract fields from', 'input': None}

# Bug 2 — MCP search
Error searching memory: Qdrant.search() got an unexpected keyword argument 'limit'

# Bug 3 — MCP list
Error listing memories: get_all() got an unexpected keyword argument 'user_id'
# (or "at least one of user_id/agent_id/run_id required in filters", depending on SDK version)

# Bug 4 — categorization
INFO HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 401 Unauthorized"
ERROR [ERROR] Failed to get categories: Error code: 401 - Incorrect API key provided: sk-xxx
```

**After the patch:**

- `PUT /api/v1/config/` returns 200 with the merged config; `GET /api/v1/config/` immediately reflects the change; `reset_memory_client()` is invoked so subsequent `add_memory` calls use the new provider.
- MCP `search_memory` returns hits instead of the kwarg error.
- MCP `list_memories` returns the user's memories instead of the kwarg error.
- `add_memory` no longer logs three 401s per call; DeepSeek returns categories via JSON mode (`HTTP/1.1 200 OK`).

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (steps above)
- [ ] No tests needed

Happy to add unit tests if maintainers point me at the preferred location — I didn't see existing tests for the touched files (`app/routers/config.py`, `app/mcp_server.py`, `app/utils/categorization.py`) and wanted to align with the project's testing conventions before adding any.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] Existing tests still pass locally (`openmemory/api` has no test suite yet for the touched files; `pytest openmemory/api/tests` runs unchanged)
- [x] No public API changes → no doc update needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
