### PR TITLE
feat: add LanceDB vector store provider

### DIFF
--- a/docs/components/vectordbs/dbs/lancedb.mdx
+++ b/docs/components/vectordbs/dbs/lancedb.mdx
@@ -59,7 +59,7 @@ Here are the parameters available for configuring LanceDB:
 
 1. **Local persistence**: Vectors and payloads are stored under `path`. Persist that directory (or mount a volume in Docker) so data survives process restarts.
 2. **Single-writer deployments**: LanceDB local mode is best for one writer. Avoid multiple processes writing to the same database path concurrently.
-3. **Metadata filters**: Simple equality / `in` filters are applied after vector recall in Python. Complex operators such as `$and` / `$or` are not fully supported in the first version.
+3. **Metadata filters**: LanceDB supports Mem0's equality, list / `in`, wildcard, logical `AND` / `OR` / `NOT`, comparison, and string containment filters. To preserve arbitrary metadata keys while remaining compatible with LanceDB 0.17, filters are evaluated in Python after vector recall. Search expands the recall window until it finds `top_k` matches or reaches the end of the table, so highly selective filters can scan the full table and may be slower on large collections.
 4. **Embedding dimensions**: If you change `embedding_model_dims`, create a new table or rebuild the store. Existing tables keep the dimension they were created with.
 
 ### Distance Metrics

--- a/docs/components/vectordbs/dbs/lancedb.mdx
+++ b/docs/components/vectordbs/dbs/lancedb.mdx
@@ -68,4 +68,4 @@ LanceDB in Mem0 supports three distance metrics. Search results are returned as 
 
 - **cosine**: Cosine distance converted with `score = max(0.0, 1.0 - distance)`
 - **l2**: Euclidean distance converted with `score = 1.0 / (1.0 + distance)`
-- **dot**: Inner product / dot similarity (already higher = better)
+- **dot**: Inner product distance converted with `score = 1.0 - distance`

