### PR TITLE
fix(ts-oss): forward responseFormat to Gemini in generateResponse

### DIFF
--- a/mem0-ts/src/oss/src/llms/google.ts
+++ b/mem0-ts/src/oss/src/llms/google.ts
@@ -59,6 +59,15 @@ export class GoogleLLM implements LLM {
       ];
     }
 
+    // Honor a requested JSON response format (parity with the Python SDK's
+    // mem0/llms/gemini.py). Gemini's structured output is opt-in via
+    // responseMimeType — without it the model is never told to emit JSON, so
+    // callers passing json_object silently get free-form text and depend on a
+    // fragile markdown-fence strip downstream.
+    if (responseFormat?.type === "json_object") {
+      config.responseMimeType = "application/json";
+    }
+
     const completion = await this.google.models.generateContent({
       contents,
       model: this.model,

--- a/mem0-ts/src/oss/tests/google-llm.test.ts
+++ b/mem0-ts/src/oss/tests/google-llm.test.ts
@@ -185,6 +185,37 @@ describe("GoogleLLM (unit)", () => {
     expect(response.toolCalls[1].name).toBe("add_graph_memory");
   });
 
+  // Regression: generateResponse accepted a responseFormat argument but never
+  // forwarded it, so Gemini was never told to emit JSON (parity with the Python
+  // SDK's mem0/llms/gemini.py, which sets response_mime_type/response_schema).
+  it("forwards json_object responseFormat as responseMimeType", async () => {
+    mockGenerateContent.mockResolvedValueOnce({
+      text: '{"facts": ["fact1"]}',
+      functionCalls: null,
+    });
+
+    const llm = new GoogleLLM({ apiKey: "test-key" });
+    await llm.generateResponse([{ role: "user", content: "Extract facts" }], {
+      type: "json_object",
+    });
+
+    const callArgs = mockGenerateContent.mock.calls[0][0];
+    expect(callArgs.config.responseMimeType).toBe("application/json");
+  });
+
+  it("does not set responseMimeType when no responseFormat is given", async () => {
+    mockGenerateContent.mockResolvedValueOnce({
+      text: "plain text",
+      functionCalls: null,
+    });
+
+    const llm = new GoogleLLM({ apiKey: "test-key" });
+    await llm.generateResponse([{ role: "user", content: "Hello" }]);
+
+    const callArgs = mockGenerateContent.mock.calls[0][0];
+    expect(callArgs.config.responseMimeType).toBeUndefined();
+  });
+
   it("formats generateChat messages and joins Gemini response parts", async () => {
     mockGenerateContent.mockResolvedValueOnce({
       candidates: [


### PR DESCRIPTION
## Linked Issue

Closes #6467

## Description

`GoogleLLM.generateResponse` accepted `responseFormat` but never forwarded it, so `{ type: "json_object" }` (what the extraction step passes) was a no-op. Gemini's JSON output is opt-in via `responseMimeType`, so the model was never told to return JSON - we were just relying on the markdown fence strip downstream to bail us out, which only works when Gemini happens to fence its reply.

This sets `config.responseMimeType = "application/json"` when `json_object` is requested, same as the Python SDK already does in `mem0/llms/gemini.py`. Signature is unchanged (matches the base `LLM` interface and `openai.ts`).

Same bug as the Anthropic one, different provider.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

Added two cases to `google-llm.test.ts`: `responseMimeType` is set to `application/json` for `json_object`, and left unset when no format is passed. Verified only `memory/index.ts` passes `responseFormat` and it never passes `tools` alongside it, so this can't collide with Gemini's function-calling path.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
