### PR TITLE
fix(memory): close hash-dedup TOCTOU race in add() with per-instance lock

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -509,11 +509,21 @@ class Memory(MemoryBase):
         # Entity store is initialized lazily on first use
         self._entity_store = None
 
-        # Serializes the dedup-recheck + insert step in _add_to_vector_store so
-        # concurrent add() calls extracting the same fact can't both pass a
-        # stale dedup snapshot and both insert (see issue tracking the
-        # hash-dedup TOCTOU race).
-        self._add_lock = threading.Lock()
+        # Per-scope locks for the dedup-recheck + insert step in
+        # _add_to_vector_store, so concurrent add() calls extracting the same
+        # fact can't both pass a stale dedup snapshot and both insert (the
+        # hash-dedup TOCTOU race). Keyed by session scope so add() calls for
+        # different user_id/agent_id/run_id — which can never hash-collide —
+        # don't serialize against each other; only same-scope callers do.
+        #
+        # Scope of protection: these locks live on the Memory instance, so they
+        # only serialize callers sharing one instance in one process. They do
+        # NOT coordinate across multiple workers/replicas (e.g. this repo's
+        # server/ and openmemory/ scale-out deployments, which hold the client
+        # as a per-process singleton) — closing that cross-process window would
+        # need a shared/distributed lock and is out of scope here.
+        self._add_locks = {}
+        self._add_locks_guard = threading.Lock()
 
         if MEM0_TELEMETRY:
             # Create telemetry config manually to avoid deepcopy issues with thread locks
@@ -1032,13 +1042,20 @@ class Memory(MemoryBase):
             self.db.save_messages(messages, session_scope)
             return []
 
-        # Phase 5: Hash dedup + Phase 6: Batch persist, serialized.
+        # Phase 5: Hash dedup + Phase 6: Batch persist, serialized per scope.
         # The Phase 1 snapshot (existing_results) can go stale by the time we get
         # here (an LLM round-trip + embedding calls have happened since). Holding
-        # self._add_lock and re-checking hashes fresh right before insert closes
-        # that TOCTOU window: two concurrent add() calls extracting the same fact
-        # can no longer both pass dedup and both insert a permanent duplicate.
-        with self._add_lock:
+        # the session-scoped lock and re-checking hashes fresh right before insert
+        # closes that TOCTOU window: two concurrent add() calls extracting the
+        # same fact can no longer both pass dedup and both insert a permanent
+        # duplicate. Only same-scope callers serialize here (see __init__).
+        with self._add_locks_guard:
+            add_lock = self._add_locks.get(session_scope)
+            if add_lock is None:
+                add_lock = threading.Lock()
+                self._add_locks[session_scope] = add_lock
+
+        with add_lock:
             fresh_existing = self.vector_store.search(
                 query=parsed_messages,
                 vectors=query_embedding,
@@ -2195,11 +2212,20 @@ class AsyncMemory(MemoryBase):
         self.custom_instructions = self.config.custom_instructions
         self._entity_store = None
 
-        # Serializes the dedup-recheck + insert step in _add_to_vector_store so
-        # concurrent add() calls extracting the same fact can't both pass a
-        # stale dedup snapshot and both insert (see issue tracking the
-        # hash-dedup TOCTOU race).
-        self._add_lock = asyncio.Lock()
+        # Per-scope locks for the dedup-recheck + insert step in
+        # _add_to_vector_store, so concurrent add() calls extracting the same
+        # fact can't both pass a stale dedup snapshot and both insert (the
+        # hash-dedup TOCTOU race). Keyed by session scope so add() calls for
+        # different user_id/agent_id/run_id — which can never hash-collide —
+        # don't serialize against each other; only same-scope callers do.
+        #
+        # Scope of protection: these locks live on the AsyncMemory instance, so
+        # they only serialize callers sharing one instance in one process/event
+        # loop. They do NOT coordinate across multiple workers/replicas (e.g.
+        # this repo's server/ and openmemory/ scale-out deployments, which hold
+        # the client as a per-process singleton) — closing that cross-process
+        # window would need a shared/distributed lock and is out of scope here.
+        self._add_locks = {}
 
         # Initialize reranker if configured
         self.reranker = None
@@ -2701,13 +2727,21 @@ class AsyncMemory(MemoryBase):
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)
             return []
 
