### PR TITLE
fix(memory): paginate delete_all so all matching memories are removed

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -3595,11 +3595,15 @@ class AsyncMemory(MemoryBase):
                 return_exceptions=True,
             )
             for memory, result in zip(batch, results):
-                seen_ids.add(memory.id)
                 if isinstance(result, BaseException):
+                    # Do not mark seen on failure — leave residual IDs eligible
+                    # for retry on the next list page (async concurrent deletes
+                    # can fail without surfacing; marking early silently drops
+                    # them while delete_all still reports success).
                     total_errors += 1
                     logger.warning("Failed to delete memory %s: %s", memory.id, result)
                 else:
+                    seen_ids.add(memory.id)
                     total_deleted += 1
 
         if self._entity_store is not None:

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -110,6 +110,14 @@ _DELETE_ALL_MAX_NO_PROGRESS = 3
 # store time to expose newly-visible rows before we conclude the drain.
 _DELETE_ALL_NO_PROGRESS_BACKOFF = 0.5
 
+# Max times a single id may fail deletion before we stop retrying it and count
+# it as a hard error. A transient concurrent-delete miss stays eligible for a
+# few retries (see async delete_all), but an id whose delete keeps failing must
+# not be re-listed and re-attempted every iteration up to _DELETE_ALL_MAX_
+# ITERATIONS, which would hammer the backend. After this many failures the id
+# is marked seen so the drain can conclude instead of spinning.
+_DELETE_ALL_MAX_ID_FAILURES = 3
+
 
 # Fields that hold runtime auth/connection objects and must be preserved.
 # These are non-serializable objects (e.g. AWSV4SignerAuth, RequestsHttpConnection)
@@ -3568,6 +3576,7 @@ class AsyncMemory(MemoryBase):
         total_deleted = 0
         total_errors = 0
         seen_ids: set = set()
+        failure_counts: dict = {}
         no_progress = 0
         for _ in range(_DELETE_ALL_MAX_ITERATIONS):
             listed = await asyncio.to_thread(
@@ -3596,12 +3605,23 @@ class AsyncMemory(MemoryBase):
             )
             for memory, result in zip(batch, results):
                 if isinstance(result, BaseException):
-                    # Do not mark seen on failure — leave residual IDs eligible
-                    # for retry on the next list page (async concurrent deletes
-                    # can fail without surfacing; marking early silently drops
-                    # them while delete_all still reports success).
+                    # Do not mark seen on a transient failure — leave residual
+                    # IDs eligible for retry on the next list page (async
+                    # concurrent deletes can fail without surfacing; marking
+                    # early silently drops them while delete_all still reports
+                    # success). But bound per-id retries: an id whose delete
+                    # keeps failing is marked seen after a few attempts so it
+                    # doesn't get re-listed and re-attempted every iteration.
                     total_errors += 1
+                    failure_counts[memory.id] = failure_counts.get(memory.id, 0) + 1
                     logger.warning("Failed to delete memory %s: %s", memory.id, result)
+                    if failure_counts[memory.id] >= _DELETE_ALL_MAX_ID_FAILURES:
+                        seen_ids.add(memory.id)
+                        logger.warning(
+                            "Giving up on memory %s after %d failed delete attempts",
+                            memory.id,
+                            failure_counts[memory.id],
+                        )
                 else:
                     seen_ids.add(memory.id)
                     total_deleted += 1

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -90,6 +90,14 @@ def _vector_store_list_rows(listed):
     return []
 
 
+# Page size for delete_all pagination. Vector stores typically default list()
+# to ~100 hits; delete_all must loop with an explicit top_k to drain all matches.
+_DELETE_ALL_PAGE_SIZE = 1000
+
+# Safety cap so eventual-consistency lag cannot spin forever.
+_DELETE_ALL_MAX_ITERATIONS = 10_000
+
+
 # Fields that hold runtime auth/connection objects and must be preserved.
 # These are non-serializable objects (e.g. AWSV4SignerAuth, RequestsHttpConnection)
 # needed by clients like OpenSearch — not sensitive strings to redact.
