### PR TITLE
fix: use word-boundary regex for assistant keyword rewrite (#6036)

### DIFF
--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import re
 from typing import Dict, List, Optional, Union
 
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
@@ -87,7 +88,7 @@ class AzureOpenAILLM(LLMBase):
         messages = copy.deepcopy(messages)
         last_content = messages[-1].get("content")
         if isinstance(last_content, str):
-            messages[-1]["content"] = last_content.replace("assistant", "ai")
+            messages[-1]["content"] = re.sub(r"\bassistant\b", "ai", last_content, flags=re.IGNORECASE)
         return messages
 
     def _parse_response(self, response, tools):

--- a/mem0/llms/azure_openai_structured.py
+++ b/mem0/llms/azure_openai_structured.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import re
 from typing import Dict, List, Optional
 
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
@@ -119,7 +120,7 @@ class AzureOpenAIStructuredLLM(LLMBase):
         messages = copy.deepcopy(messages)
         last_content = messages[-1].get("content")
         if isinstance(last_content, str):
-            messages[-1]["content"] = last_content.replace("assistant", "ai")
+            messages[-1]["content"] = re.sub(r"\bassistant\b", "ai", last_content, flags=re.IGNORECASE)
         return messages
 
     def _parse_response(self, response, tools):


### PR DESCRIPTION
## Linked Issue

Closes #6036

## Description

The Azure OpenAI content filter rewrites the literal word `assistant` to `ai` in the last message's content before sending it to Azure. This was done with a plain ``str.replace``, which has no word-boundary awareness: every occurrence of the substring `assistant` inside any other word gets rewritten too (e.g. `assistance` -> `aiance`).

Fix: replace `str.replace` with `re.sub(r"\bassistant\b", "ai", ..., flags=re.IGNORECASE)` in both Azure LLM backends so only the standalone role token `assistant` is replaced.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)