-        # Phase 5: Hash dedup + Phase 6: Batch persist, serialized.
+        # Phase 5: Hash dedup + Phase 6: Batch persist, serialized per scope.
         # The Phase 1 snapshot (existing_results) can go stale by the time we get
         # here (an LLM round-trip + embedding calls have happened since). Holding
-        # self._add_lock and re-checking hashes fresh right before insert closes
-        # that TOCTOU window: two concurrent add() calls extracting the same fact
-        # can no longer both pass dedup and both insert a permanent duplicate.
-        async with self._add_lock:
+        # the session-scoped lock and re-checking hashes fresh right before insert
+        # closes that TOCTOU window: two concurrent add() calls extracting the
+        # same fact can no longer both pass dedup and both insert a permanent
+        # duplicate. Only same-scope callers serialize here (see __init__).
+        # The get/set below has no await between the check and the assignment, so
+        # it is atomic within a single event loop — no extra guard lock needed.
+        add_lock = self._add_locks.get(session_scope)
+        if add_lock is None:
+            add_lock = asyncio.Lock()
+            self._add_locks[session_scope] = add_lock
+
+        async with add_lock:
             fresh_existing = await asyncio.to_thread(
                 self.vector_store.search,
                 query=parsed_messages,

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import os
+import threading
 import time
 import uuid
 import warnings
@@ -508,6 +509,12 @@ class Memory(MemoryBase):
         # Entity store is initialized lazily on first use
         self._entity_store = None
 
+        # Serializes the dedup-recheck + insert step in _add_to_vector_store so
+        # concurrent add() calls extracting the same fact can't both pass a
+        # stale dedup snapshot and both insert (see issue tracking the
+        # hash-dedup TOCTOU race).
+        self._add_lock = threading.Lock()
+
         if MEM0_TELEMETRY:
             # Create telemetry config manually to avoid deepcopy issues with thread locks
             telemetry_config_dict = {}
@@ -992,14 +999,7 @@ class Memory(MemoryBase):
                 except Exception as e:
                     logger.warning(f"Failed to embed memory text: {e}")
 
-        # Phase 4: Per-memory CPU processing + Phase 5: Hash dedup
-        # Build set of existing hashes for dedup
-        existing_hashes = set()
-        for mem in existing_results:
-            h = mem.payload.get("hash") if hasattr(mem, "payload") and mem.payload else None
-            if h:
-                existing_hashes.add(h)
-
+        # Phase 4: Per-memory CPU processing
         records = []  # (memory_id, text, embedding, payload)
         seen_hashes = set()  # dedup within the current batch
         for mem in extracted_memories:
@@ -1008,7 +1008,7 @@ class Memory(MemoryBase):
                 continue
 
             mem_hash = hashlib.md5(text.encode()).hexdigest()
-            if mem_hash in existing_hashes or mem_hash in seen_hashes:
+            if mem_hash in seen_hashes:
                 logger.debug(f"Skipping duplicate memory (hash match): {text[:50]}")
                 continue
             seen_hashes.add(mem_hash)
@@ -1032,24 +1032,47 @@ class Memory(MemoryBase):
             self.db.save_messages(messages, session_scope)
             return []
 
-        # Phase 6: Batch persist
-        all_vectors = [r[2] for r in records]
-        all_ids = [r[0] for r in records]
-        all_payloads = [r[3] for r in records]
-
-        try:
-            self.vector_store.insert(
-                vectors=all_vectors,
-                ids=all_ids,
-                payloads=all_payloads,
+        # Phase 5: Hash dedup + Phase 6: Batch persist, serialized.
+        # The Phase 1 snapshot (existing_results) can go stale by the time we get
+        # here (an LLM round-trip + embedding calls have happened since). Holding
+        # self._add_lock and re-checking hashes fresh right before insert closes
+        # that TOCTOU window: two concurrent add() calls extracting the same fact
+        # can no longer both pass dedup and both insert a permanent duplicate.
+        with self._add_lock:
+            fresh_existing = self.vector_store.search(
+                query=parsed_messages,
+                vectors=query_embedding,
+                top_k=10,
+                filters=search_filters,
             )
-        except Exception:
-            # Fallback: insert one by one
-            for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
-                try:
-                    self.vector_store.insert(vectors=[vec], ids=[mid], payloads=[pay])
-                except Exception as e:
-                    logger.error(f"Failed to insert memory {mid}: {e}")
+            fresh_hashes = {
+                mem.payload.get("hash")
+                for mem in fresh_existing
+                if hasattr(mem, "payload") and mem.payload and mem.payload.get("hash")
+            }
+            records = [r for r in records if r[3]["hash"] not in fresh_hashes]
+
+            if not records:
+                self.db.save_messages(messages, session_scope)
+                return []
+
+            all_vectors = [r[2] for r in records]
+            all_ids = [r[0] for r in records]
+            all_payloads = [r[3] for r in records]
+
+            try:
+                self.vector_store.insert(
+                    vectors=all_vectors,
+                    ids=all_ids,
+                    payloads=all_payloads,
+                )
+            except Exception:
+                # Fallback: insert one by one
+                for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
+                    try:
+                        self.vector_store.insert(vectors=[vec], ids=[mid], payloads=[pay])
+                    except Exception as e:
+                        logger.error(f"Failed to insert memory {mid}: {e}")
 
         # Batch history
         history_records = [
@@ -2172,6 +2195,12 @@ class AsyncMemory(MemoryBase):
         self.custom_instructions = self.config.custom_instructions
         self._entity_store = None
 
+        # Serializes the dedup-recheck + insert step in _add_to_vector_store so
+        # concurrent add() calls extracting the same fact can't both pass a
+        # stale dedup snapshot and both insert (see issue tracking the
+        # hash-dedup TOCTOU race).
+        self._add_lock = asyncio.Lock()
+
         # Initialize reranker if configured
         self.reranker = None
         if config.reranker:
@@ -2639,13 +2668,7 @@ class AsyncMemory(MemoryBase):
                 except Exception as e:
                     logger.warning(f"Failed to embed memory text (async): {e}")
 
-        # Phase 4: Per-memory CPU processing + Phase 5: Hash dedup
-        existing_hashes = set()
-        for mem in existing_results:
-            h = mem.payload.get("hash") if hasattr(mem, "payload") and mem.payload else None
-            if h:
-                existing_hashes.add(h)
-
+        # Phase 4: Per-memory CPU processing
         records = []
         seen_hashes = set()
         for mem in extracted_memories:
@@ -2654,7 +2677,7 @@ class AsyncMemory(MemoryBase):
                 continue
 
             mem_hash = hashlib.md5(text.encode()).hexdigest()
-            if mem_hash in existing_hashes or mem_hash in seen_hashes:
+            if mem_hash in seen_hashes:
                 logger.debug(f"Skipping duplicate memory (hash match, async): {text[:50]}")
                 continue
             seen_hashes.add(mem_hash)
@@ -2678,24 +2701,48 @@ class AsyncMemory(MemoryBase):
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)
             return []
 
-        # Phase 6: Batch persist
-        all_vectors = [r[2] for r in records]
-        all_ids = [r[0] for r in records]
-        all_payloads = [r[3] for r in records]
-
-        try:
-            await asyncio.to_thread(
-                self.vector_store.insert,
-                vectors=all_vectors,
-                ids=all_ids,
-                payloads=all_payloads,
+        # Phase 5: Hash dedup + Phase 6: Batch persist, serialized.
+        # The Phase 1 snapshot (existing_results) can go stale by the time we get
+        # here (an LLM round-trip + embedding calls have happened since). Holding
+        # self._add_lock and re-checking hashes fresh right before insert closes
+        # that TOCTOU window: two concurrent add() calls extracting the same fact
+        # can no longer both pass dedup and both insert a permanent duplicate.
+        async with self._add_lock:
+            fresh_existing = await asyncio.to_thread(
+                self.vector_store.search,
+                query=parsed_messages,
+                vectors=query_embedding,
+                top_k=10,
+                filters=search_filters,
             )
-        except Exception:
-            for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
-                try:
-                    await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
-                except Exception as e:
-                    logger.error(f"Failed to insert memory {mid} (async): {e}")
+            fresh_hashes = {
+                mem.payload.get("hash")
+                for mem in fresh_existing
+                if hasattr(mem, "payload") and mem.payload and mem.payload.get("hash")
+            }
+            records = [r for r in records if r[3]["hash"] not in fresh_hashes]
+
+            if not records:
+                await asyncio.to_thread(self.db.save_messages, messages, session_scope)
+                return []
+
+            all_vectors = [r[2] for r in records]
+            all_ids = [r[0] for r in records]
+            all_payloads = [r[3] for r in records]
+
+            try:
+                await asyncio.to_thread(
+                    self.vector_store.insert,
+                    vectors=all_vectors,
+                    ids=all_ids,
+                    payloads=all_payloads,
+                )
+            except Exception:
+                for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
+                    try:
+                        await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
+                    except Exception as e:
+                        logger.error(f"Failed to insert memory {mid} (async): {e}")
 
         # Batch history
         history_records = [

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+import threading
 import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -1177,4 +1179,118 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         )
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
+        )
+
+
+class TestConcurrentAddDedupRace:
+    """Regression tests for the hash-dedup TOCTOU race in _add_to_vector_store.
+
+    The Phase 1 existing-memory snapshot is taken before the LLM extraction call.
+    Without a fresh recheck immediately before insert, two concurrent add() calls
+    extracting the identical fact both pass dedup against the same stale snapshot
+    and both insert, producing a permanent duplicate memory.
+    """
+
+    @staticmethod
+    def _make_fake_store():
+        store = []
+        store_lock = threading.Lock()
+
+        def fake_search(query, vectors, top_k, filters):
+            with store_lock:
+                return [MagicMock(payload={"hash": r["hash"]}, id=r["id"]) for r in store]
+
+        def fake_insert(vectors, ids, payloads):
+            with store_lock:
+                for i, p in zip(ids, payloads):
+                    store.append({"id": i, "hash": p["hash"]})
+
+        return store, fake_search, fake_insert
+
+    def test_concurrent_add_same_fact_does_not_duplicate(self, mocker):
+        memory = _build_memory_instance(mocker, Memory)
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+
+        store, fake_search, fake_insert = self._make_fake_store()
+        memory.vector_store.search = Mock(side_effect=fake_search)
+        memory.vector_store.insert = Mock(side_effect=fake_insert)
+        memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+
+        def slow_generate_response(**kwargs):
+            # Simulates real LLM latency — the window during which a second,
+            # concurrent add() call can race past the same stale dedup snapshot.
+            time.sleep(0.1)
+            return '{"memory": [{"text": "User likes coffee"}]}'
+
+        memory.llm.generate_response = Mock(side_effect=slow_generate_response)
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[])
+
+        errors = []
+
+        def worker():
+            try:
+                memory._add_to_vector_store(
+                    messages=[{"role": "user", "content": "I really like coffee"}],
+                    metadata={"user_id": "u1"},
+                    filters={"user_id": "u1"},
+                    infer=True,
+                )
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert not errors, f"worker thread raised: {errors}"
+        assert len(store) == 1, (
+            f"expected exactly 1 persisted memory after two concurrent add() calls "
+            f"for the same fact, got {len(store)}: {store}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_concurrent_add_same_fact_does_not_duplicate(self, mocker):
+        memory = _build_memory_instance(mocker, AsyncMemory)
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+
+        store, fake_search, fake_insert = self._make_fake_store()
+        memory.vector_store.search = Mock(side_effect=fake_search)
+        memory.vector_store.insert = Mock(side_effect=fake_insert)
+        memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+
+        def slow_generate_response(**kwargs):
+            time.sleep(0.1)
+            return '{"memory": [{"text": "User likes coffee"}]}'
+
+        memory.llm.generate_response = Mock(side_effect=slow_generate_response)
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[])
+
+        await asyncio.gather(
+            memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "I really like coffee"}],
+                metadata={"user_id": "u1"},
+                effective_filters={"user_id": "u1"},
+                infer=True,
+            ),
+            memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "I really like coffee"}],
+                metadata={"user_id": "u1"},
+                effective_filters={"user_id": "u1"},
+                infer=True,
+            ),
+        )
+
+        assert len(store) == 1, (
+            f"expected exactly 1 persisted memory after two concurrent add() calls "
+            f"for the same fact, got {len(store)}: {store}"
         )

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1339,3 +1339,40 @@ class TestConcurrentAddDedupRace:
         assert len(store) == 2, f"expected 1 memory per distinct scope, got {store}"
         # ...and each distinct scope got its own lock, not one shared instance lock.
         assert len(memory._add_locks) == 2
