### PR TITLE
fix(dashboard): clear the LLM API key on provider change

### DIFF
--- a/server/dashboard/src/app/(root)/dashboard/configuration/page.tsx
+++ b/server/dashboard/src/app/(root)/dashboard/configuration/page.tsx
@@ -128,7 +128,10 @@ export default function ConfigurationPage() {
               <Label className="text-xs">Provider</Label>
               <Select
                 value={llmProvider}
-                onValueChange={setLlmProvider}
+                onValueChange={(value) => {
+                  setLlmProvider(value);
+                  setLlmApiKey("");
+                }}
                 disabled={!isAdmin || !providers}
               >
                 <SelectTrigger>

--- a/server/dashboard/src/app/setup/page.tsx
+++ b/server/dashboard/src/app/setup/page.tsx
@@ -419,7 +419,10 @@ export default function SetupPage() {
                     <Label htmlFor="setup-llm-provider">LLM Provider</Label>
                     <Select
                       value={llmProvider}
-                      onValueChange={setLlmProvider}
+                      onValueChange={(value) => {
+                        setLlmProvider(value);
+                        setLlmApiKey("");
+                      }}
                       disabled={!providers}
                     >
                       <SelectTrigger id="setup-llm-provider">


### PR DESCRIPTION
## Linked Issue

Refs #4984

## Description

Changing the LLM provider in the self-hosted Configuration page or Setup wizard could leave the previous provider's key in the LLM API Key field. Saving then paired the new provider with stale credential text.

This change clears the page-local LLM API Key field the moment the LLM provider selection changes on both dashboard surfaces, so a stale cross-provider key can no longer be saved.

## Root cause

Both LLM provider selects updated only `llmProvider`, while both save paths still read the unchanged `llmApiKey` state and pass it directly into `buildProviderConfig(...)`.

## Scope

This PR changes only the two dashboard page components. It leaves server-side `.env` and database precedence, persisted overrides, embedder behavior, payload shaping, docs, and provider implementations unchanged. The separate server-state half of `#4984` remains open.

## Attribution

This slice follows maintainer confirmation in https://github.com/mem0ai/mem0/issues/4984#issuecomment-4716787944 and the original dashboard-file work in stale PR https://github.com/mem0ai/mem0/pull/4996 .

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed

Verification:
- [x] `pnpm --dir server/dashboard run typecheck`
- [ ] `pnpm --dir server/dashboard run lint`
- [x] `pnpm --dir server/dashboard run build`
- [x] `pnpm --dir server/dashboard run dev`, then verify the Configuration and Setup provider-change flows locally against a stubbed local API on base and head

Manual verification:
- Configuration on base kept `sk-old-provider` after `openai` to `gemini`, and the patched branch cleared it immediately.
- Setup on base kept `anthropic-old` after `anthropic` to `gemini`, and the patched branch cleared it immediately.
- Empty-key transitions and adjacent non-provider edits kept the field empty or preserved `preserve-me` as expected on the patched branch.
- `pnpm --dir server/dashboard run lint` still reports existing package-wide Prettier drift: `Code style issues found in 111 files. Run Prettier with --write to fix.`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
