### PR TITLE
fix(memory): paginate delete_all so it removes all matching memories

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -90,6 +90,16 @@ def _vector_store_list_rows(listed):
     return []
 
 
+# Page size used by delete_all when iterating through vector store results.
+# Vector stores cap list() at a default page size (Qdrant/Pinecone/Milvus
+# default to 100); delete_all must loop to remove all matching memories.
+_DELETE_ALL_PAGE_SIZE = 1000
+
+# Safety cap on pagination iterations to prevent infinite loops when a vector
+# store's list() does not shrink after deletion (e.g. eventual-consistency lag).
+_DELETE_ALL_MAX_ITERATIONS = 10_000
+
+
 # Fields that hold runtime auth/connection objects and must be preserved.
 # These are non-serializable objects (e.g. AWSV4SignerAuth, RequestsHttpConnection)
 # needed by clients like OpenSearch — not sensitive strings to redact.
@@ -1885,14 +1895,30 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
-        memories = self.vector_store.list(filters=filters)[0]
-        for memory in memories:
-            self._delete_memory(memory.id)
 
-        logger.info(f"Deleted {len(memories)} memories")
+        # Paginate: delete in batches until the store returns an empty page.
+        # Deleting inside the loop ensures the result set shrinks between calls.
+        total_deleted = 0
+        seen_ids: set = set()
+        for _ in range(_DELETE_ALL_MAX_ITERATIONS):
+            listed = self.vector_store.list(filters=filters, top_k=_DELETE_ALL_PAGE_SIZE)
+            batch = _vector_store_list_rows(listed)
+            # Filter out IDs we already deleted (guards against eventual-consistency lag)
+            batch = [m for m in batch if m.id not in seen_ids]
+            if not batch:
+                break
+            for memory in batch:
+                try:
+                    self._delete_memory(memory.id)
+                    seen_ids.add(memory.id)
+                    total_deleted += 1
+                except Exception as e:
+                    logger.warning("Failed to delete memory %s: %s", memory.id, e)
+                    seen_ids.add(memory.id)  # skip on retry to avoid infinite loop
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories))
+        logger.info(f"Deleted {total_deleted} memories")
+
+        decay_usage_notice = detect_decay_usage_from_delete_all(total_deleted)
         if decay_usage_notice:
             display_decay_usage_notice(self, "sync", "delete_all", *decay_usage_notice)
         else:
@@ -3515,26 +3541,48 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
 
-        delete_tasks = []
-        for memory in memories[0]:
-            delete_tasks.append(self._delete_memory(memory.id, skip_entity_cleanup=True))
+        # Paginate: delete in batches until the store returns an empty page.
+        # Deleting inside the loop ensures the result set shrinks between calls,
+        # preventing the infinite-loop bug when matches exceed the page size.
+        total_deleted = 0
+        total_errors = 0
+        seen_ids: set = set()
+        for _ in range(_DELETE_ALL_MAX_ITERATIONS):
+            listed = await asyncio.to_thread(
+                self.vector_store.list, filters=filters, top_k=_DELETE_ALL_PAGE_SIZE
+            )
+            batch = _vector_store_list_rows(listed)
+            # Filter out IDs we already deleted (guards against eventual-consistency lag)
+            batch = [m for m in batch if m.id not in seen_ids]
+            if not batch:
+                break
 
-        results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+            delete_tasks = [
+                self._delete_memory(memory.id, skip_entity_cleanup=True)
+                for memory in batch
+            ]
+            results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+
+            for memory, result in zip(batch, results):
+                seen_ids.add(memory.id)
+                if isinstance(result, BaseException):
+                    total_errors += 1
+                    logger.warning("Failed to delete memory %s: %s", memory.id, result)
+                else:
+                    total_deleted += 1
 
         if self._entity_store is not None:
             await self._bulk_clear_entity_store(filters)
 
-        errors = [r for r in results if isinstance(r, BaseException)]
-        if errors:
-            logger.warning("Failed to delete %d out of %d memories", len(errors), len(results))
-            for err in errors:
-                logger.warning("Delete error: %s", err)
+        if total_errors:
+            logger.warning(
+                "Failed to delete %d out of %d memories", total_errors, total_deleted + total_errors
+            )
 