+
+    @pytest.mark.asyncio
+    async def test_async_different_scopes_use_separate_locks_and_both_persist(self, mocker):
+        """Async twin: different scopes must not falsely dedup against each other
+        and must each get their own lock entry."""
+        memory = _build_memory_instance(mocker, AsyncMemory)
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+
+        store, fake_search, fake_insert = self._make_fake_store()
+        memory.vector_store.search = Mock(side_effect=fake_search)
+        memory.vector_store.insert = Mock(side_effect=fake_insert)
+        memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        memory.llm.generate_response = Mock(
+            return_value='{"memory": [{"text": "User likes coffee"}]}'
+        )
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[])
+
+        await asyncio.gather(
+            *(
+                memory._add_to_vector_store(
+                    messages=[{"role": "user", "content": "I really like coffee"}],
+                    metadata={"user_id": uid},
+                    effective_filters={"user_id": uid},
+                    infer=True,
+                )
+                for uid in ("u1", "u2")
+            )
+        )
+
+        # Both scopes persisted their own memory (no false cross-scope dedup)...
+        assert len(store) == 2, f"expected 1 memory per distinct scope, got {store}"
+        # ...and each distinct scope got its own lock, not one shared instance lock.
+        assert len(memory._add_locks) == 2

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1195,15 +1195,27 @@ class TestConcurrentAddDedupRace:
     def _make_fake_store():
         store = []
         store_lock = threading.Lock()