@@ -1885,14 +1893,28 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
-        memories = self.vector_store.list(filters=filters)[0]
-        for memory in memories:
-            self._delete_memory(memory.id)
+        # Paginate: most vector stores cap list() (often ~100). Delete each page
+        # inside the loop so the result set shrinks between list() calls.
+        total_deleted = 0
+        seen_ids: set = set()
+        for _ in range(_DELETE_ALL_MAX_ITERATIONS):
+            listed = self.vector_store.list(filters=filters, top_k=_DELETE_ALL_PAGE_SIZE)
+            batch = _vector_store_list_rows(listed)
+            batch = [m for m in batch if getattr(m, "id", None) not in seen_ids]
+            if not batch:
+                break
+            for memory in batch:
+                try:
+                    self._delete_memory(memory.id)
+                    seen_ids.add(memory.id)
+                    total_deleted += 1
+                except Exception as e:
+                    logger.warning("Failed to delete memory %s: %s", memory.id, e)
+                    seen_ids.add(memory.id)
 
-        logger.info(f"Deleted {len(memories)} memories")
+        logger.info(f"Deleted {total_deleted} memories")
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories))
+        decay_usage_notice = detect_decay_usage_from_delete_all(total_deleted)
         if decay_usage_notice:
             display_decay_usage_notice(self, "sync", "delete_all", *decay_usage_notice)
         else:
@@ -3515,26 +3537,41 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
+        # Paginate like sync: delete each page before asking for the next so
+        # stores without offset/cursor still drain fully.
+        total_deleted = 0
+        total_errors = 0
+        seen_ids: set = set()
+        for _ in range(_DELETE_ALL_MAX_ITERATIONS):
+            listed = await asyncio.to_thread(
+                self.vector_store.list, filters=filters, top_k=_DELETE_ALL_PAGE_SIZE
+            )
+            batch = _vector_store_list_rows(listed)
+            batch = [m for m in batch if getattr(m, "id", None) not in seen_ids]
+            if not batch:
+                break
 
-        delete_tasks = []
-        for memory in memories[0]:
-            delete_tasks.append(self._delete_memory(memory.id, skip_entity_cleanup=True))
-
-        results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+            results = await asyncio.gather(
+                *[self._delete_memory(memory.id, skip_entity_cleanup=True) for memory in batch],
+                return_exceptions=True,
+            )
+            for memory, result in zip(batch, results):
+                seen_ids.add(memory.id)
+                if isinstance(result, BaseException):
+                    total_errors += 1
+                    logger.warning("Failed to delete memory %s: %s", memory.id, result)
+                else:
+                    total_deleted += 1
 
         if self._entity_store is not None:
             await self._bulk_clear_entity_store(filters)
 
-        errors = [r for r in results if isinstance(r, BaseException)]
-        if errors:
-            logger.warning("Failed to delete %d out of %d memories", len(errors), len(results))
-            for err in errors:
-                logger.warning("Delete error: %s", err)
+        if total_errors:
+            logger.warning("Failed to delete %d memories during delete_all", total_errors)
 
-        logger.info(f"Deleted {len(results) - len(errors)} memories")
+        logger.info(f"Deleted {total_deleted} memories")
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories[0]))
+        decay_usage_notice = detect_decay_usage_from_delete_all(total_deleted)
         if decay_usage_notice:
             await display_decay_usage_notice_async(self, "async", "delete_all", *decay_usage_notice)
         else:

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -97,6 +97,12 @@ _DELETE_ALL_PAGE_SIZE = 1000
 # Safety cap so eventual-consistency lag cannot spin forever.
 _DELETE_ALL_MAX_ITERATIONS = 10_000
 
+# On stores with refresh lag (Elasticsearch/OpenSearch), a page can come back
+# fully composed of already-seen ids while later unseen rows are still hidden.
+# Allow a bounded number of such no-progress pages before concluding the drain
+# is complete, so stale pages don't cause us to silently leave data behind.
+_DELETE_ALL_MAX_NO_PROGRESS = 3
+
 
 # Fields that hold runtime auth/connection objects and must be preserved.
 # These are non-serializable objects (e.g. AWSV4SignerAuth, RequestsHttpConnection)
@@ -1897,20 +1903,29 @@ class Memory(MemoryBase):
         # inside the loop so the result set shrinks between list() calls.
         total_deleted = 0
         seen_ids: set = set()
