### PR TITLE
fix(llms/anthropic): find the text block in no-tools responses instead of indexing content[0]

### DIFF
--- a/mem0/llms/anthropic.py
+++ b/mem0/llms/anthropic.py
@@ -149,4 +149,11 @@ class AnthropicLLM(LLMBase):
                 elif block.type == "tool_use":
                     result["tool_calls"].append({"name": block.name, "arguments": block.input})
             return result
-        return response.content[0].text
+
+        # Thinking-enabled responses put a thinking block before the text
+        # block, and a response can carry no text block at all, so find the
+        # text block like the tools branch above instead of indexing content[0].
+        for block in response.content:
+            if block.type == "text":
+                return block.text
+        return ""

--- a/tests/llms/test_anthropic.py
+++ b/tests/llms/test_anthropic.py
@@ -166,6 +166,56 @@ def test_enable_sampling_parameters_for_current_models(mock_anthropic_client, mo
     assert ("temperature" in call_kwargs) is expected
 
 
+def test_generate_response_returns_text_when_thinking_block_precedes_it(mock_anthropic_client):
+    """Extended thinking responses put a thinking block before the text block; parsing must skip it."""
+    config = AnthropicConfig(model="claude-opus-4-6", api_key="test-key")
+    llm = AnthropicLLM(config)
+
+    thinking_block = Mock(spec=["type", "thinking", "signature"])
+    thinking_block.type = "thinking"
+    text_block = Mock(spec=["type", "text"])
+    text_block.type = "text"
+    text_block.text = "The answer"
+
+    mock_response = Mock()
+    mock_response.content = [thinking_block, text_block]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    result = llm.generate_response([{"role": "user", "content": "Hi"}])
+
+    assert result == "The answer"
+
+
+def test_generate_response_returns_empty_string_on_empty_content(mock_anthropic_client):
+    """A response with no content blocks must return "" instead of raising IndexError."""
+    config = AnthropicConfig(model="claude-opus-4-6", api_key="test-key")
+    llm = AnthropicLLM(config)
+
+    mock_response = Mock()
+    mock_response.content = []
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    result = llm.generate_response([{"role": "user", "content": "Hi"}])
+
+    assert result == ""
+
+
+def test_generate_response_returns_text_for_plain_text_response(mock_anthropic_client):
+    """Regular single-text-block responses keep returning the text unchanged."""
+    config = AnthropicConfig(model="claude-opus-4-6", api_key="test-key")
+    llm = AnthropicLLM(config)
+
+    text_block = Mock(spec=["type", "text"])
+    text_block.type = "text"
+    text_block.text = "Hello!"
+
+    mock_response = Mock()
+    mock_response.content = [text_block]
+    mock_anthropic_client.messages.create.return_value = mock_response
+
+    assert llm.generate_response([{"role": "user", "content": "Hi"}]) == "Hello!"
+
+
 def test_enable_sampling_parameters_respects_explicit_override(mock_anthropic_client):
     config = AnthropicConfig(
         model="claude-opus-4-6",


### PR DESCRIPTION
## Linked Issue

Closes #6480

## Description

The no-tools path of `AnthropicLLM._parse_response` returns `response.content[0].text` (mem0/llms/anthropic.py:152). When extended thinking is enabled the response starts with a thinking block, which has no `.text`, so the call raises AttributeError even though the model answered. An empty content list raises IndexError the same way. This mirrors #6368 on the Bedrock side, where the same content[0] indexing crashed on a leading reasoningContent block. The fix iterates the blocks and returns the first text block's text, falling back to an empty string, exactly like the tools branch a few lines above already does.

One note on tests: the whole `tests/llms/test_anthropic.py` module is guarded by `pytest.importorskip("anthropic")` and the `anthropic` package is not part of the dev env features, so CI skips it (same as the existing tests in that file). I verified locally with anthropic installed: both new regression tests fail on main (AttributeError and IndexError at anthropic.py:152) and pass on this branch, plus a third test pinning the plain single-text-block behavior, which passes on both. `make lint` and `make test-py-3.11` are green (1709 passed).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (ran the new tests against main's anthropic.py to confirm they reproduce the AttributeError and IndexError, then against the branch where all 25 module tests pass)
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

---

*small disclosure like on my previous PRs: I'm a freshman doing my best to give back to tools I use. Claude Code helped me trace this one and write the fix and tests, and I ran all the gates locally myself. if anything here misses the mark I would honestly rather hear it than not, still learning :)*