+        scope_keys = ("user_id", "agent_id", "run_id")
+
+        def _scope(payload):
+            return tuple(payload.get(k) for k in scope_keys)
 
         def fake_search(query, vectors, top_k, filters):
+            # Mirror a real backend: results are scoped by the entity filters,
+            # so a different user_id/agent_id/run_id never sees another scope's
+            # rows (and thus can't falsely dedup against them).
+            want = tuple((filters or {}).get(k) for k in scope_keys)
             with store_lock:
-                return [MagicMock(payload={"hash": r["hash"]}, id=r["id"]) for r in store]
+                return [
+                    MagicMock(payload={"hash": r["hash"]}, id=r["id"])
+                    for r in store
+                    if r["scope"] == want
+                ]
 
         def fake_insert(vectors, ids, payloads):
             with store_lock:
                 for i, p in zip(ids, payloads):
-                    store.append({"id": i, "hash": p["hash"]})
+                    store.append({"id": i, "hash": p["hash"], "scope": _scope(p)})
 
         return store, fake_search, fake_insert
 
@@ -1294,3 +1306,36 @@ class TestConcurrentAddDedupRace:
             f"expected exactly 1 persisted memory after two concurrent add() calls "
             f"for the same fact, got {len(store)}: {store}"
         )
+
+    def test_different_scopes_use_separate_locks_and_both_persist(self, mocker):
+        """add() calls for different scopes must not serialize on one lock, and
+        must not falsely dedup against each other (different user_id can't
+        hash-collide). Each scope gets its own lock entry."""
+        memory = _build_memory_instance(mocker, Memory)
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+
+        store, fake_search, fake_insert = self._make_fake_store()
+        memory.vector_store.search = Mock(side_effect=fake_search)
+        memory.vector_store.insert = Mock(side_effect=fake_insert)
+        memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        memory.llm.generate_response = Mock(
+            return_value='{"memory": [{"text": "User likes coffee"}]}'
+        )
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[])
+
+        for uid in ("u1", "u2"):
+            memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "I really like coffee"}],
+                metadata={"user_id": uid},
+                filters={"user_id": uid},
+                infer=True,
+            )
+
+        # Both scopes persisted their own memory (no false cross-scope dedup)...
+        assert len(store) == 2, f"expected 1 memory per distinct scope, got {store}"
+        # ...and each distinct scope got its own lock, not one shared instance lock.
+        assert len(memory._add_locks) == 2


### PR DESCRIPTION
## Linked Issue

Closes #6515

## Description

`_add_to_vector_store` (both `Memory` and `AsyncMemory`) takes a snapshot of existing memories in Phase 1, then checks the hash-dedup guard against that same snapshot in Phase 4/5 — after an LLM extraction round-trip and embedding calls have already happened. Two concurrent `add()` calls extracting the identical fact for the same scope (a retried request, a double-submitted webhook, two parallel agent turns) both pass dedup against the same stale snapshot and both insert, creating a permanent duplicate memory (same `hash`, different `memory_id`). No error or warning is raised — it's silent.

This PR serializes the dedup-recheck + insert step with a **per-session-scope lock** (`threading.Lock` for `Memory`, `asyncio.Lock` for `AsyncMemory` — same convention already accepted for the entity-store race in #6243) and re-fetches existing hashes fresh, immediately before insert, instead of reusing the Phase 1 snapshot. This closes the race at the application level, independent of any specific vector store backend's own thread-safety.

The lock is keyed by session scope (`user_id`/`agent_id`/`run_id`), created lazily, so `add()` calls for **different** scopes — which can never hash-collide — do not serialize against each other; only same-scope callers do.

### Scope / limitation

These locks live on the `Memory`/`AsyncMemory` instance, so they only serialize callers **sharing one instance in one process**. They do **not** coordinate across multiple workers or replicas — e.g. this repo's `server/` and `openmemory/` scale-out deployments hold the client as a per-process singleton, so each process gets its own lock and the race window stays open **across** processes. Closing that cross-process window would require a shared/distributed lock (Redis/DB advisory lock, etc.) and is intentionally out of scope for this PR. This is documented at both lock sites in the code so the guarantee isn't misread as cross-worker.

Distinct from:
- #6243 — entity-store `linked_memory_ids` read-modify-write race (different data, different code path)
- #4892 — concurrent writes corrupting the Qdrant HNSW index (a storage-engine corruption bug; this bug reproduces with a plain in-memory fake vector store, so it's a pipeline-level design gap, not backend-specific)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — no public API changes. One extra `vector_store.search()` call happens per `add()` invocation that produces at least one record (needed to close the race); this is the same cost class as the existing Phase 1 search and only runs when there's something to persist.

## Test Coverage

- [x] I added/updated unit tests

Three regression tests in `tests/memory/test_main.py::TestConcurrentAddDedupRace`:
- `test_concurrent_add_same_fact_does_not_duplicate` — `Memory`, real `threading.Thread`s
- `test_async_concurrent_add_same_fact_does_not_duplicate` — `AsyncMemory`, `asyncio.gather`
- `test_different_scopes_use_separate_locks_and_both_persist` — asserts distinct scopes get distinct locks and both persist (no false cross-scope dedup, no needless cross-scope serialization)

All use a plain in-memory fake vector store (scope-aware, no backend-specific behavior); the race tests use an artificially slow mocked LLM call to reliably force the race window.

**Proof — red on `upstream/main`, green with the fix** (race tests run against a clean `upstream/main` checkout of `mem0/memory/main.py`, then against this branch):

```
# BEFORE (raw upstream/main — Phase 4/5 dedup checked only against the stale Phase 1 snapshot):
$ pytest tests/memory/test_main.py -k concurrent_add_same_fact
FAILED test_concurrent_add_same_fact_does_not_duplicate
  AssertionError: expected exactly 1 persisted memory after two concurrent add()
  calls for the same fact, got 2: [{'id': '...', 'hash': 'f6e56b29...'}, {'id': '...', 'hash': 'f6e56b29...'}]
FAILED test_async_concurrent_add_same_fact_does_not_duplicate
  AssertionError: expected exactly 1 persisted memory ... got 2: [...]
2 failed, 49 deselected

# AFTER (this branch — per-scope lock + fresh in-lock recheck immediately before insert):
$ pytest tests/memory/test_main.py -k ConcurrentAddDedupRace
3 passed, 48 deselected

# Full memory suite + lint, clean on this branch:
$ pytest tests/memory/ -q
355 passed

$ ruff check mem0/memory/main.py tests/memory/test_main.py
All checks passed!
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A — internal concurrency fix, no public API/doc change; scope limitation documented inline)