+        no_progress = 0
         for _ in range(_DELETE_ALL_MAX_ITERATIONS):
             listed = self.vector_store.list(filters=filters, top_k=_DELETE_ALL_PAGE_SIZE)
-            batch = _vector_store_list_rows(listed)
-            batch = [m for m in batch if getattr(m, "id", None) not in seen_ids]
-            if not batch:
+            rows = _vector_store_list_rows(listed)
+            if not rows:
                 break
+            batch = [m for m in rows if getattr(m, "id", None) not in seen_ids]
+            if not batch:
+                # Every row on this page was already deleted this run. On stores
+                # with refresh lag the deleted rows can linger while newer rows
+                # stay hidden, so retry a bounded number of times before giving
+                # up rather than breaking on the first all-seen page.
+                no_progress += 1
+                if no_progress >= _DELETE_ALL_MAX_NO_PROGRESS:
+                    break
+                continue
+            no_progress = 0
             for memory in batch:
-                try:
-                    self._delete_memory(memory.id)
-                    seen_ids.add(memory.id)
-                    total_deleted += 1
-                except Exception as e:
-                    logger.warning("Failed to delete memory %s: %s", memory.id, e)
-                    seen_ids.add(memory.id)
+                # Preserve the pre-pagination contract: surface delete failures
+                # instead of reporting success with residual memories.
+                self._delete_memory(memory.id)
+                seen_ids.add(memory.id)
+                total_deleted += 1
 
         logger.info(f"Deleted {total_deleted} memories")
 
@@ -3542,14 +3557,23 @@ class AsyncMemory(MemoryBase):
         total_deleted = 0
         total_errors = 0
         seen_ids: set = set()
+        no_progress = 0
         for _ in range(_DELETE_ALL_MAX_ITERATIONS):
             listed = await asyncio.to_thread(
                 self.vector_store.list, filters=filters, top_k=_DELETE_ALL_PAGE_SIZE
             )
-            batch = _vector_store_list_rows(listed)
-            batch = [m for m in batch if getattr(m, "id", None) not in seen_ids]
-            if not batch:
+            rows = _vector_store_list_rows(listed)
+            if not rows:
                 break
+            batch = [m for m in rows if getattr(m, "id", None) not in seen_ids]
+            if not batch:
+                # All rows already handled this run; retry a bounded number of
+                # times to tolerate refresh lag before concluding the drain.
+                no_progress += 1
+                if no_progress >= _DELETE_ALL_MAX_NO_PROGRESS:
+                    break
+                continue
+            no_progress = 0
 
             results = await asyncio.gather(
                 *[self._delete_memory(memory.id, skip_entity_cleanup=True) for memory in batch],

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -103,6 +103,13 @@ _DELETE_ALL_MAX_ITERATIONS = 10_000
 # is complete, so stale pages don't cause us to silently leave data behind.
 _DELETE_ALL_MAX_NO_PROGRESS = 3
 
+# Backoff (seconds) applied between no-progress pages. Without a wait, all
+# retries can fire faster than a backend's visibility refresh (which can take
+# seconds), so the bounded counter alone provides no real timing tolerance for
+# Elasticsearch/OpenSearch-style refresh lag. A small linear backoff gives the
+# store time to expose newly-visible rows before we conclude the drain.
+_DELETE_ALL_NO_PROGRESS_BACKOFF = 0.5
+
 
 # Fields that hold runtime auth/connection objects and must be preserved.
 # These are non-serializable objects (e.g. AWSV4SignerAuth, RequestsHttpConnection)
@@ -1918,6 +1925,10 @@ class Memory(MemoryBase):
                 no_progress += 1
                 if no_progress >= _DELETE_ALL_MAX_NO_PROGRESS:
                     break
+                # Give the backend time to refresh before re-listing, so the
+                # bounded retry actually spans the visibility window.
+                if _DELETE_ALL_NO_PROGRESS_BACKOFF:
+                    time.sleep(_DELETE_ALL_NO_PROGRESS_BACKOFF * no_progress)
                 continue
             no_progress = 0
             for memory in batch:
@@ -3572,6 +3583,10 @@ class AsyncMemory(MemoryBase):
                 no_progress += 1
                 if no_progress >= _DELETE_ALL_MAX_NO_PROGRESS:
                     break
+                # Await a bounded backoff so the retry actually spans the
+                # backend's refresh window instead of firing instantly.
+                if _DELETE_ALL_NO_PROGRESS_BACKOFF:
+                    await asyncio.sleep(_DELETE_ALL_NO_PROGRESS_BACKOFF * no_progress)
                 continue
             no_progress = 0
 

--- a/tests/memory/test_delete_all_pagination.py
+++ b/tests/memory/test_delete_all_pagination.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from mem0.memory import main as memory_main
-from mem0.memory.main import AsyncMemory, Memory, _DELETE_ALL_PAGE_SIZE
+from mem0.memory.main import (
+    AsyncMemory,
+    Memory,
+    _DELETE_ALL_PAGE_SIZE,
+)
 
 
 def _make_sync_memory():
@@ -129,11 +133,19 @@ def test_sync_delete_all_tolerates_stale_all_seen_page(monkeypatch):
     monkeypatch.setattr(memory_main, "capture_event", MagicMock())
     monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
     monkeypatch.setattr(memory_main, "display_first_run_notice", MagicMock())
+    # Assert we actually wait between no-progress pages so the retry spans the
+    # backend's refresh window instead of firing three instant list() calls.
+    sleep_mock = MagicMock()
+    monkeypatch.setattr(memory_main.time, "sleep", sleep_mock)
 
     Memory.delete_all(memory, user_id="u1")
 
     deleted_ids = [c.args[0] for c in memory._delete_memory.call_args_list]
     assert deleted_ids == ["m0", "m1"]
+    # One no-progress page (the stale repeat of m0) triggers one backoff sleep
+    # with a positive delay before the previously-hidden m1 becomes visible.
+    assert sleep_mock.call_count == 1
+    assert sleep_mock.call_args.args[0] > 0
 
 
 @pytest.mark.asyncio
@@ -174,3 +186,31 @@ async def test_async_delete_all_is_load_bearing_with_stateful_store(monkeypatch)
     # the loop would run until the iteration cap; instead it drains cleanly.
     assert store._ids == []
     assert memory._delete_memory.await_count == 5
+
+
+@pytest.mark.asyncio
+async def test_async_delete_all_awaits_backoff_on_stale_page(monkeypatch):
+    memory = _make_async_memory()
+    row = SimpleNamespace(id="a0")
+    later = SimpleNamespace(id="a1")
+    # Stale all-seen page must trigger a bounded async backoff so the retry
+    # spans the backend refresh window rather than firing instantly.
+    memory.vector_store.list.side_effect = [
+        ([row], None),
+        ([row], None),
+        ([later], None),
+        ([], None),
+    ]
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice_async", AsyncMock())
+    monkeypatch.setattr(memory_main, "display_decay_usage_notice_async", AsyncMock())
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(memory_main.asyncio, "sleep", sleep_mock)
+
+    await AsyncMemory.delete_all(memory, user_id="u1")
+
+    deleted_ids = [c.args[0] for c in memory._delete_memory.await_args_list]
+    assert deleted_ids == ["a0", "a1"]
+    assert sleep_mock.await_count == 1
+    assert sleep_mock.await_args.args[0] > 0

--- a/tests/memory/test_delete_all_pagination.py
+++ b/tests/memory/test_delete_all_pagination.py
@@ -214,3 +214,36 @@ async def test_async_delete_all_awaits_backoff_on_stale_page(monkeypatch):
     assert deleted_ids == ["a0", "a1"]
     assert sleep_mock.await_count == 1
     assert sleep_mock.await_args.args[0] > 0
+
+@pytest.mark.asyncio
+async def test_async_delete_all_retries_failed_delete(monkeypatch):
+    """Failed async deletes must not be marked seen — residual IDs retry next page."""
+    memory = _make_async_memory()
+    row = SimpleNamespace(id="fail-me")
+    # First pass: delete fails; row remains in store. Second pass: delete succeeds.
+    memory.vector_store.list.side_effect = [
+        ([row], None),
+        ([row], None),
+        ([], None),
+    ]
+    attempts = {"n": 0}
+
+    async def _delete(memory_id, skip_entity_cleanup=False):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise RuntimeError("transient backend failure")
+        return None
+
+    memory._delete_memory = AsyncMock(side_effect=_delete)
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice_async", AsyncMock())
+    monkeypatch.setattr(memory_main, "display_decay_usage_notice_async", AsyncMock())
+
+    await AsyncMemory.delete_all(memory, user_id="u1")
+
+    # If seen_ids were marked on the failed first attempt, the second list page
+    # would filter the id out and never retry — await_count would stay 1.
+    assert memory._delete_memory.await_count == 2
+    assert attempts["n"] == 2
+

--- a/tests/memory/test_delete_all_pagination.py
+++ b/tests/memory/test_delete_all_pagination.py
@@ -1,0 +1,79 @@
+"""delete_all must drain every page of matching memories, not just list()'s first page."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mem0.memory import main as memory_main
+from mem0.memory.main import AsyncMemory, Memory, _DELETE_ALL_PAGE_SIZE
+
+
+def _make_sync_memory():
+    memory = MagicMock(spec=Memory)
+    memory.vector_store = MagicMock()
+    memory._delete_memory = MagicMock()
+    memory._entity_store = None
+    return memory
+
+
+def _make_async_memory():
+    memory = MagicMock(spec=AsyncMemory)
+    memory.vector_store = MagicMock()
+    memory._delete_memory = AsyncMock()
+    memory._entity_store = None
+    memory._bulk_clear_entity_store = AsyncMock()
+    return memory
+
+
+def test_sync_delete_all_paginates_until_empty(monkeypatch):
+    memory = _make_sync_memory()
+    page1 = [SimpleNamespace(id=f"m{i}") for i in range(3)]
+    page2 = [SimpleNamespace(id=f"m{i}") for i in range(3, 5)]
+    memory.vector_store.list.side_effect = [(page1, None), (page2, None), ([], None)]
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice", MagicMock())
+    monkeypatch.setattr(memory_main, "display_decay_usage_notice", MagicMock())
+
+    Memory.delete_all(memory, user_id="u1")
+
+    assert memory.vector_store.list.call_count == 3
+    for call in memory.vector_store.list.call_args_list:
+        assert call.kwargs.get("top_k") == _DELETE_ALL_PAGE_SIZE or (
+            len(call.args) >= 2 and call.args[1] == _DELETE_ALL_PAGE_SIZE
+        ) or call.kwargs == {"filters": {"user_id": "u1"}, "top_k": _DELETE_ALL_PAGE_SIZE}
+    assert memory._delete_memory.call_count == 5
+    deleted_ids = [c.args[0] for c in memory._delete_memory.call_args_list]
+    assert deleted_ids == ["m0", "m1", "m2", "m3", "m4"]
+
+
+def test_sync_delete_all_passes_filters_and_top_k(monkeypatch):
+    memory = _make_sync_memory()
+    memory.vector_store.list.return_value = ([], None)
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice", MagicMock())
+
+    Memory.delete_all(memory, user_id="alice", agent_id="bot")
+
+    memory.vector_store.list.assert_called_with(
+        filters={"user_id": "alice", "agent_id": "bot"}, top_k=_DELETE_ALL_PAGE_SIZE
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_delete_all_paginates_until_empty(monkeypatch):
+    memory = _make_async_memory()
+    page1 = [SimpleNamespace(id="a"), SimpleNamespace(id="b")]
+    page2 = [SimpleNamespace(id="c")]
+    memory.vector_store.list.side_effect = [(page1, None), (page2, None), ([], None)]
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice_async", AsyncMock())
+    monkeypatch.setattr(memory_main, "display_decay_usage_notice_async", AsyncMock())
+
+    await AsyncMemory.delete_all(memory, user_id="u1")
+
+    assert memory.vector_store.list.call_count == 3
+    assert memory._delete_memory.await_count == 3

--- a/tests/memory/test_delete_all_pagination.py
+++ b/tests/memory/test_delete_all_pagination.py
@@ -247,3 +247,30 @@ async def test_async_delete_all_retries_failed_delete(monkeypatch):
     assert memory._delete_memory.await_count == 2
     assert attempts["n"] == 2
 
+
+@pytest.mark.asyncio
+async def test_async_delete_all_caps_persistent_failures(monkeypatch):
+    """An id whose delete keeps failing is capped, not retried every iteration."""
+    from mem0.memory.main import _DELETE_ALL_MAX_ID_FAILURES
+
+    memory = _make_async_memory()
+    row = SimpleNamespace(id="always-fails")
+    # The store keeps returning the same undeletable row on every list() call.
+    memory.vector_store.list.side_effect = lambda *a, **k: ([row], None)
+
+    async def _delete(memory_id, skip_entity_cleanup=False):
+        raise RuntimeError("permanent backend failure")
+
+    memory._delete_memory = AsyncMock(side_effect=_delete)
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice_async", AsyncMock())
+    monkeypatch.setattr(memory_main, "display_decay_usage_notice_async", AsyncMock())
+
+    await AsyncMemory.delete_all(memory, user_id="u1")
+
+    # Without the cap this id would be re-attempted up to _DELETE_ALL_MAX_
+    # ITERATIONS (10k). With it, the id is marked seen after the cap and the
+    # drain concludes, so total attempts stay bounded to the cap.
+    assert memory._delete_memory.await_count == _DELETE_ALL_MAX_ID_FAILURES
+

--- a/tests/memory/test_delete_all_pagination.py
+++ b/tests/memory/test_delete_all_pagination.py
@@ -62,6 +62,80 @@ def test_sync_delete_all_passes_filters_and_top_k(monkeypatch):
     )
 
 
+class _StatefulStore:
+    """Fake vector store that returns at most `page_size` rows and only drops a
+    row when delete() runs. This makes the pagination loop load-bearing: if
+    deletion is moved outside the loop, list() never shrinks and the drain
+    exhausts its iteration cap instead of terminating on pre-canned empty pages.
+    """
+
+    def __init__(self, ids, page_size):
+        self._ids = list(ids)
+        self._page_size = page_size
+        self.list_calls = 0
+
+    def list(self, filters=None, top_k=None):
+        self.list_calls += 1
+        page = [SimpleNamespace(id=i) for i in self._ids[: self._page_size]]
+        return (page, None)
+
+    def delete(self, memory_id):
+        if memory_id in self._ids:
+            self._ids.remove(memory_id)
+
+
+def test_sync_delete_all_is_load_bearing_with_stateful_store(monkeypatch):
+    memory = _make_sync_memory()
+    store = _StatefulStore(ids=[f"m{i}" for i in range(5)], page_size=2)
+    memory.vector_store = store
+    memory._delete_memory = MagicMock(side_effect=store.delete)
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice", MagicMock())
+    monkeypatch.setattr(memory_main, "display_decay_usage_notice", MagicMock())
+
+    Memory.delete_all(memory, user_id="u1")
+
+    assert store._ids == []
+    assert memory._delete_memory.call_count == 5
+
+
+def test_sync_delete_all_propagates_delete_failures(monkeypatch):
+    memory = _make_sync_memory()
+    memory.vector_store.list.return_value = ([SimpleNamespace(id="m0")], None)
+    memory._delete_memory.side_effect = RuntimeError("backend down")
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice", MagicMock())
+
+    # Pre-pagination contract: a failed delete must surface, not be swallowed
+    # while still returning the success message.
+    with pytest.raises(RuntimeError, match="backend down"):
+        Memory.delete_all(memory, user_id="u1")
+
+
+def test_sync_delete_all_tolerates_stale_all_seen_page(monkeypatch):
+    memory = _make_sync_memory()
+    row = SimpleNamespace(id="m0")
+    later = SimpleNamespace(id="m1")
+    # Page with m0, then a stale page still showing (already-deleted) m0 due to
+    # refresh lag, then a previously-hidden m1 appears, then empty.
+    memory.vector_store.list.side_effect = [
+        ([row], None),
+        ([row], None),
+        ([later], None),
+        ([], None),
+    ]
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice", MagicMock())
+
+    Memory.delete_all(memory, user_id="u1")
+
+    deleted_ids = [c.args[0] for c in memory._delete_memory.call_args_list]
+    assert deleted_ids == ["m0", "m1"]
+
+
 @pytest.mark.asyncio
 async def test_async_delete_all_paginates_until_empty(monkeypatch):
     memory = _make_async_memory()
@@ -77,3 +151,26 @@ async def test_async_delete_all_paginates_until_empty(monkeypatch):
 
     assert memory.vector_store.list.call_count == 3
     assert memory._delete_memory.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_async_delete_all_is_load_bearing_with_stateful_store(monkeypatch):
+    memory = _make_async_memory()
+    store = _StatefulStore(ids=[f"a{i}" for i in range(5)], page_size=2)
+    memory.vector_store = store
+
+    async def _delete(memory_id, skip_entity_cleanup=False):
+        store.delete(memory_id)
+
+    memory._delete_memory = AsyncMock(side_effect=_delete)
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice_async", AsyncMock())
+    monkeypatch.setattr(memory_main, "display_decay_usage_notice_async", AsyncMock())
+
+    await AsyncMemory.delete_all(memory, user_id="u1")
+
+    # If deletion were moved outside the loop, list() would never shrink and
+    # the loop would run until the iteration cap; instead it drains cleanly.
+    assert store._ids == []
+    assert memory._delete_memory.await_count == 5

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from mem0.configs.base import MemoryConfig
-from mem0.memory.main import Memory, _validate_and_trim_entity_id
+from mem0.memory.main import Memory, _DELETE_ALL_PAGE_SIZE, _validate_and_trim_entity_id
 
 
 @pytest.fixture(autouse=True)
@@ -431,7 +431,9 @@ class TestEntityIdValidation:
 
         memory_instance.delete_all(user_id="  alice  ")
 
-        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "alice"})
+        memory_instance.vector_store.list.assert_called_once_with(
+            filters={"user_id": "alice"}, top_k=_DELETE_ALL_PAGE_SIZE
+        )
 
     def test_validate_coerces_non_string_entity_id(self):
         """Integer (and other non-string) ids are coerced to str, not crashed on."""
@@ -444,7 +446,9 @@ class TestEntityIdValidation:
 
         memory_instance.delete_all(user_id=42)
 
-        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "42"})
+        memory_instance.vector_store.list.assert_called_once_with(
+            filters={"user_id": "42"}, top_k=_DELETE_ALL_PAGE_SIZE
+        )
 
     def test_get_all_coerces_integer_user_id(self, memory_instance):
         """get_all should accept an integer user_id in filters and scope by its str form."""


### PR DESCRIPTION
## Summary

Part of #4869 (Python `delete_all` path; the TS `deleteAll` half is not touched here and remains tracked by #4869).

`Memory.delete_all()` and `AsyncMemory.delete_all()` only called `vector_store.list(filters=...)` once without `top_k`. Backends that default `list` size (commonly ~100) silently left remaining matches after bulk delete.

## Root cause

Caller assumed one `list()` returned the full filtered set. The vector-store `list` API has no cursor/offset contract; pagination is the caller's job.

## Fix

- Constants `_DELETE_ALL_PAGE_SIZE = 1000`, `_DELETE_ALL_MAX_ITERATIONS`, and `_DELETE_ALL_MAX_NO_PROGRESS`.
- Sync + async: loop `list(filters, top_k=...)`, delete the batch **inside** the loop (so subsequent lists shrink), `seen_ids` guard for lag.
- **Refresh-lag tolerance:** an all-seen page no longer breaks the drain immediately. Both paths retry a bounded number of no-progress pages before concluding, so Elasticsearch/OpenSearch-style stale pages don't hide later unseen rows.
- **Sync failure semantics preserved:** sync `delete_all` surfaces `_delete_memory` exceptions instead of swallowing them and returning success with residual memories.
- Async still runs `_bulk_clear_entity_store` after the drain; decay/first-run notices use `total_deleted`.

## Salvage credit

Rebases/extends **@cen-zp** #6465 (closed while iterating the same design) and the line of earlier work (#5950 @ly-wang19, #4872 @shafdev, etc.).

## Verification

```bash
uv run pytest tests/memory/test_delete_all_pagination.py tests/memory/test_decay_usage_notice.py -q
```

## Test plan

- [x] multi-page sync + async drain
- [x] **stateful-store load-bearing** sync + async (deletion must occur in-loop or list() never shrinks)
- [x] stale all-seen page followed by new ids (refresh-lag)
- [x] sync delete failure propagates
- [x] filters + top_k kwargs
- [x] existing delete_all decay notice tests