### PR TITLE
ci: match "ts sdk" when inferring issue components

### DIFF
--- a/.github/component-keywords.json
+++ b/.github/component-keywords.json
@@ -7,7 +7,7 @@
     ],
     "sdk-typescript": [
       "typescript", "javascript", "pnpm", "yarn", "node.js", "nodejs",
-      "mem0-ts", "mem0ai/oss", "tsconfig", "await import",
+      "mem0-ts", "mem0ai/oss", "tsconfig", "ts sdk", "await import",
       "=> {", "undefined is not"
     ]
   },

--- a/.github/scripts/infer-component-labels.test.js
+++ b/.github/scripts/infer-component-labels.test.js
@@ -90,6 +90,11 @@ ${cliRegressionCase.body}`;
   assert.ok(!inferred.includes('cli'), `expected 'cli' absent (body contains 'Mem0 client', a substring of the removed 'mem0 cli' term), got ${JSON.stringify(inferred)}`);
 });
 
+run('#6472 terseAbbreviationIsLabeled', () => {
+  const text = 'test: issue in ts sdk\n\ntest issue in ts sdk';
+  assert.deepStrictEqual(inferComponentLabels(text, keywords), ['sdk-typescript']);
+});
+
 run('noKeywordMatchReturnsEmptyArray', () => {
   const text = 'The weather today is sunny and I went for a walk in the park with my dog.';
   assert.deepStrictEqual(inferComponentLabels(text, keywords), []);
@@ -105,4 +110,4 @@ ${failures} test(s) failed.`);
   process.exit(1);
 }
 console.log(`
-All ${cases.length + 3} tests passed.`);
+All ${cases.length + 4} tests passed.`);


### PR DESCRIPTION
## Linked Issue

Closes #6472

## Description

#6472 was filed as a blank issue reading `test: issue in ts sdk`. The labeler ran (`29848399967`, succeeded) and logged `No component could be inferred from the issue text`.

The cause is the keyword map, not the workflow. `sdk-typescript` matched on `typescript`, `javascript`, `pnpm`, `yarn`, `node.js`, `nodejs`, `mem0-ts`, `mem0ai/oss`, `tsconfig`, `await import`, `=> {`, and `undefined is not`. The bare abbreviation `ts sdk` was in none of them, so both axes scored zero and the inference abstained.

Adds `ts sdk` to the `sdk-typescript` list.

### Why not bare `ts`

Measured and rejected. `toMatcher` builds a leading `\b` with no trailing boundary, so `ts` fires on any word starting with those letters. On the 277-issue ground-truth set that drops `sdk-typescript` precision from **.688 to .595** and macro F1 from **.638 to .629**.

`\.ts`, `tsup`, `node sdk`, and `js sdk` were each neutral on their own, but adding all five together costs precision (.688 to .667) because collectively they fire on more issues. `ts sdk` alone is the surgical change.

### Impact

Re-scored against the same 277-issue ground truth used to tune the map:

| | Before | After |
|---|---|---|
| Accuracy | .733 | .733 |
| Macro F1 | .638 | .638 |
| `sdk-typescript` F1 | .772 | .772 |

Zero movement, because the issues in that set which mention `ts sdk` already match on `typescript` or `mem0-ts`. The gain is on terse issues that carry only the abbreviation, which is what #6472 is. The phrase appears in **48 of the 805 issues** in the tuning corpus, so this is a real phrasing rather than a synthetic one.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. One term added to a keyword list. The step still only adds labels, and only to issues carrying none of the nine component labels.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

`node .github/scripts/infer-component-labels.test.js`: 12 assertions, all passing. Adds `#6472 terseAbbreviationIsLabeled`, which pins the exact title and body of #6472 to `['sdk-typescript']` and fails without this change.

Also re-ran the full 277-issue ground-truth evaluation against the edited file to confirm the no-regression numbers in the table above.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
