### PR TITLE
fix(embeddings/huggingface): forward api_key on base_url/TEI path

### DIFF
--- a/docs/components/embedders/models/huggingface.mdx
+++ b/docs/components/embedders/models/huggingface.mdx
@@ -99,6 +99,7 @@ Here are the parameters available for configuring the Hugging Face embedder:
 | `embedding_dims` | Dimensions of the embedding model | `selected_model_dimensions` |
 | `model_kwargs` | Additional arguments for the model | `None` |
 | `huggingface_base_url` | URL to connect to Text Embeddings Inference (TEI) API | `None` |
+| `api_key` | API key for the TEI or OpenAI-compatible endpoint; falls back to the `HUGGINGFACE_API_KEY` env var | `"hf"` |
 </Tab>
 <Tab title="TypeScript">
 | Parameter | Description | Default Value |

--- a/mem0/embeddings/huggingface.py
+++ b/mem0/embeddings/huggingface.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Literal, Optional
 
 from openai import OpenAI
@@ -17,7 +18,11 @@ class HuggingFaceEmbedding(EmbeddingBase):
         super().__init__(config)
 
         if self.config.huggingface_base_url:
-            self.client = OpenAI(base_url=self.config.huggingface_base_url)
+            # TEI / OpenAI-compatible endpoints may require auth. Prefer config,
+            # then HUGGINGFACE_API_KEY. Some local TEI installs accept any
+            # non-empty key — keep "hf" as last-resort default for that case.
+            api_key = self.config.api_key or os.getenv("HUGGINGFACE_API_KEY") or "hf"
+            self.client = OpenAI(base_url=self.config.huggingface_base_url, api_key=api_key)
             self.config.model = self.config.model or "tei"
         else:
             self.config.model = self.config.model or "multi-qa-MiniLM-L6-cos-v1"

--- a/tests/embeddings/test_huggingface_embeddings.py
+++ b/tests/embeddings/test_huggingface_embeddings.py
@@ -72,7 +72,8 @@ def test_embed_with_custom_embedding_dims(mock_sentence_transformer):
     assert result == [1.0, 1.1, 1.2]
 
 
-def test_embed_with_huggingface_base_url():
+def test_embed_with_huggingface_base_url(monkeypatch):
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
     config = BaseEmbedderConfig(
         huggingface_base_url="http://localhost:8080",
         model="my-custom-model",
@@ -94,7 +95,7 @@ def test_embed_with_huggingface_base_url():
         embedder = HuggingFaceEmbedding(config)
         result = embedder.embed("Hello from custom endpoint")
 
-        mock_openai.assert_called_once_with(base_url="http://localhost:8080")
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="hf")
         mock_client.embeddings.create.assert_called_once_with(
             input="Hello from custom endpoint",
             model="my-custom-model",
@@ -169,3 +170,38 @@ def test_embed_batch_count_mismatch_raises_sentence_transformer(mock_sentence_tr
 
     with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
         embedder.embed_batch(["first text", "second text"])
+
+
+
+def test_base_url_forwards_config_api_key(monkeypatch):
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    config = BaseEmbedderConfig(huggingface_base_url="http://localhost:8080", api_key="hf_configToken")
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+        assert mock_openai.call_args.kwargs["api_key"] == "hf_configToken"
+
+
+def test_base_url_uses_env_api_key_when_config_unset(monkeypatch):
+    monkeypatch.setenv("HUGGINGFACE_API_KEY", "hf_envToken")
+    config = BaseEmbedderConfig(huggingface_base_url="http://localhost:8080")
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+        assert mock_openai.call_args.kwargs["api_key"] == "hf_envToken"
+
+
+def test_base_url_defaults_api_key_when_unset(monkeypatch):
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    config = BaseEmbedderConfig(huggingface_base_url="http://localhost:8080")
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+        assert mock_openai.call_args.kwargs["api_key"] == "hf"
+
+
+def test_base_url_config_api_key_wins_over_env(monkeypatch):
+    monkeypatch.setenv("HUGGINGFACE_API_KEY", "hf_envToken")
+    config = BaseEmbedderConfig(
+        huggingface_base_url="http://localhost:8080", api_key="hf_configToken"
+    )
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+        assert mock_openai.call_args.kwargs["api_key"] == "hf_configToken"


### PR DESCRIPTION
## Summary

Closes #6301.

When `huggingface_base_url` is set, `HuggingFaceEmbedding` builds an OpenAI-compatible client for TEI (or similar) endpoints but never passed `api_key`. Configured keys and `HUGGINGFACE_API_KEY` were ignored, so authenticated endpoints silently dropped auth.

## Root cause

```python
self.client = OpenAI(base_url=self.config.huggingface_base_url)
```

No `api_key=` argument; the local SentenceTransformer path was unaffected.

## Fix

- Prefer `config.api_key`, then `HUGGINGFACE_API_KEY`, then `"hf"` (local TEI often accepts any non-empty key).
- Document `api_key` on the HuggingFace embedder table.
- Tests: config key, env key, default, config-over-env, and updated existing base_url test.

## Differential value vs #6302

Same core fix as #6302 (also open). This PR adds explicit config-over-env precedence coverage and keeps the docs table in sync. Happy to close as duplicate if #6302 merges first.

## Verification

```bash
uv run pytest tests/embeddings/test_huggingface_embeddings.py -q
# 15 passed
```

## Test plan

- [x] unit tests for TEI client api_key wiring
- [ ] CI green on Python SDK matrix