-        logger.info(f"Deleted {len(results) - len(errors)} memories")
+        logger.info(f"Deleted {total_deleted} memories")
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories[0]))
+        decay_usage_notice = detect_decay_usage_from_delete_all(total_deleted + total_errors)
         if decay_usage_notice:
             await display_decay_usage_notice_async(self, "async", "delete_all", *decay_usage_notice)
         else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -431,7 +431,9 @@ class TestEntityIdValidation:
 
         memory_instance.delete_all(user_id="  alice  ")
 
-        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "alice"})
+        memory_instance.vector_store.list.assert_called_once_with(
+            filters={"user_id": "alice"}, top_k=1000
+        )
 
     def test_validate_coerces_non_string_entity_id(self):
         """Integer (and other non-string) ids are coerced to str, not crashed on."""
@@ -444,7 +446,9 @@ class TestEntityIdValidation:
 
         memory_instance.delete_all(user_id=42)
 
-        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "42"})
+        memory_instance.vector_store.list.assert_called_once_with(
+            filters={"user_id": "42"}, top_k=1000
+        )
 
     def test_get_all_coerces_integer_user_id(self, memory_instance):
         """get_all should accept an integer user_id in filters and scope by its str form."""

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1570,3 +1570,159 @@ async def test_async_procedural_memory_default_path_without_langchain(mock_llm_f
 
     assert result["results"][0]["event"] == "ADD"
     memory.llm.generate_response.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for delete_all pagination (issue #4869)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_memory(id_: str):
+    """Create a mock memory object with the given id."""
+    m = MagicMock()
+    m.id = id_
+    m.payload = {"data": f"memory-{id_}", "created_at": "2024-01-01T00:00:00+00:00", "actor_id": None, "role": None}
+    return m
+
+
+class _StatefulVectorStore:
+    """Simulates a vector store that shrinks as memories are deleted.
+
+    list() returns at most `page_size` items regardless of top_k,
+    mimicking real stores that enforce internal pagination limits.
+    delete() removes an item from the store.
+    """
+
+    def __init__(self, memories, page_size=2):
+        self._store = list(memories)
+        self._page_size = page_size
+        self.list_call_count = 0
+        self.deleted_ids = []
+
+    def list(self, filters=None, top_k=None):
+        self.list_call_count += 1
+        # Real vector stores enforce their own internal page size cap
+        limit = min(top_k or self._page_size, self._page_size)
+        page = self._store[:limit]
+        return (page, None)
+
+    def delete(self, vector_id):
+        self._store = [m for m in self._store if m.id != vector_id]
+        self.deleted_ids.append(vector_id)
+
+    def get(self, vector_id):
+        for m in self._store:
+            if m.id == vector_id:
+                return m
+        return None
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+def test_sync_delete_all_paginates_through_all_memories(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Sync delete_all must iterate through all pages, not just the first."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    # 5 memories, page_size=2 → requires 3 list() calls (2+2+1) + 1 empty = 4
+    memories = [_make_mock_memory(f"m{i}") for i in range(5)]
+    store = _StatefulVectorStore(memories, page_size=2)
+    mock_vector_factory.return_value = store
+
+    from mem0.memory.main import Memory
+    config = MemoryConfig()
+    memory = Memory(config)
+
+    result = memory.delete_all(user_id="test-user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert len(store.deleted_ids) == 5
+    assert store.list_call_count == 4  # 3 pages with data + 1 empty page to stop
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+def test_sync_delete_all_stops_when_first_page_empty(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Sync delete_all with no matching memories should call list() once and delete nothing."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    store = _StatefulVectorStore([], page_size=2)
+    mock_vector_factory.return_value = store
+
+    from mem0.memory.main import Memory
+    config = MemoryConfig()
+    memory = Memory(config)
+
+    result = memory.delete_all(user_id="no-memories-user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert store.list_call_count == 1
+    assert len(store.deleted_ids) == 0
+
+
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+async def test_async_delete_all_paginates_through_all_memories(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Async delete_all must delete inside the loop so the store shrinks between pages."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    # 5 memories, page_size=2 → requires multiple iterations
+    memories = [_make_mock_memory(f"m{i}") for i in range(5)]
+    store = _StatefulVectorStore(memories, page_size=2)
+    mock_vector_factory.return_value = store
+
+    from mem0.memory.main import AsyncMemory
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+
+    result = await memory.delete_all(user_id="test-user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert len(store.deleted_ids) == 5
+    # Must have called list() multiple times (proves pagination, not single-call)
+    assert store.list_call_count >= 3
+
+
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+async def test_async_delete_all_stops_when_first_page_empty(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Async delete_all with no matching memories should call list() once."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    store = _StatefulVectorStore([], page_size=2)
+    mock_vector_factory.return_value = store
+
+    from mem0.memory.main import AsyncMemory
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+
+    result = await memory.delete_all(user_id="no-memories-user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert store.list_call_count == 1
+    assert len(store.deleted_ids) == 0


### PR DESCRIPTION
## Summary

Fixes #4869.

`Memory.delete_all()` and `AsyncMemory.delete_all()` previously called `vector_store.list(filters=filters)` exactly once without specifying `top_k`, so they only received the first page of matching memories (most vector stores default to 100). When a user had more matching memories than the page size, the older entries were silently left behind.

This fix iterates in pages: each loop calls `list(filters, top_k=_DELETE_ALL_PAGE_SIZE)`, deletes the returned batch **inside the loop** (so the result set shrinks between calls), and stops when the store returns an empty page.

## Root Cause

The vector store `list()` interface has no offset/cursor parameter — pagination must happen on the caller side. The original code assumed a single `list()` call would return all matching memories, which is incorrect for stores that cap results at a default page size (Qdrant, Pinecone, Milvus, Turbopuffer all default to 100).

The async path had an additional latent bug: if deletion were deferred until after the loop (as in PR #5950's approach), the store would never shrink between `list()` calls, causing an infinite loop when matches ≥ page size.

## Changes

### `mem0/memory/main.py`

* Added module-level constants `_DELETE_ALL_PAGE_SIZE = 1000` and `_DELETE_ALL_MAX_ITERATIONS = 10_000` (safety cap).

* **Sync `delete_all`**: loops calling `list(filters, top_k=1000)` → deletes each batch → repeats until empty page. Uses `seen_ids` set to guard against eventual-consistency lag (e.g. Elasticsearch/OpenSearch refresh delay re-listing a deleted ID). Individual delete failures are logged and skipped rather than aborting the entire operation.

* **Async `delete_all`**: same pagination loop with `asyncio.gather` for batch deletion **inside** the loop. Entity store bulk cleanup happens once after all pages are processed. Error handling preserved (`return_exceptions=True`).

* Both paths reuse the existing `_vector_store_list_rows()` helper for consistent return-format normalization.

### `tests/test_main.py`

* Updated `test_delete_all_trims_user_id_before_list` and `test_delete_all_coerces_integer_user_id_before_list` assertions to include `top_k=1000` (reflecting the new explicit pagination parameter).

### `tests/test_memory.py`

Added 4 regression tests with a `_StatefulVectorStore` that simulates a store with an internal page-size cap:

* `test_sync_delete_all_paginates_through_all_memories` — 5 memories, page\_size=2 → asserts all 5 deleted across multiple list() calls.

* `test_sync_delete_all_stops_when_first_page_empty` — empty store → exactly 1 list() call, 0 deletes.

* `test_async_delete_all_paginates_through_all_memories` — same coverage for AsyncMemory; proves deletion happens inside the loop (store shrinks between pages).

* `test_async_delete_all_stops_when_first_page_empty` — empty store → 1 list() call, 0 deletes.

## Testing

```bash
# Targeted pagination tests
pytest tests/test_memory.py -k delete_all -v
# → 6 passed

# Full test files
pytest tests/test_main.py tests/test_memory.py
# → 105 passed, 1 failed (pre-existing langchain_core import, unrelated)

# Lint
ruff check mem0/memory/main.py tests/test_memory.py tests/test_main.py
# → All checks passed!
```

**Red-green verification**: reverting the sync/async loops back to a single `list()` call causes the pagination tests to fail (`assert len(store.deleted_ids) == 5` → only 2 deleted), confirming the tests are load-bearing.

## Related Issue

Closes #4869
