### PR TITLE
fix(ts-oss/baidu): convert L2 distance to similarity score in search()

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/baidu.ts
+++ b/mem0-ts/src/oss/src/vector_stores/baidu.ts
@@ -453,7 +453,12 @@ export class BaiduDB implements VectorStore {
     return (response.rows ?? []).map((result) => ({
       id: String(result.row.id),
       payload: resultPayload(result.row),
-      score: result.score,
+      // Mochow returns the raw L2 distance (lower = closer). Convert it to a
+      // similarity score (higher = better) to satisfy the VectorStore contract,
+      // mirroring the Python provider and the milvus store. Non-L2 metrics
+      // already return a higher-is-better score, so they pass through untouched.
+      score:
+        this.metricType === "L2" ? 1 / (1 + (result.score ?? 0)) : result.score,
     }));
   }
 

--- a/mem0-ts/src/oss/src/vector_stores/baidu.ts
+++ b/mem0-ts/src/oss/src/vector_stores/baidu.ts
@@ -453,12 +453,13 @@ export class BaiduDB implements VectorStore {
     return (response.rows ?? []).map((result) => ({
       id: String(result.row.id),
       payload: resultPayload(result.row),
-      // Mochow returns the raw L2 distance (lower = closer). Convert it to a
-      // similarity score (higher = better) to satisfy the VectorStore contract,
-      // mirroring the Python provider and the milvus store. Non-L2 metrics
-      // already return a higher-is-better score, so they pass through untouched.
+      // L2 is a distance (lower = closer); the VectorStore contract wants higher = better.
       score:
-        this.metricType === "L2" ? 1 / (1 + (result.score ?? 0)) : result.score,
+        this.metricType === "L2"
+          ? result.score != null
+            ? 1 / (1 + result.score)
+            : undefined
+          : result.score,
     }));
   }
 

--- a/mem0-ts/src/oss/tests/baidu.test.ts
+++ b/mem0-ts/src/oss/tests/baidu.test.ts
@@ -431,9 +431,13 @@ describe("BaiduDB reads", () => {
       ],
     });
 
-    const results = await makeStore(client).search([1, 2, 3], 5, {
-      userId: "alice",
-    });
+    // A non-L2 metric already returns a higher-is-better score, so it passes
+    // through untouched; this keeps the envelope-mapping assertion about shape.
+    const results = await makeStore(client, { metricType: "COSINE" }).search(
+      [1, 2, 3],
+      5,
+      { userId: "alice" },
+    );
     expect(results).toEqual([{ id: "m1", payload: { data: "x" }, score: 0.8 }]);
 
     const { request } = client.vectorSearch.mock.calls[0][0];
@@ -443,6 +447,28 @@ describe("BaiduDB reads", () => {
     expect(request.filter).toBe('metadata["userId"] = "alice"');
     expect(request.projections).toEqual(["id", "data", "metadata"]);
     expect(request.config.params).toEqual({ ef: 200 });
+  });
+
+  it("converts an L2 distance into a similarity score (higher = better)", async () => {
+    // On the default L2 metric, Mochow returns raw distances (lower = closer).
+    // search() must convert them to similarity scores (higher = better) to
+    // satisfy the VectorStore contract, otherwise the memory layer ranks and
+    // thresholds them backwards. Mirrors the Python provider (#6435).
+    const client = fakeClient();
+    client.vectorSearch.mockResolvedValue({
+      ...OK,
+      rows: [
+        { row: { id: "near", metadata: {} }, score: 0.5 },
+        { row: { id: "far", metadata: {} }, score: 2.0 },
+      ],
+    });
+
+    const results = await makeStore(client).search([1, 2, 3], 2);
+
+    // 1 / (1 + distance): the closer memory must score higher than the far one.
+    expect(results[0].score).toBeCloseTo(1 / 1.5, 10);
+    expect(results[1].score).toBeCloseTo(1 / 3.0, 10);
+    expect(results[0].score!).toBeGreaterThan(results[1].score!);
   });
 
   it("omits the filter when no filters are supplied", async () => {

--- a/mem0-ts/src/oss/tests/baidu.test.ts
+++ b/mem0-ts/src/oss/tests/baidu.test.ts
@@ -431,8 +431,7 @@ describe("BaiduDB reads", () => {
       ],
     });
 
-    // A non-L2 metric already returns a higher-is-better score, so it passes
-    // through untouched; this keeps the envelope-mapping assertion about shape.
+    // Non-L2 metrics already return a higher-is-better score and pass through untouched.
     const results = await makeStore(client, { metricType: "COSINE" }).search(
       [1, 2, 3],
       5,
@@ -450,10 +449,7 @@ describe("BaiduDB reads", () => {
   });
 
   it("converts an L2 distance into a similarity score (higher = better)", async () => {
-    // On the default L2 metric, Mochow returns raw distances (lower = closer).
-    // search() must convert them to similarity scores (higher = better) to
-    // satisfy the VectorStore contract, otherwise the memory layer ranks and
-    // thresholds them backwards. Mirrors the Python provider (#6435).
+    // Mirrors the Python provider (#6435): 1 / (1 + distance), so closer scores higher.
     const client = fakeClient();
     client.vectorSearch.mockResolvedValue({
       ...OK,
@@ -465,10 +461,20 @@ describe("BaiduDB reads", () => {
 
     const results = await makeStore(client).search([1, 2, 3], 2);
 
-    // 1 / (1 + distance): the closer memory must score higher than the far one.
     expect(results[0].score).toBeCloseTo(1 / 1.5, 10);
     expect(results[1].score).toBeCloseTo(1 / 3.0, 10);
-    expect(results[0].score!).toBeGreaterThan(results[1].score!);
+  });
+
+  it("leaves an unscored L2 row's score undefined instead of treating it as the closest match", async () => {
+    const client = fakeClient();
+    client.vectorSearch.mockResolvedValue({
+      ...OK,
+      rows: [{ row: { id: "unscored", metadata: {} } }],
+    });
+
+    const results = await makeStore(client).search([1, 2, 3], 1);
+
+    expect(results[0].score).toBeUndefined();
   });
 
   it("omits the filter when no filters are supplied", async () => {


### PR DESCRIPTION
### Description

The TS OSS Baidu store returned the raw L2 distance from Mochow as the result `score`. The memory layer treats `score` as a similarity where higher is better: `scoreAndRank()` sorts descending and applies the threshold to it. Passing a raw L2 distance (lower = closer) inverts the ranking, so the farthest matches come back first and threshold filtering keeps the wrong rows. L2 is the default metric, so this affects the default config, not an edge case.

The fix converts the L2 distance to a similarity with `1 / (1 + distance)` before returning, matching the Python provider (fixed in #6435) and the milvus store. Non-L2 metrics (COSINE, IP) already return a higher-is-better score and pass through untouched. `keywordSearch()` (BM25) is already higher-is-better and is left alone.

Closes #6484

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`jest src/oss/tests/baidu.test.ts` (run from the `mem0-ts` root), 29 passed.

- Added `converts an L2 distance into a similarity score (higher = better)`: two hits with L2 distances 0.5 and 2.0 come back as `1/1.5` and `1/3.0`, closer scored higher. Reverting the source change fails exactly this test and nothing else.
- Updated the existing envelope-mapping test to use a non-L2 (COSINE) metric so its pass-through score assertion stays about shape, mirroring how the Python test suite splits these two cases.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes