### PR TITLE
fix(ts-oss): carry updatedAt into inferred add ADD history events

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1055,7 +1055,10 @@ export class Memory {
       newValue: r.text as string | null,
       action: "ADD",
       createdAt: r.payload.createdAt as string | undefined,
-      updatedAt: undefined as string | undefined,
+      // An ADD carries updatedAt equal to createdAt (both set on the payload
+      // above). Leaving it undefined recorded the ADD event with updated_at
+      // NULL while the stored memory had it set, so the two disagreed.
+      updatedAt: r.payload.updatedAt as string | undefined,
       isDeleted: 0,
     }));
 
@@ -1072,6 +1075,7 @@ export class Memory {
               hr.newValue,
               "ADD",
               hr.createdAt,
+              hr.updatedAt,
             );
           } catch (e) {
             console.error(`Failed to add history for ${hr.memoryId}: ${e}`);

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -191,4 +191,20 @@ describe("Memory - add()", () => {
       expect.objectContaining({ event: "ADD" }),
     );
   });
+
+  test("records the ADD history event with updatedAt set to createdAt", async () => {
+    const result: SearchResult = await memory.add("I deploy on Fridays", {
+      userId,
+    });
+    const memoryId = result.results[0].id;
+
+    const history = await memory.history(memoryId);
+    const addEntry = history.find((h: any) => h.action === "ADD");
+    expect(addEntry).toBeDefined();
+    // A freshly added memory carries updatedAt == createdAt, so its ADD history
+    // event must record the same. It used to be written with updated_at NULL
+    // while the stored memory had it set, so the two disagreed.
+    expect(addEntry.created_at).toBeTruthy();
+    expect(addEntry.updated_at).toBe(addEntry.created_at);
+  });
 });


### PR DESCRIPTION
### Description

The inferred (default `infer: true`) add pipeline stores each memory with `createdAt` and `updatedAt` set to the same creation timestamp, but built the ADD history record with `updatedAt` hardcoded to `undefined`, and the two one-by-one `addHistory()` fallbacks in the same block omitted the argument entirely. `batchAddHistory()` persists `updatedAt ?? null`, so the ADD event landed with `updated_at` NULL while the stored memory had it set. `history(id)` then returned an audit trail that disagreed with the record it describes.

The fix passes the payload's `updatedAt` (equal to `createdAt` at creation) through to the batch record and both fallbacks, matching what the Python `_create_memory` records for its ADD history event.

Closes #6494

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`jest src/oss/tests/memory.add.test.ts` (run from the `mem0-ts` root), 12 passed.

- Added `records the ADD history event with updatedAt set to createdAt`: adds a memory with inference on, reads `history(id)`, and asserts the ADD entry's `updated_at` equals its `created_at` (both non-null). Reverting the source change fails exactly this test with `updated_at` coming back `null`.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes