### PR TITLE
fix(qdrant): harden production server integration

### DIFF
--- a/docs/open-source/configuration.mdx
+++ b/docs/open-source/configuration.mdx
@@ -36,6 +36,10 @@ pip install qdrant-client   # Python only
 docker run -p 6333:6333 qdrant/qdrant
 ```
 
+Use Qdrant server mode for production. Embedded `path` mode is suitable for local prototypes and tests, but its data is
+not a replacement for a monitored, backed-up Qdrant service. When reusing a collection, its unnamed dense vector must
+match `embedding_model_dims` and cosine distance; Mem0 fails non-destructively when the schema is incompatible.
+
 ## Define your configuration
 
 Each component takes a `provider` and a `config`. Keys are `snake_case` in Python and `camelCase` in TypeScript. Pass the config when you create `Memory`:

--- a/docs/open-source/features/rest-api.mdx
+++ b/docs/open-source/features/rest-api.mdx
@@ -119,7 +119,9 @@ docker build -t mem0-api-server .
 </Tip>
 
 <Note>
-  The REST server reads the same configuration you use locally, so you can point it at your preferred LLM, vector store, and reranker without changing code.
+  The REST server accepts `VECTOR_STORE_PROVIDER` and a JSON `VECTOR_STORE_CONFIG`. When either is supplied, the vector
+  store is environment-managed and cannot be replaced through `POST /configure`. Postgres remains required for server
+  authentication, settings, audit logs, and migrations.
 </Note>
 
 ---
@@ -260,7 +262,7 @@ The OSS REST server exposes the following endpoints. None use the `/v1/` prefix.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/configure` | Set memory configuration. Rejects unbundled providers with a 400 |
+| `POST` | `/configure` | Set memory configuration. Rejects environment-managed vector-store changes and unbundled providers with a 400 |
 | `GET` | `/configure` | Get the current memory configuration |
 | `GET` | `/configure/providers` | List the LLM and embedder providers bundled in the container |
 | `POST` | `/memories` | Create memories |

--- a/docs/open-source/setup.mdx
+++ b/docs/open-source/setup.mdx
@@ -58,7 +58,8 @@ VECTOR_STORE_PROVIDER=qdrant
 VECTOR_STORE_CONFIG={"url":"https://qdrant.example.internal:6333","api_key":"...","collection_name":"mem0","embedding_model_dims":1536}
 ```
 
-For a private CA, mount its bundle and set both `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` to the mounted path. The
+For a private CA, mount its bundle and set `SSL_CERT_FILE` to the mounted path; this is the setting used by Qdrant's
+httpx transport. Set `REQUESTS_CA_BUNDLE` too only if another configured provider uses Python Requests. The
 dimension must match the embedder and any existing collection. Mem0 checks dimension and cosine distance at startup and
 does not automatically resize, delete, or recreate incompatible collections.
 

--- a/docs/open-source/setup.mdx
+++ b/docs/open-source/setup.mdx
@@ -40,10 +40,32 @@ Copy `server/.env.example` to `server/.env` and fill in the required values. The
 | `AUTH_DISABLED` | Optional | `true` turns off auth for local development only. Never enable in production. |
 | `DASHBOARD_URL` | Optional | Origin the API accepts for CORS. Defaults to `http://localhost:3000`. Set this when you front the dashboard on a custom domain. |
 | `POSTGRES_*` | Optional | Override the bundled Postgres / pgvector connection. |
+| `VECTOR_STORE_PROVIDER` | Optional | Select a non-default memory vector store, such as `qdrant`. Requires `VECTOR_STORE_CONFIG` for Qdrant. |
+| `VECTOR_STORE_CONFIG` | Optional | JSON object containing provider connection settings. Supplying it without `VECTOR_STORE_PROVIDER` is an error. |
+| `COLLECTION_NAME` | Optional | Generic collection-name fallback. A `collection_name` inside `VECTOR_STORE_CONFIG` takes precedence. |
 
 <Tip>
   Generate a `JWT_SECRET` with `openssl rand -base64 48` or `python -c "import secrets; print(secrets.token_urlsafe(48))"`.
 </Tip>
+
+### Remote Qdrant
+
+Postgres remains part of the REST server control plane even when Qdrant stores memory vectors. Configure a production
+Qdrant server with an explicit endpoint, collection, and embedding dimension:
+
+```dotenv
+VECTOR_STORE_PROVIDER=qdrant
+VECTOR_STORE_CONFIG={"url":"https://qdrant.example.internal:6333","api_key":"...","collection_name":"mem0","embedding_model_dims":1536}
+```
+
+For a private CA, mount its bundle and set both `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` to the mounted path. The
+dimension must match the embedder and any existing collection. Mem0 checks dimension and cosine distance at startup and
+does not automatically resize, delete, or recreate incompatible collections.
+
+When these generic vector-store variables are present, the vector store is environment-managed: stored dashboard/API
+overrides are ignored and `POST /configure` rejects vector-store changes. Invalid JSON or a missing endpoint stops
+startup instead of silently creating a local database. Embedded Qdrant is development-only and requires an explicit
+`path` in `VECTOR_STORE_CONFIG`.
 
 ---
 

--- a/mem0/configs/vector_stores/qdrant.py
+++ b/mem0/configs/vector_stores/qdrant.py
@@ -20,24 +20,59 @@ class QdrantConfig(BaseModel):
         None,
         description="Whether to force HTTPS on or off. Explicit schemes in url take precedence.",
     )
