### PR TITLE
feat(llms): add Mistral LLM provider

### DIFF
--- a/docs/components/llms/models/mistral_AI.mdx
+++ b/docs/components/llms/models/mistral_AI.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mistral AI
-description: "Configure Mistral AI as an LLM provider in Mem0 using the litellm integration and Mixtral model family."
+description: "Configure Mistral AI as a native LLM provider in Mem0, or via the litellm integration."
 ---
 
 To use mistral's models, please obtain the Mistral AI api key from their [console](https://console.mistral.ai/). Set the `MISTRAL_API_KEY` environment variable to use the model as given below in the example.
@@ -17,9 +17,9 @@ os.environ["MISTRAL_API_KEY"] = "your-api-key"
 
 config = {
     "llm": {
-        "provider": "litellm",
+        "provider": "mistral",
         "config": {
-            "model": "open-mixtral-8x7b",
+            "model": "mistral-small-latest",
             "temperature": 0.1,
             "max_tokens": 2000,
         }
@@ -30,7 +30,7 @@ m = Memory.from_config(config)
 messages = [
     {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
     {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
-    {"role": "user", "content": "I’m not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
     {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."}
 ]
 m.add(messages, user_id="alice", metadata={"category": "movies"})
@@ -62,6 +62,10 @@ await memory.add(messages, { userId: "alice", metadata: { category: "movies" } }
 ```
 </CodeGroup>
 
+<Note>
+  Prefer the native `mistral` provider shown above for new projects. Mistral models also remain reachable through the generic `litellm` provider (e.g. `"provider": "litellm", "config": {"model": "open-mixtral-8x7b"}`) if you're already using `litellm` for other models.
+</Note>
+
 ## Config
 
-All available parameters for the `litellm` config are present in [Master List of All Params in Config](../config).
+All available parameters for the `mistral` config are present in [Master List of All Params in Config](../config).

--- a/mem0/llms/configs.py
+++ b/mem0/llms/configs.py
@@ -24,6 +24,7 @@ class LlmConfig(BaseModel):
             "gemini",
             "deepseek",
             "minimax",
+            "mistral",
             "xai",
             "sarvam",
             "lmstudio",

--- a/mem0/llms/mistral.py
+++ b/mem0/llms/mistral.py
@@ -1,0 +1,112 @@
+import json
+import logging
+import os
+from typing import Dict, List, Optional
+
+try:
+    from mistralai.client import Mistral
+except ImportError:
+    raise ImportError("The 'mistralai' library is required. Please install it using 'pip install mistralai'.")
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
+
+logger = logging.getLogger(__name__)
+
+
+class MistralLLM(LLMBase):
+    def __init__(self, config: Optional[BaseLlmConfig] = None):
+        super().__init__(config)
+
+        if not self.config.model:
+            self.config.model = "mistral-small-latest"
+
+        api_key = self.config.api_key or os.getenv("MISTRAL_API_KEY")
+        self.client = Mistral(api_key=api_key)
+
+    @staticmethod
+    def _convert_content_to_string(content):
+        """Reasoning models return content as a list of chunks, not a string; keep only the text ones."""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            return "".join(getattr(chunk, "text", "") for chunk in content if getattr(chunk, "type", None) == "text")
+        return str(content) if content is not None else ""
+
+    def _parse_response(self, response, tools):
+        """
+        Process the response based on whether tools are used or not.
+
+        Args:
+            response: The raw response from the Mistral API.
+            tools: The list of tools provided in the request.
+
+        Returns:
+            str or dict: The processed response.
+        """
+        if tools:
+            processed_response = {
+                "content": self._convert_content_to_string(response.choices[0].message.content),
+                "tool_calls": [],
+            }
+
+            if response.choices[0].message.tool_calls:
+                for tool_call in response.choices[0].message.tool_calls:
+                    arguments = tool_call.function.arguments
+                    # arguments can be a dict already, not always a JSON string
+                    if isinstance(arguments, str):
+                        arguments = json.loads(extract_json(arguments))
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": arguments,
+                        }
+                    )
+
+            return processed_response
+        else:
+            return self._convert_content_to_string(response.choices[0].message.content)
+
+    def generate_response(
+        self,
+        messages: List[Dict[str, str]],
+        response_format=None,
+        tools: Optional[List[Dict]] = None,
+        tool_choice: str = "auto",
+        **kwargs,
+    ):
+        """
+        Generate a response based on the given messages using Mistral.
+
+        Args:
+            messages (list): List of message dicts containing 'role' and 'content'.
+            response_format (str or object, optional): Format of the response. Defaults to None.
+            tools (list, optional): List of tools that the model can call. Defaults to None.
+            tool_choice (str, optional): Tool choice method. Defaults to "auto".
+            **kwargs: Additional provider-specific parameters forwarded to the Mistral
+                client (matches the ``LLMBase.generate_response`` contract).
+
+        Returns:
+            str or dict: The generated response.
+        """
+        params = {
+            "model": self.config.model,
+            "messages": messages,
+            "temperature": self.config.temperature,
+            "max_tokens": self.config.max_tokens,
+            "top_p": self.config.top_p,
+        }
+        # sent as-is; Mistral does no client-side model gating for this param
+        reasoning_effort = getattr(self.config, "reasoning_effort", None)
+        if reasoning_effort:
+            params["reasoning_effort"] = reasoning_effort
+        params.update(kwargs)
+        if response_format:
+            params["response_format"] = response_format
+        if tools:
+            params["tools"] = tools
+            params["tool_choice"] = tool_choice
+
+        response = self.client.chat.complete(**params)
+        return self._parse_response(response, tools)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -51,6 +51,7 @@ class LlmFactory:
         "gemini": ("mem0.llms.gemini.GeminiLLM", GeminiConfig),
         "deepseek": ("mem0.llms.deepseek.DeepSeekLLM", DeepSeekConfig),
         "minimax": ("mem0.llms.minimax.MiniMaxLLM", MinimaxConfig),
+        "mistral": ("mem0.llms.mistral.MistralLLM", BaseLlmConfig),
         "xai": ("mem0.llms.xai.XAILLM", XAIConfig),
         "sarvam": ("mem0.llms.sarvam.SarvamLLM", BaseLlmConfig),
         "lmstudio": ("mem0.llms.lmstudio.LMStudioLLM", LMStudioConfig),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ llms = [
     "vertexai>=0.1.0",
     "google-generativeai>=0.3.0",
     "google-genai>=1.0.0",
+    "mistralai>=2.0.0",
 ]
 extras = [
     "boto3>=1.34.0",

--- a/tests/llms/test_mistral.py
+++ b/tests/llms/test_mistral.py
@@ -1,0 +1,251 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.llms.configs import LlmConfig
+from mem0.llms.mistral import MistralLLM
+from mem0.utils.factory import LlmFactory
+
+
+@pytest.fixture
+def mock_mistral_client():
+    with patch("mem0.llms.mistral.Mistral") as mock_mistral:
+        mock_client = Mock()
+        mock_mistral.return_value = mock_client
+        yield mock_client
+
+
+def test_generate_response_without_tools(mock_mistral_client):
+    config = BaseLlmConfig(model="mistral-small-latest", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = MistralLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="I'm doing well, thank you for asking!"))]
+    mock_mistral_client.chat.complete.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    mock_mistral_client.chat.complete.assert_called_once_with(
+        model="mistral-small-latest", messages=messages, temperature=0.7, max_tokens=100, top_p=1.0
+    )
+    assert response == "I'm doing well, thank you for asking!"
+
+
+def test_generate_response_forwards_extra_kwargs(mock_mistral_client):
+    """Per the LLMBase contract, extra provider-specific kwargs must be accepted and
+    forwarded to the Mistral client (matching together/langchain/sarvam behavior)."""
+    config = BaseLlmConfig(model="mistral-small-latest", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = MistralLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi"))]
+    mock_mistral_client.chat.complete.return_value = mock_response
+
+    response = llm.generate_response(messages, frequency_penalty=0.5)
+
+    assert response == "Hi"
+    call_kwargs = mock_mistral_client.chat.complete.call_args.kwargs
+    assert call_kwargs["frequency_penalty"] == 0.5
+
+
+def test_generate_response_with_tools(mock_mistral_client):
+    config = BaseLlmConfig(model="mistral-small-latest", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = MistralLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Add a new memory: Today is a sunny day."},
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"data": {"type": "string", "description": "Data to add to memory"}},
+                    "required": ["data"],
+                },
+            },
+        }
+    ]
+
+    mock_response = Mock()
+    mock_message = Mock()
+    mock_message.content = "I've added the memory for you."
+
+    mock_tool_call = Mock()
+    mock_tool_call.function.name = "add_memory"
+    mock_tool_call.function.arguments = '{"data": "Today is a sunny day."}'
+
+    mock_message.tool_calls = [mock_tool_call]
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_mistral_client.chat.complete.return_value = mock_response
+
+    response = llm.generate_response(messages, tools=tools)
+
+    mock_mistral_client.chat.complete.assert_called_once_with(
+        model="mistral-small-latest",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        tools=tools,
+        tool_choice="auto",
+    )
+    assert response["content"] == "I've added the memory for you."
+    assert len(response["tool_calls"]) == 1
+    assert response["tool_calls"][0]["name"] == "add_memory"
+    assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
+
+
+def test_generate_response_with_tools_already_parsed_arguments(mock_mistral_client):
+    # The official mistralai SDK types FunctionCall.arguments as
+    # Union[Dict[str, Any], str] -- verify the already-a-dict case doesn't
+    # crash json.loads().
+    config = BaseLlmConfig(model="mistral-small-latest", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = MistralLLM(config)
+    messages = [{"role": "user", "content": "Add a new memory: Today is a sunny day."}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"data": {"type": "string"}},
+                    "required": ["data"],
+                },
+            },
+        }
+    ]
+
+    mock_response = Mock()
+    mock_message = Mock()
+    mock_message.content = "I've added the memory for you."
+
+    mock_tool_call = Mock()
+    mock_tool_call.function.name = "add_memory"
+    mock_tool_call.function.arguments = {"data": "Today is a sunny day."}
+
+    mock_message.tool_calls = [mock_tool_call]
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_mistral_client.chat.complete.return_value = mock_response
+
+    response = llm.generate_response(messages, tools=tools)
+
+    assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
+
+
+def test_generate_response_with_response_format(mock_mistral_client):
+    config = BaseLlmConfig(model="mistral-small-latest", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = MistralLLM(config)
+    messages = [{"role": "user", "content": "Return JSON."}]
+    response_format = {"type": "json_object"}
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content='{"key": "value"}'))]
+    mock_mistral_client.chat.complete.return_value = mock_response
+
+    response = llm.generate_response(messages, response_format=response_format)
+
+    mock_mistral_client.chat.complete.assert_called_once_with(
+        model="mistral-small-latest",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        response_format=response_format,
+    )
+    assert response == '{"key": "value"}'
+
+
+def test_generate_response_with_reasoning_effort(mock_mistral_client):
+    config = BaseLlmConfig(
+        model="mistral-medium-3-5", temperature=0.7, max_tokens=100, top_p=1.0, reasoning_effort="high"
+    )
+    llm = MistralLLM(config)
+    messages = [{"role": "user", "content": "Solve this step by step."}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Reasoned answer."))]
+    mock_mistral_client.chat.complete.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    mock_mistral_client.chat.complete.assert_called_once_with(
+        model="mistral-medium-3-5",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        reasoning_effort="high",
+    )
+    assert response == "Reasoned answer."
+
+
+def test_generate_response_with_reasoning_returns_chunk_list_as_plain_text(mock_mistral_client):
+    # message.content becomes a chunk list under reasoning_effort; must collapse to text only
+    config = BaseLlmConfig(
+        model="mistral-medium-3-5", temperature=0.7, max_tokens=100, top_p=1.0, reasoning_effort="high"
+    )
+    llm = MistralLLM(config)
+    messages = [{"role": "user", "content": "What is 17 * 23?"}]
+
+    think_chunk = Mock(type="thinking", thinking=[Mock(type="text", text="Let me work through this...")])
+    text_chunk = Mock(type="text", text="391")
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content=[think_chunk, text_chunk]))]
+    mock_mistral_client.chat.complete.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    assert response == "391"
+
+
+def test_generate_response_without_reasoning_effort_omits_param(mock_mistral_client):
+    config = BaseLlmConfig(model="mistral-small-latest", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = MistralLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi there"))]
+    mock_mistral_client.chat.complete.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_mistral_client.chat.complete.call_args.kwargs
+    assert "reasoning_effort" not in call_kwargs
+
+
+def test_mistral_llm_default_model(mock_mistral_client):
+    config = BaseLlmConfig(api_key="test-key")
+    llm = MistralLLM(config)
+    assert llm.config.model == "mistral-small-latest"
+
+
+def test_mistral_llm_env_api_key(monkeypatch):
+    monkeypatch.setenv("MISTRAL_API_KEY", "env-api-key")
+    with patch("mem0.llms.mistral.Mistral") as mock_mistral_class:
+        config = BaseLlmConfig(model="mistral-small-latest")
+        MistralLLM(config)
+        mock_mistral_class.assert_called_once_with(api_key="env-api-key")
+
+
+def test_factory_creates_mistral_llm(mock_mistral_client):
+    llm = LlmFactory.create("mistral", {"model": "mistral-small-latest", "api_key": "test-key"})
+    assert isinstance(llm, MistralLLM)
+    assert llm.config.model == "mistral-small-latest"
+
+
+def test_mistral_accepts_base_llm_config():
+    config = LlmConfig(provider="mistral", config={"model": "mistral-small-latest"})
+    assert config.provider == "mistral"


### PR DESCRIPTION
## Linked Issue

Closes #6478 

## Description

Adds a native `mistral` LLM provider (`mem0/llms/mistral.py`) using the official `mistralai` client, bringing the Python SDK to parity with the existing TypeScript provider (`mem0-ts/src/oss/src/llms/mistral.ts`, added in #2496). Mistral models remain reachable via the generic `litellm` provider as before; this adds a first-class alternative alongside it.

- `mem0/llms/mistral.py`: `MistralLLM`, registered with plain `BaseLlmConfig` (no dedicated config class needed, matching `groq`/`together`/`sarvam`)
- Supports tool calls, `response_format`, `reasoning_effort`, and forwards arbitrary extra kwargs per the `LLMBase` contract
- `mem0/utils/factory.py`, `mem0/llms/configs.py`: provider registration
- `pyproject.toml`: `mistralai>=2.0.0` dependency
- `docs/components/llms/models/mistral_AI.mdx`: document the native provider alongside the existing `litellm`-based example
- `tests/llms/test_mistral.py`: 12 unit tests

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

12 unit tests in `tests/llms/test_mistral.py` (mocked client), covering: plain text generation, extra-kwarg forwarding, tool calls (both string and already-parsed-dict `arguments`, per the SDK's `Union[Dict[str, Any], str]` typing), `response_format`, `reasoning_effort` (including the case where `message.content` comes back as a list of reasoning/text chunks rather than a string), default model resolution, env-var API key, and factory/config registration.

Also ran all 12 scenarios manually against the real Mistral API with a live key before opening this PR, which surfaced a couple of real issues the mocks couldn't catch — both are fixed here.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
