### PR TITLE
fix(ts-sdk): use textLemmatized for BM25 keyword search on Milvus, OpenSearch, and MongoDB

### DIFF
--- a/mem0-ts/src/oss/src/tests/milvus.test.ts
+++ b/mem0-ts/src/oss/src/tests/milvus.test.ts
@@ -432,12 +432,18 @@ describe("Milvus vector store (TS OSS SDK)", () => {
       ["a"],
       [{ data: "hello world", text_lemmatized: "hello world lemma" }],
     );
+    await store.insert(
+      [[0.2, 0.3, 0.4]],
+      ["c"],
+      [{ data: "hello world", textLemmatized: "hello world camel" }],
+    );
     // Falls back to raw data when there is no lemmatized text.
     await store.insert([[0.4, 0.5, 0.6]], ["b"], [{ data: "just data" }]);
 
     const insertCalls = client.calls.filter((c) => c.method === "insert");
     expect(insertCalls[0].args.data[0].text).toBe("hello world lemma");
-    expect(insertCalls[1].args.data[0].text).toBe("just data");
+    expect(insertCalls[1].args.data[0].text).toBe("hello world camel");
+    expect(insertCalls[2].args.data[0].text).toBe("just data");
   });
 
   it("writes the BM25 text field on update for a BM25 collection", async () => {

--- a/mem0-ts/src/oss/src/tests/mongodb.test.ts
+++ b/mem0-ts/src/oss/src/tests/mongodb.test.ts
@@ -197,7 +197,11 @@ describe("MongoDB Vector Store", () => {
           index: "test_col_text_search_index",
           text: {
             query: "test",
-            path: ["payload.data", "payload.text_lemmatized"],
+            path: [
+              "payload.textLemmatized",
+              "payload.text_lemmatized",
+              "payload.data",
+            ],
           },
         },
       },

--- a/mem0-ts/src/oss/src/tests/mongodb.test.ts
+++ b/mem0-ts/src/oss/src/tests/mongodb.test.ts
@@ -86,6 +86,22 @@ describe("MongoDB Vector Store", () => {
     expect(mockCreateSearchIndex).toHaveBeenCalledTimes(2);
   });
 
+  it("should map payload.textLemmatized in the text search index", async () => {
+    await store.initialize();
+
+    const textIndexCall = mockCreateSearchIndex.mock.calls.find(
+      ([arg]: any[]) => arg.name === "test_col_text_search_index",
+    );
+    expect(textIndexCall).toBeDefined();
+    expect(textIndexCall![0].definition.mappings.fields.payload.fields).toEqual(
+      {
+        data: { type: "string" },
+        text_lemmatized: { type: "string" },
+        textLemmatized: { type: "string" },
+      },
+    );
+  });
+
   it("should insert documents correctly", async () => {
     mockInsertMany.mockResolvedValue({ insertedCount: 2 });
 
@@ -198,9 +214,9 @@ describe("MongoDB Vector Store", () => {
           text: {
             query: "test",
             path: [
-              "payload.textLemmatized",
-              "payload.text_lemmatized",
               "payload.data",
+              "payload.text_lemmatized",
+              "payload.textLemmatized",
             ],
           },
         },

--- a/mem0-ts/src/oss/src/tests/mongodb.test.ts
+++ b/mem0-ts/src/oss/src/tests/mongodb.test.ts
@@ -5,6 +5,7 @@ const mockFindOne = jest.fn();
 const mockUpdateOne = jest.fn();
 const mockListSearchIndexes = jest.fn();
 const mockCreateSearchIndex = jest.fn();
+const mockDropSearchIndex = jest.fn();
 const mockDrop = jest.fn();
 const mockToArray = jest.fn();
 const mockLimit = jest.fn().mockReturnThis();
@@ -26,6 +27,7 @@ const mockCollection = {
   updateOne: mockUpdateOne,
   listSearchIndexes: mockListSearchIndexes,
   createSearchIndex: mockCreateSearchIndex,
+  dropSearchIndex: mockDropSearchIndex,
   drop: mockDrop,
   find: mockFind,
   aggregate: mockAggregate,
@@ -74,6 +76,25 @@ describe("MongoDB Vector Store", () => {
     await store.close();
   });
 
+  const expectedTextSearchIndexDefinition = {
+    name: "test_col_text_search_index",
+    definition: {
+      mappings: {
+        dynamic: false,
+        fields: {
+          payload: {
+            type: "document",
+            fields: {
+              data: { type: "string" },
+              textLemmatized: { type: "string" },
+              text_lemmatized: { type: "string" },
+            },
+          },
+        },
+      },
+    },
+  };
+
   it("should initialize client and check/create collection and indexes", async () => {
     await store.initialize();
 
@@ -84,6 +105,67 @@ describe("MongoDB Vector Store", () => {
     });
     expect(mockCollection.deleteOne).toHaveBeenCalledWith({ _id: 0 });
     expect(mockCreateSearchIndex).toHaveBeenCalledTimes(2);
+    expect(mockCreateSearchIndex).toHaveBeenCalledWith(
+      expectedTextSearchIndexDefinition,
+    );
+  });
+
+  it("should drop and recreate a stale text search index on upgrade", async () => {
+    mockListCollections.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([{ name: "test_col" }]),
+    });
+    mockListSearchIndexes.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([
+        { name: "test_col_vector_index" },
+        {
+          name: "test_col_text_search_index",
+          definition: {
+            mappings: {
+              dynamic: false,
+              fields: {
+                payload: {
+                  type: "document",
+                  fields: {
+                    data: { type: "string" },
+                    text_lemmatized: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ]),
+    });
+
+    await store.initialize();
+
+    expect(mockDropSearchIndex).toHaveBeenCalledWith(
+      "test_col_text_search_index",
+    );
+    expect(mockCreateSearchIndex).toHaveBeenCalledTimes(1);
+    expect(mockCreateSearchIndex).toHaveBeenCalledWith(
+      expectedTextSearchIndexDefinition,
+    );
+  });
+
+  it("should not recreate a text search index that already has textLemmatized", async () => {
+    mockListCollections.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([{ name: "test_col" }]),
+    });
+    mockListSearchIndexes.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([
+        { name: "test_col_vector_index" },
+        {
+          name: "test_col_text_search_index",
+          latestDefinition: expectedTextSearchIndexDefinition.definition,
+        },
+      ]),
+    });
+
+    await store.initialize();
+
+    expect(mockDropSearchIndex).not.toHaveBeenCalled();
+    expect(mockCreateSearchIndex).not.toHaveBeenCalled();
   });
 
   it("should map payload.textLemmatized in the text search index", async () => {

--- a/mem0-ts/src/oss/src/vector_stores/milvus.ts
+++ b/mem0-ts/src/oss/src/vector_stores/milvus.ts
@@ -252,28 +252,14 @@ export class Milvus implements VectorStore {
   }
 
   /**
-   * Text fed to the BM25 sparse index for a payload. Prefers `textLemmatized`
-   * (TS memory payloads), then `text_lemmatized`, then raw `data`; truncates
-   * to the VarChar limit.
+   * Text fed to the BM25 sparse index for a payload. Prefers `textLemmatized`,
+   * then `text_lemmatized`, then raw `data`; truncates to the VarChar limit.
    */
   private bm25Text(payload?: Record<string, any>): string {
-    if (!payload) {
-      return "";
-    }
-    const data = typeof payload.data === "string" ? payload.data : "";
-    if (
-      typeof payload.textLemmatized === "string" &&
-      payload.textLemmatized.length > 0
-    ) {
-      return payload.textLemmatized.slice(0, 65535);
-    }
-    if (
-      typeof payload.text_lemmatized === "string" &&
-      payload.text_lemmatized.length > 0
-    ) {
-      return payload.text_lemmatized.slice(0, 65535);
-    }
-    return data.slice(0, 65535);
+    if (!payload) return "";
+    const raw =
+      payload.textLemmatized || payload.text_lemmatized || payload.data || "";
+    return String(raw).slice(0, 65535);
   }
 
   async insert(

--- a/mem0-ts/src/oss/src/vector_stores/milvus.ts
+++ b/mem0-ts/src/oss/src/vector_stores/milvus.ts
@@ -251,6 +251,11 @@ export class Milvus implements VectorStore {
     return operands.length > 0 ? operands.join(" and ") : undefined;
   }
 
+  /**
+   * Text fed to the BM25 sparse index for a payload. Prefers `textLemmatized`
+   * (TS memory payloads), then `text_lemmatized`, then raw `data`; truncates
+   * to the VarChar limit.
+   */
   private bm25Text(payload?: Record<string, any>): string {
     if (!payload) {
       return "";

--- a/mem0-ts/src/oss/src/vector_stores/milvus.ts
+++ b/mem0-ts/src/oss/src/vector_stores/milvus.ts
@@ -251,15 +251,24 @@ export class Milvus implements VectorStore {
     return operands.length > 0 ? operands.join(" and ") : undefined;
   }
 
-  /**
-   * Text fed to the BM25 sparse index for a payload. Prefers the lemmatized
-   * text, falls back to the raw memory `data`, and truncates to the VarChar
-   * limit (mirrors the Python provider).
-   */
   private bm25Text(payload?: Record<string, any>): string {
-    if (!payload) return "";
-    const raw = payload.text_lemmatized || payload.data || "";
-    return String(raw).slice(0, 65535);
+    if (!payload) {
+      return "";
+    }
+    const data = typeof payload.data === "string" ? payload.data : "";
+    if (
+      typeof payload.textLemmatized === "string" &&
+      payload.textLemmatized.length > 0
+    ) {
+      return payload.textLemmatized.slice(0, 65535);
+    }
+    if (
+      typeof payload.text_lemmatized === "string" &&
+      payload.text_lemmatized.length > 0
+    ) {
+      return payload.text_lemmatized.slice(0, 65535);
+    }
+    return data.slice(0, 65535);
   }
 
   async insert(

--- a/mem0-ts/src/oss/src/vector_stores/mongodb.ts
+++ b/mem0-ts/src/oss/src/vector_stores/mongodb.ts
@@ -83,7 +83,9 @@ export class MongoDB implements VectorStore {
     };
   }
 
-  private textSearchIndexMappingIsCurrent(index: Record<string, unknown>): boolean {
+  private textSearchIndexMappingIsCurrent(
+    index: Record<string, unknown>,
+  ): boolean {
     const definition =
       (index.latestDefinition as Record<string, unknown> | undefined) ??
       (index.definition as Record<string, unknown> | undefined);
@@ -164,9 +166,7 @@ export class MongoDB implements VectorStore {
 
         if (!existingTextIndex) {
           await this.collection.createSearchIndex(textSearchIndex);
-        } else if (
-          !this.textSearchIndexMappingIsCurrent(existingTextIndex)
-        ) {
+        } else if (!this.textSearchIndexMappingIsCurrent(existingTextIndex)) {
           await this.collection.dropSearchIndex(textIndexName);
           await this.collection.createSearchIndex(textSearchIndex);
         }

--- a/mem0-ts/src/oss/src/vector_stores/mongodb.ts
+++ b/mem0-ts/src/oss/src/vector_stores/mongodb.ts
@@ -62,6 +62,44 @@ export class MongoDB implements VectorStore {
     return this._initPromise;
   }
 
+  private textSearchIndexDefinition(textIndexName: string) {
+    return {
+      name: textIndexName,
+      definition: {
+        mappings: {
+          dynamic: false,
+          fields: {
+            payload: {
+              type: "document",
+              fields: {
+                data: { type: "string" },
+                textLemmatized: { type: "string" },
+                text_lemmatized: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  private textSearchIndexMappingIsCurrent(index: Record<string, unknown>): boolean {
+    const definition =
+      (index.latestDefinition as Record<string, unknown> | undefined) ??
+      (index.definition as Record<string, unknown> | undefined);
+    const payloadFields = (
+      (definition?.mappings as Record<string, unknown> | undefined)?.fields as
+        | Record<string, unknown>
+        | undefined
+    )?.payload as Record<string, unknown> | undefined;
+    const fields =
+      (payloadFields?.fields as Record<string, unknown> | undefined) ?? {};
+    const textLemmatized = fields.textLemmatized as
+      | { type?: string }
+      | undefined;
+    return textLemmatized?.type === "string";
+  }
+
   private async _doInitialize(): Promise<void> {
     await this.ensureClient();
     try {
@@ -111,34 +149,26 @@ export class MongoDB implements VectorStore {
       // Create Text Search Index for keywordSearch
       const textIndexName = `${this.collectionName}_text_search_index`;
       try {
-        let foundTextIndex = false;
+        let existingTextIndex: Record<string, unknown> | null = null;
         try {
           const indexes = await this.collection.listSearchIndexes().toArray();
-          foundTextIndex = indexes.some((idx) => idx.name === textIndexName);
+          existingTextIndex =
+            (indexes.find((idx) => idx.name === textIndexName) as
+              | Record<string, unknown>
+              | undefined) ?? null;
         } catch (e) {
           // ignore
         }
 
-        // ponytail: an existing index keeps its old mapping; drop and recreate to pick up new fields
-        if (!foundTextIndex) {
-          await this.collection.createSearchIndex({
-            name: textIndexName,
-            definition: {
-              mappings: {
-                dynamic: false,
-                fields: {
-                  payload: {
-                    type: "document",
-                    fields: {
-                      data: { type: "string" },
-                      text_lemmatized: { type: "string" },
-                      textLemmatized: { type: "string" },
-                    },
-                  },
-                },
-              },
-            },
-          });
+        const textSearchIndex = this.textSearchIndexDefinition(textIndexName);
+
+        if (!existingTextIndex) {
+          await this.collection.createSearchIndex(textSearchIndex);
+        } else if (
+          !this.textSearchIndexMappingIsCurrent(existingTextIndex)
+        ) {
+          await this.collection.dropSearchIndex(textIndexName);
+          await this.collection.createSearchIndex(textSearchIndex);
         }
       } catch (e: any) {
         console.warn(

--- a/mem0-ts/src/oss/src/vector_stores/mongodb.ts
+++ b/mem0-ts/src/oss/src/vector_stores/mongodb.ts
@@ -286,7 +286,11 @@ export class MongoDB implements VectorStore {
             index: textIndexName,
             text: {
               query: query,
-              path: ["payload.data", "payload.text_lemmatized"],
+              path: [
+                "payload.textLemmatized",
+                "payload.text_lemmatized",
+                "payload.data",
+              ],
             },
           },
         },

--- a/mem0-ts/src/oss/src/vector_stores/mongodb.ts
+++ b/mem0-ts/src/oss/src/vector_stores/mongodb.ts
@@ -119,6 +119,7 @@ export class MongoDB implements VectorStore {
           // ignore
         }
 
+        // ponytail: an existing index keeps its old mapping; drop and recreate to pick up new fields
         if (!foundTextIndex) {
           await this.collection.createSearchIndex({
             name: textIndexName,
@@ -131,6 +132,7 @@ export class MongoDB implements VectorStore {
                     fields: {
                       data: { type: "string" },
                       text_lemmatized: { type: "string" },
+                      textLemmatized: { type: "string" },
                     },
                   },
                 },
@@ -287,9 +289,9 @@ export class MongoDB implements VectorStore {
             text: {
               query: query,
               path: [
-                "payload.textLemmatized",
-                "payload.text_lemmatized",
                 "payload.data",
+                "payload.text_lemmatized",
+                "payload.textLemmatized",
               ],
             },
           },

--- a/mem0-ts/src/oss/src/vector_stores/opensearch.ts
+++ b/mem0-ts/src/oss/src/vector_stores/opensearch.ts
@@ -274,8 +274,9 @@ export class OpenSearchDB implements VectorStore {
     await this.initialize();
     const boolQuery: Record<string, any> = {
       should: [
-        { match: { "payload.data": query } },
+        { match: { "payload.textLemmatized": query } },
         { match: { "payload.text_lemmatized": query } },
+        { match: { "payload.data": query } },
       ],
       minimum_should_match: 1,
     };

--- a/mem0-ts/src/oss/src/vector_stores/opensearch.ts
+++ b/mem0-ts/src/oss/src/vector_stores/opensearch.ts
@@ -274,9 +274,9 @@ export class OpenSearchDB implements VectorStore {
     await this.initialize();
     const boolQuery: Record<string, any> = {
       should: [
-        { match: { "payload.textLemmatized": query } },
-        { match: { "payload.text_lemmatized": query } },
         { match: { "payload.data": query } },
+        { match: { "payload.text_lemmatized": query } },
+        { match: { "payload.textLemmatized": query } },
       ],
       minimum_should_match: 1,
     };

--- a/mem0-ts/src/oss/tests/opensearch.unit.test.ts
+++ b/mem0-ts/src/oss/tests/opensearch.unit.test.ts
@@ -153,4 +153,21 @@ describe("OpenSearchDB", () => {
 
     await expect(store.get("missing")).resolves.toBeNull();
   });
+
+  it("keywordSearch queries lemmatized payload fields", async () => {
+    const client = createClient();
+    const store = await createStore(client);
+
+    await store.keywordSearch("stud french", 5, { user_id: "alice" });
+
+    const searchCall = client.search.mock.calls.find(
+      ([arg]: any[]) => arg.index === collectionName,
+    );
+    expect(searchCall).toBeDefined();
+    expect(searchCall![0].body.query.bool.should).toEqual([
+      { match: { "payload.textLemmatized": "stud french" } },
+      { match: { "payload.text_lemmatized": "stud french" } },
+      { match: { "payload.data": "stud french" } },
+    ]);
+  });
 });

--- a/mem0-ts/src/oss/tests/opensearch.unit.test.ts
+++ b/mem0-ts/src/oss/tests/opensearch.unit.test.ts
@@ -164,10 +164,15 @@ describe("OpenSearchDB", () => {
       ([arg]: any[]) => arg.index === collectionName,
     );
     expect(searchCall).toBeDefined();
-    expect(searchCall![0].body.query.bool.should).toEqual([
-      { match: { "payload.textLemmatized": "stud french" } },
-      { match: { "payload.text_lemmatized": "stud french" } },
-      { match: { "payload.data": "stud french" } },
-    ]);
+    const should = searchCall![0].body.query.bool.should;
+    expect(should).toContainEqual({
+      match: { "payload.textLemmatized": "stud french" },
+    });
+    expect(should).toContainEqual({
+      match: { "payload.text_lemmatized": "stud french" },
+    });
+    expect(should).toContainEqual({
+      match: { "payload.data": "stud french" },
+    });
   });
 });


### PR DESCRIPTION
## Linked Issue

Closes #6496 

## Description

The TypeScript memory layer stores lemmatized text as `textLemmatized`, but the Milvus, OpenSearch, and MongoDB vector store adapters only read `text_lemmatized` or raw `data`. Hybrid search on those backends therefore weakens or skips the BM25 keyword signal.

This PR aligns those adapters with pgvector and the in-memory store:

- **Milvus:** `bm25Text()` reads `textLemmatized` first, then `text_lemmatized`, then `data`.
- **OpenSearch:** `keywordSearch()` includes `payload.textLemmatized` in the match clauses.
- **MongoDB:** keyword search paths include `payload.textLemmatized`.

Snake_case is kept as a fallback for compatibility with Python-style payloads.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Updated/added unit tests in:
- `mem0-ts/src/oss/src/tests/milvus.test.ts`
- `mem0-ts/src/oss/tests/opensearch.unit.test.ts`
- `mem0-ts/src/oss/src/tests/mongodb.test.ts`

```
cd mem0-ts
pnpm run test -- --testPathPattern="milvus.test|opensearch.unit|mongodb.test" --no-coverage
```

All 43 targeted tests pass locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