-    on_disk: Optional[bool] = Field(False,description="Enables persistent storage. Vectors are kept on disk (True) or in memory (False). Does not delete the local database path.")
+    on_disk: Optional[bool] = Field(
+        False,
+        description=(
+            "Enables persistent storage. Vectors are kept on disk (True) or in memory (False). "
+            "Does not delete the local database path."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod
     def check_host_port_or_path(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(values, dict):
+            return values
+        if values.get("client") is not None:
+            return values
+
         host, port, path, url = (
             values.get("host"),
             values.get("port"),
             values.get("path"),
             values.get("url"),
         )
-        if not path and not (host and port) and not url:
+        has_host = isinstance(host, str) and bool(host.strip())
+        has_path = isinstance(path, str) and bool(path.strip())
+        has_url = isinstance(url, str) and bool(url.strip())
+        if has_host:
+            if isinstance(port, str) and port.isdigit():
+                port = int(port)
+                values["port"] = port
+            if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+                raise ValueError("Qdrant host mode requires a port between 1 and 65535.")
+        elif port is not None:
+            raise ValueError("Qdrant port requires a non-empty host.")
+
+        if not has_path and not has_host and not has_url:
             raise ValueError("Either 'host' and 'port', 'url', or 'path' must be provided.")
+        if has_url and has_host:
+            raise ValueError("'url' and 'host'/'port' modes cannot be configured together.")
+        if has_path and (has_url or has_host):
+            raise ValueError("Local 'path' and remote Qdrant endpoint modes cannot be configured together.")
+        if has_path:
+            remote_only = [key for key in ("api_key", "https") if values.get(key) is not None]
+            if remote_only:
+                raise ValueError(
+                    "Local 'path' mode cannot use remote-only option(s): " + ", ".join(sorted(remote_only)) + "."
+                )
         return values
 
     @model_validator(mode="before")
     @classmethod
     def validate_extra_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(values, dict):
+            return values
         allowed_fields = set(cls.model_fields.keys())
         input_fields = set(values.keys())
         extra_fields = input_fields - allowed_fields

--- a/mem0/configs/vector_stores/qdrant.py
+++ b/mem0/configs/vector_stores/qdrant.py
@@ -1,6 +1,6 @@
 from typing import Any, ClassVar, Dict, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class QdrantConfig(BaseModel):
@@ -27,6 +27,13 @@ class QdrantConfig(BaseModel):
             "Does not delete the local database path."
         ),
     )
+
+    @field_validator("collection_name")
+    @classmethod
+    def validate_collection_name(cls, value: str) -> str:
+        if not value.strip() or any(ord(character) < 32 or ord(character) == 127 for character in value):
+            raise ValueError("Qdrant collection_name must be non-empty and contain no control characters.")
+        return value
 
     @model_validator(mode="before")
     @classmethod

--- a/mem0/configs/vector_stores/qdrant.py
+++ b/mem0/configs/vector_stores/qdrant.py
@@ -13,7 +13,7 @@ class QdrantConfig(BaseModel):
     client: Optional[QdrantClient] = Field(None, description="Existing Qdrant client instance")
     host: Optional[str] = Field(None, description="Host address for Qdrant server")
     port: Optional[int] = Field(None, description="Port for Qdrant server")
-    path: Optional[str] = Field("/tmp/qdrant", description="Path for local Qdrant database")
+    path: Optional[str] = Field(None, description="Path for local Qdrant database")
     url: Optional[str] = Field(None, description="Full URL for Qdrant server")
     api_key: Optional[str] = Field(None, description="API key for Qdrant server")
     https: Optional[bool] = Field(
@@ -25,15 +25,14 @@ class QdrantConfig(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_host_port_or_path(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        host, port, path, url, api_key = (
+        host, port, path, url = (
             values.get("host"),
             values.get("port"),
             values.get("path"),
             values.get("url"),
-            values.get("api_key"),
         )
-        if not path and not (host and port) and not (url and api_key):
-            raise ValueError("Either 'host' and 'port' or 'url' and 'api_key' or 'path' must be provided.")
+        if not path and not (host and port) and not url:
+            raise ValueError("Either 'host' and 'port', 'url', or 'path' must be provided.")
         return values
 
     @model_validator(mode="before")

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -269,8 +269,8 @@ def _safe_deepcopy_config(config):
     """Safely deepcopy config, falling back to dict-based cloning for non-serializable objects."""
     try:
         return deepcopy(config)
-    except Exception as e:
-        logger.debug(f"Deepcopy failed, using dict-based cloning: {e}")
+    except Exception as exc:
+        logger.debug("Deepcopy failed, using dict-based cloning (%s)", type(exc).__name__)
 
         config_class = type(config)
 
@@ -598,8 +598,8 @@ class Memory(MemoryBase):
         """Return existing entity rows keyed by normalized payload data."""
         try:
             listed = self.entity_store.list(filters=filters, top_k=10000)
-        except Exception as e:
-            logger.debug(f"Exact entity lookup failed, falling back to semantic dedup: {e}")
+        except Exception as exc:
+            logger.debug("Exact entity lookup failed; using semantic dedup (%s)", type(exc).__name__)
             return {}
 
         rows_by_text = {}
@@ -731,6 +731,47 @@ class Memory(MemoryBase):
         if failed and strict:
             raise RuntimeError(f"Entity cleanup did not complete ({failed} failed operation(s)).")
         return failed == 0
+
+    def _bulk_clear_entity_store(self, filters):
+        """Drain entity records for a scope once after delete_all has removed its memories."""
+        search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        store = self.entity_store
+        previous_page_ids = None
+        repeated_pages = 0
+
+        for _ in range(DELETE_ALL_MAX_ITERATIONS):
+            try:
+                listed = store.list(filters=search_filters, top_k=ENTITY_CLEANUP_PAGE_SIZE)
+            except Exception as exc:
+                logger.warning("Bulk entity-store listing failed (%s)", type(exc).__name__)
+                raise RuntimeError("Bulk entity-store cleanup could not list matching entities.") from None
+
+            rows = normalize_list_result(listed)
+            if not rows:
+                return
+            page_ids = tuple(sorted(str(row.id) for row in rows))
+            if page_ids == previous_page_ids:
+                repeated_pages += 1
+                if repeated_pages >= DELETE_ALL_MAX_STALE_ITERATIONS:
+                    raise RuntimeError("Bulk entity-store cleanup repeatedly returned the same records.")
+            else:
+                previous_page_ids = page_ids
+                repeated_pages = 0
+
+            deleted = 0
+            for row in rows:
+                try:
+                    store.delete(vector_id=row.id)
+                except Exception:
+                    continue
+                deleted += 1
+            if deleted == 0:
+                raise RuntimeError("Bulk entity-store cleanup made no forward progress.")
+            logger.info(
+                "Bulk entity cleanup: requested=%d deleted=%d failed=%d", len(rows), deleted, len(rows) - deleted
+            )
+
+        raise RuntimeError("Bulk entity-store cleanup exceeded the safety iteration limit.")
 
     def _link_entities_for_memory(self, memory_id, text, filters):
         """Extract entities from `text` and link them to `memory_id` in the
@@ -1930,7 +1971,6 @@ class Memory(MemoryBase):
         deleted_ids = set()
         known_ids = set()
         pending_history = {}
-        pending_entities = {}
         deleted_count = 0
         stale_iterations = 0
 
@@ -1945,32 +1985,12 @@ class Memory(MemoryBase):
                     failed_this_iteration += 1
                     continue
                 pending_history.pop(memory_id)
-                progress += 1
-                payload = memory.payload or {}
-                entity_filters = {key: payload[key] for key in ("user_id", "agent_id", "run_id") if payload.get(key)}
-                try:
-                    self._remove_memory_from_entity_store(memory_id, entity_filters, strict=True)
-                except Exception:
-                    pending_entities[memory_id] = memory
-                else:
-                    deleted_ids.add(memory_id)
-                    deleted_count += 1
-
-            for memory_id, memory in list(pending_entities.items()):
-                payload = memory.payload or {}
-                entity_filters = {key: payload[key] for key in ("user_id", "agent_id", "run_id") if payload.get(key)}
-                try:
-                    self._remove_memory_from_entity_store(memory_id, entity_filters, strict=True)
-                except Exception:
-                    failed_this_iteration += 1
-                    continue
-                pending_entities.pop(memory_id)
                 deleted_ids.add(memory_id)
                 deleted_count += 1
                 progress += 1
 
             memories = normalize_list_result(self.vector_store.list(filters=filters, top_k=DELETE_ALL_PAGE_SIZE))
-            if not memories and not pending_history and not pending_entities:
+            if not memories and not pending_history:
                 break
 
             known_ids.update(memory.id for memory in memories)
@@ -1979,17 +1999,13 @@ class Memory(MemoryBase):
                 for memory in memories
                 if memory.id not in deleted_ids
                 and memory.id not in pending_history
-                and memory.id not in pending_entities
             }
             pending = list(pending_by_id.values())
             for memory in pending:
                 try:
-                    self._delete_memory(memory.id, memory, strict_entity_cleanup=True)
+                    self._delete_memory(memory.id, memory, skip_entity_cleanup=True)
                 except _DeleteHistoryError as exc:
                     pending_history[memory.id] = exc.memory
-                    progress += 1
-                except _DeleteEntityError as exc:
-                    pending_entities[memory.id] = exc.memory
                     progress += 1
                 except Exception:
                     failed_this_iteration += 1
@@ -2002,7 +2018,7 @@ class Memory(MemoryBase):
                 "Delete-all progress: requested=%d deleted=%d pending=%d failed=%d",
                 len(known_ids),
                 deleted_count,
-                len(pending_history) + len(pending_entities),
+                len(pending_history),
                 failed_this_iteration,
             )
             if progress:
@@ -2013,6 +2029,8 @@ class Memory(MemoryBase):
                     raise RuntimeError("Unable to delete all matching memories because deletion made no progress.")
         else:
             raise RuntimeError("Unable to delete all matching memories before the safety iteration limit.")
+
+        self._bulk_clear_entity_store(filters)
 
         logger.info("Deleted %d memories", deleted_count)
 
@@ -2185,7 +2203,13 @@ class Memory(MemoryBase):
             is_deleted=1,
         )
 
-    def _delete_memory(self, memory_id, existing_memory=None, strict_entity_cleanup=False):
+    def _delete_memory(
+        self,
+        memory_id,
+        existing_memory=None,
+        strict_entity_cleanup=False,
+        skip_entity_cleanup=False,
+    ):
         logger.info(f"Deleting memory with {memory_id=}")
         if existing_memory is None:
             existing_memory = self.vector_store.get(vector_id=memory_id)
@@ -2201,10 +2225,11 @@ class Memory(MemoryBase):
 
         # Entity-store cleanup: strip this memory's id from any entity records
         # that linked to it. Non-fatal — the helper swallows errors.
-        try:
-            self._remove_memory_from_entity_store(memory_id, session_filters, strict=strict_entity_cleanup)
-        except Exception:
-            raise _DeleteEntityError(existing_memory) from None
+        if not skip_entity_cleanup:
+            try:
+                self._remove_memory_from_entity_store(memory_id, session_filters, strict=strict_entity_cleanup)
+            except Exception:
+                raise _DeleteEntityError(existing_memory) from None
 
         return memory_id
 
@@ -2333,8 +2358,8 @@ class AsyncMemory(MemoryBase):
         """Return existing entity rows keyed by normalized payload data."""
         try:
             listed = self.entity_store.list(filters=filters, top_k=10000)
-        except Exception as e:
-            logger.debug(f"Exact entity lookup failed, falling back to semantic dedup: {e}")
+        except Exception as exc:
+            logger.debug("Exact entity lookup failed; using semantic dedup (%s)", type(exc).__name__)
             return {}
 
         rows_by_text = {}

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -72,7 +72,7 @@ from mem0.utils.scoring import (
     normalize_bm25,
     score_and_rank,
 )
-from mem0.vector_stores.base import VectorStoreBase
+from mem0.vector_stores.base import VectorStoreBase, VectorStoreConfigurationError
 from mem0.vector_stores.utils import normalize_list_result
 
 # Suppress SWIG deprecation warnings globally
@@ -134,6 +134,19 @@ DELETE_ALL_PAGE_SIZE = 1_000
 DELETE_ALL_MAX_ITERATIONS = 10_000
 DELETE_ALL_MAX_STALE_ITERATIONS = 3
 DELETE_ALL_ASYNC_CONCURRENCY = 20
+ENTITY_CLEANUP_PAGE_SIZE = 1_000
+
+
+class _DeleteHistoryError(RuntimeError):
+    def __init__(self, memory):
+        super().__init__("Memory vector was deleted, but its history entry could not be persisted.")
+        self.memory = memory
+
+
+class _DeleteEntityError(RuntimeError):
+    def __init__(self, memory):
+        super().__init__("Memory vector and history were deleted, but entity cleanup did not complete.")
+        self.memory = memory
 
 
 def _strip_identity_keys(metadata: Dict[str, Any], existing_payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -431,6 +444,30 @@ _UNSET = object()
 _PROJECT_UPDATE_UNSUPPORTED_ERROR = "Project updates are not supported by the OSS Memory SDK."
 
 
+def _resolve_qdrant_embedding_dimension(config: MemoryConfig, embedding_model) -> None:
+    """Make Qdrant's declared dimension match the resolved embedder before connecting."""
+    if config.vector_store.provider != "qdrant":
+        return
+
+    vector_config = config.vector_store.config
+    embedder_config = getattr(embedding_model, "config", None)
+    actual_dimension = getattr(embedder_config, "embedding_dims", None)
+    if not isinstance(actual_dimension, int) or isinstance(actual_dimension, bool) or actual_dimension <= 0:
+        return
+
+    configured_dimension = getattr(vector_config, "embedding_model_dims", None)
+    fields_set = getattr(vector_config, "model_fields_set", set())
+    dimension_was_explicit = "embedding_model_dims" in fields_set and configured_dimension is not None
+    if dimension_was_explicit and configured_dimension != actual_dimension:
+        raise VectorStoreConfigurationError(
+            "Qdrant embedding dimension does not match the resolved embedder: "
+            f"vector store expects {configured_dimension}, embedder produces {actual_dimension}. "
+            "Select a matching embedding model/dimension or collection."
+        )
+
+    vector_config.embedding_model_dims = actual_dimension
+
+
 class _OSSProject:
     def update(
         self,
@@ -466,6 +503,7 @@ class Memory(MemoryBase):
             self.config.embedder.config,
             self.config.vector_store.config,
         )
+        _resolve_qdrant_embedding_dimension(self.config, self.embedding_model)
         self.vector_store = VectorStoreFactory.create(
             self.config.vector_store.provider, self.config.vector_store.config
         )
@@ -622,7 +660,7 @@ class Memory(MemoryBase):
         except Exception as e:
             logger.warning(f"Entity upsert failed for '{entity_text}': {e}")
 
-    def _remove_memory_from_entity_store(self, memory_id, filters):
+    def _remove_memory_from_entity_store(self, memory_id, filters, strict=False):
         """Strip `memory_id` from every entity record scoped to `filters`.
 
         For each entity whose `linked_memory_ids` contains `memory_id`:
@@ -630,52 +668,69 @@ class Memory(MemoryBase):
           - otherwise re-embed the entity text and update the payload
             (the vector store's update() requires a vector).
 
-        No-op if the entity store has never been initialized in this process.
-        Errors on individual entities are swallowed at debug level; outer
-        failures are swallowed at warning level so the primary delete/update
-        path is never broken by entity cleanup.
+        The entity store is initialized lazily even in a fresh process. When
+        ``strict`` is true, any incomplete cleanup is surfaced to delete_all.
         """
-        if self._entity_store is None:
-            return
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        failed = 0
         try:
-            listed = self.entity_store.list(filters=search_filters, top_k=10000)
-            rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
-            for row in rows or []:
-                try:
-                    payload = getattr(row, "payload", None) or {}
-                    linked = payload.get("linked_memory_ids", [])
-                    if not isinstance(linked, list) or memory_id not in linked:
-                        continue
-                    remaining = [mid for mid in linked if mid != memory_id]
-                    if not remaining:
-                        try:
-                            self.entity_store.delete(vector_id=row.id)
-                        except Exception as e:
-                            logger.debug(f"Entity delete failed for id={row.id}: {e}")
-                    else:
+            store = self.entity_store
+            offset = None
+            seen_ids = set()
+            requested = ENTITY_CLEANUP_PAGE_SIZE
+            for _ in range(DELETE_ALL_MAX_ITERATIONS):
+                if self.config.vector_store.provider == "qdrant":
+                    listed = store.list(filters=search_filters, top_k=ENTITY_CLEANUP_PAGE_SIZE, offset=offset)
+                else:
+                    listed = store.list(filters=search_filters, top_k=requested)
+                rows = normalize_list_result(listed)
+                new_rows = [row for row in rows if getattr(row, "id", None) not in seen_ids]
+                if not new_rows:
+                    break
+
+                for row in new_rows:
+                    seen_ids.add(getattr(row, "id", None))
+                    try:
+                        payload = getattr(row, "payload", None) or {}
+                        linked = payload.get("linked_memory_ids", [])
+                        if not isinstance(linked, list) or memory_id not in linked:
+                            continue
+                        remaining = [mid for mid in linked if mid != memory_id]
+                        if not remaining:
+                            store.delete(vector_id=row.id)
+                            continue
+
                         entity_text = payload.get("data")
                         if not isinstance(entity_text, str) or not entity_text:
-                            logger.debug(f"Entity id={row.id} missing 'data'; skipping update during cleanup")
+                            failed += 1
                             continue
-                        try:
-                            vec = self.embedding_model.embed(entity_text, "update")
-                        except Exception as e:
-                            logger.debug(f"Entity re-embed failed for '{entity_text}': {e}")
-                            continue
-                        new_payload = {**payload, "linked_memory_ids": remaining}
-                        try:
-                            self.entity_store.update(
-                                vector_id=row.id,
-                                vector=vec,
-                                payload=new_payload,
-                            )
-                        except Exception as e:
-                            logger.debug(f"Entity update failed for id={row.id}: {e}")
-                except Exception as e:
-                    logger.debug(f"Entity cleanup error: {e}")
-        except Exception as e:
-            logger.warning(f"Entity store cleanup failed for memory_id={memory_id}: {e}")
+                        vector = self.embedding_model.embed(entity_text, "update")
+                        store.update(
+                            vector_id=row.id,
+                            vector=vector,
+                            payload={**payload, "linked_memory_ids": remaining},
+                        )
+                    except Exception as exc:
+                        failed += 1
+                        logger.debug("Entity cleanup operation failed (%s)", type(exc).__name__)
+
+                if self.config.vector_store.provider == "qdrant":
+                    offset = listed[1] if isinstance(listed, tuple) and len(listed) == 2 else None
+                    if offset is None:
+                        break
+                else:
+                    if len(rows) < requested:
+                        break
+                    requested += ENTITY_CLEANUP_PAGE_SIZE
+            else:
+                failed += 1
+        except Exception as exc:
+            failed += 1
+            logger.warning("Entity store cleanup failed (%s)", type(exc).__name__)
+
+        if failed and strict:
+            raise RuntimeError(f"Entity cleanup did not complete ({failed} failed operation(s)).")
+        return failed == 0
 
     def _link_entities_for_memory(self, memory_id, text, filters):
         """Extract entities from `text` and link them to `memory_id` in the
@@ -704,8 +759,8 @@ class Memory(MemoryBase):
     def from_config(cls, config_dict: Dict[str, Any]):
         try:
             config = MemoryConfig(**config_dict)
-        except ValidationError as e:
-            logger.error(f"Configuration validation error: {e}")
+        except ValidationError:
+            logger.error("Configuration validation failed")
             raise
         return cls(config)
 
@@ -1872,39 +1927,90 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
         deleted_ids = set()
+        known_ids = set()
+        pending_history = {}
+        pending_entities = {}
         deleted_count = 0
         stale_iterations = 0
 
         for _ in range(DELETE_ALL_MAX_ITERATIONS):
-            memories = normalize_list_result(
-                self.vector_store.list(filters=filters, top_k=DELETE_ALL_PAGE_SIZE)
-            )
-            if not memories:
+            progress = 0
+            failed_this_iteration = 0
+
+            for memory_id, memory in list(pending_history.items()):
+                try:
+                    self._record_delete_history(memory_id, memory)
+                except Exception:
+                    failed_this_iteration += 1
+                    continue
+                pending_history.pop(memory_id)
+                progress += 1
+                payload = memory.payload or {}
+                entity_filters = {key: payload[key] for key in ("user_id", "agent_id", "run_id") if payload.get(key)}
+                try:
+                    self._remove_memory_from_entity_store(memory_id, entity_filters, strict=True)
+                except Exception:
+                    pending_entities[memory_id] = memory
+                else:
+                    deleted_ids.add(memory_id)
+                    deleted_count += 1
+
+            for memory_id, memory in list(pending_entities.items()):
+                payload = memory.payload or {}
+                entity_filters = {key: payload[key] for key in ("user_id", "agent_id", "run_id") if payload.get(key)}
+                try:
+                    self._remove_memory_from_entity_store(memory_id, entity_filters, strict=True)
+                except Exception:
+                    failed_this_iteration += 1
+                    continue
+                pending_entities.pop(memory_id)
+                deleted_ids.add(memory_id)
+                deleted_count += 1
+                progress += 1
+
+            memories = normalize_list_result(self.vector_store.list(filters=filters, top_k=DELETE_ALL_PAGE_SIZE))
+            if not memories and not pending_history and not pending_entities:
                 break
 
-            pending_by_id = {memory.id: memory for memory in memories if memory.id not in deleted_ids}
+            known_ids.update(memory.id for memory in memories)
+            pending_by_id = {
+                memory.id: memory
+                for memory in memories
+                if memory.id not in deleted_ids
+                and memory.id not in pending_history
+                and memory.id not in pending_entities
+            }
             pending = list(pending_by_id.values())
-            successful_this_page = 0
             for memory in pending:
                 try:
-                    self._delete_memory(memory.id, memory)
-                except Exception as exc:
-                    logger.warning("Failed to delete memory id=%s: %s", memory.id, exc)
+                    self._delete_memory(memory.id, memory, strict_entity_cleanup=True)
+                except _DeleteHistoryError as exc:
+                    pending_history[memory.id] = exc.memory
+                    progress += 1
+                except _DeleteEntityError as exc:
+                    pending_entities[memory.id] = exc.memory
+                    progress += 1
+                except Exception:
+                    failed_this_iteration += 1
                 else:
                     deleted_ids.add(memory.id)
                     deleted_count += 1
-                    successful_this_page += 1
+                    progress += 1
 
-            if successful_this_page:
+            logger.info(
+                "Delete-all progress: requested=%d deleted=%d pending=%d failed=%d",
+                len(known_ids),
+                deleted_count,
+                len(pending_history) + len(pending_entities),
+                failed_this_iteration,
+            )
+            if progress:
                 stale_iterations = 0
             else:
                 stale_iterations += 1
                 if stale_iterations >= DELETE_ALL_MAX_STALE_ITERATIONS:
-                    raise RuntimeError(
-                        "Unable to delete all matching memories because the vector store made no progress."
-                    )
+                    raise RuntimeError("Unable to delete all matching memories because deletion made no progress.")
         else:
             raise RuntimeError("Unable to delete all matching memories before the safety iteration limit.")
 
@@ -2065,33 +2171,40 @@ class Memory(MemoryBase):
 
         return memory_id
 
-    def _delete_memory(self, memory_id, existing_memory=None):
+    def _record_delete_history(self, memory_id, existing_memory):
+        payload = existing_memory.payload or {}
+        self.db.add_history(
+            memory_id,
+            payload.get("data", ""),
+            None,
+            "DELETE",
+            created_at=_normalize_iso_timestamp_to_utc(payload.get("created_at")),
+            updated_at=datetime.now(timezone.utc).isoformat(),
+            actor_id=payload.get("actor_id"),
+            role=payload.get("role"),
+            is_deleted=1,
+        )
+
+    def _delete_memory(self, memory_id, existing_memory=None, strict_entity_cleanup=False):
         logger.info(f"Deleting memory with {memory_id=}")
         if existing_memory is None:
             existing_memory = self.vector_store.get(vector_id=memory_id)
             if existing_memory is None:
                 raise ValueError(f"Memory with id {memory_id} not found. Please provide a valid 'memory_id'")
-        prev_value = existing_memory.payload.get("data", "")
-        created_at = _normalize_iso_timestamp_to_utc(existing_memory.payload.get("created_at"))
-        updated_at = datetime.now(timezone.utc).isoformat()
         payload = existing_memory.payload or {}
         session_filters = {k: payload[k] for k in ("user_id", "agent_id", "run_id") if payload.get(k)}
         self.vector_store.delete(vector_id=memory_id)
-        self.db.add_history(
-            memory_id,
-            prev_value,
-            None,
-            "DELETE",
-            created_at=created_at,
-            updated_at=updated_at,
-            actor_id=existing_memory.payload.get("actor_id"),
-            role=existing_memory.payload.get("role"),
-            is_deleted=1,
-        )
+        try:
+            self._record_delete_history(memory_id, existing_memory)
+        except Exception:
+            raise _DeleteHistoryError(existing_memory) from None
 
         # Entity-store cleanup: strip this memory's id from any entity records
         # that linked to it. Non-fatal — the helper swallows errors.
-        self._remove_memory_from_entity_store(memory_id, session_filters)
+        try:
+            self._remove_memory_from_entity_store(memory_id, session_filters, strict=strict_entity_cleanup)
+        except Exception:
+            raise _DeleteEntityError(existing_memory) from None
 
         return memory_id
 
@@ -2146,6 +2259,7 @@ class AsyncMemory(MemoryBase):
             self.config.embedder.config,
             self.config.vector_store.config,
         )
+        _resolve_qdrant_embedding_dimension(self.config, self.embedding_model)
         self.vector_store = VectorStoreFactory.create(
             self.config.vector_store.provider, self.config.vector_store.config
         )
@@ -2291,64 +2405,120 @@ class AsyncMemory(MemoryBase):
         concurrent _delete_memory coroutines each try to read-modify-write
         the same entity rows' linked_memory_ids lists.
         """
-        if self._entity_store is None:
-            return
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        try:
-            listed = await asyncio.to_thread(self.entity_store.list, filters=search_filters, top_k=10000)
-            rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
-            for row in rows or []:
-                try:
-                    await asyncio.to_thread(self.entity_store.delete, vector_id=row.id)
-                except Exception as e:
-                    logger.debug(f"Bulk entity delete failed for id={row.id}: {e}")
-        except Exception as e:
-            logger.warning(f"Bulk entity store cleanup failed: {e}")
+        store = self.entity_store
+        semaphore = asyncio.Semaphore(DELETE_ALL_ASYNC_CONCURRENCY)
+        previous_page_ids = None
+        repeated_pages = 0
 
-    async def _remove_memory_from_entity_store(self, memory_id, filters):
-        """Async variant of `Memory._remove_memory_from_entity_store`."""
-        if self._entity_store is None:
-            return
-        search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-        try:
-            listed = await asyncio.to_thread(self.entity_store.list, filters=search_filters, top_k=10000)
-            rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
-            for row in rows or []:
+        async def delete_entity(row):
+            async with semaphore:
                 try:
-                    payload = getattr(row, "payload", None) or {}
-                    linked = payload.get("linked_memory_ids", [])
-                    if not isinstance(linked, list) or memory_id not in linked:
-                        continue
-                    remaining = [mid for mid in linked if mid != memory_id]
-                    if not remaining:
-                        try:
-                            await asyncio.to_thread(self.entity_store.delete, vector_id=row.id)
-                        except Exception as e:
-                            logger.debug(f"Entity delete failed for id={row.id} (async): {e}")
-                    else:
+                    await asyncio.to_thread(store.delete, vector_id=row.id)
+                except Exception:
+                    return False
+                return True
+
+        for _ in range(DELETE_ALL_MAX_ITERATIONS):
+            try:
+                listed = await asyncio.to_thread(
+                    store.list,
+                    filters=search_filters,
+                    top_k=ENTITY_CLEANUP_PAGE_SIZE,
+                )
+            except Exception as exc:
+                logger.warning("Bulk entity-store listing failed (%s)", type(exc).__name__)
+                raise RuntimeError("Bulk entity-store cleanup could not list matching entities.") from None
+
+            rows = normalize_list_result(listed)
+            if not rows:
+                return
+            page_ids = tuple(sorted(str(row.id) for row in rows))
+            if page_ids == previous_page_ids:
+                repeated_pages += 1
+                if repeated_pages >= DELETE_ALL_MAX_STALE_ITERATIONS:
+                    raise RuntimeError("Bulk entity-store cleanup repeatedly returned the same records.")
+            else:
+                previous_page_ids = page_ids
+                repeated_pages = 0
+            results = await asyncio.gather(*(delete_entity(row) for row in rows))
+            deleted = sum(results)
+            if deleted == 0:
+                raise RuntimeError("Bulk entity-store cleanup made no forward progress.")
+            logger.info(
+                "Bulk entity cleanup: requested=%d deleted=%d failed=%d", len(rows), deleted, len(rows) - deleted
+            )
+
+        raise RuntimeError("Bulk entity-store cleanup exceeded the safety iteration limit.")
+
+    async def _remove_memory_from_entity_store(self, memory_id, filters, strict=False):
+        """Async variant of `Memory._remove_memory_from_entity_store`."""
+        search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        failed = 0
+        try:
+            store = self.entity_store
+            offset = None
+            seen_ids = set()
+            requested = ENTITY_CLEANUP_PAGE_SIZE
+            for _ in range(DELETE_ALL_MAX_ITERATIONS):
+                if self.config.vector_store.provider == "qdrant":
+                    listed = await asyncio.to_thread(
+                        store.list,
+                        filters=search_filters,
+                        top_k=ENTITY_CLEANUP_PAGE_SIZE,
+                        offset=offset,
+                    )
+                else:
+                    listed = await asyncio.to_thread(store.list, filters=search_filters, top_k=requested)
+                rows = normalize_list_result(listed)
+                new_rows = [row for row in rows if getattr(row, "id", None) not in seen_ids]
+                if not new_rows:
+                    break
+
+                for row in new_rows:
+                    seen_ids.add(getattr(row, "id", None))
+                    try:
+                        payload = getattr(row, "payload", None) or {}
+                        linked = payload.get("linked_memory_ids", [])
+                        if not isinstance(linked, list) or memory_id not in linked:
+                            continue
+                        remaining = [mid for mid in linked if mid != memory_id]
+                        if not remaining:
+                            await asyncio.to_thread(store.delete, vector_id=row.id)
+                            continue
+
                         entity_text = payload.get("data")
                         if not isinstance(entity_text, str) or not entity_text:
-                            logger.debug(f"Entity id={row.id} missing 'data'; skipping update during cleanup (async)")
+                            failed += 1
                             continue
-                        try:
-                            vec = await asyncio.to_thread(self.embedding_model.embed, entity_text, "update")
-                        except Exception as e:
-                            logger.debug(f"Entity re-embed failed for '{entity_text}' (async): {e}")
-                            continue
-                        new_payload = {**payload, "linked_memory_ids": remaining}
-                        try:
-                            await asyncio.to_thread(
-                                self.entity_store.update,
-                                vector_id=row.id,
-                                vector=vec,
-                                payload=new_payload,
-                            )
-                        except Exception as e:
-                            logger.debug(f"Entity update failed for id={row.id} (async): {e}")
-                except Exception as e:
-                    logger.debug(f"Entity cleanup error (async): {e}")
-        except Exception as e:
-            logger.warning(f"Entity store cleanup failed for memory_id={memory_id} (async): {e}")
+                        vector = await asyncio.to_thread(self.embedding_model.embed, entity_text, "update")
+                        await asyncio.to_thread(
+                            store.update,
+                            vector_id=row.id,
+                            vector=vector,
+                            payload={**payload, "linked_memory_ids": remaining},
+                        )
+                    except Exception as exc:
+                        failed += 1
+                        logger.debug("Async entity cleanup operation failed (%s)", type(exc).__name__)
+
+                if self.config.vector_store.provider == "qdrant":
+                    offset = listed[1] if isinstance(listed, tuple) and len(listed) == 2 else None
+                    if offset is None:
+                        break
+                else:
+                    if len(rows) < requested:
+                        break
+                    requested += ENTITY_CLEANUP_PAGE_SIZE
+            else:
+                failed += 1
+        except Exception as exc:
+            failed += 1
+            logger.warning("Async entity-store cleanup failed (%s)", type(exc).__name__)
+
+        if failed and strict:
+            raise RuntimeError(f"Entity cleanup did not complete ({failed} failed operation(s)).")
+        return failed == 0
 
     async def _link_entities_for_memory(self, memory_id, text, filters):
         """Async variant of `Memory._link_entities_for_memory`."""
@@ -2373,8 +2543,8 @@ class AsyncMemory(MemoryBase):
     def from_config(cls, config_dict: Dict[str, Any]):
         try:
             config = MemoryConfig(**config_dict)
-        except ValidationError as e:
-            logger.error(f"Configuration validation error: {e}")
+        except ValidationError:
+            logger.error("Configuration validation failed")
             raise
         return cls(config)
 
@@ -3523,6 +3693,8 @@ class AsyncMemory(MemoryBase):
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
         deleted_ids = set()
+        known_ids = set()
+        pending_history = {}
         deleted_count = 0
         stale_iterations = 0
         semaphore = asyncio.Semaphore(DELETE_ALL_ASYNC_CONCURRENCY)
@@ -3536,40 +3708,75 @@ class AsyncMemory(MemoryBase):
                 return memory.id, None
 
         for _ in range(DELETE_ALL_MAX_ITERATIONS):
+            progress = 0
+            failed_this_iteration = 0
+
+            async def retry_history(item):
+                memory_id, memory = item
+                async with semaphore:
+                    try:
+                        await self._record_delete_history(memory_id, memory)
+                    except Exception:
+                        return memory_id, False
+                    return memory_id, True
+
+            if pending_history:
+                history_results = await asyncio.gather(*(retry_history(item) for item in pending_history.items()))
+                for memory_id, succeeded in history_results:
+                    if not succeeded:
+                        failed_this_iteration += 1
+                        continue
+                    pending_history.pop(memory_id)
+                    deleted_ids.add(memory_id)
+                    deleted_count += 1
+                    progress += 1
+
             listed = await asyncio.to_thread(
                 self.vector_store.list,
                 filters=filters,
                 top_k=DELETE_ALL_PAGE_SIZE,
             )
             memories = normalize_list_result(listed)
-            if not memories:
+            if not memories and not pending_history:
                 break
 
-            pending_by_id = {memory.id: memory for memory in memories if memory.id not in deleted_ids}
+            known_ids.update(memory.id for memory in memories)
+            pending_by_id = {
+                memory.id: memory
+                for memory in memories
+                if memory.id not in deleted_ids and memory.id not in pending_history
+            }
             pending = list(pending_by_id.values())
             results = await asyncio.gather(*(delete_one(memory) for memory in pending))
-            successful_this_page = 0
             for memory_id, error in results:
+                if isinstance(error, _DeleteHistoryError):
+                    pending_history[memory_id] = error.memory
+                    progress += 1
+                    continue
                 if error is not None:
-                    logger.warning("Failed to delete memory id=%s: %s", memory_id, error)
+                    failed_this_iteration += 1
                     continue
                 deleted_ids.add(memory_id)
                 deleted_count += 1
-                successful_this_page += 1
+                progress += 1
 
-            if successful_this_page:
+            logger.info(
+                "Async delete-all progress: requested=%d deleted=%d pending=%d failed=%d",
+                len(known_ids),
+                deleted_count,
+                len(pending_history),
+                failed_this_iteration,
+            )
+            if progress:
                 stale_iterations = 0
             else:
                 stale_iterations += 1
                 if stale_iterations >= DELETE_ALL_MAX_STALE_ITERATIONS:
-                    raise RuntimeError(
-                        "Unable to delete all matching memories because the vector store made no progress."
-                    )
+                    raise RuntimeError("Unable to delete all matching memories because deletion made no progress.")
         else:
             raise RuntimeError("Unable to delete all matching memories before the safety iteration limit.")
 
-        if self._entity_store is not None:
-            await self._bulk_clear_entity_store(filters)
+        await self._bulk_clear_entity_store(filters)
 
         logger.info("Deleted %d memories", deleted_count)
 
@@ -3752,34 +3959,51 @@ class AsyncMemory(MemoryBase):
 
         return memory_id
 
-    async def _delete_memory(self, memory_id, existing_memory=None, skip_entity_cleanup=False):
+    async def _record_delete_history(self, memory_id, existing_memory):
+        payload = existing_memory.payload or {}
+        await asyncio.to_thread(
+            self.db.add_history,
+            memory_id,
+            payload.get("data", ""),
+            None,
+            "DELETE",
+            created_at=_normalize_iso_timestamp_to_utc(payload.get("created_at")),
+            updated_at=datetime.now(timezone.utc).isoformat(),
+            actor_id=payload.get("actor_id"),
+            role=payload.get("role"),
+            is_deleted=1,
+        )
+
+    async def _delete_memory(
+        self,
+        memory_id,
+        existing_memory=None,
+        skip_entity_cleanup=False,
+        strict_entity_cleanup=False,
+    ):
         logger.info(f"Deleting memory with {memory_id=}")
         if existing_memory is None:
             existing_memory = await asyncio.to_thread(self.vector_store.get, vector_id=memory_id)
             if existing_memory is None:
                 raise ValueError(f"Memory with id {memory_id} not found. Please provide a valid 'memory_id'")
-        prev_value = existing_memory.payload.get("data", "")
-        created_at = _normalize_iso_timestamp_to_utc(existing_memory.payload.get("created_at"))
-        updated_at = datetime.now(timezone.utc).isoformat()
         payload = existing_memory.payload or {}
         session_filters = {k: payload[k] for k in ("user_id", "agent_id", "run_id") if payload.get(k)}
 
         await asyncio.to_thread(self.vector_store.delete, vector_id=memory_id)
-        await asyncio.to_thread(
-            self.db.add_history,
-            memory_id,
-            prev_value,
-            None,
-            "DELETE",
-            created_at=created_at,
-            updated_at=updated_at,
-            actor_id=existing_memory.payload.get("actor_id"),
-            role=existing_memory.payload.get("role"),
-            is_deleted=1,
-        )
+        try:
+            await self._record_delete_history(memory_id, existing_memory)
+        except Exception:
+            raise _DeleteHistoryError(existing_memory) from None
 
         if not skip_entity_cleanup:
-            await self._remove_memory_from_entity_store(memory_id, session_filters)
+            try:
+                await self._remove_memory_from_entity_store(
+                    memory_id,
+                    session_filters,
+                    strict=strict_entity_cleanup,
+                )
+            except Exception:
+                raise _DeleteEntityError(existing_memory) from None
 
         return memory_id
 

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -73,6 +73,7 @@ from mem0.utils.scoring import (
     score_and_rank,
 )
 from mem0.vector_stores.base import VectorStoreBase
+from mem0.vector_stores.utils import normalize_list_result
 
 # Suppress SWIG deprecation warnings globally
 warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*SwigPy.*")
@@ -80,14 +81,6 @@ warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*swigva
 
 # Initialize logger early for util functions
 logger = logging.getLogger(__name__)
-
-
-def _vector_store_list_rows(listed):
-    if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list):
-        return listed[0]
-    if isinstance(listed, (list, tuple)):
-        return listed
-    return []
 
 
 # Fields that hold runtime auth/connection objects and must be preserved.
@@ -136,6 +129,11 @@ ENTITY_PARAMS = frozenset({"user_id", "agent_id", "run_id"})
 
 # Tenant-scoping fields that update() must never let caller-supplied metadata overwrite (issues #4490, #6277).
 _IDENTITY_KEYS = ENTITY_PARAMS | {"actor_id"}
+
+DELETE_ALL_PAGE_SIZE = 1_000
+DELETE_ALL_MAX_ITERATIONS = 10_000
+DELETE_ALL_MAX_STALE_ITERATIONS = 3
+DELETE_ALL_ASYNC_CONCURRENCY = 20
 
 
 def _strip_identity_keys(metadata: Dict[str, Any], existing_payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -567,7 +565,7 @@ class Memory(MemoryBase):
             return {}
 
         rows_by_text = {}
-        for row in _vector_store_list_rows(listed):
+        for row in normalize_list_result(listed):
             payload = getattr(row, "payload", None) or {}
             text = payload.get("data")
             if not isinstance(text, str):
@@ -1296,18 +1294,7 @@ class Memory(MemoryBase):
     def _get_all_from_vector_store(self, filters, limit, show_expired=False, output_limit=None):
         memories_result = self.vector_store.list(filters=filters, top_k=limit)
 
-        # Handle different vector store return formats by inspecting first element
-        if isinstance(memories_result, (tuple, list)) and len(memories_result) > 0:
-            first_element = memories_result[0]
-
-            # If first element is a container, unwrap one level
-            if isinstance(first_element, (list, tuple)):
-                actual_memories = first_element
-            else:
-                # First element is a memory object, structure is already flat
-                actual_memories = memories_result
-        else:
-            actual_memories = memories_result
+        actual_memories = normalize_list_result(memories_result)
 
         promoted_payload_keys = [
             "user_id",
@@ -1886,13 +1873,44 @@ class Memory(MemoryBase):
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
         # delete all vector memories and reset the collections
-        memories = self.vector_store.list(filters=filters)[0]
-        for memory in memories:
-            self._delete_memory(memory.id)
+        deleted_ids = set()
+        deleted_count = 0
+        stale_iterations = 0
 
-        logger.info(f"Deleted {len(memories)} memories")
+        for _ in range(DELETE_ALL_MAX_ITERATIONS):
+            memories = normalize_list_result(
+                self.vector_store.list(filters=filters, top_k=DELETE_ALL_PAGE_SIZE)
+            )
+            if not memories:
+                break
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories))
+            pending_by_id = {memory.id: memory for memory in memories if memory.id not in deleted_ids}
+            pending = list(pending_by_id.values())
+            successful_this_page = 0
+            for memory in pending:
+                try:
+                    self._delete_memory(memory.id, memory)
+                except Exception as exc:
+                    logger.warning("Failed to delete memory id=%s: %s", memory.id, exc)
+                else:
+                    deleted_ids.add(memory.id)
+                    deleted_count += 1
+                    successful_this_page += 1
+
+            if successful_this_page:
+                stale_iterations = 0
+            else:
+                stale_iterations += 1
+                if stale_iterations >= DELETE_ALL_MAX_STALE_ITERATIONS:
+                    raise RuntimeError(
+                        "Unable to delete all matching memories because the vector store made no progress."
+                    )
+        else:
+            raise RuntimeError("Unable to delete all matching memories before the safety iteration limit.")
+
+        logger.info("Deleted %d memories", deleted_count)
+
+        decay_usage_notice = detect_decay_usage_from_delete_all(deleted_count)
         if decay_usage_notice:
             display_decay_usage_notice(self, "sync", "delete_all", *decay_usage_notice)
         else:
@@ -2206,7 +2224,7 @@ class AsyncMemory(MemoryBase):
             return {}
 
         rows_by_text = {}
-        for row in _vector_store_list_rows(listed):
+        for row in normalize_list_result(listed):
             payload = getattr(row, "payload", None) or {}
             text = payload.get("data")
             if not isinstance(text, str):
@@ -2928,18 +2946,7 @@ class AsyncMemory(MemoryBase):
     async def _get_all_from_vector_store(self, filters, limit, show_expired=False, output_limit=None):
         memories_result = await asyncio.to_thread(self.vector_store.list, filters=filters, top_k=limit)
 
-        # Handle different vector store return formats by inspecting first element
-        if isinstance(memories_result, (tuple, list)) and len(memories_result) > 0:
-            first_element = memories_result[0]
-
-            # If first element is a container, unwrap one level
-            if isinstance(first_element, (list, tuple)):
-                actual_memories = first_element
-            else:
-                # First element is a memory object, structure is already flat
-                actual_memories = memories_result
-        else:
-            actual_memories = memories_result
+        actual_memories = normalize_list_result(memories_result)
 
         promoted_payload_keys = [
             "user_id",
@@ -3515,26 +3522,58 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
+        deleted_ids = set()
+        deleted_count = 0
+        stale_iterations = 0
+        semaphore = asyncio.Semaphore(DELETE_ALL_ASYNC_CONCURRENCY)
 
-        delete_tasks = []
-        for memory in memories[0]:
-            delete_tasks.append(self._delete_memory(memory.id, skip_entity_cleanup=True))
+        async def delete_one(memory):
+            async with semaphore:
+                try:
+                    await self._delete_memory(memory.id, memory, skip_entity_cleanup=True)
+                except Exception as exc:
+                    return memory.id, exc
+                return memory.id, None
 
-        results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+        for _ in range(DELETE_ALL_MAX_ITERATIONS):
+            listed = await asyncio.to_thread(
+                self.vector_store.list,
+                filters=filters,
+                top_k=DELETE_ALL_PAGE_SIZE,
+            )
+            memories = normalize_list_result(listed)
+            if not memories:
+                break
+
+            pending_by_id = {memory.id: memory for memory in memories if memory.id not in deleted_ids}
+            pending = list(pending_by_id.values())
+            results = await asyncio.gather(*(delete_one(memory) for memory in pending))
+            successful_this_page = 0
+            for memory_id, error in results:
+                if error is not None:
+                    logger.warning("Failed to delete memory id=%s: %s", memory_id, error)
+                    continue
+                deleted_ids.add(memory_id)
+                deleted_count += 1
+                successful_this_page += 1
+
+            if successful_this_page:
+                stale_iterations = 0
+            else:
+                stale_iterations += 1
+                if stale_iterations >= DELETE_ALL_MAX_STALE_ITERATIONS:
+                    raise RuntimeError(
+                        "Unable to delete all matching memories because the vector store made no progress."
+                    )
+        else:
+            raise RuntimeError("Unable to delete all matching memories before the safety iteration limit.")
 
         if self._entity_store is not None:
             await self._bulk_clear_entity_store(filters)
 
-        errors = [r for r in results if isinstance(r, BaseException)]
-        if errors:
-            logger.warning("Failed to delete %d out of %d memories", len(errors), len(results))
-            for err in errors:
-                logger.warning("Delete error: %s", err)
+        logger.info("Deleted %d memories", deleted_count)
 
-        logger.info(f"Deleted {len(results) - len(errors)} memories")
-
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories[0]))
+        decay_usage_notice = detect_decay_usage_from_delete_all(deleted_count)
         if decay_usage_notice:
             await display_decay_usage_notice_async(self, "async", "delete_all", *decay_usage_notice)
         else:

--- a/mem0/vector_stores/base.py
+++ b/mem0/vector_stores/base.py
@@ -1,6 +1,10 @@
 from abc import ABC, abstractmethod
 
 
+class VectorStoreConfigurationError(ValueError):
+    """A safe, operator-actionable vector-store configuration incompatibility."""
+
+
 class VectorStoreBase(ABC):
     @abstractmethod
     def create_col(self, name, vector_size, distance):

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -59,8 +59,12 @@ class VectorStoreConfig(BaseModel):
                 raise ValueError(f"Invalid config type for provider {provider}")
             return self
 
-        # also check if path in allowed kays for pydantic model, and whether config extra fields are allowed
-        if "path" not in config and "path" in config_class.__annotations__:
+        # Keep the SDK's local default, but do not inject a local path when an
+        # explicit remote Qdrant endpoint was supplied.
+        has_remote_qdrant = provider == "qdrant" and (
+            config.get("url") or (config.get("host") and config.get("port"))
+        )
+        if "path" not in config and "path" in config_class.__annotations__ and not has_remote_qdrant:
             config["path"] = f"/tmp/{provider}"
 
         self.config = config_class(**config)

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -8,7 +8,7 @@ class VectorStoreConfig(BaseModel):
         description="Provider of the vector store (e.g., 'qdrant', 'chroma', 'upstash_vector')",
         default="qdrant",
     )
-    config: Optional[Dict] = Field(description="Configuration for the specific vector store", default=None)
+    config: Optional[Any] = Field(description="Configuration for the specific vector store", default=None)
 
     _provider_configs: Dict[str, str] = {
         "qdrant": "QdrantConfig",
@@ -59,12 +59,18 @@ class VectorStoreConfig(BaseModel):
                 raise ValueError(f"Invalid config type for provider {provider}")
             return self
 
+        # Provider validators may normalize top-level values. Copy the mapping
+        # without cloning runtime objects such as an existing Qdrant client.
+        config = config.copy()
+
         # Keep the SDK's local default, but do not inject a local path when an
         # explicit remote Qdrant endpoint was supplied.
-        has_remote_qdrant = provider == "qdrant" and (
-            config.get("url") or (config.get("host") and config.get("port"))
+        has_qdrant_target = provider == "qdrant" and (
+            config.get("client") is not None
+            or config.get("url")
+            or (config.get("host") and config.get("port"))
         )
-        if "path" not in config and "path" in config_class.__annotations__ and not has_remote_qdrant:
+        if "path" not in config and "path" in config_class.__annotations__ and not has_qdrant_target:
             config["path"] = f"/tmp/{provider}"
 
         self.config = config_class(**config)

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -21,7 +21,7 @@ from qdrant_client.models import (
     VectorParams,
 )
 
-from mem0.vector_stores.base import VectorStoreBase
+from mem0.vector_stores.base import VectorStoreBase, VectorStoreConfigurationError
 
 logger = logging.getLogger(__name__)
 
@@ -59,23 +59,33 @@ class Qdrant(VectorStoreBase):
         """
         if client:
             self.client = client
-            self.is_local = False
+            self.is_local = bool(path and not url and not host)
         else:
-            params = {}
-            if api_key:
-                params["api_key"] = api_key
-            if url:
-                params["url"] = url
-            if host and port:
-                params["host"] = host
-                params["port"] = port
-            if https is not None:
-                params["https"] = https
+            has_url = bool(url)
+            has_host = bool(host)
+            has_path = bool(path)
+            if has_url and (has_host or port is not None):
+                raise VectorStoreConfigurationError("Qdrant url and host/port modes cannot be configured together.")
+            if has_path and (has_url or has_host or port is not None):
+                raise VectorStoreConfigurationError(
+                    "Qdrant local path and remote endpoint modes cannot be configured together."
+                )
+            if has_path and (api_key is not None or https is not None):
+                raise VectorStoreConfigurationError("Qdrant local path mode cannot use api_key or https.")
+            if has_host != (port is not None):
+                raise VectorStoreConfigurationError("Qdrant host mode requires both host and port.")
 
-            if not params:
-                params["path"] = path
+            if has_path:
+                params = {"path": path}
                 self.is_local = True
             else:
+                if not has_url and not has_host:
+                    raise VectorStoreConfigurationError("Qdrant requires a url, host and port, or local path.")
+                params = {"url": url} if has_url else {"host": host, "port": port}
+                if api_key is not None:
+                    params["api_key"] = api_key
+                if https is not None:
+                    params["https"] = https
                 self.is_local = False
 
             self.client = QdrantClient(**params)
@@ -134,48 +144,63 @@ class Qdrant(VectorStoreBase):
             on_disk (bool): Enables persistent storage.
             distance (Distance, optional): Distance metric for vector similarity. Defaults to Distance.COSINE.
         """
-        # Skip creating collection if already exists
         response = self.list_cols()
         for collection in response.collections:
             if collection.name == self.collection_name:
                 logger.debug(f"Collection {self.collection_name} already exists. Skipping creation.")
                 info = self.client.get_collection(self.collection_name)
-                self._validate_existing_collection(info, vector_size, distance)
-                sparse_cfg = info.config.params.sparse_vectors
-                self._has_bm25_slot = bool(sparse_cfg and "bm25" in sparse_cfg)
-                if not self._has_bm25_slot:
-                    logger.warning(
-                        f"Collection '{self.collection_name}' predates v3 hybrid search (no 'bm25' sparse slot). "
-                        "BM25 keyword scoring will be disabled for this collection; semantic search works normally. "
-                        "To enable hybrid search, use a fresh collection."
-                    )
-                self._create_filter_indexes()
+                self._prepare_existing_collection(info, vector_size, distance)
                 return
 
-        self.client.create_collection(
-            collection_name=self.collection_name,
-            vectors_config=VectorParams(size=vector_size, distance=distance, on_disk=on_disk),
-            sparse_vectors_config={
-                "bm25": SparseVectorParams(
-                    modifier=models.Modifier.IDF,
-                ),
-            },
-        )
+        try:
+            created = self.client.create_collection(
+                collection_name=self.collection_name,
+                vectors_config=VectorParams(size=vector_size, distance=distance, on_disk=on_disk),
+                sparse_vectors_config={
+                    "bm25": SparseVectorParams(
+                        modifier=models.Modifier.IDF,
+                    ),
+                },
+            )
+        except Exception as exc:
+            if getattr(exc, "status_code", None) != 409:
+                raise
+            info = self.client.get_collection(self.collection_name)
+            self._prepare_existing_collection(info, vector_size, distance)
+            return
+
+        if created is False:
+            info = self.client.get_collection(self.collection_name)
+            self._prepare_existing_collection(info, vector_size, distance)
+            return
+
         self._has_bm25_slot = True
         self._create_filter_indexes()
+
+    def _prepare_existing_collection(self, info, vector_size: int, distance: Distance) -> None:
+        self._validate_existing_collection(info, vector_size, distance)
+        sparse_cfg = info.config.params.sparse_vectors
+        self._has_bm25_slot = bool(sparse_cfg and "bm25" in sparse_cfg)
+        if not self._has_bm25_slot:
+            logger.warning(
+                f"Collection '{self.collection_name}' predates v3 hybrid search (no 'bm25' sparse slot). "
+                "BM25 keyword scoring will be disabled for this collection; semantic search works normally. "
+                "To enable hybrid search, use a fresh collection."
+            )
+        self._create_filter_indexes(info)
 
     def _validate_existing_collection(self, info, expected_size: int, expected_distance: Distance) -> None:
         """Fail non-destructively when an existing collection is incompatible with this adapter."""
         vectors_config = info.config.params.vectors
         if isinstance(vectors_config, dict):
             vector_names = ", ".join(sorted(vectors_config)) or "none"
-            raise ValueError(
+            raise VectorStoreConfigurationError(
                 f"Qdrant collection '{self.collection_name}' uses named dense vectors ({vector_names}), but Mem0 "
                 "requires one unnamed dense vector. Select a compatible collection or perform an operator-managed "
                 "migration."
             )
         if not isinstance(vectors_config, VectorParams):
-            raise ValueError(
+            raise VectorStoreConfigurationError(
                 f"Qdrant collection '{self.collection_name}' has an unsupported dense vector configuration. "
                 "Select a compatible collection or perform an operator-managed migration."
             )
@@ -186,14 +211,14 @@ class Qdrant(VectorStoreBase):
         actual_distance_value = getattr(actual_distance, "value", actual_distance)
 
         if actual_size != expected_size or actual_distance_value != expected_distance_value:
-            raise ValueError(
+            raise VectorStoreConfigurationError(
                 f"Qdrant collection '{self.collection_name}' is incompatible: expected dimension {expected_size} "
                 f"and distance {expected_distance_value}, found dimension {actual_size} and distance "
                 f"{actual_distance_value}. Select the matching embedding model or collection, or perform an "
                 "operator-managed migration."
             )
 
-    def _create_filter_indexes(self):
+    def _create_filter_indexes(self, collection_info=None):
         """Create indexes for commonly used filter fields to enable filtering."""
         # Only create payload indexes for remote Qdrant servers
         if self.is_local:
@@ -201,17 +226,52 @@ class Qdrant(VectorStoreBase):
             return
 
         common_fields = ["user_id", "agent_id", "run_id", "actor_id"]
+        payload_schema = getattr(collection_info, "payload_schema", None)
+        payload_schema = payload_schema if isinstance(payload_schema, dict) else {}
 
         for field in common_fields:
+            existing_schema = payload_schema.get(field)
+            if existing_schema is not None:
+                data_type = getattr(existing_schema, "data_type", existing_schema)
+                data_type = getattr(data_type, "value", data_type)
+                if str(data_type).lower() != "keyword":
+                    raise VectorStoreConfigurationError(
+                        f"Qdrant collection '{self.collection_name}' payload field '{field}' must use a keyword "
+                        "index. Select a compatible collection or perform an operator-managed migration."
+                    )
+                continue
             try:
                 self.client.create_payload_index(
                     collection_name=self.collection_name,
                     field_name=field,
-                    field_schema="keyword"
+                    field_schema="keyword",
                 )
                 logger.info(f"Created index for {field} in collection {self.collection_name}")
-            except Exception as e:
-                logger.debug(f"Index for {field} might already exist: {e}")
+            except Exception as exc:
+                try:
+                    refreshed_schema = getattr(
+                        self.client.get_collection(self.collection_name),
+                        "payload_schema",
+                        {},
+                    )
+                    refreshed_schema = refreshed_schema if isinstance(refreshed_schema, dict) else {}
+                    refreshed = refreshed_schema.get(field)
+                    refreshed_type = getattr(refreshed, "data_type", refreshed)
+                    refreshed_type = getattr(refreshed_type, "value", refreshed_type)
+                    if refreshed is not None and str(refreshed_type).lower() == "keyword":
+                        continue
+                except Exception:
+                    pass
+                logger.error(
+                    "Failed to ensure Qdrant payload index for field '%s' in collection '%s' (%s)",
+                    field,
+                    self.collection_name,
+                    type(exc).__name__,
+                )
+                raise RuntimeError(
+                    f"Failed to ensure required Qdrant payload index for field '{field}' in collection "
+                    f"'{self.collection_name}'."
+                ) from exc
 
     def insert(self, vectors: list, payloads: list = None, ids: list = None):
         """
@@ -600,13 +660,14 @@ class Qdrant(VectorStoreBase):
         """
         return self.client.get_collection(collection_name=self.collection_name)
 
-    def list(self, filters: dict = None, top_k: int = 100) -> list:
+    def list(self, filters: dict = None, top_k: int = 100, offset=None) -> list:
         """
         List all vectors in a collection.
 
         Args:
             filters (dict, optional): Filters to apply to the list. Defaults to None.
             top_k (int, optional): Number of vectors to return. Defaults to 100.
+            offset: Qdrant scroll offset returned by a previous call. Defaults to None.
 
         Returns:
             list: List of vectors.
@@ -616,6 +677,7 @@ class Qdrant(VectorStoreBase):
             collection_name=self.collection_name,
             scroll_filter=query_filter,
             limit=top_k,
+            offset=offset,
             with_payload=True,
             with_vectors=False,
         )

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -26,6 +26,33 @@ from mem0.vector_stores.base import VectorStoreBase, VectorStoreConfigurationErr
 logger = logging.getLogger(__name__)
 
 
+def _is_local_client(client, path=None, url=None, host=None) -> bool:
+    """Detect Qdrant local mode when an already-constructed client is supplied."""
+    internal_client = getattr(client, "_client", None)
+    internal_type = type(internal_client).__name__
+    if internal_type == "QdrantLocal":
+        return True
+    if internal_type == "QdrantRemote":
+        return False
+
+    init_options = getattr(client, "init_options", None)
+    if isinstance(init_options, dict):
+        return init_options.get("location") == ":memory:" or init_options.get("path") is not None
+
+    return bool(path and not url and not host)
+
+
+def _validate_collection_name(collection_name: str) -> None:
+    if (
+        not isinstance(collection_name, str)
+        or not collection_name.strip()
+        or any(ord(character) < 32 or ord(character) == 127 for character in collection_name)
+    ):
+        raise VectorStoreConfigurationError(
+            "Qdrant collection_name must be non-empty and contain no control characters."
+        )
+
+
 class Qdrant(VectorStoreBase):
     def __init__(
         self,
@@ -57,9 +84,10 @@ class Qdrant(VectorStoreBase):
             on_disk (bool, optional): Enables persistent storage. Vectors are stored on disk (True) or in memory (False).
                 Does not delete the local database path. Defaults to False.
         """
+        _validate_collection_name(collection_name)
         if client:
             self.client = client
-            self.is_local = bool(path and not url and not host)
+            self.is_local = _is_local_client(client, path=path, url=url, host=host)
         else:
             has_url = bool(url)
             has_host = bool(host)
@@ -99,6 +127,23 @@ class Qdrant(VectorStoreBase):
         # collection is rejected by Qdrant ("Not existing vector name error: bm25").
         self._has_bm25_slot = False
         self.create_col(embedding_model_dims, on_disk)
+
+    def _collection_exists(self) -> bool:
+        """Use the constant-size existence probe, with compatibility fallback for older servers/clients."""
+        collection_exists = getattr(self.client, "collection_exists", None)
+        if callable(collection_exists):
+            try:
+                return bool(collection_exists(self.collection_name))
+            except Exception as exc:
+                if getattr(exc, "status_code", None) != 404:
+                    raise
+
+        response = self.list_cols()
+        for collection in response.collections:
+            name = collection.get("name") if isinstance(collection, dict) else getattr(collection, "name", None)
+            if name == self.collection_name:
+                return True
+        return False
 
     def _get_bm25_encoder(self):
         """Lazy-load the BM25 sparse text encoder (fastembed)."""
@@ -144,13 +189,11 @@ class Qdrant(VectorStoreBase):
             on_disk (bool): Enables persistent storage.
             distance (Distance, optional): Distance metric for vector similarity. Defaults to Distance.COSINE.
         """
-        response = self.list_cols()
-        for collection in response.collections:
-            if collection.name == self.collection_name:
-                logger.debug(f"Collection {self.collection_name} already exists. Skipping creation.")
-                info = self.client.get_collection(self.collection_name)
-                self._prepare_existing_collection(info, vector_size, distance)
-                return
+        if self._collection_exists():
+            logger.debug(f"Collection {self.collection_name} already exists. Skipping creation.")
+            info = self.client.get_collection(self.collection_name)
+            self._prepare_existing_collection(info, vector_size, distance)
+            return
 
         try:
             created = self.client.create_collection(

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -140,6 +140,7 @@ class Qdrant(VectorStoreBase):
             if collection.name == self.collection_name:
                 logger.debug(f"Collection {self.collection_name} already exists. Skipping creation.")
                 info = self.client.get_collection(self.collection_name)
+                self._validate_existing_collection(info, vector_size, distance)
                 sparse_cfg = info.config.params.sparse_vectors
                 self._has_bm25_slot = bool(sparse_cfg and "bm25" in sparse_cfg)
                 if not self._has_bm25_slot:
@@ -162,6 +163,35 @@ class Qdrant(VectorStoreBase):
         )
         self._has_bm25_slot = True
         self._create_filter_indexes()
+
+    def _validate_existing_collection(self, info, expected_size: int, expected_distance: Distance) -> None:
+        """Fail non-destructively when an existing collection is incompatible with this adapter."""
+        vectors_config = info.config.params.vectors
+        if isinstance(vectors_config, dict):
+            vector_names = ", ".join(sorted(vectors_config)) or "none"
+            raise ValueError(
+                f"Qdrant collection '{self.collection_name}' uses named dense vectors ({vector_names}), but Mem0 "
+                "requires one unnamed dense vector. Select a compatible collection or perform an operator-managed "
+                "migration."
+            )
+        if not isinstance(vectors_config, VectorParams):
+            raise ValueError(
+                f"Qdrant collection '{self.collection_name}' has an unsupported dense vector configuration. "
+                "Select a compatible collection or perform an operator-managed migration."
+            )
+
+        actual_size = vectors_config.size
+        actual_distance = vectors_config.distance
+        expected_distance_value = getattr(expected_distance, "value", expected_distance)
+        actual_distance_value = getattr(actual_distance, "value", actual_distance)
+
+        if actual_size != expected_size or actual_distance_value != expected_distance_value:
+            raise ValueError(
+                f"Qdrant collection '{self.collection_name}' is incompatible: expected dimension {expected_size} "
+                f"and distance {expected_distance_value}, found dimension {actual_size} and distance "
+                f"{actual_distance_value}. Select the matching embedding model or collection, or perform an "
+                "operator-managed migration."
+            )
 
     def _create_filter_indexes(self):
         """Create indexes for commonly used filter fields to enable filtering."""

--- a/mem0/vector_stores/utils.py
+++ b/mem0/vector_stores/utils.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import UUID
 
 
 def normalize_list_result(result: Any) -> list:
@@ -10,12 +11,17 @@ def normalize_list_result(result: Any) -> list:
     if not result:
         return []
 
-    first = result[0]
-    if isinstance(first, (list, tuple)):
-        if len(result) > 2:
-            raise TypeError(f"Malformed vector-store list result container: {type(result).__name__}")
-        return list(first)
-
     if isinstance(result, tuple):
+        if len(result) == 1 and isinstance(result[0], (list, tuple)):
+            return list(result[0])
+        if len(result) == 2 and isinstance(result[0], (list, tuple)):
+            offset = result[1]
+            if offset is None or (isinstance(offset, (str, int, UUID)) and not isinstance(offset, bool)):
+                return list(result[0])
         raise TypeError("Malformed vector-store list result container: tuple")
+
+    if len(result) == 1 and isinstance(result[0], (list, tuple)):
+        return list(result[0])
+    if any(isinstance(item, (list, tuple)) for item in result):
+        raise TypeError("Malformed vector-store list result container: list")
     return list(result)

--- a/mem0/vector_stores/utils.py
+++ b/mem0/vector_stores/utils.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+
+def normalize_list_result(result: Any) -> list:
+    """Normalize vector-store list results without discarding pagination metadata at the adapter boundary."""
+    if result is None:
+        return []
+    if not isinstance(result, (list, tuple)):
+        raise TypeError(f"Unsupported vector-store list result type: {type(result).__name__}")
+    if not result:
+        return []
+
+    first = result[0]
+    if isinstance(first, (list, tuple)):
+        if len(result) > 2:
+            raise TypeError(f"Malformed vector-store list result container: {type(result).__name__}")
+        return list(first)
+
+    if isinstance(result, tuple):
+        raise TypeError("Malformed vector-store list result container: tuple")
+    return list(result)

--- a/mem0/vector_stores/utils.py
+++ b/mem0/vector_stores/utils.py
@@ -2,6 +2,14 @@ from typing import Any
 from uuid import UUID
 
 
+def _is_supported_scroll_offset(offset: Any) -> bool:
+    if offset is None or (isinstance(offset, (str, int, UUID)) and not isinstance(offset, bool)):
+        return True
+
+    descriptor = getattr(type(offset), "DESCRIPTOR", None)
+    return getattr(descriptor, "full_name", None) == "qdrant.PointId"
+
+
 def normalize_list_result(result: Any) -> list:
     """Normalize vector-store list results without discarding pagination metadata at the adapter boundary."""
     if result is None:
@@ -16,7 +24,7 @@ def normalize_list_result(result: Any) -> list:
             return list(result[0])
         if len(result) == 2 and isinstance(result[0], (list, tuple)):
             offset = result[1]
-            if offset is None or (isinstance(offset, (str, int, UUID)) and not isinstance(offset, bool)):
+            if _is_supported_scroll_offset(offset):
                 return list(result[0])
         raise TypeError("Malformed vector-store list result container: tuple")
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -18,7 +18,8 @@ POSTGRES_COLLECTION_NAME=memories
 # VECTOR_STORE_PROVIDER=qdrant
 # VECTOR_STORE_CONFIG={"url":"https://qdrant.example.internal:6333","api_key":"...","collection_name":"mem0","embedding_model_dims":1536}
 # COLLECTION_NAME=memories
-# For private CAs, also set SSL_CERT_FILE and REQUESTS_CA_BUNDLE to the mounted CA bundle.
+# For private CAs, set SSL_CERT_FILE to the mounted CA bundle (Qdrant/httpx).
+# Set REQUESTS_CA_BUNDLE too only for other configured providers that use Python Requests.
 
 ADMIN_API_KEY=
 JWT_SECRET=

--- a/server/.env.example
+++ b/server/.env.example
@@ -12,6 +12,14 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=
 POSTGRES_COLLECTION_NAME=memories
 
+# Optional vector-store override. When either variable is set, the vector store
+# is managed by environment and cannot be changed through POST /configure.
+# Remote Qdrant example (embedding_model_dims must match the embedder and collection):
+# VECTOR_STORE_PROVIDER=qdrant
+# VECTOR_STORE_CONFIG={"url":"https://qdrant.example.internal:6333","api_key":"...","collection_name":"mem0","embedding_model_dims":1536}
+# COLLECTION_NAME=memories
+# For private CAs, also set SSL_CERT_FILE and REQUESTS_CA_BUNDLE to the mounted CA bundle.
+
 ADMIN_API_KEY=
 JWT_SECRET=
 # Local development only. Leave false in production.

--- a/server/README.md
+++ b/server/README.md
@@ -89,7 +89,8 @@ VECTOR_STORE_CONFIG={"url":"https://qdrant.example.internal:6333","api_key":"...
 
 `embedding_model_dims` must match both the configured embedder and the existing collection. Mem0 validates an existing
 collection's dimension and cosine distance and fails without modifying it when they are incompatible. For a private CA,
-mount the CA bundle and point `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` at it.
+mount the CA bundle and point `SSL_CERT_FILE` at it. Set `REQUESTS_CA_BUNDLE` as well only when another configured
+provider uses Python Requests; Qdrant's httpx transport uses `SSL_CERT_FILE`.
 
 Setting `VECTOR_STORE_PROVIDER` or `VECTOR_STORE_CONFIG` makes the vector store environment-managed. Persisted runtime
 overrides cannot replace it, and `POST /configure` rejects vector-store updates until those variables are removed.

--- a/server/README.md
+++ b/server/README.md
@@ -77,6 +77,31 @@ Then open `http://localhost:3000` and complete the setup wizard.
 - Auth is enabled by default.
 - `AUTH_DISABLED=true` exists for local development only and should not be used in production.
 
+## Use a remote Qdrant vector store
+
+Postgres remains required for users, API keys, settings, request logs, and migrations. To store memories in Qdrant
+instead of pgvector, configure the vector-store component explicitly:
+
+```dotenv
+VECTOR_STORE_PROVIDER=qdrant
+VECTOR_STORE_CONFIG={"url":"https://qdrant.example.internal:6333","api_key":"...","collection_name":"mem0","embedding_model_dims":1536}
+```
+
+`embedding_model_dims` must match both the configured embedder and the existing collection. Mem0 validates an existing
+collection's dimension and cosine distance and fails without modifying it when they are incompatible. For a private CA,
+mount the CA bundle and point `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` at it.
+
+Setting `VECTOR_STORE_PROVIDER` or `VECTOR_STORE_CONFIG` makes the vector store environment-managed. Persisted runtime
+overrides cannot replace it, and `POST /configure` rejects vector-store updates until those variables are removed.
+Malformed or incomplete Qdrant configuration stops the server; it never falls back to `/tmp/qdrant`.
+
+Embedded Qdrant is intended only for disposable development and must be selected explicitly:
+
+```dotenv
+VECTOR_STORE_PROVIDER=qdrant
+VECTOR_STORE_CONFIG={"path":"./qdrant-data","collection_name":"mem0-dev","embedding_model_dims":1536}
+```
+
 ## Forgotten password
 
 Reset an admin password from the host while the stack is running:

--- a/server/errors.py
+++ b/server/errors.py
@@ -72,7 +72,11 @@ def upstream_error() -> UpstreamError:
     exc = sys.exc_info()[1]
     code, message = _classify(exc)
     rid = request_id_var.get()
-    logging.exception("Upstream provider error (code=%s)", code)
+    logging.error(
+        "Upstream provider error (code=%s, exception_type=%s)",
+        code,
+        type(exc).__name__ if exc is not None else "None",
+    )
     return UpstreamError(code=code, detail=message, request_id=rid)
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -20,6 +20,7 @@ from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from mem0.exceptions import ValidationError as Mem0ValidationError
+from mem0.vector_stores.utils import normalize_list_result
 from models import RequestLog, User
 from pydantic import BaseModel, Field
 from rate_limit import limiter
@@ -38,6 +39,7 @@ from server_state import (
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy import func, select
+from vector_store_config import build_vector_store_config
 
 load_dotenv()
 
@@ -104,31 +106,15 @@ elif not ADMIN_API_KEY:
 
 telemetry.log_status()
 
-POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "postgres")
-POSTGRES_PORT = os.environ.get("POSTGRES_PORT", "5432")
-POSTGRES_DB = os.environ.get("POSTGRES_DB", "postgres")
-POSTGRES_USER = os.environ.get("POSTGRES_USER", "postgres")
-POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "postgres")
-POSTGRES_COLLECTION_NAME = os.environ.get("POSTGRES_COLLECTION_NAME", "memories")
-
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 HISTORY_DB_PATH = os.environ.get("HISTORY_DB_PATH", "/app/history/history.db")
 DEFAULT_LLM_MODEL = os.environ.get("MEM0_DEFAULT_LLM_MODEL", "gpt-4.1-nano-2025-04-14")
 DEFAULT_EMBEDDER_MODEL = os.environ.get("MEM0_DEFAULT_EMBEDDER_MODEL", "text-embedding-3-small")
+VECTOR_STORE, LOCKED_CONFIG_COMPONENTS = build_vector_store_config(os.environ)
 
 DEFAULT_CONFIG = {
     "version": "v1.1",
-    "vector_store": {
-        "provider": "pgvector",
-        "config": {
-            "host": POSTGRES_HOST,
-            "port": int(POSTGRES_PORT),
-            "dbname": POSTGRES_DB,
-            "user": POSTGRES_USER,
-            "password": POSTGRES_PASSWORD,
-            "collection_name": POSTGRES_COLLECTION_NAME,
-        },
-    },
+    "vector_store": VECTOR_STORE,
     "llm": {
         "provider": "openai",
         "config": {"api_key": OPENAI_API_KEY, "temperature": 0.2, "model": DEFAULT_LLM_MODEL},
@@ -139,7 +125,18 @@ DEFAULT_CONFIG = {
 
 
 set_session_factory(SessionLocal)
-initialize_state(DEFAULT_CONFIG)
+initialize_state(DEFAULT_CONFIG, locked_components=LOCKED_CONFIG_COMPONENTS)
+
+vector_config = VECTOR_STORE["config"]
+vector_mode = "explicit-local" if vector_config.get("path") else "remote"
+logging.info(
+    "Mem0 vector store configured (provider=%s, mode=%s, collection=%s, dimensions=%s, environment_locked=%s)",
+    VECTOR_STORE["provider"],
+    vector_mode,
+    vector_config.get("collection_name"),
+    vector_config.get("embedding_model_dims", "provider-default"),
+    "vector_store" in LOCKED_CONFIG_COMPONENTS,
+)
 
 
 app = FastAPI(
@@ -331,8 +328,13 @@ def list_bundled_providers(_auth=Depends(verify_auth)):
 @app.post("/configure", summary="Configure Mem0")
 def set_config(config: Dict[str, Any], _auth=Depends(require_admin)):
     """Set memory configuration. Requires admin role."""
-    _validate_bundled_providers(config)
-    update_config(config)
+    try:
+        _validate_bundled_providers(config)
+        update_config(config)
+    except (ValueError, Mem0ValidationError) as e:
+        raise _client_error(e)
+    except Exception:
+        raise upstream_error()
     return {"message": "Configuration set successfully"}
 
 
@@ -403,7 +405,7 @@ def _serialize_memory(row: Any) -> Dict[str, Any]:
 
 def _list_all_memories(limit: int = ALL_MEMORIES_LIMIT) -> Dict[str, Any]:
     results = get_memory_instance().vector_store.list(top_k=limit)
-    rows = results[0] if results and isinstance(results, list) and isinstance(results[0], list) else results or []
+    rows = normalize_list_result(results)
     return {"results": [_serialize_memory(row) for row in rows]}
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -22,7 +22,7 @@ from fastapi.responses import JSONResponse, RedirectResponse
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from mem0.vector_stores.utils import normalize_list_result
 from models import RequestLog, User
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError as PydanticValidationError
 from rate_limit import limiter
 from routers import api_keys as api_keys_router
 from routers import auth as auth_router
@@ -31,15 +31,15 @@ from routers import requests as requests_router
 from schemas import MessageResponse
 from server_state import (
     get_current_config,
-    get_memory_instance,
     initialize_state,
+    memory_instance_lease,
     set_session_factory,
     update_config,
 )
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy import func, select
-from vector_store_config import build_vector_store_config
+from vector_store_config import build_vector_store_config, sanitized_validation_error_message
 
 load_dotenv()
 
@@ -127,11 +127,12 @@ DEFAULT_CONFIG = {
 set_session_factory(SessionLocal)
 initialize_state(DEFAULT_CONFIG, locked_components=LOCKED_CONFIG_COMPONENTS)
 
-vector_config = VECTOR_STORE["config"]
+effective_vector_store = get_current_config()["vector_store"]
+vector_config = effective_vector_store["config"]
 vector_mode = "explicit-local" if vector_config.get("path") else "remote"
 logging.info(
     "Mem0 vector store configured (provider=%s, mode=%s, collection=%s, dimensions=%s, environment_locked=%s)",
-    VECTOR_STORE["provider"],
+    effective_vector_store["provider"],
     vector_mode,
     vector_config.get("collection_name"),
     vector_config.get("embedding_model_dims", "provider-default"),
@@ -210,7 +211,10 @@ class GenerateInstructionsRequest(BaseModel):
 def _client_error(exc: Exception) -> HTTPException:
     """Map core validation / not-found errors to 4xx so clients can tell a bad
     request from an upstream outage. 'not found' is a 404, everything else a 400."""
-    detail = str(exc)
+    if isinstance(exc, PydanticValidationError):
+        detail = sanitized_validation_error_message(exc)
+    else:
+        detail = str(exc)
     status_code = 404 if isinstance(exc, ValueError) and "not found" in detail.lower() else 400
     return HTTPException(status_code=status_code, detail=detail)
 
@@ -331,6 +335,8 @@ def set_config(config: Dict[str, Any], _auth=Depends(require_admin)):
     try:
         _validate_bundled_providers(config)
         update_config(config)
+    except HTTPException:
+        raise
     except (ValueError, Mem0ValidationError) as e:
         raise _client_error(e)
     except Exception:
@@ -342,18 +348,18 @@ def set_config(config: Dict[str, Any], _auth=Depends(require_admin)):
 def generate_instructions(req: GenerateInstructionsRequest, _auth=Depends(verify_auth)):
     """Generate custom instructions and a contextual test message tailored to a use case."""
     try:
-        llm = get_memory_instance().llm
-        prompt = (
-            "You are configuring a memory system. Given the use case below, produce two things:\n"
-            "1. INSTRUCTIONS: A short paragraph of custom instructions telling the memory extraction system "
-            "what kinds of facts, preferences, and context to prioritize. Be specific to the use case.\n"
-            "2. TEST_MESSAGE: A single realistic sentence a user in this use case would say, suitable for "
-            "testing that the memory system works.\n\n"
-            "Respond in exactly this format (no markdown, no extra text):\n"
-            "INSTRUCTIONS: <your instructions>\n"
-            f"TEST_MESSAGE: <your test message>\n\nUse case: {req.use_case}"
-        )
-        response = llm.generate_response([{"role": "user", "content": prompt}])
+        with memory_instance_lease() as memory:
+            prompt = (
+                "You are configuring a memory system. Given the use case below, produce two things:\n"
+                "1. INSTRUCTIONS: A short paragraph of custom instructions telling the memory extraction system "
+                "what kinds of facts, preferences, and context to prioritize. Be specific to the use case.\n"
+                "2. TEST_MESSAGE: A single realistic sentence a user in this use case would say, suitable for "
+                "testing that the memory system works.\n\n"
+                "Respond in exactly this format (no markdown, no extra text):\n"
+                "INSTRUCTIONS: <your instructions>\n"
+                f"TEST_MESSAGE: <your test message>\n\nUse case: {req.use_case}"
+            )
+            response = memory.llm.generate_response([{"role": "user", "content": prompt}])
         instructions = response
         test_message = "I like to hike on weekends."
         if "INSTRUCTIONS:" in response and "TEST_MESSAGE:" in response:
@@ -373,7 +379,8 @@ def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
 
     params = {k: v for k, v in memory_create.model_dump().items() if v is not None and k != "messages"}
     try:
-        response = get_memory_instance().add(messages=[m.model_dump() for m in memory_create.messages], **params)
+        with memory_instance_lease() as memory:
+            response = memory.add(messages=[m.model_dump() for m in memory_create.messages], **params)
         if response.get("results"):
             telemetry.log_dashboard_nudge_once(DASHBOARD_URL)
         return JSONResponse(content=response)
@@ -404,7 +411,8 @@ def _serialize_memory(row: Any) -> Dict[str, Any]:
 
 
 def _list_all_memories(limit: int = ALL_MEMORIES_LIMIT) -> Dict[str, Any]:
-    results = get_memory_instance().vector_store.list(top_k=limit)
+    with memory_instance_lease() as memory:
+        results = memory.vector_store.list(top_k=limit)
     rows = normalize_list_result(results)
     return {"results": [_serialize_memory(row) for row in rows]}
 
@@ -434,7 +442,8 @@ def get_all_memories(
         if top_k is not None:
             params["top_k"] = top_k
         params["show_expired"] = show_expired
-        return get_memory_instance().get_all(**params)
+        with memory_instance_lease() as memory:
+            return memory.get_all(**params)
     except HTTPException:
         raise
     except Exception:
@@ -445,7 +454,8 @@ def get_all_memories(
 def get_memory(memory_id: str, _auth=Depends(verify_auth)):
     """Retrieve a specific memory by ID."""
     try:
-        return get_memory_instance().get(memory_id)
+        with memory_instance_lease() as memory:
+            return memory.get(memory_id)
     except Exception:
         raise upstream_error()
 
@@ -476,7 +486,8 @@ def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
             params["explain"] = search_req.explain
         if search_req.show_expired is not None:
             params["show_expired"] = search_req.show_expired
-        return get_memory_instance().search(query=search_req.query, filters=filters, **params)
+        with memory_instance_lease() as memory:
+            return memory.search(query=search_req.query, filters=filters, **params)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except HTTPException:
@@ -497,7 +508,8 @@ def update_memory(memory_id: str, updated_memory: MemoryUpdate, _auth=Depends(ve
             params["metadata"] = updated_memory.metadata
         if "expiration_date" in fields_set:
             params["expiration_date"] = updated_memory.expiration_date
-        return get_memory_instance().update(**params)
+        with memory_instance_lease() as memory:
+            return memory.update(**params)
     except (ValueError, Mem0ValidationError) as e:
         raise _client_error(e)
     except Exception:
@@ -508,7 +520,8 @@ def update_memory(memory_id: str, updated_memory: MemoryUpdate, _auth=Depends(ve
 def memory_history(memory_id: str, _auth=Depends(verify_auth)):
     """Retrieve memory history."""
     try:
-        return get_memory_instance().history(memory_id=memory_id)
+        with memory_instance_lease() as memory:
+            return memory.history(memory_id=memory_id)
     except Exception:
         raise upstream_error()
 
@@ -517,7 +530,8 @@ def memory_history(memory_id: str, _auth=Depends(verify_auth)):
 def delete_memory(memory_id: str, _auth=Depends(verify_auth)):
     """Delete a specific memory by ID."""
     try:
-        get_memory_instance().delete(memory_id=memory_id)
+        with memory_instance_lease() as memory:
+            memory.delete(memory_id=memory_id)
         return MessageResponse(message="Memory deleted successfully")
     except (ValueError, Mem0ValidationError) as e:
         raise _client_error(e)
@@ -536,10 +550,9 @@ def delete_all_memories(
     if not any([user_id, run_id, agent_id]):
         raise HTTPException(status_code=400, detail="At least one identifier is required.")
     try:
-        params = {
-            k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v
-        }
-        get_memory_instance().delete_all(**params)
+        params = {k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v}
+        with memory_instance_lease() as memory:
+            memory.delete_all(**params)
         return MessageResponse(message="All relevant memories deleted")
     except Exception:
         raise upstream_error()
@@ -549,7 +562,8 @@ def delete_all_memories(
 def reset_memory(_auth=Depends(require_admin)):
     """Completely reset stored memories. Requires admin role."""
     try:
-        get_memory_instance().reset()
+        with memory_instance_lease() as memory:
+            memory.reset()
         return {"message": "All memories reset"}
     except Exception:
         raise upstream_error()

--- a/server/routers/entities.py
+++ b/server/routers/entities.py
@@ -7,7 +7,7 @@ from errors import upstream_error
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from schemas import MessageResponse
-from server_state import get_memory_instance
+from server_state import memory_instance_lease
 from mem0.vector_stores.utils import normalize_list_result
 
 router = APIRouter(prefix="/entities", tags=["entities"])
@@ -27,7 +27,8 @@ class Entity(BaseModel):
 
 
 def _iter_payloads() -> list[dict[str, Any]]:
-    results = get_memory_instance().vector_store.list(top_k=SCAN_LIMIT)
+    with memory_instance_lease() as memory:
+        results = memory.vector_store.list(top_k=SCAN_LIMIT)
     rows = normalize_list_result(results)
     return [getattr(row, "payload", None) or {} for row in rows]
 
@@ -71,7 +72,8 @@ def list_entities(_auth=Depends(verify_auth)):
 @router.delete("/{entity_type}/{entity_id}", response_model=MessageResponse)
 def delete_entity(entity_type: EntityType, entity_id: str, _auth=Depends(require_admin)):
     try:
-        get_memory_instance().delete_all(**{TYPE_TO_FIELD[entity_type]: entity_id})
+        with memory_instance_lease() as memory:
+            memory.delete_all(**{TYPE_TO_FIELD[entity_type]: entity_id})
     except Exception:
         raise upstream_error()
     return MessageResponse(message="Entity deleted")

--- a/server/routers/entities.py
+++ b/server/routers/entities.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from schemas import MessageResponse
 from server_state import get_memory_instance
+from mem0.vector_stores.utils import normalize_list_result
 
 router = APIRouter(prefix="/entities", tags=["entities"])
 
@@ -27,7 +28,7 @@ class Entity(BaseModel):
 
 def _iter_payloads() -> list[dict[str, Any]]:
     results = get_memory_instance().vector_store.list(top_k=SCAN_LIMIT)
-    rows = results[0] if results and isinstance(results, list) and isinstance(results[0], list) else results or []
+    rows = normalize_list_result(results)
     return [getattr(row, "payload", None) or {} for row in rows]
 
 

--- a/server/server_state.py
+++ b/server/server_state.py
@@ -1,17 +1,22 @@
 import json
 import logging
 import threading
+from contextlib import contextmanager
 from copy import deepcopy
-from typing import Any, Callable, Dict, Iterable
+from typing import Any, Callable, Dict, Iterable, Iterator
 
 from mem0 import Memory
 from mem0.configs.base import MemoryConfig
+from mem0.vector_stores.base import VectorStoreConfigurationError
+from pydantic import ValidationError as PydanticValidationError
 
 _state_lock = threading.RLock()
 _current_config: Dict[str, Any] = {}
 _memory_instance: Memory | None = None
 _session_factory: Callable | None = None
 _locked_components: set[str] = set()
+_active_leases: Dict[int, int] = {}
+_retired_instances: Dict[int, Memory] = {}
 
 _PROVIDER_COMPONENTS = {"vector_store", "llm", "embedder", "reranker"}
 
@@ -44,25 +49,36 @@ def _load_overrides() -> Dict[str, Any]:
         return {}
 
 
-def _save_overrides(overrides: Dict[str, Any]) -> None:
+def _merge_and_save_overrides(updates: Dict[str, Any]) -> Dict[str, Any]:
+    """Atomically merge persisted overrides under a cross-process Postgres lock."""
     if _session_factory is None:
-        return
+        return deepcopy(updates)
     from models import Settings
-    from sqlalchemy.dialects.postgresql import insert
+    from sqlalchemy import select, text
 
     session = _session_factory()
     try:
-        serialized = json.dumps(overrides)
-        stmt = (
-            insert(Settings)
-            .values(key="config_overrides", value=serialized)
-            .on_conflict_do_update(
-                index_elements=[Settings.key],
-                set_={"value": serialized},
-            )
+        session.execute(
+            text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
+            {"lock_key": "mem0.config_overrides"},
         )
-        session.execute(stmt)
+        row = session.execute(
+            select(Settings).where(Settings.key == "config_overrides").with_for_update()
+        ).scalar_one_or_none()
+        current = {}
+        if row is not None:
+            current = json.loads(row.value)
+            if not isinstance(current, dict):
+                raise RuntimeError("Persisted configuration overrides must be a JSON object.")
+
+        merged = _merge_config(_without_locked_components(current), updates)
+        serialized = json.dumps(merged)
+        if row is None:
+            session.add(Settings(key="config_overrides", value=serialized))
+        else:
+            row.value = serialized
         session.commit()
+        return merged
     except Exception as exc:
         if hasattr(session, "rollback"):
             session.rollback()
@@ -97,35 +113,90 @@ def _without_locked_components(config: Dict[str, Any]) -> Dict[str, Any]:
     return {key: deepcopy(value) for key, value in config.items() if key not in _locked_components}
 
 
+def _validated_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        from vector_store_config import sanitized_validation_error_message, validate_server_config
+    except ModuleNotFoundError:
+        from server.vector_store_config import sanitized_validation_error_message, validate_server_config
+
+    candidate = deepcopy(config)
+    validate_server_config(candidate)
+    try:
+        model = MemoryConfig(**candidate)
+    except PydanticValidationError as exc:
+        raise ValueError(sanitized_validation_error_message(exc)) from None
+    if hasattr(model, "model_dump"):
+        return model.model_dump(mode="python")
+    if isinstance(model, dict):
+        return deepcopy(model)
+    return candidate
+
+
+def _active_config(instance: Memory, fallback: Dict[str, Any]) -> Dict[str, Any]:
+    config = getattr(instance, "config", None)
+    if hasattr(config, "model_dump"):
+        dumped = config.model_dump(mode="python")
+        if isinstance(dumped, dict):
+            return dumped
+    return deepcopy(fallback)
+
+
 def _close_memory_instance(instance: Memory | None) -> None:
     if instance is None:
         return
-    try:
-        vector_client = getattr(getattr(instance, "vector_store", None), "client", None)
-        if vector_client is not None and hasattr(vector_client, "close"):
-            vector_client.close()
-        history_db = getattr(instance, "db", None)
-        if history_db is not None and hasattr(history_db, "close"):
-            history_db.close()
-    except Exception as exc:
-        logging.warning("Failed to close the previous Mem0 runtime (%s)", type(exc).__name__)
+
+    resources = [
+        getattr(getattr(instance, "vector_store", None), "client", None),
+        getattr(getattr(instance, "_entity_store", None), "client", None),
+        getattr(getattr(instance, "embedding_model", None), "client", None),
+        getattr(getattr(instance, "llm", None), "client", None),
+        getattr(instance, "db", None),
+    ]
+    closed_ids: set[int] = set()
+    for resource in resources:
+        if resource is None or id(resource) in closed_ids or not hasattr(resource, "close"):
+            continue
+        closed_ids.add(id(resource))
+        try:
+            resource.close()
+        except Exception as exc:
+            logging.warning("Failed to close a previous Mem0 runtime resource (%s)", type(exc).__name__)
+
+
+def _retire_memory_instance(instance: Memory | None) -> None:
+    if instance is None:
+        return
+    instance_id = id(instance)
+    if _active_leases.get(instance_id, 0):
+        _retired_instances[instance_id] = instance
+        return
+    _close_memory_instance(instance)
 
 
 def initialize_state(default_config: Dict[str, Any], locked_components: Iterable[str] = ()) -> None:
     global _current_config, _memory_instance, _locked_components
     with _state_lock:
         _locked_components = set(locked_components)
-        next_config = deepcopy(default_config)
+        next_config = _validated_config(default_config)
         overrides = _load_overrides()
         if overrides:
-            next_config = _merge_config(next_config, _without_locked_components(overrides))
-        MemoryConfig(**deepcopy(next_config))
-        next_instance = Memory.from_config(next_config)
+            merged_config = _merge_config(default_config, _without_locked_components(overrides))
+            try:
+                next_config = _validated_config(merged_config)
+            except Exception as exc:
+                logging.warning("Ignoring invalid persisted config overrides (%s)", type(exc).__name__)
+        try:
+            next_instance = Memory.from_config(next_config)
+        except VectorStoreConfigurationError:
+            raise
+        except Exception:
+            raise RuntimeError("Failed to initialize Mem0 from the startup configuration.") from None
+        next_config = _active_config(next_instance, next_config)
         previous_instance = _memory_instance
         _current_config = next_config
         _memory_instance = next_instance
         if previous_instance is not next_instance:
-            _close_memory_instance(previous_instance)
+            _retire_memory_instance(previous_instance)
 
 
 def update_config(updates: Dict[str, Any]) -> Dict[str, Any]:
@@ -136,13 +207,16 @@ def update_config(updates: Dict[str, Any]) -> Dict[str, Any]:
             joined = ", ".join(locked_updates)
             raise ValueError(f"Configuration component(s) managed by environment variables cannot be changed: {joined}")
 
-        next_config = _merge_config(_current_config, updates)
-        MemoryConfig(**deepcopy(next_config))
-        next_instance = Memory.from_config(next_config)
-        overrides = _load_overrides()
-        next_overrides = _merge_config(_without_locked_components(overrides), updates)
+        next_config = _validated_config(_merge_config(_current_config, updates))
         try:
-            _save_overrides(next_overrides)
+            next_instance = Memory.from_config(next_config)
+        except VectorStoreConfigurationError:
+            raise
+        except Exception as exc:
+            raise RuntimeError("Failed to initialize the candidate Mem0 configuration.") from exc
+        next_config = _active_config(next_instance, next_config)
+        try:
+            _merge_and_save_overrides(updates)
         except Exception:
             _close_memory_instance(next_instance)
             raise
@@ -151,7 +225,7 @@ def update_config(updates: Dict[str, Any]) -> Dict[str, Any]:
         _current_config = next_config
         _memory_instance = next_instance
         if previous_instance is not next_instance:
-            _close_memory_instance(previous_instance)
+            _retire_memory_instance(previous_instance)
         return deepcopy(_current_config)
 
 
@@ -165,6 +239,31 @@ def get_memory_instance() -> Memory:
         if _memory_instance is None:
             raise RuntimeError("Mem0 runtime has not been initialized.")
         return _memory_instance
+
+
+@contextmanager
+def memory_instance_lease() -> Iterator[Memory]:
+    """Keep a runtime alive until the request using it has completed."""
+    with _state_lock:
+        if _memory_instance is None:
+            raise RuntimeError("Mem0 runtime has not been initialized.")
+        instance = _memory_instance
+        instance_id = id(instance)
+        _active_leases[instance_id] = _active_leases.get(instance_id, 0) + 1
+
+    try:
+        yield instance
+    finally:
+        close_instance = None
+        with _state_lock:
+            remaining = _active_leases.get(instance_id, 1) - 1
+            if remaining:
+                _active_leases[instance_id] = remaining
+            else:
+                _active_leases.pop(instance_id, None)
+                close_instance = _retired_instances.pop(instance_id, None)
+        if close_instance is not None:
+            _close_memory_instance(close_instance)
 
 
 def get_locked_components() -> set[str]:

--- a/server/server_state.py
+++ b/server/server_state.py
@@ -2,14 +2,18 @@ import json
 import logging
 import threading
 from copy import deepcopy
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Iterable
 
 from mem0 import Memory
+from mem0.configs.base import MemoryConfig
 
 _state_lock = threading.RLock()
 _current_config: Dict[str, Any] = {}
 _memory_instance: Memory | None = None
 _session_factory: Callable | None = None
+_locked_components: set[str] = set()
+
+_PROVIDER_COMPONENTS = {"vector_store", "llm", "embedder", "reranker"}
 
 
 def set_session_factory(factory: Callable) -> None:
@@ -28,43 +32,59 @@ def _load_overrides() -> Dict[str, Any]:
             row = session.get(Settings, "config_overrides")
             if row is None:
                 return {}
-            return json.loads(row.value)
+            overrides = json.loads(row.value)
+            if not isinstance(overrides, dict):
+                logging.warning("Ignoring malformed persisted config overrides: expected a JSON object")
+                return {}
+            return overrides
         finally:
             session.close()
-    except Exception:
+    except Exception as exc:
+        logging.warning("Failed to load config overrides from database (%s)", type(exc).__name__)
         return {}
 
 
 def _save_overrides(overrides: Dict[str, Any]) -> None:
-    try:
-        if _session_factory is None:
-            return
-        from models import Settings
-        from sqlalchemy.dialects.postgresql import insert
+    if _session_factory is None:
+        return
+    from models import Settings
+    from sqlalchemy.dialects.postgresql import insert
 
-        session = _session_factory()
-        try:
-            serialized = json.dumps(overrides)
-            stmt = (
-                insert(Settings)
-                .values(key="config_overrides", value=serialized)
-                .on_conflict_do_update(
-                    index_elements=[Settings.key],
-                    set_={"value": serialized},
-                )
+    session = _session_factory()
+    try:
+        serialized = json.dumps(overrides)
+        stmt = (
+            insert(Settings)
+            .values(key="config_overrides", value=serialized)
+            .on_conflict_do_update(
+                index_elements=[Settings.key],
+                set_={"value": serialized},
             )
-            session.execute(stmt)
-            session.commit()
-        finally:
-            session.close()
-    except Exception:
-        logging.warning("Failed to persist config overrides to database", exc_info=True)
+        )
+        session.execute(stmt)
+        session.commit()
+    except Exception as exc:
+        if hasattr(session, "rollback"):
+            session.rollback()
+        logging.warning("Failed to persist config overrides to database (%s)", type(exc).__name__)
+        raise RuntimeError("Failed to persist Mem0 configuration.") from exc
+    finally:
+        session.close()
 
 
 def _merge_config(base: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, Any]:
     merged = deepcopy(base)
 
-    for key, value in updates.items():
+    for key, value in deepcopy(updates).items():
+        if (
+            key in _PROVIDER_COMPONENTS
+            and isinstance(value, dict)
+            and isinstance(merged.get(key), dict)
+            and value.get("provider") is not None
+            and value.get("provider") != merged[key].get("provider")
+        ):
+            merged[key] = value
+            continue
         if isinstance(value, dict) and isinstance(merged.get(key), dict):
             merged[key] = _merge_config(merged[key], value)
         else:
@@ -73,25 +93,65 @@ def _merge_config(base: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, An
     return merged
 
 
-def initialize_state(default_config: Dict[str, Any]) -> None:
-    global _current_config, _memory_instance
+def _without_locked_components(config: Dict[str, Any]) -> Dict[str, Any]:
+    return {key: deepcopy(value) for key, value in config.items() if key not in _locked_components}
+
+
+def _close_memory_instance(instance: Memory | None) -> None:
+    if instance is None:
+        return
+    try:
+        vector_client = getattr(getattr(instance, "vector_store", None), "client", None)
+        if vector_client is not None and hasattr(vector_client, "close"):
+            vector_client.close()
+        history_db = getattr(instance, "db", None)
+        if history_db is not None and hasattr(history_db, "close"):
+            history_db.close()
+    except Exception as exc:
+        logging.warning("Failed to close the previous Mem0 runtime (%s)", type(exc).__name__)
+
+
+def initialize_state(default_config: Dict[str, Any], locked_components: Iterable[str] = ()) -> None:
+    global _current_config, _memory_instance, _locked_components
     with _state_lock:
-        _current_config = deepcopy(default_config)
+        _locked_components = set(locked_components)
+        next_config = deepcopy(default_config)
         overrides = _load_overrides()
         if overrides:
-            _current_config = _merge_config(_current_config, overrides)
-        _memory_instance = Memory.from_config(_current_config)
+            next_config = _merge_config(next_config, _without_locked_components(overrides))
+        MemoryConfig(**deepcopy(next_config))
+        next_instance = Memory.from_config(next_config)
+        previous_instance = _memory_instance
+        _current_config = next_config
+        _memory_instance = next_instance
+        if previous_instance is not next_instance:
+            _close_memory_instance(previous_instance)
 
 
 def update_config(updates: Dict[str, Any]) -> Dict[str, Any]:
     global _current_config, _memory_instance
     with _state_lock:
+        locked_updates = sorted(set(updates) & _locked_components)
+        if locked_updates:
+            joined = ", ".join(locked_updates)
+            raise ValueError(f"Configuration component(s) managed by environment variables cannot be changed: {joined}")
+
         next_config = _merge_config(_current_config, updates)
-        _current_config = next_config
-        _memory_instance = Memory.from_config(next_config)
+        MemoryConfig(**deepcopy(next_config))
+        next_instance = Memory.from_config(next_config)
         overrides = _load_overrides()
-        overrides = _merge_config(overrides, updates)
-        _save_overrides(overrides)
+        next_overrides = _merge_config(_without_locked_components(overrides), updates)
+        try:
+            _save_overrides(next_overrides)
+        except Exception:
+            _close_memory_instance(next_instance)
+            raise
+
+        previous_instance = _memory_instance
+        _current_config = next_config
+        _memory_instance = next_instance
+        if previous_instance is not next_instance:
+            _close_memory_instance(previous_instance)
         return deepcopy(_current_config)
 
 
@@ -105,3 +165,8 @@ def get_memory_instance() -> Memory:
         if _memory_instance is None:
             raise RuntimeError("Mem0 runtime has not been initialized.")
         return _memory_instance
+
+
+def get_locked_components() -> set[str]:
+    with _state_lock:
+        return set(_locked_components)

--- a/server/vector_store_config.py
+++ b/server/vector_store_config.py
@@ -1,7 +1,9 @@
 import json
 import logging
 from copy import deepcopy
-from typing import Mapping
+from typing import Mapping, Type
+
+from pydantic import ValidationError
 
 
 def _collection_name(environ: Mapping[str, str]) -> str:
@@ -19,7 +21,7 @@ def _parse_json_object(raw_config: str) -> dict:
     return parsed
 
 
-def _validate_qdrant_config(config: dict) -> None:
+def _validate_qdrant_config(config: dict, error_type: Type[Exception] = RuntimeError) -> None:
     url = config.get("url")
     host = config.get("host")
     port = config.get("port")
@@ -35,17 +37,45 @@ def _validate_qdrant_config(config: dict) -> None:
             port = int(port)
             config["port"] = port
         if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
-            raise RuntimeError("Qdrant host configuration requires a port between 1 and 65535.")
+            raise error_type("Qdrant host configuration requires a port between 1 and 65535.")
     elif port is not None:
-        raise RuntimeError("Qdrant port requires a non-empty host.")
+        raise error_type("Qdrant port requires a non-empty host.")
 
     if not has_remote and not has_path:
-        raise RuntimeError("Qdrant requires a non-empty url, host and port, or an explicit local path.")
+        raise error_type("Qdrant requires a non-empty url, host and port, or an explicit local path.")
+    if has_url and has_host:
+        raise error_type("Qdrant url and host/port modes cannot be configured together.")
     if has_remote and has_path:
-        raise RuntimeError("Qdrant remote endpoint and local path modes cannot be configured together.")
+        raise error_type("Qdrant remote endpoint and local path modes cannot be configured together.")
 
     if has_path:
+        remote_only = [key for key in ("api_key", "https") if config.get(key) is not None]
+        if remote_only:
+            raise error_type(
+                "Qdrant local path mode cannot use remote-only option(s): " + ", ".join(sorted(remote_only)) + "."
+            )
         logging.warning("Qdrant explicit local path mode is enabled; use a remote Qdrant server in production.")
+
+
+def validate_server_config(config: dict) -> None:
+    """Validate server-only invariants after startup/runtime configuration merges."""
+    vector_store = config.get("vector_store")
+    if not isinstance(vector_store, dict) or vector_store.get("provider") != "qdrant":
+        return
+
+    qdrant_config = vector_store.get("config")
+    if not isinstance(qdrant_config, dict):
+        raise ValueError("Qdrant vector-store configuration must be a JSON object.")
+    _validate_qdrant_config(qdrant_config, error_type=ValueError)
+
+
+def sanitized_validation_error_message(exc: ValidationError) -> str:
+    """Render Pydantic errors without their input values, which may contain credentials."""
+    issues = []
+    for error in exc.errors(include_url=False, include_context=False, include_input=False):
+        location = ".".join(str(part) for part in error.get("loc", ())) or "configuration"
+        issues.append(f"{location}: {error.get('msg', 'Invalid value')}")
+    return "Invalid configuration" + (f": {'; '.join(issues)}" if issues else ".")
 
 
 def build_vector_store_config(environ: Mapping[str, str]) -> tuple[dict, set[str]]:

--- a/server/vector_store_config.py
+++ b/server/vector_store_config.py
@@ -1,0 +1,88 @@
+import json
+import logging
+from copy import deepcopy
+from typing import Mapping
+
+
+def _collection_name(environ: Mapping[str, str]) -> str:
+    return environ.get("COLLECTION_NAME") or environ.get("POSTGRES_COLLECTION_NAME") or "memories"
+
+
+def _parse_json_object(raw_config: str) -> dict:
+    try:
+        parsed = json.loads(raw_config)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("VECTOR_STORE_CONFIG must be a valid JSON object.") from exc
+
+    if not isinstance(parsed, dict):
+        raise RuntimeError("VECTOR_STORE_CONFIG must decode to a JSON object.")
+    return parsed
+
+
+def _validate_qdrant_config(config: dict) -> None:
+    url = config.get("url")
+    host = config.get("host")
+    port = config.get("port")
+    path = config.get("path")
+
+    has_url = isinstance(url, str) and bool(url.strip())
+    has_host = isinstance(host, str) and bool(host.strip())
+    has_path = isinstance(path, str) and bool(path.strip())
+    has_remote = has_url or has_host
+
+    if has_host:
+        if isinstance(port, str) and port.isdigit():
+            port = int(port)
+            config["port"] = port
+        if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+            raise RuntimeError("Qdrant host configuration requires a port between 1 and 65535.")
+    elif port is not None:
+        raise RuntimeError("Qdrant port requires a non-empty host.")
+
+    if not has_remote and not has_path:
+        raise RuntimeError("Qdrant requires a non-empty url, host and port, or an explicit local path.")
+    if has_remote and has_path:
+        raise RuntimeError("Qdrant remote endpoint and local path modes cannot be configured together.")
+
+    if has_path:
+        logging.warning("Qdrant explicit local path mode is enabled; use a remote Qdrant server in production.")
+
+
+def build_vector_store_config(environ: Mapping[str, str]) -> tuple[dict, set[str]]:
+    """Build the REST server vector-store config and environment lock set.
+
+    Direct SDK defaults remain unchanged. This strict parser applies only when
+    the REST server is explicitly configured through generic vector-store
+    environment variables.
+    """
+    provider_is_set = "VECTOR_STORE_PROVIDER" in environ
+    config_is_set = "VECTOR_STORE_CONFIG" in environ
+    locked_components = {"vector_store"} if provider_is_set or config_is_set else set()
+
+    if config_is_set and not provider_is_set:
+        raise RuntimeError("VECTOR_STORE_PROVIDER is required when VECTOR_STORE_CONFIG is set.")
+
+    provider = environ.get("VECTOR_STORE_PROVIDER", "pgvector").strip().lower()
+    if not provider:
+        raise RuntimeError("VECTOR_STORE_PROVIDER must not be empty.")
+
+    if config_is_set:
+        config = _parse_json_object(environ["VECTOR_STORE_CONFIG"])
+    elif provider == "pgvector":
+        config = {
+            "host": environ.get("POSTGRES_HOST", "postgres"),
+            "port": int(environ.get("POSTGRES_PORT", "5432")),
+            "dbname": environ.get("POSTGRES_DB", "postgres"),
+            "user": environ.get("POSTGRES_USER", "postgres"),
+            "password": environ.get("POSTGRES_PASSWORD", "postgres"),
+        }
+    else:
+        raise RuntimeError(f"VECTOR_STORE_CONFIG is required when VECTOR_STORE_PROVIDER is '{provider}'.")
+
+    config = deepcopy(config)
+    config.setdefault("collection_name", _collection_name(environ))
+
+    if provider == "qdrant":
+        _validate_qdrant_config(config)
+
+    return {"provider": provider, "config": config}, locked_components

--- a/tests/memory/test_decay_usage_notice.py
+++ b/tests/memory/test_decay_usage_notice.py
@@ -11,6 +11,7 @@ def make_sync_memory():
     memory = Memory.__new__(Memory)
     memory.vector_store = MagicMock()
     memory._delete_memory = MagicMock()
+    memory._bulk_clear_entity_store = MagicMock()
     return memory
 
 

--- a/tests/memory/test_decay_usage_notice.py
+++ b/tests/memory/test_decay_usage_notice.py
@@ -91,7 +91,7 @@ def test_sync_delete_failure_does_not_trigger_decay_usage_notice(monkeypatch):
 def test_sync_delete_all_decay_usage_runs_after_success(monkeypatch):
     memory = make_sync_memory()
     memories = [SimpleNamespace(id="memory-1"), SimpleNamespace(id="memory-2")]
-    memory.vector_store.list.return_value = (memories, None)
+    memory.vector_store.list.side_effect = [(memories, None), ([], None)]
     decay_notice = MagicMock()
     first_run_notice = MagicMock()
     detect_decay = MagicMock(return_value=("delete_all", "bulk_delete", None, 2))
@@ -189,7 +189,7 @@ async def test_async_delete_failure_does_not_trigger_decay_usage_notice(monkeypa
 async def test_async_delete_all_decay_usage_runs_after_success(monkeypatch):
     memory = make_async_memory()
     memories = [SimpleNamespace(id="memory-1"), SimpleNamespace(id="memory-2")]
-    memory.vector_store.list.return_value = (memories, None)
+    memory.vector_store.list.side_effect = [(memories, None), ([], None)]
     decay_notice = AsyncMock()
     first_run_notice = AsyncMock()
     detect_decay = MagicMock(return_value=("delete_all", "bulk_delete", None, 2))

--- a/tests/memory/test_decay_usage_notice.py
+++ b/tests/memory/test_decay_usage_notice.py
@@ -18,7 +18,8 @@ def make_async_memory():
     memory = AsyncMemory.__new__(AsyncMemory)
     memory.vector_store = MagicMock()
     memory._delete_memory = AsyncMock()
-    memory._entity_store = None
+    memory._entity_store = MagicMock()
+    memory._entity_store.list.return_value = ([], None)
     return memory
 
 

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1015,6 +1015,7 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         mock_memory.embedding_model.embed = Mock(return_value=[0.1] * 10)
 
         mock_memory._entity_store = Mock()
+        mock_memory._entity_store.list = Mock(return_value=([], None))
         mock_memory._entity_store.search_batch = Mock(return_value=[[]])
         mock_memory._entity_store.insert = Mock()
         mock_memory._entity_store.update = Mock()
@@ -1059,6 +1060,7 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         mock_async_memory.embedding_model.embed = Mock(return_value=[0.1] * 10)
 
         mock_async_memory._entity_store = Mock()
+        mock_async_memory._entity_store.list = Mock(return_value=([], None))
         mock_async_memory._entity_store.search_batch = Mock(return_value=[[]])
         mock_async_memory._entity_store.insert = Mock()
         mock_async_memory._entity_store.update = Mock()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -280,17 +280,43 @@ def test_delete(memory_instance):
 
 def test_delete_all(memory_instance):
     mock_memories = [Mock(id="1"), Mock(id="2")]
-    memory_instance.vector_store.list = Mock(return_value=(mock_memories, None))
+    memory_instance.vector_store.list = Mock(side_effect=[(mock_memories, None), ([], None)])
     memory_instance.vector_store.reset = Mock()
     memory_instance._delete_memory = Mock()
 
     result = memory_instance.delete_all(user_id="test_user")
 
     assert memory_instance._delete_memory.call_count == 2
+    memory_instance._delete_memory.assert_any_call("1", mock_memories[0])
+    memory_instance._delete_memory.assert_any_call("2", mock_memories[1])
     # Ensure the collection is NOT dropped — only matched memories should be removed
     memory_instance.vector_store.reset.assert_not_called()
 
     assert result["message"] == "Memories deleted successfully!"
+
+
+def test_delete_all_drains_multiple_pages(memory_instance):
+    first_page = [Mock(id="1"), Mock(id="2")]
+    second_page = [Mock(id="3")]
+    memory_instance.vector_store.list = Mock(
+        side_effect=[(first_page, "next"), [second_page], ([], None)]
+    )
+    memory_instance._delete_memory = Mock()
+
+    result = memory_instance.delete_all(agent_id="agent")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert [call.args[0] for call in memory_instance._delete_memory.call_args_list] == ["1", "2", "3"]
+
+
+def test_delete_all_fails_after_repeated_zero_progress(memory_instance, monkeypatch):
+    memory = Mock(id="stuck")
+    memory_instance.vector_store.list = Mock(return_value=([memory], None))
+    memory_instance._delete_memory = Mock(side_effect=RuntimeError("cannot delete"))
+    monkeypatch.setattr("mem0.memory.main.DELETE_ALL_MAX_STALE_ITERATIONS", 2)
+
+    with pytest.raises(RuntimeError, match="made no progress"):
+        memory_instance.delete_all(run_id="run")
 
 
 def test_get_all(memory_instance):
@@ -431,7 +457,7 @@ class TestEntityIdValidation:
 
         memory_instance.delete_all(user_id="  alice  ")
 
-        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "alice"})
+        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "alice"}, top_k=1000)
 
     def test_validate_coerces_non_string_entity_id(self):
         """Integer (and other non-string) ids are coerced to str, not crashed on."""
@@ -444,7 +470,7 @@ class TestEntityIdValidation:
 
         memory_instance.delete_all(user_id=42)
 
-        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "42"})
+        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "42"}, top_k=1000)
 
     def test_get_all_coerces_integer_user_id(self, memory_instance):
         """get_all should accept an integer user_id in filters and scope by its str form."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -287,8 +287,8 @@ def test_delete_all(memory_instance):
     result = memory_instance.delete_all(user_id="test_user")
 
     assert memory_instance._delete_memory.call_count == 2
-    memory_instance._delete_memory.assert_any_call("1", mock_memories[0])
-    memory_instance._delete_memory.assert_any_call("2", mock_memories[1])
+    memory_instance._delete_memory.assert_any_call("1", mock_memories[0], strict_entity_cleanup=True)
+    memory_instance._delete_memory.assert_any_call("2", mock_memories[1], strict_entity_cleanup=True)
     # Ensure the collection is NOT dropped — only matched memories should be removed
     memory_instance.vector_store.reset.assert_not_called()
 
@@ -317,6 +317,65 @@ def test_delete_all_fails_after_repeated_zero_progress(memory_instance, monkeypa
 
     with pytest.raises(RuntimeError, match="made no progress"):
         memory_instance.delete_all(run_id="run")
+
+
+def test_delete_all_retries_history_after_vector_was_deleted(memory_instance):
+    memory = Mock(
+        id="mem-1",
+        payload={"data": "one", "user_id": "alice", "created_at": "2026-01-01T00:00:00+00:00"},
+    )
+    memory_instance.vector_store.list = Mock(side_effect=[([memory], None), ([], None)])
+    memory_instance.vector_store.delete = Mock()
+    memory_instance.db = Mock()
+    memory_instance.db.add_history.side_effect = [RuntimeError("history unavailable"), None]
+    memory_instance._entity_store = Mock()
+    memory_instance._entity_store.list.return_value = ([], None)
+
+    result = memory_instance.delete_all(user_id="alice")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    memory_instance.vector_store.delete.assert_called_once_with(vector_id="mem-1")
+    assert memory_instance.db.add_history.call_count == 2
+
+
+def test_delete_all_never_reports_success_when_history_cannot_be_written(memory_instance, monkeypatch):
+    memory = Mock(
+        id="mem-1",
+        payload={"data": "one", "user_id": "alice", "created_at": "2026-01-01T00:00:00+00:00"},
+    )
+    calls = 0
+
+    def list_memories(**kwargs):
+        nonlocal calls
+        calls += 1
+        return ([memory], None) if calls == 1 else ([], None)
+
+    memory_instance.vector_store.list = Mock(side_effect=list_memories)
+    memory_instance.vector_store.delete = Mock()
+    memory_instance.db = Mock()
+    memory_instance.db.add_history.side_effect = RuntimeError("history unavailable")
+    monkeypatch.setattr("mem0.memory.main.DELETE_ALL_MAX_STALE_ITERATIONS", 2)
+
+    with pytest.raises(RuntimeError, match="made no progress"):
+        memory_instance.delete_all(user_id="alice")
+
+    memory_instance.vector_store.delete.assert_called_once_with(vector_id="mem-1")
+
+
+def test_delete_all_stops_at_safety_iteration_limit(memory_instance, monkeypatch):
+    counter = 0
+
+    def endless_pages(**kwargs):
+        nonlocal counter
+        counter += 1
+        return ([Mock(id=f"mem-{counter}")], None)
+
+    memory_instance.vector_store.list = Mock(side_effect=endless_pages)
+    memory_instance._delete_memory = Mock()
+    monkeypatch.setattr("mem0.memory.main.DELETE_ALL_MAX_ITERATIONS", 2)
+
+    with pytest.raises(RuntimeError, match="safety iteration limit"):
+        memory_instance.delete_all(user_id="alice")
 
 
 def test_get_all(memory_instance):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -283,12 +283,13 @@ def test_delete_all(memory_instance):
     memory_instance.vector_store.list = Mock(side_effect=[(mock_memories, None), ([], None)])
     memory_instance.vector_store.reset = Mock()
     memory_instance._delete_memory = Mock()
+    memory_instance._bulk_clear_entity_store = Mock()
 
     result = memory_instance.delete_all(user_id="test_user")
 
     assert memory_instance._delete_memory.call_count == 2
-    memory_instance._delete_memory.assert_any_call("1", mock_memories[0], strict_entity_cleanup=True)
-    memory_instance._delete_memory.assert_any_call("2", mock_memories[1], strict_entity_cleanup=True)
+    memory_instance._delete_memory.assert_any_call("1", mock_memories[0], skip_entity_cleanup=True)
+    memory_instance._delete_memory.assert_any_call("2", mock_memories[1], skip_entity_cleanup=True)
     # Ensure the collection is NOT dropped — only matched memories should be removed
     memory_instance.vector_store.reset.assert_not_called()
 
@@ -302,6 +303,7 @@ def test_delete_all_drains_multiple_pages(memory_instance):
         side_effect=[(first_page, "next"), [second_page], ([], None)]
     )
     memory_instance._delete_memory = Mock()
+    memory_instance._bulk_clear_entity_store = Mock()
 
     result = memory_instance.delete_all(agent_id="agent")
 
@@ -313,6 +315,7 @@ def test_delete_all_fails_after_repeated_zero_progress(memory_instance, monkeypa
     memory = Mock(id="stuck")
     memory_instance.vector_store.list = Mock(return_value=([memory], None))
     memory_instance._delete_memory = Mock(side_effect=RuntimeError("cannot delete"))
+    memory_instance._bulk_clear_entity_store = Mock()
     monkeypatch.setattr("mem0.memory.main.DELETE_ALL_MAX_STALE_ITERATIONS", 2)
 
     with pytest.raises(RuntimeError, match="made no progress"):
@@ -372,6 +375,7 @@ def test_delete_all_stops_at_safety_iteration_limit(memory_instance, monkeypatch
 
     memory_instance.vector_store.list = Mock(side_effect=endless_pages)
     memory_instance._delete_memory = Mock()
+    memory_instance._bulk_clear_entity_store = Mock()
     monkeypatch.setattr("mem0.memory.main.DELETE_ALL_MAX_ITERATIONS", 2)
 
     with pytest.raises(RuntimeError, match="safety iteration limit"):
@@ -513,6 +517,7 @@ class TestEntityIdValidation:
     def test_delete_all_trims_user_id_before_list(self, memory_instance):
         """delete_all should trim leading/trailing whitespace on entity IDs."""
         memory_instance.vector_store.list = Mock(return_value=([], None))
+        memory_instance._bulk_clear_entity_store = Mock()
 
         memory_instance.delete_all(user_id="  alice  ")
 
@@ -526,6 +531,7 @@ class TestEntityIdValidation:
     def test_delete_all_coerces_integer_user_id_before_list(self, memory_instance):
         """delete_all should accept an integer user_id and scope by its str form."""
         memory_instance.vector_store.list = Mock(return_value=([], None))
+        memory_instance._bulk_clear_entity_store = Mock()
 
         memory_instance.delete_all(user_id=42)
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -983,22 +983,20 @@ async def test_async_delete_all_continues_on_partial_failure(mock_sqlite, mock_l
     mem3.id = "mem-3"
     mem3.payload = {"data": "three", "created_at": "2024-01-01T00:00:00+00:00", "actor_id": None, "role": None}
 
-    mock_vector_store.list.return_value = ([mem1, mem2, mem3],)
+    mock_vector_store.list.side_effect = [([mem1, mem2, mem3],), ([mem2],), ([],)]
+    delete_attempts = {"mem-2": 0}
 
-    def _get_side_effect(vector_id):
-        if vector_id == "mem-2":
+    def _delete_side_effect(vector_id):
+        if vector_id == "mem-2" and delete_attempts["mem-2"] == 0:
+            delete_attempts["mem-2"] += 1
             raise RuntimeError("simulated store failure")
-        return {
-            "mem-1": mem1,
-            "mem-3": mem3,
-        }.get(vector_id)
 
-    mock_vector_store.get.side_effect = _get_side_effect
+    mock_vector_store.delete.side_effect = _delete_side_effect
 
     result = await memory.delete_all(user_id="test-user")
 
     assert result == {"message": "Memories deleted successfully!"}
-    assert mock_vector_store.delete.call_count == 2
+    assert mock_vector_store.delete.call_count == 4
 
 
 @patch('mem0.utils.factory.EmbedderFactory.create')
@@ -1473,7 +1471,7 @@ class TestAsyncDeleteAllEntityRace:
         mem_b = MagicMock()
         mem_b.id = "mem-b"
         mem_b.payload = {"data": "Alice works at Acme", "user_id": "alice"}
-        mock_vector_store.list.return_value = ([mem_a, mem_b],)
+        mock_vector_store.list.side_effect = [([mem_a, mem_b],), ([],)]
         mock_vector_store.get.side_effect = lambda vector_id: {"mem-a": mem_a, "mem-b": mem_b}[vector_id]
         mock_vector_factory.return_value = mock_vector_store
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from pydantic import ValidationError as PydanticValidationError
 
 from mem0 import Memory
 from mem0.configs.base import MemoryConfig
@@ -675,10 +676,85 @@ async def test_async_update_propagates_vector_store_failure(mock_sqlite, mock_ll
     mock_vector_store.update.assert_not_called()
 
 
-@patch('mem0.utils.factory.EmbedderFactory.create')
-@patch('mem0.utils.factory.VectorStoreFactory.create')
-@patch('mem0.utils.factory.LlmFactory.create')
-@patch('mem0.memory.storage.SQLiteManager')
+@pytest.mark.parametrize("memory_class_name", ["Memory", "AsyncMemory"])
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
+def test_qdrant_dimension_follows_resolved_embedder_when_omitted(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    memory_class_name,
+):
+    embedder = MagicMock()
+    embedder.config.embedding_dims = 768
+    mock_embedder_factory.return_value = embedder
+    mock_vector_factory.return_value = MagicMock()
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+    config = MemoryConfig(vector_store={"provider": "qdrant", "config": {"path": "/tmp/qdrant"}})
+
+    from mem0.memory.main import AsyncMemory, Memory as MemoryClass
+
+    memory_class = MemoryClass if memory_class_name == "Memory" else AsyncMemory
+    memory_class(config)
+
+    vector_config = mock_vector_factory.call_args.args[1]
+    assert vector_config.embedding_model_dims == 768
+
+
+@pytest.mark.parametrize("memory_class_name", ["Memory", "AsyncMemory"])
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+def test_explicit_qdrant_dimension_mismatch_fails_before_vector_connection(
+    mock_vector_factory,
+    mock_embedder_factory,
+    memory_class_name,
+):
+    embedder = MagicMock()
+    embedder.config.embedding_dims = 768
+    mock_embedder_factory.return_value = embedder
+    config = MemoryConfig(
+        vector_store={
+            "provider": "qdrant",
+            "config": {"path": "/tmp/qdrant", "embedding_model_dims": 1024},
+        }
+    )
+
+    from mem0.memory.main import AsyncMemory, Memory as MemoryClass
+
+    memory_class = MemoryClass if memory_class_name == "Memory" else AsyncMemory
+    with pytest.raises(ValueError, match="expects 1024, embedder produces 768"):
+        memory_class(config)
+
+    mock_vector_factory.assert_not_called()
+
+
+@pytest.mark.parametrize("memory_class_name", ["Memory", "AsyncMemory"])
+def test_from_config_validation_log_does_not_expose_qdrant_secret(memory_class_name, caplog):
+    from mem0.memory.main import AsyncMemory, Memory as MemoryClass
+
+    memory_class = MemoryClass if memory_class_name == "Memory" else AsyncMemory
+    secret = "S3CR3T-log-sentinel"
+    with pytest.raises(PydanticValidationError):
+        memory_class.from_config(
+            {
+                "vector_store": {
+                    "provider": "qdrant",
+                    "config": {"url": "https://qdrant", "api_key": secret, "unsupported": True},
+                }
+            }
+        )
+
+    assert secret not in caplog.text
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
 def test_add_infer_false_embeds_once(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
     """
     Regression test for issue #3723: adding with infer=False should not trigger duplicate embedding calls.
@@ -965,7 +1041,9 @@ async def test_async_delete_all_continues_on_partial_failure(mock_sqlite, mock_l
     """
     mock_embedder_factory.return_value = MagicMock()
     mock_vector_store = MagicMock()
-    mock_vector_factory.return_value = mock_vector_store
+    mock_entity_store = MagicMock()
+    mock_entity_store.list.return_value = ([], None)
+    mock_vector_factory.side_effect = [mock_vector_store, mock_entity_store]
     mock_llm_factory.return_value = MagicMock()
     mock_sqlite.return_value = MagicMock()
 
@@ -999,10 +1077,88 @@ async def test_async_delete_all_continues_on_partial_failure(mock_sqlite, mock_l
     assert mock_vector_store.delete.call_count == 4
 
 
-@patch('mem0.utils.factory.EmbedderFactory.create')
-@patch('mem0.utils.factory.VectorStoreFactory.create')
-@patch('mem0.utils.factory.LlmFactory.create')
-@patch('mem0.memory.storage.SQLiteManager')
+@pytest.mark.asyncio
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.main.SQLiteManager")
+async def test_async_delete_all_retries_history_without_redeleting_vector(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+):
+    mock_embedder_factory.return_value = MagicMock()
+    vector_store = MagicMock()
+    entity_store = MagicMock()
+    entity_store.list.return_value = ([], None)
+    mock_vector_factory.side_effect = [vector_store, entity_store]
+    mock_llm_factory.return_value = MagicMock()
+    history_db = MagicMock()
+    history_db.add_history.side_effect = [RuntimeError("history unavailable"), None]
+    mock_sqlite.return_value = history_db
+    memory_row = MagicMock(
+        id="mem-1",
+        payload={"data": "one", "user_id": "alice", "created_at": "2026-01-01T00:00:00+00:00"},
+    )
+    vector_store.list.side_effect = [([memory_row], None), ([], None)]
+
+    from mem0.memory.main import AsyncMemory
+
+    memory = AsyncMemory(MemoryConfig())
+    result = await memory.delete_all(user_id="alice")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    vector_store.delete.assert_called_once_with(vector_id="mem-1")
+    assert history_db.add_history.call_count == 2
+
+
+@pytest.mark.asyncio
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.main.SQLiteManager")
+async def test_async_delete_all_never_reports_success_after_permanent_history_failure(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    monkeypatch,
+):
+    mock_embedder_factory.return_value = MagicMock()
+    vector_store = MagicMock()
+    mock_vector_factory.return_value = vector_store
+    mock_llm_factory.return_value = MagicMock()
+    history_db = MagicMock()
+    history_db.add_history.side_effect = RuntimeError("history unavailable")
+    mock_sqlite.return_value = history_db
+    memory_row = MagicMock(
+        id="mem-1",
+        payload={"data": "one", "user_id": "alice", "created_at": "2026-01-01T00:00:00+00:00"},
+    )
+    calls = 0
+
+    def list_memories(**kwargs):
+        nonlocal calls
+        calls += 1
+        return ([memory_row], None) if calls == 1 else ([], None)
+
+    vector_store.list.side_effect = list_memories
+    monkeypatch.setattr("mem0.memory.main.DELETE_ALL_MAX_STALE_ITERATIONS", 2)
+
+    from mem0.memory.main import AsyncMemory
+
+    memory = AsyncMemory(MemoryConfig())
+    with pytest.raises(RuntimeError, match="made no progress"):
+        await memory.delete_all(user_id="alice")
+
+    vector_store.delete.assert_called_once_with(vector_id="mem-1")
+
+
+@patch("mem0.utils.factory.EmbedderFactory.create")
+@patch("mem0.utils.factory.VectorStoreFactory.create")
+@patch("mem0.utils.factory.LlmFactory.create")
+@patch("mem0.memory.storage.SQLiteManager")
 class TestProcessMetadataFiltersMerge:
     """Regression tests for issue #3952: multiple operators on the same key must be merged."""
 
@@ -1473,8 +1629,6 @@ class TestAsyncDeleteAllEntityRace:
         mem_b.payload = {"data": "Alice works at Acme", "user_id": "alice"}
         mock_vector_store.list.side_effect = [([mem_a, mem_b],), ([],)]
         mock_vector_store.get.side_effect = lambda vector_id: {"mem-a": mem_a, "mem-b": mem_b}[vector_id]
-        mock_vector_factory.return_value = mock_vector_store
-
         mock_entity_store = MagicMock()
         entity_row = MagicMock()
         entity_row.id = "entity-alice"
@@ -1483,18 +1637,62 @@ class TestAsyncDeleteAllEntityRace:
             "user_id": "alice",
             "linked_memory_ids": ["mem-a", "mem-b"],
         }
-        mock_entity_store.list.return_value = ([entity_row],)
+        mock_entity_store.list.side_effect = [([entity_row],), ([], None)]
+        mock_vector_factory.side_effect = [mock_vector_store, mock_entity_store]
 
         from mem0.memory.main import AsyncMemory
         config = MemoryConfig()
         memory = AsyncMemory(config)
-        memory._entity_store = mock_entity_store
 
         await memory.delete_all(user_id="alice")
 
+        assert mock_vector_factory.call_count == 2
         mock_entity_store.delete.assert_called_once_with(vector_id="entity-alice")
 
         assert mock_vector_store.delete.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("mem0.utils.factory.EmbedderFactory.create")
+    @patch("mem0.utils.factory.VectorStoreFactory.create")
+    @patch("mem0.utils.factory.LlmFactory.create")
+    @patch("mem0.memory.storage.SQLiteManager")
+    async def test_async_entity_cleanup_drains_multiple_pages_after_restart(
+        self,
+        mock_sqlite,
+        mock_llm_factory,
+        mock_vector_factory,
+        mock_embedder_factory,
+        monkeypatch,
+    ):
+        mock_embedder_factory.return_value = MagicMock()
+        mock_llm_factory.return_value = MagicMock()
+        mock_sqlite.return_value = MagicMock()
+        memory_store = MagicMock()
+        memory_store.list.return_value = ([], None)
+        entity_store = MagicMock()
+        remaining = {
+            f"entity-{index}": MagicMock(id=f"entity-{index}", payload={"user_id": "alice"})
+            for index in range(5)
+        }
+
+        def list_entities(**kwargs):
+            return (list(remaining.values())[:2], None)
+
+        def delete_entity(vector_id):
+            remaining.pop(vector_id)
+
+        entity_store.list.side_effect = list_entities
+        entity_store.delete.side_effect = delete_entity
+        mock_vector_factory.side_effect = [memory_store, entity_store]
+        monkeypatch.setattr("mem0.memory.main.ENTITY_CLEANUP_PAGE_SIZE", 2)
+
+        from mem0.memory.main import AsyncMemory
+
+        memory = AsyncMemory(MemoryConfig())
+        await memory.delete_all(user_id="alice")
+
+        assert not remaining
+        assert entity_store.delete.call_count == 5
 
 
 @pytest.mark.asyncio

--- a/tests/test_qdrant_hardening_adversarial.py
+++ b/tests/test_qdrant_hardening_adversarial.py
@@ -1,0 +1,427 @@
+import asyncio
+import threading
+import time
+import warnings
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from qdrant_client import QdrantClient, models
+from qdrant_client.grpc import PointId
+from qdrant_client.http.exceptions import UnexpectedResponse
+from qdrant_client.models import Distance, PayloadIndexInfo, PayloadSchemaType, SparseVectorParams, VectorParams
+
+from mem0.configs.base import MemoryConfig
+from mem0.configs.vector_stores.qdrant import QdrantConfig
+from mem0.memory import main as memory_main
+from mem0.memory.main import AsyncMemory, Memory, _safe_deepcopy_config
+from mem0.vector_stores import qdrant as qdrant_module
+from mem0.vector_stores.configs import VectorStoreConfig
+from mem0.vector_stores.qdrant import Qdrant
+from mem0.vector_stores.utils import normalize_list_result
+from server import server_state
+
+
+def test_existing_remote_client_does_not_gain_local_fallback_path():
+    client = MagicMock(spec=QdrantClient)
+
+    config = VectorStoreConfig(provider="qdrant", config={"client": client})
+
+    assert config.config.client is client
+    assert config.config.path is None
+
+
+def test_vector_store_config_does_not_mutate_caller_when_injecting_sdk_default():
+    caller_config = {}
+
+    config = VectorStoreConfig(provider="qdrant", config=caller_config)
+
+    assert caller_config == {}
+    assert config.config.path == "/tmp/qdrant"
+
+
+def test_existing_local_client_is_detected_without_repeating_path(monkeypatch):
+    client = QdrantClient(":memory:")
+    monkeypatch.setattr(qdrant_module.Qdrant, "create_col", lambda *args, **kwargs: None)
+    try:
+        store = Qdrant(collection_name="memories", embedding_model_dims=4, client=client)
+        assert store.is_local is True
+    finally:
+        client.close()
+
+
+def test_qdrant_grpc_point_id_is_a_supported_scroll_offset():
+    rows = [SimpleNamespace(id="one")]
+
+    assert normalize_list_result((rows, PointId(num=42))) == rows
+
+
+def test_real_payload_schema_model_is_recognized_as_keyword():
+    store = Qdrant.__new__(Qdrant)
+    store.client = MagicMock()
+    store.collection_name = "memories"
+    store.is_local = False
+    info = SimpleNamespace(
+        payload_schema={
+            field: PayloadIndexInfo(data_type=PayloadSchemaType.KEYWORD, points=1)
+            for field in ("user_id", "agent_id", "run_id", "actor_id")
+        }
+    )
+
+    store._create_filter_indexes(info)
+
+    store.client.create_payload_index.assert_not_called()
+
+
+def test_false_collection_create_result_revalidates_the_winner():
+    store = Qdrant.__new__(Qdrant)
+    store.client = MagicMock()
+    store.collection_name = "memories"
+    store.is_local = True
+    store.client.collection_exists.return_value = False
+    store.client.create_collection.return_value = False
+    info = SimpleNamespace(
+        config=SimpleNamespace(
+            params=SimpleNamespace(
+                vectors=VectorParams(size=4, distance=Distance.COSINE),
+                sparse_vectors={"bm25": SparseVectorParams(modifier=models.Modifier.IDF)},
+            )
+        ),
+        payload_schema={},
+    )
+    store.client.get_collection.return_value = info
+
+    store.create_col(vector_size=4, on_disk=False)
+
+    store.client.get_collection.assert_called_once_with("memories")
+    assert store._has_bm25_slot is True
+
+
+def test_real_qdrant_conflict_revalidates_without_recreating():
+    store = Qdrant.__new__(Qdrant)
+    store.client = MagicMock()
+    store.collection_name = "memories"
+    store.is_local = True
+    store.client.collection_exists.return_value = False
+    store.client.create_collection.side_effect = UnexpectedResponse(
+        status_code=409,
+        reason_phrase="Conflict",
+        content=b"already exists",
+        headers={},
+    )
+    info = SimpleNamespace(
+        config=SimpleNamespace(
+            params=SimpleNamespace(
+                vectors=VectorParams(size=4, distance=Distance.COSINE),
+                sparse_vectors={},
+            )
+        ),
+        payload_schema={},
+    )
+    store.client.get_collection.return_value = info
+
+    store.create_col(vector_size=4, on_disk=False)
+
+    store.client.get_collection.assert_called_once_with("memories")
+    store.client.delete_collection.assert_not_called()
+
+
+def test_collection_probe_does_not_list_every_qdrant_collection():
+    store = Qdrant.__new__(Qdrant)
+    store.client = MagicMock()
+    store.collection_name = "memories"
+    store.is_local = True
+    store.client.collection_exists.return_value = True
+    store.client.get_collections.side_effect = AssertionError("full collection scan is unnecessary")
+    info = SimpleNamespace(
+        config=SimpleNamespace(
+            params=SimpleNamespace(
+                vectors=VectorParams(size=4, distance=Distance.COSINE),
+                sparse_vectors={},
+            )
+        ),
+        payload_schema={},
+    )
+    store.client.get_collection.return_value = info
+
+    store.create_col(vector_size=4, on_disk=False)
+
+    store.client.collection_exists.assert_called_once_with("memories")
+    store.client.get_collections.assert_not_called()
+
+
+def test_collection_probe_falls_back_for_older_qdrant_server():
+    store = Qdrant.__new__(Qdrant)
+    store.client = MagicMock()
+    store.collection_name = "memories"
+    store.is_local = True
+    store.client.collection_exists.side_effect = UnexpectedResponse(
+        status_code=404,
+        reason_phrase="Not Found",
+        content=b"endpoint unavailable",
+        headers={},
+    )
+    store.client.get_collections.return_value = SimpleNamespace(collections=[SimpleNamespace(name="memories")])
+    info = SimpleNamespace(
+        config=SimpleNamespace(
+            params=SimpleNamespace(
+                vectors=VectorParams(size=4, distance=Distance.COSINE),
+                sparse_vectors={},
+            )
+        ),
+        payload_schema={},
+    )
+    store.client.get_collection.return_value = info
+
+    store.create_col(vector_size=4, on_disk=False)
+
+    store.client.get_collections.assert_called_once()
+    store.client.create_collection.assert_not_called()
+
+
+@pytest.mark.parametrize("collection_name", ["", "   ", "bad\nname", "bad\x7fname"])
+def test_invalid_collection_names_fail_before_client_calls(collection_name, monkeypatch):
+    with pytest.raises(ValueError, match="collection_name"):
+        QdrantConfig(url="https://qdrant.internal", collection_name=collection_name)
+
+    client = MagicMock(spec=QdrantClient)
+    with pytest.raises(ValueError, match="collection_name"):
+        Qdrant(collection_name=collection_name, embedding_model_dims=4, client=client)
+    client.collection_exists.assert_not_called()
+
+
+def test_validated_server_config_does_not_mutate_caller_dictionary():
+    config = {
+        "vector_store": {
+            "provider": "qdrant",
+            "config": {"host": "qdrant.internal", "port": "6333"},
+        }
+    }
+
+    normalized = server_state._validated_config(config)
+
+    assert config["vector_store"]["config"]["port"] == "6333"
+    assert normalized["vector_store"]["config"]["port"] == 6333
+
+
+def test_valid_qdrant_config_serialization_does_not_warn_with_api_key():
+    secret = "S3CR3T-valid-config-sentinel"
+    config = {
+        "vector_store": {
+            "provider": "qdrant",
+            "config": {"url": "https://qdrant.internal", "api_key": secret},
+        }
+    }
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        normalized = server_state._validated_config(config)
+
+    assert normalized["vector_store"]["config"]["api_key"] == secret
+    assert not captured
+
+
+def test_memory_config_model_dump_serializes_provider_config_without_warning():
+    config = MemoryConfig(
+        vector_store={
+            "provider": "qdrant",
+            "config": {"url": "https://qdrant.internal", "api_key": "S3CR3T-sdk-sentinel"},
+        }
+    )
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        dumped = config.model_dump(mode="python")
+
+    assert dumped["vector_store"]["config"]["url"] == "https://qdrant.internal"
+    assert not captured
+
+
+def test_config_clone_failure_logs_only_exception_type(caplog):
+    secret = "https://user:S3CR3T-clone@qdrant.internal"
+
+    class ExplodingConfig:
+        def __deepcopy__(self, memo):
+            raise RuntimeError(secret)
+
+    with caplog.at_level("DEBUG"):
+        _safe_deepcopy_config(ExplodingConfig())
+
+    assert "RuntimeError" in caplog.text
+    assert secret not in caplog.text
+
+
+def test_entity_list_failure_does_not_log_provider_exception_text(caplog):
+    secret = "https://user:S3CR3T-list@qdrant.internal"
+    memory = Memory.__new__(Memory)
+    memory._entity_store = MagicMock()
+    memory._entity_store.list.side_effect = RuntimeError(secret)
+
+    with caplog.at_level("DEBUG"):
+        assert memory._existing_entities_by_text({"user_id": "alice"}) == {}
+
+    assert "RuntimeError" in caplog.text
+    assert secret not in caplog.text
+
+
+def test_real_qdrant_delete_all_drains_more_than_one_page_and_preserves_other_tenant(tmp_path, monkeypatch):
+    store = Qdrant(
+        collection_name="memories",
+        embedding_model_dims=1,
+        path=str(tmp_path / "qdrant"),
+    )
+    try:
+        alice_count = memory_main.DELETE_ALL_PAGE_SIZE + 5
+        ids = list(range(alice_count + 1))
+        store.insert(
+            vectors=[[0.1] for _ in ids],
+            ids=ids,
+            payloads=[
+                {"data": "", "user_id": "alice", "created_at": "2026-01-01T00:00:00+00:00"} for _ in range(alice_count)
+            ]
+            + [{"data": "", "user_id": "bob", "created_at": "2026-01-01T00:00:00+00:00"}],
+        )
+
+        memory = Memory.__new__(Memory)
+        memory.vector_store = store
+        memory.config = MemoryConfig(
+            vector_store={
+                "provider": "qdrant",
+                "config": {"path": str(tmp_path / "qdrant"), "embedding_model_dims": 1},
+            }
+        )
+        memory.db = MagicMock()
+        memory.embedding_model = MagicMock()
+        memory._entity_store = MagicMock()
+        memory._entity_store.list.return_value = ([], None)
+        monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+        monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+        monkeypatch.setattr(memory_main, "display_first_run_notice", MagicMock())
+
+        result = memory.delete_all(user_id="alice")
+
+        assert result == {"message": "Memories deleted successfully!"}
+        assert normalize_list_result(store.list(filters={"user_id": "alice"}, top_k=10)) == []
+        bob = normalize_list_result(store.list(filters={"user_id": "bob"}, top_k=10))
+        assert len(bob) == 1
+        assert memory.db.add_history.call_count == alice_count
+        assert memory._entity_store.list.call_count <= 2
+    finally:
+        store.client.close()
+
+
+def test_sync_entity_cleanup_drains_pages_and_retries_partial_failures(monkeypatch):
+    remaining = {f"entity-{index}": SimpleNamespace(id=f"entity-{index}") for index in range(5)}
+    failed_once = set()
+
+    class EntityStore:
+        def list(self, **kwargs):
+            return (list(remaining.values())[:2], None)
+
+        def delete(self, vector_id):
+            if vector_id == "entity-0" and vector_id not in failed_once:
+                failed_once.add(vector_id)
+                raise RuntimeError("transient")
+            remaining.pop(vector_id)
+
+    memory = Memory.__new__(Memory)
+    memory._entity_store = EntityStore()
+    monkeypatch.setattr(memory_main, "ENTITY_CLEANUP_PAGE_SIZE", 2)
+
+    memory._bulk_clear_entity_store({"user_id": "alice"})
+
+    assert not remaining
+    assert failed_once == {"entity-0"}
+
+
+def test_real_qdrant_bulk_entity_cleanup_is_tenant_scoped(tmp_path, monkeypatch):
+    store = Qdrant(
+        collection_name="mem0_entities",
+        embedding_model_dims=1,
+        path=str(tmp_path / "qdrant-entities"),
+    )
+    try:
+        store.insert(
+            vectors=[[0.1] for _ in range(6)],
+            ids=list(range(6)),
+            payloads=[{"data": "", "user_id": "alice"} for _ in range(5)] + [{"data": "", "user_id": "bob"}],
+        )
+        memory = Memory.__new__(Memory)
+        memory._entity_store = store
+        monkeypatch.setattr(memory_main, "ENTITY_CLEANUP_PAGE_SIZE", 2)
+
+        memory._bulk_clear_entity_store({"user_id": "alice"})
+
+        assert normalize_list_result(store.list(filters={"user_id": "alice"}, top_k=10)) == []
+        bob = normalize_list_result(store.list(filters={"user_id": "bob"}, top_k=10))
+        assert len(bob) == 1
+    finally:
+        store.client.close()
+
+
+def test_sync_delete_all_surfaces_incomplete_bulk_entity_cleanup(monkeypatch):
+    memory = Memory.__new__(Memory)
+    memory.vector_store = MagicMock()
+    memory.vector_store.list.return_value = ([], None)
+    memory._bulk_clear_entity_store = MagicMock(side_effect=RuntimeError("entity cleanup incomplete"))
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+
+    with pytest.raises(RuntimeError, match="entity cleanup incomplete"):
+        memory.delete_all(user_id="alice")
+
+
+@pytest.mark.asyncio
+async def test_async_entity_cleanup_uses_bounded_parallelism(monkeypatch):
+    record_count = 50
+    remaining = {f"entity-{index}": SimpleNamespace(id=f"entity-{index}") for index in range(record_count)}
+    guard = threading.Lock()
+    active = 0
+    maximum_active = 0
+
+    class EntityStore:
+        def list(self, **kwargs):
+            return (list(remaining.values()), None)
+
+        def delete(self, vector_id):
+            nonlocal active, maximum_active
+            with guard:
+                active += 1
+                maximum_active = max(maximum_active, active)
+            try:
+                time.sleep(0.005)
+                remaining.pop(vector_id)
+            finally:
+                with guard:
+                    active -= 1
+
+    memory = AsyncMemory.__new__(AsyncMemory)
+    memory._entity_store = EntityStore()
+    monkeypatch.setattr(memory_main, "DELETE_ALL_ASYNC_CONCURRENCY", 7)
+
+    await memory._bulk_clear_entity_store({"user_id": "alice"})
+
+    assert not remaining
+    assert 1 < maximum_active <= 7
+
+
+@pytest.mark.asyncio
+async def test_multiple_runtime_leases_delay_close_until_last_request(monkeypatch):
+    instance = MagicMock()
+    monkeypatch.setattr(server_state, "_memory_instance", instance)
+    monkeypatch.setattr(server_state, "_active_leases", {})
+    monkeypatch.setattr(server_state, "_retired_instances", {})
+    closed = MagicMock()
+    monkeypatch.setattr(server_state, "_close_memory_instance", closed)
+
+    first = server_state.memory_instance_lease()
+    second = server_state.memory_instance_lease()
+    first.__enter__()
+    second.__enter__()
+    server_state._retire_memory_instance(instance)
+    first.__exit__(None, None, None)
+    closed.assert_not_called()
+
+    await asyncio.sleep(0)
+    second.__exit__(None, None, None)
+
+    closed.assert_called_once_with(instance)

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1,0 +1,224 @@
+from copy import deepcopy
+from unittest.mock import MagicMock
+
+import pytest
+
+from server import server_state
+from server.vector_store_config import build_vector_store_config
+
+
+def test_legacy_pgvector_config_when_generic_environment_is_absent():
+    config, locked = build_vector_store_config(
+        {
+            "POSTGRES_HOST": "db",
+            "POSTGRES_PORT": "5433",
+            "POSTGRES_DB": "mem0",
+            "POSTGRES_USER": "mem0",
+            "POSTGRES_PASSWORD": "secret",
+            "POSTGRES_COLLECTION_NAME": "legacy",
+        }
+    )
+
+    assert locked == set()
+    assert config == {
+        "provider": "pgvector",
+        "config": {
+            "host": "db",
+            "port": 5433,
+            "dbname": "mem0",
+            "user": "mem0",
+            "password": "secret",
+            "collection_name": "legacy",
+        },
+    }
+
+
+def test_remote_qdrant_config_is_locked_and_prefers_json_collection():
+    config, locked = build_vector_store_config(
+        {
+            "VECTOR_STORE_PROVIDER": "qdrant",
+            "VECTOR_STORE_CONFIG": (
+                '{"url":"https://qdrant.internal:6333","api_key":"secret",'
+                '"collection_name":"from-json","embedding_model_dims":1024}'
+            ),
+            "COLLECTION_NAME": "from-generic",
+            "POSTGRES_COLLECTION_NAME": "from-legacy",
+        }
+    )
+
+    assert locked == {"vector_store"}
+    assert config["provider"] == "qdrant"
+    assert config["config"]["collection_name"] == "from-json"
+    assert "path" not in config["config"]
+
+
+def test_qdrant_host_port_and_explicit_local_modes(caplog):
+    remote, _ = build_vector_store_config(
+        {
+            "VECTOR_STORE_PROVIDER": "qdrant",
+            "VECTOR_STORE_CONFIG": '{"host":"qdrant","port":"6333"}',
+        }
+    )
+    assert remote["config"]["port"] == 6333
+
+    local, _ = build_vector_store_config(
+        {
+            "VECTOR_STORE_PROVIDER": "qdrant",
+            "VECTOR_STORE_CONFIG": '{"path":"./qdrant-data"}',
+        }
+    )
+    assert local["config"]["path"] == "./qdrant-data"
+    assert "production" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("environ", "message"),
+    [
+        ({"VECTOR_STORE_CONFIG": "{}"}, "VECTOR_STORE_PROVIDER is required"),
+        (
+            {"VECTOR_STORE_PROVIDER": "qdrant"},
+            "VECTOR_STORE_CONFIG is required",
+        ),
+        (
+            {"VECTOR_STORE_PROVIDER": "qdrant", "VECTOR_STORE_CONFIG": "not-json"},
+            "valid JSON object",
+        ),
+        (
+            {"VECTOR_STORE_PROVIDER": "qdrant", "VECTOR_STORE_CONFIG": "[]"},
+            "decode to a JSON object",
+        ),
+        (
+            {"VECTOR_STORE_PROVIDER": "qdrant", "VECTOR_STORE_CONFIG": "{}"},
+            "requires a non-empty url",
+        ),
+        (
+            {
+                "VECTOR_STORE_PROVIDER": "qdrant",
+                "VECTOR_STORE_CONFIG": '{"host":"qdrant","port":0}',
+            },
+            "port between 1 and 65535",
+        ),
+        (
+            {
+                "VECTOR_STORE_PROVIDER": "qdrant",
+                "VECTOR_STORE_CONFIG": '{"url":"https://qdrant","path":"./local"}',
+            },
+            "cannot be configured together",
+        ),
+    ],
+)
+def test_invalid_explicit_vector_store_configuration_fails(environ, message):
+    with pytest.raises(RuntimeError, match=message) as exc_info:
+        build_vector_store_config(environ)
+
+    assert "api_key" not in str(exc_info.value)
+    assert "secret" not in str(exc_info.value)
+
+
+def test_merge_replaces_changed_provider_without_mutating_inputs():
+    base = {"vector_store": {"provider": "pgvector", "config": {"password": "old", "port": 5432}}}
+    update = {"vector_store": {"provider": "qdrant", "config": {"url": "https://qdrant"}}}
+    base_before = deepcopy(base)
+    update_before = deepcopy(update)
+
+    merged = server_state._merge_config(base, update)
+
+    assert merged == update
+    assert base == base_before
+    assert update == update_before
+
+
+def test_merge_deep_merges_same_provider():
+    base = {"llm": {"provider": "openai", "config": {"model": "old", "temperature": 0.2}}}
+    update = {"llm": {"provider": "openai", "config": {"model": "new"}}}
+
+    assert server_state._merge_config(base, update) == {
+        "llm": {"provider": "openai", "config": {"model": "new", "temperature": 0.2}}
+    }
+
+
+def _prepare_state(monkeypatch, current_config, current_instance):
+    monkeypatch.setattr(server_state, "_current_config", deepcopy(current_config))
+    monkeypatch.setattr(server_state, "_memory_instance", current_instance)
+    monkeypatch.setattr(server_state, "_locked_components", set())
+    monkeypatch.setattr(server_state, "_load_overrides", lambda: {})
+    monkeypatch.setattr(server_state, "MemoryConfig", lambda **kwargs: kwargs)
+
+
+def test_environment_lock_ignores_persisted_vector_store(monkeypatch):
+    default = {
+        "vector_store": {"provider": "qdrant", "config": {"url": "https://qdrant"}},
+        "llm": {"provider": "openai", "config": {"model": "base"}},
+    }
+    monkeypatch.setattr(
+        server_state,
+        "_load_overrides",
+        lambda: {
+            "vector_store": {"provider": "pgvector", "config": {"password": "stale"}},
+            "llm": {"provider": "openai", "config": {"model": "persisted"}},
+        },
+    )
+    monkeypatch.setattr(server_state, "MemoryConfig", lambda **kwargs: kwargs)
+    created = MagicMock()
+    from_config = MagicMock(return_value=created)
+    monkeypatch.setattr(server_state.Memory, "from_config", from_config)
+    monkeypatch.setattr(server_state, "_memory_instance", None)
+
+    server_state.initialize_state(default, locked_components={"vector_store"})
+
+    effective = from_config.call_args.args[0]
+    assert effective["vector_store"]["provider"] == "qdrant"
+    assert effective["llm"]["config"]["model"] == "persisted"
+
+
+def test_locked_runtime_update_is_rejected_before_construction(monkeypatch):
+    current = {"vector_store": {"provider": "qdrant", "config": {"url": "https://qdrant"}}}
+    current_instance = MagicMock()
+    _prepare_state(monkeypatch, current, current_instance)
+    monkeypatch.setattr(server_state, "_locked_components", {"vector_store"})
+    from_config = MagicMock()
+    monkeypatch.setattr(server_state.Memory, "from_config", from_config)
+
+    with pytest.raises(ValueError, match="managed by environment variables"):
+        server_state.update_config({"vector_store": {"config": {"collection_name": "other"}}})
+
+    from_config.assert_not_called()
+    assert server_state.get_current_config() == current
+    assert server_state.get_memory_instance() is current_instance
+
+
+def test_failed_persistence_keeps_previous_runtime(monkeypatch):
+    current = {"llm": {"provider": "openai", "config": {"model": "old"}}}
+    current_instance = MagicMock()
+    candidate = MagicMock()
+    _prepare_state(monkeypatch, current, current_instance)
+    monkeypatch.setattr(server_state.Memory, "from_config", MagicMock(return_value=candidate))
+    monkeypatch.setattr(
+        server_state,
+        "_save_overrides",
+        MagicMock(side_effect=RuntimeError("persistence failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="persistence failed"):
+        server_state.update_config({"llm": {"config": {"model": "new"}}})
+
+    assert server_state.get_current_config() == current
+    assert server_state.get_memory_instance() is current_instance
+    candidate.vector_store.client.close.assert_called_once()
+
+
+def test_successful_update_persists_before_swapping(monkeypatch):
+    current = {"llm": {"provider": "openai", "config": {"model": "old", "temperature": 0.2}}}
+    current_instance = MagicMock()
+    candidate = MagicMock()
+    _prepare_state(monkeypatch, current, current_instance)
+    monkeypatch.setattr(server_state.Memory, "from_config", MagicMock(return_value=candidate))
+    save = MagicMock()
+    monkeypatch.setattr(server_state, "_save_overrides", save)
+
+    result = server_state.update_config({"llm": {"config": {"model": "new"}}})
+
+    assert result["llm"]["config"] == {"model": "new", "temperature": 0.2}
+    save.assert_called_once_with({"llm": {"config": {"model": "new"}}})
+    assert server_state.get_memory_instance() is candidate
+    current_instance.vector_store.client.close.assert_called_once()

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1,10 +1,20 @@
+import json
+import sys
 from copy import deepcopy
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import ValidationError as PydanticValidationError
 
+from mem0.configs.base import MemoryConfig
 from server import server_state
-from server.vector_store_config import build_vector_store_config
+from server.errors import upstream_error
+from server.vector_store_config import (
+    build_vector_store_config,
+    sanitized_validation_error_message,
+    validate_server_config,
+)
 
 
 def test_legacy_pgvector_config_when_generic_environment_is_absent():
@@ -69,6 +79,72 @@ def test_qdrant_host_port_and_explicit_local_modes(caplog):
     )
     assert local["config"]["path"] == "./qdrant-data"
     assert "production" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"path": "./qdrant-data", "api_key": "secret"},
+        {"path": "./qdrant-data", "https": False},
+        {"url": "https://qdrant", "host": "qdrant", "port": 6333},
+    ],
+)
+def test_qdrant_modes_are_mutually_exclusive(config):
+    with pytest.raises(RuntimeError):
+        build_vector_store_config(
+            {
+                "VECTOR_STORE_PROVIDER": "qdrant",
+                "VECTOR_STORE_CONFIG": json.dumps(config),
+            }
+        )
+
+
+def test_server_validator_rejects_runtime_qdrant_without_endpoint():
+    with pytest.raises(ValueError, match="requires a non-empty url"):
+        validate_server_config({"vector_store": {"provider": "qdrant", "config": {}}})
+
+
+def test_validation_error_message_omits_configuration_secrets():
+    secret = "S3CR3T-short-sentinel"
+    with pytest.raises(PydanticValidationError) as exc_info:
+        MemoryConfig(
+            vector_store={
+                "provider": "qdrant",
+                "config": {"url": "https://qdrant", "api_key": secret, "unsupported": True},
+            }
+        )
+
+    message = sanitized_validation_error_message(exc_info.value)
+    assert "unsupported" in message
+    assert secret not in message
+
+
+def test_server_validation_exception_omits_configuration_secrets():
+    secret = "S3CR3T-startup-sentinel"
+    with pytest.raises(ValueError) as exc_info:
+        server_state._validated_config(
+            {
+                "vector_store": {
+                    "provider": "qdrant",
+                    "config": {"url": "https://qdrant", "api_key": secret, "unsupported": True},
+                }
+            }
+        )
+
+    assert secret not in str(exc_info.value)
+
+
+def test_upstream_error_logging_omits_exception_text(caplog):
+    secret = "S3CR3T-provider-sentinel"
+    with caplog.at_level("ERROR"):
+        try:
+            raise RuntimeError(f"provider echoed {secret}")
+        except RuntimeError:
+            error = upstream_error()
+
+    assert error.status_code == 502
+    assert secret not in error.detail
+    assert secret not in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -141,7 +217,10 @@ def _prepare_state(monkeypatch, current_config, current_instance):
     monkeypatch.setattr(server_state, "_current_config", deepcopy(current_config))
     monkeypatch.setattr(server_state, "_memory_instance", current_instance)
     monkeypatch.setattr(server_state, "_locked_components", set())
-    monkeypatch.setattr(server_state, "_load_overrides", lambda: {})
+    monkeypatch.setattr(server_state, "_active_leases", {})
+    monkeypatch.setattr(server_state, "_retired_instances", {})
+    monkeypatch.setattr(server_state, "_load_overrides", lambda **kwargs: {})
+    monkeypatch.setattr(server_state, "_merge_and_save_overrides", lambda updates: deepcopy(updates))
     monkeypatch.setattr(server_state, "MemoryConfig", lambda **kwargs: kwargs)
 
 
@@ -187,6 +266,39 @@ def test_locked_runtime_update_is_rejected_before_construction(monkeypatch):
     assert server_state.get_memory_instance() is current_instance
 
 
+def test_runtime_qdrant_without_endpoint_is_rejected_before_construction(monkeypatch):
+    current = {"vector_store": {"provider": "pgvector", "config": {"host": "postgres"}}}
+    current_instance = MagicMock()
+    _prepare_state(monkeypatch, current, current_instance)
+    from_config = MagicMock()
+    monkeypatch.setattr(server_state.Memory, "from_config", from_config)
+
+    with pytest.raises(ValueError, match="requires a non-empty url"):
+        server_state.update_config({"vector_store": {"provider": "qdrant", "config": {}}})
+
+    from_config.assert_not_called()
+    assert server_state.get_memory_instance() is current_instance
+
+
+def test_invalid_persisted_qdrant_override_is_ignored_without_logging_secret(monkeypatch, caplog):
+    default = {"vector_store": {"provider": "pgvector", "config": {"host": "postgres"}}}
+    monkeypatch.setattr(
+        server_state,
+        "_load_overrides",
+        lambda: {"vector_store": {"provider": "qdrant", "config": {"api_key": "S3CR3T"}}},
+    )
+    monkeypatch.setattr(server_state, "MemoryConfig", lambda **kwargs: kwargs)
+    created = MagicMock()
+    from_config = MagicMock(return_value=created)
+    monkeypatch.setattr(server_state.Memory, "from_config", from_config)
+    monkeypatch.setattr(server_state, "_memory_instance", None)
+
+    server_state.initialize_state(default)
+
+    assert from_config.call_args.args[0]["vector_store"]["provider"] == "pgvector"
+    assert "S3CR3T" not in caplog.text
+
+
 def test_failed_persistence_keeps_previous_runtime(monkeypatch):
     current = {"llm": {"provider": "openai", "config": {"model": "old"}}}
     current_instance = MagicMock()
@@ -195,7 +307,7 @@ def test_failed_persistence_keeps_previous_runtime(monkeypatch):
     monkeypatch.setattr(server_state.Memory, "from_config", MagicMock(return_value=candidate))
     monkeypatch.setattr(
         server_state,
-        "_save_overrides",
+        "_merge_and_save_overrides",
         MagicMock(side_effect=RuntimeError("persistence failed")),
     )
 
@@ -207,6 +319,24 @@ def test_failed_persistence_keeps_previous_runtime(monkeypatch):
     candidate.vector_store.client.close.assert_called_once()
 
 
+def test_failed_candidate_construction_keeps_previous_runtime_and_sanitizes_error(monkeypatch):
+    current = {"llm": {"provider": "openai", "config": {"model": "old"}}}
+    current_instance = MagicMock()
+    _prepare_state(monkeypatch, current, current_instance)
+    monkeypatch.setattr(
+        server_state.Memory,
+        "from_config",
+        MagicMock(side_effect=ValueError("provider echoed api key S3CR3T")),
+    )
+
+    with pytest.raises(RuntimeError, match="candidate Mem0 configuration") as exc_info:
+        server_state.update_config({"llm": {"config": {"model": "new"}}})
+
+    assert "S3CR3T" not in str(exc_info.value)
+    assert server_state.get_current_config() == current
+    assert server_state.get_memory_instance() is current_instance
+
+
 def test_successful_update_persists_before_swapping(monkeypatch):
     current = {"llm": {"provider": "openai", "config": {"model": "old", "temperature": 0.2}}}
     current_instance = MagicMock()
@@ -214,7 +344,7 @@ def test_successful_update_persists_before_swapping(monkeypatch):
     _prepare_state(monkeypatch, current, current_instance)
     monkeypatch.setattr(server_state.Memory, "from_config", MagicMock(return_value=candidate))
     save = MagicMock()
-    monkeypatch.setattr(server_state, "_save_overrides", save)
+    monkeypatch.setattr(server_state, "_merge_and_save_overrides", save)
 
     result = server_state.update_config({"llm": {"config": {"model": "new"}}})
 
@@ -222,3 +352,57 @@ def test_successful_update_persists_before_swapping(monkeypatch):
     save.assert_called_once_with({"llm": {"config": {"model": "new"}}})
     assert server_state.get_memory_instance() is candidate
     current_instance.vector_store.client.close.assert_called_once()
+
+
+def test_successful_update_retires_old_runtime_after_active_lease(monkeypatch):
+    current = {"llm": {"provider": "openai", "config": {"model": "old"}}}
+    current_instance = MagicMock()
+    candidate = MagicMock()
+    _prepare_state(monkeypatch, current, current_instance)
+    monkeypatch.setattr(server_state.Memory, "from_config", MagicMock(return_value=candidate))
+
+    with server_state.memory_instance_lease() as leased:
+        assert leased is current_instance
+        server_state.update_config({"llm": {"config": {"model": "new"}}})
+        current_instance.vector_store.client.close.assert_not_called()
+
+    current_instance.vector_store.client.close.assert_called_once()
+
+
+def test_persisted_updates_use_cross_process_lock_and_merge(monkeypatch):
+    class FakeSelect:
+        def where(self, condition):
+            return self
+
+        def with_for_update(self):
+            return self
+
+    class FakeSettings:
+        key = "key"
+
+        def __init__(self, key, value):
+            self.key = key
+            self.value = value
+
+    row = SimpleNamespace(
+        value=json.dumps({"llm": {"provider": "openai", "config": {"model": "old", "temperature": 0.2}}})
+    )
+    lock_result = MagicMock()
+    row_result = MagicMock()
+    row_result.scalar_one_or_none.return_value = row
+    session = MagicMock()
+    session.execute.side_effect = [lock_result, row_result]
+    monkeypatch.setattr(server_state, "_session_factory", lambda: session)
+    monkeypatch.setitem(sys.modules, "models", SimpleNamespace(Settings=FakeSettings))
+
+    import sqlalchemy
+
+    monkeypatch.setattr(sqlalchemy, "select", lambda model: FakeSelect())
+    monkeypatch.setattr(sqlalchemy, "text", lambda statement: statement)
+
+    merged = server_state._merge_and_save_overrides({"llm": {"config": {"model": "new"}}})
+
+    assert merged["llm"]["config"] == {"model": "new", "temperature": 0.2}
+    assert json.loads(row.value) == merged
+    assert "pg_advisory_xact_lock" in session.execute.call_args_list[0].args[0]
+    session.commit.assert_called_once()

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -169,6 +169,60 @@ class TestQdrant(unittest.TestCase):
         self.client_mock.create_collection.assert_not_called()
         self.client_mock.delete_collection.assert_not_called()
 
+    def test_concurrent_collection_creation_revalidates_winner(self):
+        class ConflictError(RuntimeError):
+            status_code = 409
+
+        self.client_mock.get_collections.return_value = MagicMock(collections=[])
+        self.client_mock.create_collection.reset_mock()
+        self.client_mock.create_collection.side_effect = ConflictError("already exists")
+        info = MagicMock()
+        info.config.params.vectors = VectorParams(size=128, distance=Distance.COSINE)
+        info.config.params.sparse_vectors = {"bm25": SparseVectorParams(modifier=models.Modifier.IDF)}
+        self.client_mock.get_collection.return_value = info
+
+        self.qdrant.create_col(vector_size=128, on_disk=True)
+
+        self.client_mock.get_collection.assert_called_with("test_collection")
+        self.client_mock.delete_collection.assert_not_called()
+
+    def test_existing_keyword_payload_indexes_are_reused(self):
+        self.qdrant.is_local = False
+        info = MagicMock()
+        info.payload_schema = {
+            "user_id": "keyword",
+            "agent_id": "keyword",
+            "run_id": "keyword",
+            "actor_id": "keyword",
+        }
+        self.client_mock.create_payload_index.reset_mock()
+
+        self.qdrant._create_filter_indexes(info)
+
+        self.client_mock.create_payload_index.assert_not_called()
+
+    def test_incompatible_payload_index_fails_non_destructively(self):
+        self.qdrant.is_local = False
+        info = MagicMock()
+        info.payload_schema = {"user_id": "integer"}
+
+        with self.assertRaisesRegex(ValueError, "user_id.*keyword"):
+            self.qdrant._create_filter_indexes(info)
+
+        self.client_mock.delete_collection.assert_not_called()
+
+    def test_payload_index_creation_failure_is_not_hidden(self):
+        self.qdrant.is_local = False
+        info = MagicMock()
+        info.payload_schema = {}
+        self.client_mock.create_payload_index.side_effect = RuntimeError("permission denied")
+        refreshed = MagicMock()
+        refreshed.payload_schema = {}
+        self.client_mock.get_collection.return_value = refreshed
+
+        with self.assertRaisesRegex(RuntimeError, "required Qdrant payload index"):
+            self.qdrant._create_filter_indexes(info)
+
     def test_insert(self):
         vectors = [[0.1, 0.2], [0.3, 0.4]]
         payloads = [{"key": "value1"}, {"key": "value2"}]

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -95,6 +95,80 @@ class TestQdrant(unittest.TestCase):
             sparse_vectors_config=expected_sparse_config,
         )
 
+    def test_existing_collection_with_matching_dense_config_is_reused(self):
+        collection = MagicMock()
+        collection.name = "test_collection"
+        self.client_mock.get_collections.return_value = MagicMock(
+            collections=[collection]
+        )
+        info = MagicMock()
+        info.config.params.vectors = VectorParams(size=128, distance=Distance.COSINE, on_disk=True)
+        info.config.params.sparse_vectors = {"bm25": SparseVectorParams(modifier=models.Modifier.IDF)}
+        self.client_mock.get_collection.return_value = info
+        self.client_mock.create_collection.reset_mock()
+
+        self.qdrant.create_col(vector_size=128, on_disk=True)
+
+        self.client_mock.create_collection.assert_not_called()
+        self.client_mock.delete_collection.assert_not_called()
+        self.assertTrue(self.qdrant._has_bm25_slot)
+
+    def test_existing_collection_dimension_mismatch_fails_non_destructively(self):
+        collection = MagicMock()
+        collection.name = "test_collection"
+        self.client_mock.get_collections.return_value = MagicMock(
+            collections=[collection]
+        )
+        info = MagicMock()
+        info.config.params.vectors = VectorParams(size=1536, distance=Distance.COSINE)
+        info.config.params.sparse_vectors = {}
+        self.client_mock.get_collection.return_value = info
+        self.client_mock.create_collection.reset_mock()
+
+        with self.assertRaisesRegex(ValueError, "expected dimension 128.*found dimension 1536"):
+            self.qdrant.create_col(vector_size=128, on_disk=True)
+
+        self.client_mock.create_collection.assert_not_called()
+        self.client_mock.delete_collection.assert_not_called()
+
+    def test_existing_collection_distance_mismatch_fails_non_destructively(self):
+        collection = MagicMock()
+        collection.name = "test_collection"
+        self.client_mock.get_collections.return_value = MagicMock(
+            collections=[collection]
+        )
+        info = MagicMock()
+        info.config.params.vectors = VectorParams(size=128, distance=Distance.DOT)
+        info.config.params.sparse_vectors = {}
+        self.client_mock.get_collection.return_value = info
+        self.client_mock.create_collection.reset_mock()
+
+        with self.assertRaisesRegex(ValueError, "expected dimension 128.*Cosine.*Dot"):
+            self.qdrant.create_col(vector_size=128, on_disk=True)
+
+        self.client_mock.create_collection.assert_not_called()
+        self.client_mock.delete_collection.assert_not_called()
+
+    def test_existing_named_vector_collection_is_rejected(self):
+        collection = MagicMock()
+        collection.name = "test_collection"
+        self.client_mock.get_collections.return_value = MagicMock(
+            collections=[collection]
+        )
+        info = MagicMock()
+        info.config.params.vectors = {
+            "dense": VectorParams(size=128, distance=Distance.COSINE),
+        }
+        info.config.params.sparse_vectors = {}
+        self.client_mock.get_collection.return_value = info
+        self.client_mock.create_collection.reset_mock()
+
+        with self.assertRaisesRegex(ValueError, "uses named dense vectors.*dense"):
+            self.qdrant.create_col(vector_size=128, on_disk=True)
+
+        self.client_mock.create_collection.assert_not_called()
+        self.client_mock.delete_collection.assert_not_called()
+
     def test_insert(self):
         vectors = [[0.1, 0.2], [0.3, 0.4]]
         payloads = [{"key": "value1"}, {"key": "value2"}]

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -29,6 +29,7 @@ from mem0.vector_stores.qdrant import Qdrant
 class TestQdrant(unittest.TestCase):
     def setUp(self):
         self.client_mock = MagicMock(spec=QdrantClient)
+        self.client_mock.collection_exists.return_value = False
         self.qdrant = Qdrant(
             collection_name="test_collection",
             embedding_model_dims=128,
@@ -44,7 +45,7 @@ class TestQdrant(unittest.TestCase):
             with open(sentinel, "w", encoding="utf-8") as f:
                 f.write("keep")
             mock_client = MagicMock()
-            mock_client.get_collections.return_value = MagicMock(collections=[])
+            mock_client.collection_exists.return_value = False
             with patch("mem0.vector_stores.qdrant.QdrantClient", return_value=mock_client):
                 Qdrant(
                     collection_name="c",
@@ -96,11 +97,7 @@ class TestQdrant(unittest.TestCase):
         )
 
     def test_existing_collection_with_matching_dense_config_is_reused(self):
-        collection = MagicMock()
-        collection.name = "test_collection"
-        self.client_mock.get_collections.return_value = MagicMock(
-            collections=[collection]
-        )
+        self.client_mock.collection_exists.return_value = True
         info = MagicMock()
         info.config.params.vectors = VectorParams(size=128, distance=Distance.COSINE, on_disk=True)
         info.config.params.sparse_vectors = {"bm25": SparseVectorParams(modifier=models.Modifier.IDF)}
@@ -114,11 +111,7 @@ class TestQdrant(unittest.TestCase):
         self.assertTrue(self.qdrant._has_bm25_slot)
 
     def test_existing_collection_dimension_mismatch_fails_non_destructively(self):
-        collection = MagicMock()
-        collection.name = "test_collection"
-        self.client_mock.get_collections.return_value = MagicMock(
-            collections=[collection]
-        )
+        self.client_mock.collection_exists.return_value = True
         info = MagicMock()
         info.config.params.vectors = VectorParams(size=1536, distance=Distance.COSINE)
         info.config.params.sparse_vectors = {}
@@ -132,11 +125,7 @@ class TestQdrant(unittest.TestCase):
         self.client_mock.delete_collection.assert_not_called()
 
     def test_existing_collection_distance_mismatch_fails_non_destructively(self):
-        collection = MagicMock()
-        collection.name = "test_collection"
-        self.client_mock.get_collections.return_value = MagicMock(
-            collections=[collection]
-        )
+        self.client_mock.collection_exists.return_value = True
         info = MagicMock()
         info.config.params.vectors = VectorParams(size=128, distance=Distance.DOT)
         info.config.params.sparse_vectors = {}
@@ -150,11 +139,7 @@ class TestQdrant(unittest.TestCase):
         self.client_mock.delete_collection.assert_not_called()
 
     def test_existing_named_vector_collection_is_rejected(self):
-        collection = MagicMock()
-        collection.name = "test_collection"
-        self.client_mock.get_collections.return_value = MagicMock(
-            collections=[collection]
-        )
+        self.client_mock.collection_exists.return_value = True
         info = MagicMock()
         info.config.params.vectors = {
             "dense": VectorParams(size=128, distance=Distance.COSINE),
@@ -173,7 +158,7 @@ class TestQdrant(unittest.TestCase):
         class ConflictError(RuntimeError):
             status_code = 409
 
-        self.client_mock.get_collections.return_value = MagicMock(collections=[])
+        self.client_mock.collection_exists.return_value = False
         self.client_mock.create_collection.reset_mock()
         self.client_mock.create_collection.side_effect = ConflictError("already exists")
         info = MagicMock()
@@ -623,6 +608,7 @@ class TestQdrantEnhancedFilters(unittest.TestCase):
 
     def setUp(self):
         self.client_mock = MagicMock(spec=QdrantClient)
+        self.client_mock.collection_exists.return_value = False
         self.qdrant = Qdrant(
             collection_name="test_collection",
             embedding_model_dims=128,
@@ -1076,6 +1062,7 @@ class TestQdrantDatetimeRangeFilters(unittest.TestCase):
 
     def setUp(self):
         self.client_mock = MagicMock(spec=QdrantClient)
+        self.client_mock.collection_exists.return_value = False
         self.qdrant = Qdrant(
             collection_name="test_collection",
             embedding_model_dims=128,

--- a/tests/vector_stores/test_qdrant_config.py
+++ b/tests/vector_stores/test_qdrant_config.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from mem0.configs.vector_stores.qdrant import QdrantConfig
 from mem0.vector_stores.configs import VectorStoreConfig
 from mem0.vector_stores import qdrant as qdrant_module
@@ -52,3 +54,39 @@ def test_default_sdk_qdrant_config_keeps_explicit_local_fallback():
     config = VectorStoreConfig(provider="qdrant")
 
     assert config.config.path == "/tmp/qdrant"
+
+
+@pytest.mark.parametrize("extra", [{"api_key": "secret"}, {"https": False}])
+def test_local_qdrant_rejects_remote_only_options(extra):
+    with pytest.raises(ValueError, match="remote-only"):
+        QdrantConfig(path="/tmp/qdrant", **extra)
+
+
+def test_qdrant_adapter_uses_explicit_local_path_only(monkeypatch):
+    client_cls = MagicMock()
+    monkeypatch.setattr(qdrant_module, "QdrantClient", client_cls)
+    monkeypatch.setattr(qdrant_module.Qdrant, "create_col", lambda *args, **kwargs: None)
+
+    store = qdrant_module.Qdrant(
+        collection_name="memories",
+        embedding_model_dims=1536,
+        path="/tmp/qdrant",
+    )
+
+    client_cls.assert_called_once_with(path="/tmp/qdrant")
+    assert store.is_local is True
+
+
+def test_qdrant_adapter_rejects_ambiguous_local_mode(monkeypatch):
+    client_cls = MagicMock()
+    monkeypatch.setattr(qdrant_module, "QdrantClient", client_cls)
+
+    with pytest.raises(ValueError, match="cannot use api_key"):
+        qdrant_module.Qdrant(
+            collection_name="memories",
+            embedding_model_dims=1536,
+            path="/tmp/qdrant",
+            api_key="secret",
+        )
+
+    client_cls.assert_not_called()

--- a/tests/vector_stores/test_qdrant_config.py
+++ b/tests/vector_stores/test_qdrant_config.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from mem0.configs.vector_stores.qdrant import QdrantConfig
+from mem0.vector_stores.configs import VectorStoreConfig
 from mem0.vector_stores import qdrant as qdrant_module
 
 
@@ -35,3 +36,19 @@ def test_qdrant_passes_explicit_https_to_client(monkeypatch):
         port=6333,
         https=False,
     )
+
+
+def test_remote_qdrant_config_does_not_inject_local_path():
+    config = VectorStoreConfig(
+        provider="qdrant",
+        config={"url": "https://qdrant.internal:6333", "api_key": "test-key"},
+    )
+
+    assert config.config.url == "https://qdrant.internal:6333"
+    assert config.config.path is None
+
+
+def test_default_sdk_qdrant_config_keeps_explicit_local_fallback():
+    config = VectorStoreConfig(provider="qdrant")
+
+    assert config.config.path == "/tmp/qdrant"

--- a/tests/vector_stores/test_utils.py
+++ b/tests/vector_stores/test_utils.py
@@ -17,7 +17,18 @@ def test_normalize_list_result_supported_shapes():
     assert normalize_list_result((tuple(rows), "next")) == rows
 
 
-@pytest.mark.parametrize("result", [{}, "rows", 1, (SimpleNamespace(id="one"), None), ([1], None, "extra")])
+@pytest.mark.parametrize(
+    "result",
+    [
+        {},
+        "rows",
+        1,
+        (SimpleNamespace(id="one"), None),
+        ([1], None, "extra"),
+        [[SimpleNamespace(id="one")], {"unexpected": "offset"}],
+        ([SimpleNamespace(id="one")], object()),
+    ],
+)
 def test_normalize_list_result_rejects_malformed_shapes(result):
     with pytest.raises(TypeError, match="vector-store list result"):
         normalize_list_result(result)

--- a/tests/vector_stores/test_utils.py
+++ b/tests/vector_stores/test_utils.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+
+import pytest
+
+from mem0.vector_stores.utils import normalize_list_result
+
+
+def test_normalize_list_result_supported_shapes():
+    rows = [SimpleNamespace(id="one"), SimpleNamespace(id="two")]
+
+    assert normalize_list_result(None) == []
+    assert normalize_list_result([]) == []
+    assert normalize_list_result(()) == []
+    assert normalize_list_result(rows) == rows
+    assert normalize_list_result([rows]) == rows
+    assert normalize_list_result((rows, None)) == rows
+    assert normalize_list_result((tuple(rows), "next")) == rows
+
+
+@pytest.mark.parametrize("result", [{}, "rows", 1, (SimpleNamespace(id="one"), None), ([1], None, "extra")])
+def test_normalize_list_result_rejects_malformed_shapes(result):
+    with pytest.raises(TypeError, match="vector-store list result"):
+        normalize_list_result(result)


### PR DESCRIPTION
## Summary

This PR builds on and supersedes #5523 with a production-safe Qdrant configuration path for the Python REST server and SDK.

PR #5523 correctly identified the Qdrant `(records, offset)` server bug and stale provider-config leakage. This version preserves those fixes and adds the missing fail-closed, GitOps, collection-compatibility, and complete-deletion guarantees required for a remote production Qdrant deployment.

Co-authored attribution for the #5523-derived server work is preserved in commit `d785c52d`.

## What changes

- Parse `VECTOR_STORE_PROVIDER` and `VECTOR_STORE_CONFIG` through a strict, secret-safe startup helper.
- Reject ambiguous, malformed, or endpoint-less explicit Qdrant configuration instead of falling back to `/tmp/qdrant`.
- Lock the vector store to explicit environment configuration, ignore stale persisted vector-store overrides, and reject runtime vector-store changes while locked.
- Replace provider components atomically on provider changes and deep-merge same-provider updates.
- Construct and persist runtime configuration before swapping the active `Memory` instance.
- Centralize vector-store list result normalization for flat, nested, and Qdrant tuple results.
- Drain every filtered `delete_all` page with bounded async concurrency and zero-progress safeguards.
- Validate existing Qdrant collection dimension, cosine distance, and unnamed dense-vector layout without destructive repair.
- Keep direct SDK local-Qdrant defaults backward compatible while avoiding local path injection for explicit remote endpoints.
- Document TLS/API-key Qdrant, internal CA configuration, Postgres control-plane responsibilities, environment precedence, and explicit development-only local mode.

## Related work

- Based on and supersedes #5523
- Provider replacement semantics: #5891
- Collection dimension validation: #6319 / #6318 / #4985
- Complete filtered deletion: #4869 / #6465
- Configuration precedence: #4984
- Embedded Qdrant concurrency context: #4892 / #5002

Existing merged BM25 and batch-search/write behavior remains unchanged. This PR does not alter TypeScript/OpenMemory, add destructive collection migration, add a tenant payload field, or tune Qdrant HNSW settings.

## Validation

- `ruff check` on all changed Python files
- 238 focused Python tests on current `main`
- 237 focused Python tests after applying the equivalent patch to pinned Mem0 2.0.12 commit `726bcc80b26604fc687c2cd05e5ca1e8c5f16c57`
- Qdrant tests cover compatible and incompatible dimensions, distances, named-vector layouts, and no destructive create/delete calls
- Configuration tests cover remote URL, host/port, explicit local path, invalid JSON/shapes, collection precedence, environment lock, provider replacement, and atomic persistence failure
- Delete-all tests cover tuple results, multiple pages, retry after partial failure, and repeated zero progress

## Operational notes

Deployments setting either generic vector-store variable make `vector_store` environment-managed. Postgres remains required by the REST server for authentication, settings, request logs, and migrations. Existing incompatible Qdrant collections cause a clear startup/configuration failure and are never changed automatically.
