### PR TITLE
docs(reranker-search): read rerank_score for the reranker output, not score

### DIFF
--- a/docs/open-source/features/reranker-search.mdx
+++ b/docs/open-source/features/reranker-search.mdx
@@ -193,7 +193,7 @@ m = Memory.from_config(config)
 ```
 
 <Info icon="check">
-  Confirm `results["results"][0]["score"]` reflects the reranker output: if the field is missing, the reranker was not applied.
+  Confirm `results["results"][0]["rerank_score"]` is present: rerankers add this field on top of the existing vector `score`, so if `rerank_score` is missing the reranker was not applied.
 </Info>
 
 <Tip>
@@ -394,16 +394,18 @@ results = m.search("query", filters={"user_id": "alice"})
 ```python
 results = m.search(
     "What are my food preferences?",
-    filters={"user_id": "alice"}
+    filters={"user_id": "alice"},
+    rerank=True
 )
 
 for result in results["results"]:
     print(f"Memory: {result['memory']}")
-    print(f"Score: {result['score']}")
+    print(f"Vector score: {result['score']}")
+    print(f"Rerank score: {result['rerank_score']}")
 ```
 
 <Info icon="check">
-  Expect each result to list the reranker-adjusted score so you can compare ordering against baseline vector results.
+  Each result keeps its vector `score` and gains a `rerank_score` from the reranker, so you can compare the reranked ordering against the baseline vector results.
 </Info>
 
 ### Toggle reranking per request
@@ -491,7 +493,7 @@ results = m.search(
 
 for result in results["results"]:
     print(f"Recommendation: {result['memory']}")
-    print(f"Relevance: {result['score']:.3f}")
+    print(f"Relevance: {result['rerank_score']:.3f}")
 ```
 
 <Info icon="check">
@@ -527,7 +529,7 @@ results = m.search(
 
 ## Verify the feature is working
 
-- Inspect result payloads for both `score` (vector) and reranker scores; mismatched fields indicate the reranker didn’t execute.
+- Inspect result payloads for both `score` (vector) and `rerank_score` (reranker); a missing `rerank_score` means the reranker didn’t execute.
 - Track latency before and after enabling reranking to ensure SLAs hold.
 - Review provider logs or dashboards for throttling or quota warnings.
 - Run A/B comparisons (rerank on/off) to validate improved relevance before defaulting to reranked responses.


### PR DESCRIPTION
## Linked Issue

Closes #6491

## Description

The OSS reranking guide tells readers that `result["score"]` holds the reranker's output, but it doesn't. Every reranker copies the doc and adds a separate `rerank_score` field (mem0/reranker/*.py, e.g. cohere_reranker.py:79, huggingface_reranker.py:158), while the existing `score` is the vector/hybrid similarity from `_search_vector_store` (mem0/memory/main.py:1645) and is left untouched. `Memory.search()` returns those dicts as-is, so a reranked result carries both. The old wording was actively misleading: the "if the field is missing, the reranker was not applied" check keyed off `score`, which is always present, and the "Basic reranked search" example didn't even pass `rerank=True`. This updates the examples and callouts to read `rerank_score` for the reranker output, keeps `score` where it genuinely means the vector score, and adds the missing `rerank=True`. Docs-only change, `python3 scripts/check-llms-txt-coverage.py` is in sync.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (docs-only; verified the field names against mem0/reranker/*.py and the search return path in mem0/memory/main.py, and ran the llms.txt coverage check)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (N/A, docs-only)
- [ ] New and existing tests pass locally (N/A, docs-only; ran the llms.txt coverage gate instead)
- [x] I have updated documentation if needed

---

*quick disclosure, same as my other PRs: I'm a freshman trying to give back to tools I lean on. I traced this one with Claude Code's help (checked what the rerankers actually write vs what search returns) and ran the docs coverage gate locally. if I got any of the field semantics wrong I'd genuinely like to know, still learning the codebase :)*
