### PR TITLE
fix: replace input()/sys.exit(1) with ImportError on missing optional deps (#6118)

### DIFF
--- a/mem0/embeddings/ollama.py
+++ b/mem0/embeddings/ollama.py
@@ -1,5 +1,3 @@
-import subprocess
-import sys
 from typing import Literal, Optional
 
 from mem0.configs.embeddings.base import BaseEmbedderConfig
@@ -8,17 +6,9 @@ from mem0.embeddings.base import EmbeddingBase
 try:
     from ollama import Client
 except ImportError:
-    user_input = input("The 'ollama' library is required. Install it now? [y/N]: ")
-    if user_input.lower() == "y":
-        try:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "ollama"])
-            from ollama import Client
-        except subprocess.CalledProcessError:
-            print("Failed to install 'ollama'. Please install it manually using 'pip install ollama'.")
-            sys.exit(1)
-    else:
-        print("The required 'ollama' library is not installed.")
-        sys.exit(1)
+    raise ImportError(
+        "The 'ollama' library is required. Please install it using 'pip install ollama'."
+    )
 
 
 class OllamaEmbedding(EmbeddingBase):

--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -1,6 +1,4 @@
 import logging
-import subprocess
-import sys
 import threading
 from typing import List, Optional, Union
 
@@ -11,12 +9,9 @@ import mem0
 try:
     import litellm
 except ImportError:
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "litellm"])
-        import litellm
-    except subprocess.CalledProcessError:
-        print("Failed to install 'litellm'. Please install it manually using 'pip install litellm'.")
-        sys.exit(1)
+    raise ImportError(
+        "The 'litellm' library is required. Please install it using 'pip install litellm'."
+    )
 
 from mem0 import Memory, MemoryClient
 from mem0.configs.prompts import MEMORY_ANSWER_PROMPT


### PR DESCRIPTION
The ollama and litellm import guards used input() to prompt the user
interactively and sys.exit(1) to abort the process. This makes the
library unusable in non-interactive environments (CI, pytest, FastAPI
servers) and terminates the host application without giving callers a
chance to handle the missing dependency gracefully.

Replace both with a plain ImportError that includes the install
instruction, matching standard Python library convention.