--- a/docs/components/vectordbs/dbs/lancedb.mdx
+++ b/docs/components/vectordbs/dbs/lancedb.mdx
@@ -1,0 +1,71 @@
+---
+title: "LanceDB"
+description: "Use LanceDB as a local, file-based vector store in Mem0 for embedded similarity search without an external database server."
+---
+[LanceDB](https://lancedb.github.io/lancedb/) is an open-source, embedded vector database built on the Lance columnar format. It stores vectors on the local filesystem, so you can run Mem0 without provisioning a separate vector database service. This makes LanceDB a strong fit for local development, single-node self-hosting, and lightweight deployments.
+
+### Usage
+
+```python
+import os
+from mem0 import Memory
+
+os.environ["OPENAI_API_KEY"] = "sk-xx"
+
+config = {
+    "vector_store": {
+        "provider": "lancedb",
+        "config": {
+            "collection_name": "memories",
+            "path": "/tmp/lancedb",
+            "embedding_model_dims": 1536,
+            "distance": "cosine",
+        },
+    }
+}
+
+m = Memory.from_config(config)
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thriller movies but I love sci-fi movies."},
+    {"role": "assistant", "content": "Got it! I'll avoid thriller recommendations and suggest sci-fi movies in the future."},
+]
+m.add(messages, user_id="alice", metadata={"category": "movies"})
+```
+
+### Installation
+
+Install Mem0 with the vector-store extras (includes LanceDB), or install LanceDB directly:
+
+```bash
+pip install "mem0ai[vector-stores]"
+# or
+pip install lancedb
+```
+
+### Config
+
+Here are the parameters available for configuring LanceDB:
+
+| Parameter | Description | Default Value |
+| --- | --- | --- |
+| `collection_name` | The name of the LanceDB table | `mem0` |
+| `path` | Local directory used as the LanceDB database path | `/tmp/lancedb` |
+| `embedding_model_dims` | Dimensions of the embedding model | `1536` |
+| `distance` | Distance metric to use (`cosine`, `l2`, or `dot`) | `cosine` |
+
+### Notes
+
+1. **Local persistence**: Vectors and payloads are stored under `path`. Persist that directory (or mount a volume in Docker) so data survives process restarts.
+2. **Single-writer deployments**: LanceDB local mode is best for one writer. Avoid multiple processes writing to the same database path concurrently.
+3. **Metadata filters**: Simple equality / `in` filters are applied after vector recall in Python. Complex operators such as `$and` / `$or` are not fully supported in the first version.
+4. **Embedding dimensions**: If you change `embedding_model_dims`, create a new table or rebuild the store. Existing tables keep the dimension they were created with.
+
+### Distance Metrics
+
+LanceDB in Mem0 supports three distance metrics. Search results are returned as similarity scores where higher is better:
+
+- **cosine**: Cosine distance converted with `score = max(0.0, 1.0 - distance)`
+- **l2**: Euclidean distance converted with `score = 1.0 / (1.0 + distance)`
+- **dot**: Inner product / dot similarity (already higher = better)

--- a/docs/components/vectordbs/overview.mdx
+++ b/docs/components/vectordbs/overview.mdx
@@ -31,6 +31,7 @@ See the list of supported vector databases below.
   <Card title="Vertex AI" icon="/images/provider-icons/vertexai.svg" href="/components/vectordbs/dbs/vertex_ai"></Card>
   <Card title="Weaviate" icon="circle-nodes" href="/components/vectordbs/dbs/weaviate"></Card>
   <Card title="FAISS" icon="layer-group" href="/components/vectordbs/dbs/faiss"></Card>
+  <Card title="LanceDB" icon="database" href="/components/vectordbs/dbs/lancedb"></Card>
   <Card title="LangChain" icon="/images/provider-icons/langchain-color.svg" href="/components/vectordbs/dbs/langchain"></Card>
   <Card title="Amazon S3 Vectors" icon="/images/provider-icons/aws-color.svg" href="/components/vectordbs/dbs/s3_vectors"></Card>
   <Card title="Neptune Analytics" icon="/images/provider-icons/aws-color.svg" href="/components/vectordbs/dbs/neptune_analytics"></Card>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -220,6 +220,7 @@
                               "components/vectordbs/dbs/vertex_ai",
                               "components/vectordbs/dbs/weaviate",
                               "components/vectordbs/dbs/faiss",
+                              "components/vectordbs/dbs/lancedb",
                               "components/vectordbs/dbs/langchain",
                               "components/vectordbs/dbs/baidu",
                               "components/vectordbs/dbs/cassandra",

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -486,6 +486,7 @@ Everything below is OSS-only provider configuration. Skip this entire section wh
 - [Vertex AI Vector Search](https://docs.mem0.ai/components/vectordbs/dbs/vertex_ai) [OSS]: Use when the store is Google Cloud Vertex Vector Search.
 - [Weaviate](https://docs.mem0.ai/components/vectordbs/dbs/weaviate) [OSS]: Use when Weaviate is the backing store.
 - [FAISS](https://docs.mem0.ai/components/vectordbs/dbs/faiss) [OSS]: Use for local FAISS-based similarity search.
+- [LanceDB](https://docs.mem0.ai/components/vectordbs/dbs/lancedb) [OSS]: Use for local LanceDB file-based similarity search.
 - [LangChain Vector Store](https://docs.mem0.ai/components/vectordbs/dbs/langchain) [OSS]: Use when the vector store is wrapped behind LangChain.
 - [Baidu](https://docs.mem0.ai/components/vectordbs/dbs/baidu) [OSS]: Use when the user is on Baidu Cloud vector service.
 - [Cassandra](https://docs.mem0.ai/components/vectordbs/dbs/cassandra) [OSS]: Use when Cassandra is the backing store.

--- a/mem0/configs/vector_stores/lancedb.py
+++ b/mem0/configs/vector_stores/lancedb.py
@@ -1,0 +1,33 @@
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class LanceDBConfig(BaseModel):
+    collection_name: str = Field("mem0", description="Default name for the table")
+    path: Optional[str] = Field("/tmp/lancedb", description="Path to the LanceDB database directory")
+    embedding_model_dims: int = Field(1536, description="Dimension of the embedding vector")
+    distance: str = Field("cosine", description="Distance metric. Options: 'cosine', 'l2', 'dot'")
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_distance(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        distance = values.get("distance")
+        if distance and distance not in {"cosine", "l2", "dot"}:
+            raise ValueError("Invalid distance. Must be one of: 'cosine', 'l2', 'dot'")
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_extra_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        allowed_fields = set(cls.model_fields.keys())
+        input_fields = set(values.keys())
+        extra_fields = input_fields - allowed_fields
+        if extra_fields:
+            raise ValueError(
+                f"Extra fields not allowed: {', '.join(extra_fields)}. "
+                f"Please input only the following fields: {', '.join(allowed_fields)}"
+            )
+        return values
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/configs/vector_stores/lancedb.py
+++ b/mem0/configs/vector_stores/lancedb.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 class LanceDBConfig(BaseModel):
     collection_name: str = Field("mem0", description="Default name for the table")
     path: Optional[str] = Field("/tmp/lancedb", description="Path to the LanceDB database directory")
-    embedding_model_dims: int = Field(1536, description="Dimension of the embedding vector")
+    embedding_model_dims: int = Field(1536, gt=0, description="Dimension of the embedding vector")
     distance: str = Field("cosine", description="Distance metric. Options: 'cosine', 'l2', 'dot'")
 
     @model_validator(mode="before")

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -202,6 +202,7 @@ class VectorStoreFactory:
         "neptune": "mem0.vector_stores.neptune_analytics.NeptuneAnalyticsVector",
         "turbopuffer": "mem0.vector_stores.turbopuffer.TurbopufferDB",
         "oracledb": "mem0.vector_stores.oracledb.OracleAIVectorSearch",
+        "lancedb": "mem0.vector_stores.lancedb.LanceDB",
     }
 
     @classmethod

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -36,6 +36,7 @@ class VectorStoreConfig(BaseModel):
         "s3_vectors": "S3VectorsConfig",
         "turbopuffer": "TurbopufferConfig",
         "oracledb": "OracleAIVectorSearchConfig",
+        "lancedb": "LanceDBConfig",
     }
 
     @model_validator(mode="after")

--- a/mem0/vector_stores/lancedb.py
+++ b/mem0/vector_stores/lancedb.py
@@ -16,6 +16,10 @@ from mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 
+_FILTER_OPERATORS = {"eq", "ne", "gt", "gte", "lt", "lte", "in", "nin", "contains", "icontains"}
+_LOGICAL_FILTER_ALIASES = {"AND": "$and", "OR": "$or", "NOT": "$not"}
+_LOGICAL_FILTER_OPERATORS = {"$and", "$or", "$not"}
+
 
 class OutputData(BaseModel):
     id: Optional[str]
@@ -89,19 +93,7 @@ class LanceDB(VectorStoreBase):
         if not isinstance(expected, dict):
             return actual == expected
 
-        supported_operators = {
-            "eq",
-            "ne",
-            "gt",
-            "gte",
-            "lt",
-            "lte",
-            "in",
-            "nin",
-            "contains",
-            "icontains",
-        }
-        unsupported = set(expected) - supported_operators
+        unsupported = set(expected) - _FILTER_OPERATORS
         if unsupported:
             raise ValueError(f"Unsupported filter operator(s): {sorted(unsupported)}")
 
@@ -133,23 +125,69 @@ class LanceDB(VectorStoreBase):
         return True
 
     @classmethod
+    def _validate_filters(cls, filters: Dict) -> None:
+        if not isinstance(filters, dict):
+            raise ValueError("Filters must be a dictionary")
+
+        for key, expected in filters.items():
+            if not isinstance(key, str):
+                raise ValueError("Filter field names must be strings")
+
+            logical_key = _LOGICAL_FILTER_ALIASES.get(key, key)
+            if logical_key in _LOGICAL_FILTER_OPERATORS:
+                if not isinstance(expected, list) or not all(isinstance(item, dict) for item in expected):
+                    raise ValueError(f"{logical_key} filter value must be a list of filter dictionaries")
+                for item in expected:
+                    cls._validate_filters(item)
+                continue
+
+            if key.startswith("$"):
+                raise ValueError(f"Unsupported logical filter operator: {key}")
+
+            if not isinstance(expected, dict):
+                continue
+            if not expected:
+                raise ValueError(f"Operator filter for field {key!r} must not be empty")
+
+            unsupported = set(expected) - _FILTER_OPERATORS
+            if unsupported:
+                raise ValueError(f"Unsupported filter operator(s): {sorted(unsupported)}")
+
+            for operator, value in expected.items():
+                if operator in {"eq", "ne", "gt", "gte", "lt", "lte"}:
+                    if isinstance(value, (dict, list, tuple, set)):
+                        raise ValueError(f"Filter operator {operator!r} requires a scalar value")
+                    if operator in {"gt", "gte", "lt", "lte"} and value is None:
+                        raise ValueError(f"Filter operator {operator!r} does not support null")
+                    continue
+
+                if operator in {"in", "nin"}:
+                    if not isinstance(value, (list, tuple)) or not value:
+                        raise ValueError(f"Filter operator {operator!r} requires a non-empty list")
+                    if any(isinstance(item, (dict, list, tuple, set)) for item in value):
+                        raise ValueError(f"Filter operator {operator!r} list items must be scalar values")
+                    continue
+
+                if not isinstance(value, str):
+                    raise ValueError(f"Filter operator {operator!r} requires a string value")
+
+    @classmethod
     def _apply_filters(cls, payload: Dict, filters: Optional[Dict]) -> bool:
         if not filters:
             return True
-        if not payload:
-            return False
 
         for key, expected in filters.items():
-            if key in {"$and", "$or", "$not"}:
+            logical_key = _LOGICAL_FILTER_ALIASES.get(key, key)
+            if logical_key in _LOGICAL_FILTER_OPERATORS:
                 if not isinstance(expected, list) or not all(isinstance(item, dict) for item in expected):
-                    raise ValueError(f"{key} filter value must be a list of filter dictionaries")
+                    raise ValueError(f"{logical_key} filter value must be a list of filter dictionaries")
 
                 matches = [cls._apply_filters(payload, item) for item in expected]
-                if key == "$and" and not all(matches):
+                if logical_key == "$and" and not all(matches):
                     return False
-                if key == "$or" and not any(matches):
+                if logical_key == "$or" and not any(matches):
                     return False
-                if key == "$not" and any(matches):
+                if logical_key == "$not" and any(matches):
                     return False
                 continue
 
@@ -221,6 +259,11 @@ class LanceDB(VectorStoreBase):
     def search(
         self, query: str, vectors: List[list], top_k: int = 5, filters: Optional[Dict] = None
     ) -> List[OutputData]:
+        if filters:
+            self._validate_filters(filters)
+        if top_k == 0:
+            return []
+
         query_vector = vectors[0] if vectors and isinstance(vectors[0], list) else vectors
         if not filters:
             rows = self.table.search(query_vector).metric(self.distance).limit(top_k).to_list()
@@ -292,6 +335,11 @@ class LanceDB(VectorStoreBase):
         }
 
     def list(self, filters: Optional[Dict] = None, top_k: int = 100) -> List[List[OutputData]]:
+        if filters:
+            self._validate_filters(filters)
+        if top_k == 0:
+            return [[]]
+
         rows = self.table.to_arrow().to_pylist()
         results: List[OutputData] = []
         for row in rows:

--- a/mem0/vector_stores/lancedb.py
+++ b/mem0/vector_stores/lancedb.py
@@ -1,0 +1,242 @@
+import json
+import logging
+import os
+import uuid
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+try:
+    import lancedb
+    import pyarrow as pa
+except ImportError:
+    raise ImportError("The 'lancedb' library is required. Please install it using 'pip install lancedb'.")
+
+from mem0.vector_stores.base import VectorStoreBase
+
+logger = logging.getLogger(__name__)
+
+
+class OutputData(BaseModel):
+    id: Optional[str]
+    score: Optional[float]
+    payload: Optional[Dict]
+
+
+class LanceDB(VectorStoreBase):
+    def __init__(
+        self,
+        collection_name: str = "mem0",
+        path: Optional[str] = None,
+        embedding_model_dims: int = 1536,
+        distance: str = "cosine",
+    ):
+        self.collection_name = collection_name
+        self.path = path or "/tmp/lancedb"
+        self.embedding_model_dims = embedding_model_dims
+        self.distance = distance
+
+        os.makedirs(self.path, exist_ok=True)
+        self.client = lancedb.connect(self.path)
+        self.table = self.create_col(collection_name)
+
+    def _schema(self):
+        return pa.schema(
+            [
+                pa.field("id", pa.string()),
+                pa.field("vector", pa.list_(pa.float32(), self.embedding_model_dims)),
+                pa.field("payload", pa.string()),
+            ]
+        )
+
+    def _table_names(self) -> List[str]:
+        list_tables = getattr(self.client, "list_tables", None)
+        if callable(list_tables):
+            return list_tables()
+        table_names = self.client.table_names()
+        return table_names() if callable(table_names) else table_names
+
+    @staticmethod
+    def _escape_sql_string(value: str) -> str:
+        return str(value).replace("'", "''")
+
+    @classmethod
+    def _id_where(cls, vector_id: str) -> str:
+        return f"id = '{cls._escape_sql_string(vector_id)}'"
+
+    @staticmethod
+    def _dump_payload(payload: Optional[Dict]) -> str:
+        return json.dumps(payload or {}, ensure_ascii=False, separators=(",", ":"))
+
+    @staticmethod
+    def _load_payload(payload: Optional[str]) -> Dict:
+        if not payload:
+            return {}
+        if isinstance(payload, dict):
+            return payload
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError:
+            logger.warning("Failed to decode LanceDB payload JSON")
+            return {}
+
+    @staticmethod
+    def _apply_filters(payload: Dict, filters: Optional[Dict]) -> bool:
+        if not filters:
+            return True
+        if not payload:
+            return False
+
+        for key, expected in filters.items():
+            if key not in payload:
+                return False
+
+            actual = payload[key]
+            if isinstance(expected, list):
+                if actual not in expected:
+                    return False
+            elif isinstance(expected, dict):
+                if "eq" in expected and actual != expected["eq"]:
+                    return False
+                if "in" in expected and actual not in expected["in"]:
+                    return False
+                if not any(op in expected for op in ("eq", "in")):
+                    return False
+            elif actual != expected:
+                return False
+
+        return True
+
+    def _score_from_distance(self, raw_score: Optional[float]) -> Optional[float]:
+        if raw_score is None:
+            return None
+        raw_score = float(raw_score)
+        if self.distance == "dot":
+            return raw_score
+        if self.distance == "cosine":
+            return max(0.0, 1.0 - raw_score)
+        return 1.0 / (1.0 + raw_score)
+
+    def _parse_row(self, row: Dict) -> OutputData:
+        raw_score = row.get("_distance")
+        if raw_score is None:
+            raw_score = row.get("_score")
+        return OutputData(
+            id=row.get("id"),
+            score=self._score_from_distance(raw_score),
+            payload=self._load_payload(row.get("payload")),
+        )
+
+    def create_col(self, name: str, vector_size: Optional[int] = None, distance: Optional[str] = None):
+        if vector_size:
+            self.embedding_model_dims = vector_size
+        if distance:
+            self.distance = distance
+
+        self.collection_name = name
+        if name in self._table_names():
+            return self.client.open_table(name)
+
+        return self.client.create_table(name, schema=self._schema())
+
+    def insert(
+        self,
+        vectors: List[list],
+        payloads: Optional[List[Dict]] = None,
+        ids: Optional[List[str]] = None,
+    ):
+        if ids is None:
+            ids = [str(uuid.uuid4()) for _ in vectors]
+        if payloads is None:
+            payloads = [{} for _ in vectors]
+        if len(vectors) != len(ids) or len(vectors) != len(payloads):
+            raise ValueError("Vectors, payloads, and IDs must have the same length")
+
+        rows = [
+            {
+                "id": vector_id,
+                "vector": [float(value) for value in vector],
+                "payload": self._dump_payload(payload),
+            }
+            for vector_id, vector, payload in zip(ids, vectors, payloads)
+        ]
+        self.table.add(rows)
+        logger.info("Inserted %s vectors into LanceDB table %s", len(rows), self.collection_name)
+
+    def search(
+        self, query: str, vectors: List[list], top_k: int = 5, filters: Optional[Dict] = None
+    ) -> List[OutputData]:
+        query_vector = vectors[0] if vectors and isinstance(vectors[0], list) else vectors
+        fetch_k = max(top_k * 5, 50) if filters else top_k
+
+        rows = self.table.search(query_vector).metric(self.distance).limit(fetch_k).to_list()
+
+        results: List[OutputData] = []
+        for row in rows:
+            parsed = self._parse_row(row)
+            if filters and not self._apply_filters(parsed.payload or {}, filters):
+                continue
+            results.append(parsed)
+            if len(results) >= top_k:
+                break
+        return results
+
+    def delete(self, vector_id: str):
+        self.table.delete(self._id_where(vector_id))
+
+    def update(
+        self,
+        vector_id: str,
+        vector: Optional[List[float]] = None,
+        payload: Optional[Dict] = None,
+    ):
+        existing = self.get(vector_id)
+        if existing is None:
+            raise ValueError(f"Vector {vector_id} not found")
+
+        next_payload = payload if payload is not None else existing.payload
+        if vector is None:
+            self.table.update(where=self._id_where(vector_id), values={"payload": self._dump_payload(next_payload)})
+            return
+
+        self.delete(vector_id)
+        self.insert(vectors=[vector], payloads=[next_payload or {}], ids=[vector_id])
+
+    def get(self, vector_id: str) -> Optional[OutputData]:
+        for row in self.table.to_arrow().to_pylist():
+            if row.get("id") == vector_id:
+                return self._parse_row(row)
+        return None
+
+    def list_cols(self) -> List[str]:
+        return self._table_names()
+
+    def delete_col(self):
+        if self.collection_name in self._table_names():
+            self.client.drop_table(self.collection_name)
+        self.table = None
+
+    def col_info(self) -> Dict:
+        count = self.table.count_rows() if self.table is not None else 0
+        return {
+            "name": self.collection_name,
+            "count": count,
+            "dimension": self.embedding_model_dims,
+            "distance": self.distance,
+        }
+
+    def list(self, filters: Optional[Dict] = None, top_k: int = 100) -> List[List[OutputData]]:
+        rows = self.table.to_arrow().to_pylist()
+        results: List[OutputData] = []
+        for row in rows:
+            parsed = self._parse_row(row)
+            if filters and not self._apply_filters(parsed.payload or {}, filters):
+                continue
+            results.append(parsed)
+            if len(results) >= top_k:
+                break
+        return [results]
+
+    def reset(self):
+        logger.warning("Resetting LanceDB table %s...", self.collection_name)
+        self.table = self.client.create_table(self.collection_name, schema=self._schema(), mode="overwrite")

--- a/mem0/vector_stores/lancedb.py
+++ b/mem0/vector_stores/lancedb.py
@@ -72,8 +72,6 @@ class LanceDB(VectorStoreBase):
     def _load_payload(payload: Optional[str]) -> Dict:
         if not payload:
             return {}
-        if isinstance(payload, dict):
-            return payload
         try:
             return json.loads(payload)
         except json.JSONDecodeError:
@@ -112,15 +110,13 @@ class LanceDB(VectorStoreBase):
             return None
         raw_score = float(raw_score)
         if self.distance == "dot":
-            return raw_score
+            return 1.0 - raw_score
         if self.distance == "cosine":
             return max(0.0, 1.0 - raw_score)
         return 1.0 / (1.0 + raw_score)
 
     def _parse_row(self, row: Dict) -> OutputData:
         raw_score = row.get("_distance")
-        if raw_score is None:
-            raw_score = row.get("_score")
         return OutputData(
             id=row.get("id"),
             score=self._score_from_distance(raw_score),
@@ -203,10 +199,8 @@ class LanceDB(VectorStoreBase):
         self.insert(vectors=[vector], payloads=[next_payload or {}], ids=[vector_id])
 
     def get(self, vector_id: str) -> Optional[OutputData]:
-        for row in self.table.to_arrow().to_pylist():
-            if row.get("id") == vector_id:
-                return self._parse_row(row)
-        return None
+        rows = self.table.search().where(self._id_where(vector_id)).limit(1).to_list()
+        return self._parse_row(rows[0]) if rows else None
 
     def list_cols(self) -> List[str]:
         return self._table_names()

--- a/mem0/vector_stores/lancedb.py
+++ b/mem0/vector_stores/lancedb.py
@@ -79,28 +79,87 @@ class LanceDB(VectorStoreBase):
             return {}
 
     @staticmethod
-    def _apply_filters(payload: Dict, filters: Optional[Dict]) -> bool:
+    def _matches_filter_value(actual, expected) -> bool:
+        if expected == "*":
+            return True
+
+        if isinstance(expected, list):
+            return actual in expected
+
+        if not isinstance(expected, dict):
+            return actual == expected
+
+        supported_operators = {
+            "eq",
+            "ne",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
+            "in",
+            "nin",
+            "contains",
+            "icontains",
+        }
+        unsupported = set(expected) - supported_operators
+        if unsupported:
+            raise ValueError(f"Unsupported filter operator(s): {sorted(unsupported)}")
+
+        for operator, value in expected.items():
+            try:
+                if operator == "eq" and actual != value:
+                    return False
+                if operator == "ne" and actual == value:
+                    return False
+                if operator == "gt" and actual <= value:
+                    return False
+                if operator == "gte" and actual < value:
+                    return False
+                if operator == "lt" and actual >= value:
+                    return False
+                if operator == "lte" and actual > value:
+                    return False
+                if operator == "in" and actual not in value:
+                    return False
+                if operator == "nin" and actual in value:
+                    return False
+                if operator == "contains" and value not in actual:
+                    return False
+                if operator == "icontains" and str(value).lower() not in str(actual).lower():
+                    return False
+            except TypeError:
+                return False
+
+        return True
+
+    @classmethod
+    def _apply_filters(cls, payload: Dict, filters: Optional[Dict]) -> bool:
         if not filters:
             return True
         if not payload:
             return False
 
         for key, expected in filters.items():
+            if key in {"$and", "$or", "$not"}:
+                if not isinstance(expected, list) or not all(isinstance(item, dict) for item in expected):
+                    raise ValueError(f"{key} filter value must be a list of filter dictionaries")
+
+                matches = [cls._apply_filters(payload, item) for item in expected]
+                if key == "$and" and not all(matches):
+                    return False
+                if key == "$or" and not any(matches):
+                    return False
+                if key == "$not" and any(matches):
+                    return False
+                continue
+
+            if key.startswith("$"):
+                raise ValueError(f"Unsupported logical filter operator: {key}")
+
             if key not in payload:
                 return False
 
-            actual = payload[key]
-            if isinstance(expected, list):
-                if actual not in expected:
-                    return False
-            elif isinstance(expected, dict):
-                if "eq" in expected and actual != expected["eq"]:
-                    return False
-                if "in" in expected and actual not in expected["in"]:
-                    return False
-                if not any(op in expected for op in ("eq", "in")):
-                    return False
-            elif actual != expected:
+            if not cls._matches_filter_value(payload[key], expected):
                 return False
 
         return True
@@ -163,19 +222,32 @@ class LanceDB(VectorStoreBase):
         self, query: str, vectors: List[list], top_k: int = 5, filters: Optional[Dict] = None
     ) -> List[OutputData]:
         query_vector = vectors[0] if vectors and isinstance(vectors[0], list) else vectors
-        fetch_k = max(top_k * 5, 50) if filters else top_k
+        if not filters:
+            rows = self.table.search(query_vector).metric(self.distance).limit(top_k).to_list()
+            return [self._parse_row(row) for row in rows]
 
-        rows = self.table.search(query_vector).metric(self.distance).limit(fetch_k).to_list()
+        table_size = self.table.count_rows()
+        if table_size == 0:
+            return []
 
-        results: List[OutputData] = []
-        for row in rows:
-            parsed = self._parse_row(row)
-            if filters and not self._apply_filters(parsed.payload or {}, filters):
-                continue
-            results.append(parsed)
-            if len(results) >= top_k:
-                break
-        return results
+        # LanceDB 0.17 cannot query arbitrary fields inside the JSON payload.
+        # Grow the vector recall window until enough filtered matches are found
+        # so a selective filter cannot silently under-return top_k results.
+        fetch_k = min(max(top_k * 5, 50), table_size)
+        while True:
+            rows = self.table.search(query_vector).metric(self.distance).limit(fetch_k).to_list()
+            results: List[OutputData] = []
+            for row in rows:
+                parsed = self._parse_row(row)
+                if self._apply_filters(parsed.payload or {}, filters):
+                    results.append(parsed)
+                    if len(results) >= top_k:
+                        break
+
+            if len(results) >= top_k or fetch_k >= table_size:
+                return results[:top_k]
+
+            fetch_k = min(fetch_k * 2, table_size)
 
     def delete(self, vector_id: str):
         self.table.delete(self._id_where(vector_id))
@@ -188,7 +260,7 @@ class LanceDB(VectorStoreBase):
     ):
         existing = self.get(vector_id)
         if existing is None:
-            raise ValueError(f"Vector {vector_id} not found")
+            return
 
         next_payload = payload if payload is not None else existing.payload
         if vector is None:

--- a/mem0/vector_stores/lancedb.py
+++ b/mem0/vector_stores/lancedb.py
@@ -10,7 +10,10 @@ try:
     import lancedb
     import pyarrow as pa
 except ImportError:
-    raise ImportError("The 'lancedb' library is required. Please install it using 'pip install lancedb'.")
+    raise ImportError(
+        "The 'lancedb' library is required. Please install it using "
+        "'pip install \"mem0ai[vector-stores]\"' or 'pip install lancedb'."
+    )
 
 from mem0.vector_stores.base import VectorStoreBase
 
@@ -35,6 +38,7 @@ class LanceDB(VectorStoreBase):
         embedding_model_dims: int = 1536,
         distance: str = "cosine",
     ):
+        self._validate_embedding_dimension(embedding_model_dims)
         self.collection_name = collection_name
         self.path = path or "/tmp/lancedb"
         self.embedding_model_dims = embedding_model_dims
@@ -44,11 +48,12 @@ class LanceDB(VectorStoreBase):
         self.client = lancedb.connect(self.path)
         self.table = self.create_col(collection_name)
 
-    def _schema(self):
+    def _schema(self, vector_size: Optional[int] = None):
+        dimension = self.embedding_model_dims if vector_size is None else vector_size
         return pa.schema(
             [
                 pa.field("id", pa.string()),
-                pa.field("vector", pa.list_(pa.float32(), self.embedding_model_dims)),
+                pa.field("vector", pa.list_(pa.float32(), dimension)),
                 pa.field("payload", pa.string()),
             ]
         )
@@ -56,9 +61,28 @@ class LanceDB(VectorStoreBase):
     def _table_names(self) -> List[str]:
         list_tables = getattr(self.client, "list_tables", None)
         if callable(list_tables):
-            return list_tables()
-        table_names = self.client.table_names()
-        return table_names() if callable(table_names) else table_names
+            names: List[str] = []
+            page_token = None
+            while True:
+                response = list_tables(page_token=page_token)
+                names.extend(getattr(response, "tables", response))
+                page_token = getattr(response, "page_token", None)
+                if not page_token:
+                    return names
+
+        table_names = self.client.table_names
+        if not callable(table_names):
+            return list(table_names)
+
+        names: List[str] = []
+        page_token = None
+        page_size = 100
+        while True:
+            page = list(table_names(page_token=page_token, limit=page_size))
+            names.extend(page)
+            if len(page) < page_size:
+                return names
+            page_token = page[-1]
 
     @staticmethod
     def _escape_sql_string(value: str) -> str:
@@ -70,17 +94,44 @@ class LanceDB(VectorStoreBase):
 
     @staticmethod
     def _dump_payload(payload: Optional[Dict]) -> str:
-        return json.dumps(payload or {}, ensure_ascii=False, separators=(",", ":"))
+        if payload is None:
+            payload = {}
+        elif not isinstance(payload, dict):
+            raise TypeError("Payload must be a dictionary or None")
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+    def _normalize_vector(self, vector: List[float]) -> List[float]:
+        normalized = [float(value) for value in vector]
+        if len(normalized) != self.embedding_model_dims:
+            raise ValueError(
+                f"Vector has dimension {len(normalized)}, but LanceDB collection {self.collection_name!r} "
+                f"expects {self.embedding_model_dims}"
+            )
+        return normalized
+
+    @staticmethod
+    def _validate_top_k(top_k: int) -> None:
+        if not isinstance(top_k, int) or isinstance(top_k, bool) or top_k < 0:
+            raise ValueError("top_k must be a non-negative integer")
+
+    @staticmethod
+    def _validate_embedding_dimension(dimension: int) -> None:
+        if not isinstance(dimension, int) or dimension <= 0:
+            raise ValueError("embedding_model_dims must be a positive integer")
 
     @staticmethod
     def _load_payload(payload: Optional[str]) -> Dict:
         if not payload:
             return {}
         try:
-            return json.loads(payload)
-        except json.JSONDecodeError:
+            loaded = json.loads(payload)
+        except (json.JSONDecodeError, TypeError):
             logger.warning("Failed to decode LanceDB payload JSON")
             return {}
+        if not isinstance(loaded, dict):
+            logger.warning("LanceDB payload JSON must decode to a dictionary")
+            return {}
+        return loaded
 
     @staticmethod
     def _matches_filter_value(actual, expected) -> bool:
@@ -221,16 +272,26 @@ class LanceDB(VectorStoreBase):
         )
 
     def create_col(self, name: str, vector_size: Optional[int] = None, distance: Optional[str] = None):
-        if vector_size:
-            self.embedding_model_dims = vector_size
-        if distance:
-            self.distance = distance
+        next_dimension = self.embedding_model_dims if vector_size is None else vector_size
+        next_distance = self.distance if distance is None else distance
+        self._validate_embedding_dimension(next_dimension)
+
+        if name in self._table_names():
+            table = self.client.open_table(name)
+            existing_dimension = getattr(table.schema.field("vector").type, "list_size", None)
+            if existing_dimension != next_dimension:
+                raise ValueError(
+                    f"LanceDB collection {name!r} uses embedding dimension {existing_dimension}, "
+                    f"but requested {next_dimension}"
+                )
+        else:
+            table = self.client.create_table(name, schema=self._schema(next_dimension))
 
         self.collection_name = name
-        if name in self._table_names():
-            return self.client.open_table(name)
-
-        return self.client.create_table(name, schema=self._schema())
+        self.embedding_model_dims = next_dimension
+        self.distance = next_distance
+        self.table = table
+        return table
 
     def insert(
         self,
@@ -248,7 +309,7 @@ class LanceDB(VectorStoreBase):
         rows = [
             {
                 "id": vector_id,
-                "vector": [float(value) for value in vector],
+                "vector": self._normalize_vector(vector),
                 "payload": self._dump_payload(payload),
             }
             for vector_id, vector, payload in zip(ids, vectors, payloads)
@@ -259,12 +320,14 @@ class LanceDB(VectorStoreBase):
     def search(
         self, query: str, vectors: List[list], top_k: int = 5, filters: Optional[Dict] = None
     ) -> List[OutputData]:
-        if filters:
+        self._validate_top_k(top_k)
+        if filters is not None:
             self._validate_filters(filters)
         if top_k == 0:
             return []
 
         query_vector = vectors[0] if vectors and isinstance(vectors[0], list) else vectors
+        query_vector = self._normalize_vector(query_vector)
         if not filters:
             rows = self.table.search(query_vector).metric(self.distance).limit(top_k).to_list()
             return [self._parse_row(row) for row in rows]
@@ -305,13 +368,15 @@ class LanceDB(VectorStoreBase):
         if existing is None:
             return
 
-        next_payload = payload if payload is not None else existing.payload
-        if vector is None:
-            self.table.update(where=self._id_where(vector_id), values={"payload": self._dump_payload(next_payload)})
+        values = {}
+        if vector is not None:
+            values["vector"] = self._normalize_vector(vector)
+        if payload is not None:
+            values["payload"] = self._dump_payload(payload)
+        if not values:
             return
 
-        self.delete(vector_id)
-        self.insert(vectors=[vector], payloads=[next_payload or {}], ids=[vector_id])
+        self.table.update(where=self._id_where(vector_id), values=values)
 
     def get(self, vector_id: str) -> Optional[OutputData]:
         rows = self.table.search().where(self._id_where(vector_id)).limit(1).to_list()
@@ -335,7 +400,8 @@ class LanceDB(VectorStoreBase):
         }
 
     def list(self, filters: Optional[Dict] = None, top_k: int = 100) -> List[List[OutputData]]:
-        if filters:
+        self._validate_top_k(top_k)
+        if filters is not None:
             self._validate_filters(filters)
         if top_k == 0:
             return [[]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ vector-stores = [
     "pymilvus>=2.4.0,<2.6.0",
     "langchain-aws>=0.2.23,<0.3.0",
     "oracledb>=2.2.0",
+    "lancedb>=0.17.0,<1.0.0",
 ]
 llms = [
     "groq>=0.3.0",

--- a/tests/vector_stores/test_lancedb.py
+++ b/tests/vector_stores/test_lancedb.py
@@ -1,4 +1,7 @@
+import builtins
+import importlib.util
 import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -6,6 +9,24 @@ pytest.importorskip("lancedb")
 
 from mem0.vector_stores.configs import VectorStoreConfig
 from mem0.vector_stores.lancedb import LanceDB
+from mem0.utils.factory import VectorStoreFactory
+
+
+def test_lancedb_import_error_mentions_vector_stores_extra(monkeypatch):
+    real_import = builtins.__import__
+
+    def fail_lancedb_import(name, *args, **kwargs):
+        if name == "lancedb":
+            raise ImportError("No module named 'lancedb'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_lancedb_import)
+    module_path = Path(__file__).parents[2] / "mem0" / "vector_stores" / "lancedb.py"
+    spec = importlib.util.spec_from_file_location("missing_lancedb_test_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+
+    with pytest.raises(ImportError, match="mem0ai\\[vector-stores\\]"):
+        spec.loader.exec_module(module)
 
 
 @pytest.fixture
@@ -44,6 +65,47 @@ def test_lancedb_config_accepts_local_settings():
     assert config.config.collection_name == "memories"
     assert config.config.embedding_model_dims == 3
     assert config.config.distance == "cosine"
+
+
+def test_lancedb_factory_creates_a_persistent_store(tmp_path):
+    config = VectorStoreConfig(
+        provider="lancedb",
+        config={
+            "path": str(tmp_path),
+            "collection_name": "factory_memories",
+            "embedding_model_dims": 2,
+            "distance": "cosine",
+        },
+    )
+
+    store = VectorStoreFactory.create("lancedb", config.config)
+
+    assert isinstance(store, LanceDB)
+    assert store.col_info() == {
+        "name": "factory_memories",
+        "count": 0,
+        "dimension": 2,
+        "distance": "cosine",
+    }
+
+
+@pytest.mark.parametrize("embedding_model_dims", [0, -1])
+def test_lancedb_config_rejects_non_positive_embedding_dimensions(embedding_model_dims):
+    with pytest.raises(ValueError, match="greater than 0"):
+        VectorStoreConfig(
+            provider="lancedb",
+            config={"embedding_model_dims": embedding_model_dims},
+        )
+
+
+@pytest.mark.parametrize("embedding_model_dims", [0, -1])
+def test_lancedb_rejects_non_positive_embedding_dimensions_when_constructed_directly(tmp_path, embedding_model_dims):
+    with pytest.raises(ValueError, match="embedding_model_dims must be a positive integer"):
+        LanceDB(
+            collection_name="invalid_dimension_memories",
+            path=str(tmp_path),
+            embedding_model_dims=embedding_model_dims,
+        )
 
 
 def test_lancedb_crud_search_and_filters():
@@ -102,6 +164,109 @@ def test_lancedb_crud_search_and_filters():
 
         store.reset()
         assert store.col_info()["count"] == 0
+
+
+def test_lancedb_reopens_an_existing_collection(tmp_path):
+    first = LanceDB(
+        collection_name="persisted_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+    first.insert(vectors=[[1.0, 0.0]], ids=["m1"], payloads=[{"value": "persisted"}])
+
+    reopened = LanceDB(
+        collection_name="persisted_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+
+    assert reopened.get("m1").payload == {"value": "persisted"}
+
+
+def test_lancedb_list_cols_returns_all_collection_names(tmp_path):
+    expected_names = [f"memories_{index:02d}" for index in range(12)]
+    store = None
+    for name in expected_names:
+        store = LanceDB(
+            collection_name=name,
+            path=str(tmp_path),
+            embedding_model_dims=2,
+            distance="cosine",
+        )
+
+    assert store.list_cols() == expected_names
+
+
+def test_lancedb_delete_col_removes_the_collection(tmp_path):
+    store = LanceDB(
+        collection_name="deleted_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+
+    store.delete_col()
+
+    assert store.table is None
+    assert "deleted_memories" not in store.list_cols()
+
+
+def test_lancedb_create_col_switches_the_active_collection(tmp_path):
+    store = LanceDB(
+        collection_name="first_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+    store.insert(vectors=[[1.0, 0.0]], ids=["first"], payloads=[{"collection": "first"}])
+
+    store.create_col("second_memories")
+    store.insert(vectors=[[0.0, 1.0]], ids=["second"], payloads=[{"collection": "second"}])
+
+    assert store.col_info()["name"] == "second_memories"
+    assert store.col_info()["count"] == 1
+    assert store.get("second").payload == {"collection": "second"}
+    assert store.client.open_table("first_memories").count_rows() == 1
+
+
+def test_lancedb_rejects_existing_collection_dimension_mismatch(tmp_path):
+    LanceDB(
+        collection_name="dimensioned_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+
+    with pytest.raises(ValueError, match="uses embedding dimension 2.*requested 3"):
+        LanceDB(
+            collection_name="dimensioned_memories",
+            path=str(tmp_path),
+            embedding_model_dims=3,
+            distance="cosine",
+        )
+
+
+def test_lancedb_failed_collection_switch_preserves_the_active_collection(tmp_path):
+    store = LanceDB(
+        collection_name="stable_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+    store.insert(vectors=[[1.0, 0.0]], ids=["m1"], payloads=[{"stable": True}])
+
+    with pytest.raises(ValueError, match="uses embedding dimension 2.*requested 3"):
+        store.create_col("stable_memories", vector_size=3, distance="l2")
+
+    assert store.col_info() == {
+        "name": "stable_memories",
+        "count": 1,
+        "dimension": 2,
+        "distance": "cosine",
+    }
+    assert store.get("m1").payload == {"stable": True}
 
 
 def test_lancedb_dot_distance_similarity_direction():
@@ -208,6 +373,52 @@ def test_lancedb_list_returns_no_results_when_top_k_is_zero(populated_filter_sto
     assert results == [[]]
 
 
+@pytest.mark.parametrize("top_k", [-1, 1.5, None, True])
+@pytest.mark.parametrize("operation", ["search", "list"])
+def test_lancedb_rejects_invalid_top_k_before_querying_an_empty_table(tmp_path, operation, top_k):
+    store = LanceDB(
+        collection_name="invalid_top_k_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+
+    with pytest.raises(ValueError, match="top_k must be a non-negative integer"):
+        if operation == "search":
+            store.search(query="", vectors=[1.0, 0.0], top_k=top_k)
+        else:
+            store.list(top_k=top_k)
+
+
+@pytest.mark.parametrize("operation", ["search", "list"])
+def test_lancedb_rejects_non_dictionary_filters_even_when_empty(tmp_path, operation):
+    store = LanceDB(
+        collection_name="invalid_filter_type_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+
+    with pytest.raises(ValueError, match="Filters must be a dictionary"):
+        if operation == "search":
+            store.search(query="", vectors=[1.0, 0.0], filters=[])
+        else:
+            store.list(filters=[])
+
+
+@pytest.mark.parametrize("filters", [None, {"user_id": "alice"}])
+def test_lancedb_rejects_invalid_query_vector_before_searching_an_empty_table(tmp_path, filters):
+    store = LanceDB(
+        collection_name="invalid_query_vector_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+
+    with pytest.raises(ValueError, match="Vector has dimension 3.*expects 2"):
+        store.search(query="", vectors=[1.0, 0.0, 0.0], filters=filters)
+
+
 def test_lancedb_search_expands_recall_until_top_k_filtered_results_are_found(tmp_path):
     store = LanceDB(
         collection_name="recall_memories",
@@ -287,3 +498,87 @@ def test_lancedb_update_missing_id_is_a_noop(tmp_path):
     store.update("missing", payload={"user_id": "alice"})
 
     assert store.col_info()["count"] == 0
+
+
+@pytest.mark.parametrize(
+    ("vector", "payload", "error"),
+    [
+        ([1.0, 0.0, 0.0], {"safe": False}, ValueError),
+        (["not-a-number", 0.0], {"safe": False}, ValueError),
+        ([0.0, 1.0], {"bad": {1, 2}}, TypeError),
+    ],
+)
+def test_lancedb_failed_vector_update_preserves_the_existing_record(tmp_path, vector, payload, error):
+    store = LanceDB(
+        collection_name="safe_update_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+    store.insert(vectors=[[1.0, 0.0]], ids=["m1"], payloads=[{"safe": True}])
+
+    with pytest.raises(error):
+        store.update("m1", vector=vector, payload=payload)
+
+    assert store.get("m1").payload == {"safe": True}
+
+
+def test_lancedb_vector_only_update_preserves_the_existing_payload(tmp_path):
+    store = LanceDB(
+        collection_name="vector_only_update_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+    store.insert(vectors=[[1.0, 0.0]], ids=["m1"], payloads=[{"safe": True}])
+
+    store.update("m1", vector=[0.0, 1.0])
+
+    assert store.get("m1").payload == {"safe": True}
+    assert store.search(query="", vectors=[0.0, 1.0], top_k=1)[0].id == "m1"
+
+
+@pytest.mark.parametrize("payload", [[], ["invalid"], "invalid", 1])
+def test_lancedb_insert_rejects_non_dictionary_payloads(tmp_path, payload):
+    store = LanceDB(
+        collection_name="invalid_insert_payload_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+
+    with pytest.raises(TypeError, match="Payload must be a dictionary or None"):
+        store.insert(vectors=[[1.0, 0.0]], ids=["m1"], payloads=[payload])
+
+    assert store.col_info()["count"] == 0
+
+
+@pytest.mark.parametrize("payload", [[], ["invalid"], "invalid", 1])
+def test_lancedb_update_rejects_non_dictionary_payloads_without_modifying_the_record(tmp_path, payload):
+    store = LanceDB(
+        collection_name="invalid_update_payload_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+    store.insert(vectors=[[1.0, 0.0]], ids=["m1"], payloads=[{"safe": True}])
+
+    with pytest.raises(TypeError, match="Payload must be a dictionary or None"):
+        store.update("m1", payload=payload)
+
+    assert store.get("m1").payload == {"safe": True}
+
+
+def test_lancedb_reads_legacy_non_dictionary_payload_as_empty_metadata(tmp_path, caplog):
+    store = LanceDB(
+        collection_name="legacy_payload_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+    store.table.add([{"id": "m1", "vector": [1.0, 0.0], "payload": '["legacy"]'}])
+
+    result = store.get("m1")
+
+    assert result.payload == {}
+    assert "must decode to a dictionary" in caplog.text

--- a/tests/vector_stores/test_lancedb.py
+++ b/tests/vector_stores/test_lancedb.py
@@ -164,6 +164,50 @@ def test_lancedb_list_supports_processed_metadata_filters(populated_filter_store
     assert {result.id for result in results} == {"m1", "m3"}
 
 
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {"user_id": "alice", "AND": [{"score": {"gte": 7}}, {"category": "work"}]},
+        {"user_id": "alice", "OR": [{"category": "work"}, {"score": {"gt": 9}}]},
+        {"user_id": "alice", "NOT": [{"category": "personal"}]},
+    ],
+)
+def test_lancedb_list_supports_unprocessed_logical_filter_aliases(populated_filter_store, filters):
+    results = populated_filter_store.list(filters=filters, top_k=10)[0]
+
+    assert {result.id for result in results} == {"m1"}
+
+
+def test_lancedb_not_matches_payloads_missing_the_negated_field(tmp_path):
+    store = LanceDB(
+        collection_name="missing_field_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+    store.insert(
+        vectors=[[1.0, 0.0], [0.0, 1.0]],
+        ids=["missing", "work"],
+        payloads=[{}, {"category": "work"}],
+    )
+
+    results = store.list(filters={"$not": [{"category": "work"}]}, top_k=10)[0]
+
+    assert {result.id for result in results} == {"missing"}
+
+
+def test_lancedb_search_returns_no_results_when_top_k_is_zero(populated_filter_store):
+    results = populated_filter_store.search(query="", vectors=[1.0, 0.0], top_k=0)
+
+    assert results == []
+
+
+def test_lancedb_list_returns_no_results_when_top_k_is_zero(populated_filter_store):
+    results = populated_filter_store.list(top_k=0)
+
+    assert results == [[]]
+
+
 def test_lancedb_search_expands_recall_until_top_k_filtered_results_are_found(tmp_path):
     store = LanceDB(
         collection_name="recall_memories",
@@ -197,6 +241,39 @@ def test_lancedb_search_rejects_unknown_filter_operator(populated_filter_store):
             top_k=3,
             filters={"score": {"between": [3, 7]}},
         )
+
+
+@pytest.mark.parametrize("operation", ["search", "list"])
+def test_lancedb_rejects_unknown_filter_operator_when_table_is_empty(tmp_path, operation):
+    store = LanceDB(
+        collection_name="empty_filter_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+    filters = {"score": {"between": [3, 7]}}
+
+    with pytest.raises(ValueError, match="Unsupported filter operator"):
+        if operation == "search":
+            store.search(query="", vectors=[1.0, 0.0], top_k=3, filters=filters)
+        else:
+            store.list(filters=filters, top_k=3)
+
+
+@pytest.mark.parametrize(
+    ("filters", "error"),
+    [
+        ({"score": {}}, "must not be empty"),
+        ({"user_id": {"in": "alice,bob"}}, "requires a non-empty list"),
+        ({"user_id": {"nin": []}}, "requires a non-empty list"),
+        ({"name": {"contains": 1}}, "requires a string value"),
+        ({"score": {"gt": [6]}}, "requires a scalar value"),
+        ({"score": {"gte": None}}, "does not support null"),
+    ],
+)
+def test_lancedb_rejects_invalid_filter_operands(populated_filter_store, filters, error):
+    with pytest.raises(ValueError, match=error):
+        populated_filter_store.list(filters=filters, top_k=10)
 
 
 def test_lancedb_update_missing_id_is_a_noop(tmp_path):

--- a/tests/vector_stores/test_lancedb.py
+++ b/tests/vector_stores/test_lancedb.py
@@ -8,6 +8,26 @@ from mem0.vector_stores.configs import VectorStoreConfig
 from mem0.vector_stores.lancedb import LanceDB
 
 
+@pytest.fixture
+def populated_filter_store(tmp_path):
+    store = LanceDB(
+        collection_name="filter_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+    store.insert(
+        vectors=[[1.0, 0.0], [0.9, 0.1], [0.8, 0.2]],
+        ids=["m1", "m2", "m3"],
+        payloads=[
+            {"user_id": "alice", "score": 7, "name": "Alice Garden", "category": "work"},
+            {"user_id": "bob", "score": 3, "name": "Bob Farm", "category": "personal"},
+            {"user_id": "carol", "score": 10, "name": "ALICE archive"},
+        ],
+    )
+    return store
+
+
 def test_lancedb_config_accepts_local_settings():
     config = VectorStoreConfig(
         provider="lancedb",
@@ -102,3 +122,91 @@ def test_lancedb_dot_distance_similarity_direction():
         assert results[0].id == "perfect"
         assert results[0].score > results[1].score
         assert results[0].score == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    ("filters", "expected_ids"),
+    [
+        ({"$or": [{"user_id": "alice"}, {"score": {"lt": 4}}]}, {"m1", "m2"}),
+        ({"$not": [{"user_id": "bob"}]}, {"m1", "m3"}),
+        ({"user_id": "alice", "score": {"gte": 7}}, {"m1"}),
+        ({"category": "*"}, {"m1", "m2"}),
+        ({"score": {"eq": 7}}, {"m1"}),
+        ({"score": {"ne": 7}}, {"m2", "m3"}),
+        ({"score": {"gt": 6}}, {"m1", "m3"}),
+        ({"score": {"gte": 7}}, {"m1", "m3"}),
+        ({"score": {"lt": 7}}, {"m2"}),
+        ({"score": {"lte": 7}}, {"m1", "m2"}),
+        ({"user_id": {"in": ["alice", "carol"]}}, {"m1", "m3"}),
+        ({"user_id": {"nin": ["alice", "carol"]}}, {"m2"}),
+        ({"name": {"contains": "Alice"}}, {"m1"}),
+        ({"name": {"icontains": "alice"}}, {"m1", "m3"}),
+        ({"user_id": ["alice", "carol"]}, {"m1", "m3"}),
+    ],
+)
+def test_lancedb_search_supports_processed_metadata_filters(populated_filter_store, filters, expected_ids):
+    results = populated_filter_store.search(
+        query="",
+        vectors=[1.0, 0.0],
+        top_k=10,
+        filters=filters,
+    )
+
+    assert {result.id for result in results} == expected_ids
+
+
+def test_lancedb_list_supports_processed_metadata_filters(populated_filter_store):
+    results = populated_filter_store.list(
+        filters={"$or": [{"user_id": "alice"}, {"score": {"gt": 9}}]},
+        top_k=10,
+    )[0]
+
+    assert {result.id for result in results} == {"m1", "m3"}
+
+
+def test_lancedb_search_expands_recall_until_top_k_filtered_results_are_found(tmp_path):
+    store = LanceDB(
+        collection_name="recall_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+    excluded_count = 55
+    matching_ids = ["match-1", "match-2", "match-3"]
+    store.insert(
+        vectors=[[1.0, 0.0] for _ in range(excluded_count)] + [[0.0, 1.0] for _ in matching_ids],
+        ids=[f"excluded-{index}" for index in range(excluded_count)] + matching_ids,
+        payloads=[{"user_id": "bob"} for _ in range(excluded_count)] + [{"user_id": "alice"} for _ in matching_ids],
+    )
+
+    results = store.search(
+        query="",
+        vectors=[1.0, 0.0],
+        top_k=len(matching_ids),
+        filters={"user_id": "alice"},
+    )
+
+    assert {result.id for result in results} == set(matching_ids)
+
+
+def test_lancedb_search_rejects_unknown_filter_operator(populated_filter_store):
+    with pytest.raises(ValueError, match="Unsupported filter operator"):
+        populated_filter_store.search(
+            query="",
+            vectors=[1.0, 0.0],
+            top_k=3,
+            filters={"score": {"between": [3, 7]}},
+        )
+
+
+def test_lancedb_update_missing_id_is_a_noop(tmp_path):
+    store = LanceDB(
+        collection_name="update_memories",
+        path=str(tmp_path),
+        embedding_model_dims=2,
+        distance="cosine",
+    )
+
+    store.update("missing", payload={"user_id": "alice"})
+
+    assert store.col_info()["count"] == 0

--- a/tests/vector_stores/test_lancedb.py
+++ b/tests/vector_stores/test_lancedb.py
@@ -82,3 +82,23 @@ def test_lancedb_crud_search_and_filters():
 
         store.reset()
         assert store.col_info()["count"] == 0
+
+
+def test_lancedb_dot_distance_similarity_direction():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store = LanceDB(
+            collection_name="memories",
+            path=temp_dir,
+            embedding_model_dims=3,
+            distance="dot",
+        )
+
+        store.insert(
+            vectors=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            ids=["perfect", "orthogonal"],
+        )
+
+        results = store.search(query="", vectors=[1.0, 0.0, 0.0], top_k=2)
+        assert results[0].id == "perfect"
+        assert results[0].score > results[1].score
+        assert results[0].score == pytest.approx(1.0)

--- a/tests/vector_stores/test_lancedb.py
+++ b/tests/vector_stores/test_lancedb.py
@@ -1,0 +1,84 @@
+import tempfile
+
+import pytest
+
+pytest.importorskip("lancedb")
+
+from mem0.vector_stores.configs import VectorStoreConfig
+from mem0.vector_stores.lancedb import LanceDB
+
+
+def test_lancedb_config_accepts_local_settings():
+    config = VectorStoreConfig(
+        provider="lancedb",
+        config={
+            "path": "/tmp/lancedb",
+            "collection_name": "memories",
+            "embedding_model_dims": 3,
+            "distance": "cosine",
+        },
+    )
+
+    assert config.provider == "lancedb"
+    assert config.config.path == "/tmp/lancedb"
+    assert config.config.collection_name == "memories"
+    assert config.config.embedding_model_dims == 3
+    assert config.config.distance == "cosine"
+
+
+def test_lancedb_crud_search_and_filters():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        store = LanceDB(
+            collection_name="memories",
+            path=temp_dir,
+            embedding_model_dims=3,
+            distance="cosine",
+        )
+
+        store.insert(
+            vectors=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.9, 0.1, 0.0]],
+            ids=["m1", "m2", "m3"],
+            payloads=[
+                {"user_id": "alice", "memory": "likes drip irrigation"},
+                {"user_id": "bob", "memory": "likes flood irrigation"},
+                {"user_id": "alice", "memory": "prefers morning reminders"},
+            ],
+        )
+
+        info = store.col_info()
+        assert info["name"] == "memories"
+        assert info["count"] == 3
+        assert info["dimension"] == 3
+        assert info["distance"] == "cosine"
+
+        results = store.search(query="", vectors=[1.0, 0.0, 0.0], top_k=2)
+        assert [result.id for result in results] == ["m1", "m3"]
+        assert results[0].score == pytest.approx(1.0)
+
+        filtered = store.search(
+            query="",
+            vectors=[0.0, 1.0, 0.0],
+            top_k=3,
+            filters={"user_id": "alice"},
+        )
+        assert filtered
+        assert all(result.payload["user_id"] == "alice" for result in filtered)
+
+        assert store.get("m1").payload["memory"] == "likes drip irrigation"
+
+        store.update("m1", payload={"user_id": "alice", "memory": "updated memory"})
+        assert store.get("m1").payload["memory"] == "updated memory"
+
+        store.update("m2", vector=[1.0, 0.0, 0.0], payload={"user_id": "bob", "memory": "updated vector"})
+        moved = store.search(query="", vectors=[1.0, 0.0, 0.0], top_k=2)
+        assert "m2" in [result.id for result in moved]
+
+        listed = store.list(top_k=10)[0]
+        assert sorted(result.id for result in listed) == ["m1", "m2", "m3"]
+
+        store.delete("m3")
+        listed_after_delete = store.list(top_k=10)[0]
+        assert sorted(result.id for result in listed_after_delete) == ["m1", "m2"]
+
+        store.reset()
+        assert store.col_info()["count"] == 0


### PR DESCRIPTION
## Linked Issue

Closes #6488

## Description

Adds LanceDB as an OSS vector store provider for local / single-node Mem0 deployments.

- New `lancedb` provider implementing `VectorStoreBase`
- Config model + factory/config registration
- Optional dependency: `lancedb` in the `vector-stores` extra, so users can install it with `pip install "mem0ai[vector-stores]"`
- Unit tests for config + factory registration + CRUD/search/filter/reset
- Docs page, overview card, docs nav (`docs.json`), and `docs/llms.txt` entry

v1 notes:
- Metadata filters support equality, list / `in`, wildcard, logical `AND` / `OR` / `NOT`, comparison, and string containment operators
- Filters are evaluated after vector recall for LanceDB 0.17 compatibility; the recall window expands until `top_k` matches or the table is exhausted
- Raw `AND` / `OR` / `NOT` aliases are accepted by `list()` / `get_all()` as well as processed `$and` / `$or` / `$not` filters
- Filter syntax and operand types are validated before scanning, including on empty tables; `NOT` also handles missing fields correctly
- `top_k=0` returns an empty result consistently from search and list
- Highly selective filters may scan the full table; this is intentional for correctness on LanceDB versions that cannot push arbitrary JSON payload predicates down into the vector query
- Persistence is tested across LanceDB API changes, including reopening existing collections, listing/deleting collections, and pagination over table names
- Existing collections reject embedding dimension mismatches early instead of reporting an incorrect dimension and failing later during insert/search
- `create_col()` only commits in-memory collection state after the target table opens/creates successfully
- `update()` validates vectors and payloads before modifying the table, and uses LanceDB's table update path so invalid updates do not delete existing records
- Payloads must be dictionaries or `None`; legacy rows whose JSON payload decodes to a non-dictionary are read as empty metadata with a warning

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Ran locally:

```bash
ruff check mem0/vector_stores/lancedb.py mem0/configs/vector_stores/lancedb.py tests/vector_stores/test_lancedb.py
ruff format --check mem0/vector_stores/lancedb.py mem0/configs/vector_stores/lancedb.py tests/vector_stores/test_lancedb.py
python -X utf8 scripts/check-llms-txt-coverage.py
git diff --check
python -m build --wheel
python -m pytest tests/vector_stores/test_lancedb.py -q
```

Result: `73 passed` against LanceDB 0.17, 0.25, 0.33, and 0.34; ruff clean; docs index and diff checks pass; wheel metadata includes `Provides-Extra: vector-stores` and `Requires-Dist: lancedb<1.0.0,>=0.17.0; extra == 'vector-stores'`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed