### PR TITLE
feat(memory): add disable_history config (TS disableHistory parity)

### DIFF
--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -43,6 +43,13 @@ class MemoryConfig(BaseModel):
         description="Path to the history database",
         default=os.path.join(mem0_dir, "history.db"),
     )
+    disable_history: bool = Field(
+        description=(
+            "When True, do not open or write the history SQLite DB "
+            "(parity with TS disableHistory). get_history returns []."
+        ),
+        default=False,
+    )
     reranker: Optional[RerankerConfig] = Field(
         description="Configuration for the reranker",
         default=None,

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -49,7 +49,7 @@ from mem0.memory.notices import (
     get_temporal_feature_error_message_async,
 )
 from mem0.memory.setup import mem0_dir, setup_config
-from mem0.memory.storage import SQLiteManager
+from mem0.memory.storage import DummyHistoryManager, SQLiteManager
 from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
 from mem0.memory.utils import (
     extract_json,
@@ -460,6 +460,13 @@ class _AsyncOSSProject:
         raise ValueError(_PROJECT_UPDATE_UNSUPPORTED_ERROR)
 
 
+def _history_manager_from_config(config: MemoryConfig):
+    """Return SQLite or no-op history backend (TS disableHistory parity)."""
+    if getattr(config, "disable_history", False):
+        return DummyHistoryManager(config.history_db_path)
+    return SQLiteManager(config.history_db_path)
+
+
 class Memory(MemoryBase):
     def __init__(self, config: MemoryConfig = MemoryConfig()):
         self.config = config
@@ -473,7 +480,7 @@ class Memory(MemoryBase):
             self.config.vector_store.provider, self.config.vector_store.config
         )
         self.llm = LlmFactory.create(self.config.llm.provider, self.config.llm.config)
-        self.db = SQLiteManager(self.config.history_db_path)
+        self.db = _history_manager_from_config(self.config)
         self.collection_name = self.config.vector_store.config.collection_name
         self.api_version = self.config.version
         self.custom_instructions = self.config.custom_instructions
@@ -2103,7 +2110,7 @@ class Memory(MemoryBase):
 
         self.db.reset()
         self.db.close()
-        self.db = SQLiteManager(self.config.history_db_path)
+        self.db = _history_manager_from_config(self.config)
 
         if hasattr(self.vector_store, "reset"):
             self.vector_store = VectorStoreFactory.reset(self.vector_store)
@@ -2147,7 +2154,7 @@ class AsyncMemory(MemoryBase):
             self.config.vector_store.provider, self.config.vector_store.config
         )
         self.llm = LlmFactory.create(self.config.llm.provider, self.config.llm.config)
-        self.db = SQLiteManager(self.config.history_db_path)
+        self.db = _history_manager_from_config(self.config)
         self.collection_name = self.config.vector_store.config.collection_name
         self.api_version = self.config.version
         self.custom_instructions = self.config.custom_instructions
@@ -3795,7 +3802,7 @@ class AsyncMemory(MemoryBase):
 
         await asyncio.to_thread(self.db.reset)
         await asyncio.to_thread(self.db.close)
-        self.db = SQLiteManager(self.config.history_db_path)
+        self.db = _history_manager_from_config(self.config)
 
         self.vector_store = VectorStoreFactory.create(
             self.config.vector_store.provider, self.config.vector_store.config

--- a/mem0/memory/storage.py
+++ b/mem0/memory/storage.py
@@ -345,3 +345,53 @@ class SQLiteManager:
 
     def __del__(self):
         self.close()
+
+
+class DummyHistoryManager:
+    """No-op history backend used when MemoryConfig.disable_history is True.
+
+    Mirrors the SQLiteManager surface that Memory/AsyncMemory call so the rest of
+    the pipeline keeps working without writing an audit trail (TS parity:
+    DummyHistoryManager / disableHistory).
+    """
+
+    def __init__(self, db_path: str = ":memory:"):
+        # Keep attr for callers that introspect history_db_path-like state.
+        self.db_path = db_path
+        self.connection = None
+
+    def add_history(
+        self,
+        memory_id: str,
+        old_memory: Optional[str],
+        new_memory: Optional[str],
+        event: str,
+        *,
+        created_at: Optional[str] = None,
+        updated_at: Optional[str] = None,
+        is_deleted: int = 0,
+        actor_id: Optional[str] = None,
+        role: Optional[str] = None,
+    ) -> None:
+        return None
+
+    def batch_add_history(self, records: List[Dict[str, Any]]) -> None:
+        return None
+
+    def get_history(self, memory_id: str) -> List[Dict[str, Any]]:
+        return []
+
+    def save_messages(self, messages: List[Dict[str, Any]], session_scope: str) -> None:
+        # Message retention uses the same SQLite file; when history is disabled
+        # GDPR callers typically also do not want local message transcripts.
+        return None
+
+    def get_last_messages(self, session_scope: str, limit: int = 10) -> List[Dict[str, Any]]:
+        return []
+
+    def reset(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+

--- a/server/main.py
+++ b/server/main.py
@@ -114,6 +114,7 @@ POSTGRES_COLLECTION_NAME = os.environ.get("POSTGRES_COLLECTION_NAME", "memories"
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 HISTORY_DB_PATH = os.environ.get("HISTORY_DB_PATH", "/app/history/history.db")
+DISABLE_HISTORY = os.environ.get("DISABLE_HISTORY", "false").lower() in ("1", "true", "yes")
 DEFAULT_LLM_MODEL = os.environ.get("MEM0_DEFAULT_LLM_MODEL", "gpt-5-mini")
 DEFAULT_EMBEDDER_MODEL = os.environ.get("MEM0_DEFAULT_EMBEDDER_MODEL", "text-embedding-3-small")
 
@@ -136,6 +137,7 @@ DEFAULT_CONFIG = {
     },
     "embedder": {"provider": "openai", "config": {"api_key": OPENAI_API_KEY, "model": DEFAULT_EMBEDDER_MODEL}},
     "history_db_path": HISTORY_DB_PATH,
+    "disable_history": DISABLE_HISTORY,
 }
 
 

--- a/tests/memory/test_disable_history.py
+++ b/tests/memory/test_disable_history.py
@@ -1,0 +1,110 @@
+"""Tests for MemoryConfig.disable_history (parity with TS disableHistory)."""
+
+from unittest.mock import MagicMock, patch
+
+
+from mem0.configs.base import MemoryConfig
+from mem0.memory.storage import DummyHistoryManager, SQLiteManager
+
+
+def test_dummy_history_manager_is_noop():
+    db = DummyHistoryManager("/tmp/should-not-be-created-by-dummy.db")
+    db.add_history("m1", None, "hello", "ADD")
+    db.batch_add_history(
+        [{"memory_id": "m1", "old_memory": None, "new_memory": "x", "event": "ADD"}]
+    )
+    assert db.get_history("m1") == []
+    db.save_messages([{"role": "user", "content": "hi"}], "scope")
+    assert db.get_last_messages("scope") == []
+    db.reset()
+    db.close()
+
+
+def test_memory_config_disable_history_default_false():
+    cfg = MemoryConfig()
+    assert cfg.disable_history is False
+
+
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.LlmFactory")
+@patch("mem0.memory.main.capture_event")
+def test_memory_uses_dummy_when_disable_history(
+    mock_event, mock_llm, mock_vs, mock_emb
+):
+    from mem0.memory.main import Memory
+
+    mock_emb.create.return_value = MagicMock()
+    mock_vs.create.return_value = MagicMock()
+    mock_llm.create.return_value = MagicMock()
+
+    cfg = MemoryConfig(disable_history=True, history_db_path=":memory:")
+    mem = Memory(cfg)
+    assert isinstance(mem.db, DummyHistoryManager)
+    # history() path
+    assert mem.history("any-id") == []
+    mem.close()
+
+
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.LlmFactory")
+@patch("mem0.memory.main.capture_event")
+def test_memory_uses_sqlite_by_default(mock_event, mock_llm, mock_vs, mock_emb, tmp_path):
+    from mem0.memory.main import Memory
+
+    mock_emb.create.return_value = MagicMock()
+    mock_vs.create.return_value = MagicMock()
+    mock_llm.create.return_value = MagicMock()
+
+    db_path = str(tmp_path / "history.db")
+    cfg = MemoryConfig(history_db_path=db_path)
+    mem = Memory(cfg)
+    assert isinstance(mem.db, SQLiteManager)
+    mem.db.add_history("m1", None, "fact", "ADD", created_at="2026-01-01T00:00:00+00:00")
+    hist = mem.history("m1")
+    assert len(hist) == 1
+    assert hist[0]["new_memory"] == "fact"
+    mem.close()
+
+
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.LlmFactory")
+@patch("mem0.memory.main.capture_event")
+def test_async_memory_uses_dummy_when_disable_history(
+    mock_event, mock_llm, mock_vs, mock_emb
+):
+    from mem0.memory.main import AsyncMemory
+
+    mock_emb.create.return_value = MagicMock()
+    mock_vs.create.return_value = MagicMock()
+    mock_llm.create.return_value = MagicMock()
+
+    cfg = MemoryConfig(disable_history=True)
+    mem = AsyncMemory(cfg)
+    assert isinstance(mem.db, DummyHistoryManager)
+    mem.close()
+
+
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.LlmFactory")
+@patch("mem0.memory.main.capture_event")
+def test_reset_preserves_disable_history(mock_event, mock_llm, mock_vs, mock_emb):
+    from mem0.memory.main import Memory
+
+    mock_emb.create.return_value = MagicMock()
+    vs = MagicMock()
+    mock_vs.create.return_value = vs
+    mock_vs.reset.return_value = vs
+    mock_llm.create.return_value = MagicMock()
+    # enable reset path with hasattr reset
+    vs.reset = MagicMock()
+
+    cfg = MemoryConfig(disable_history=True)
+    mem = Memory(cfg)
+    assert isinstance(mem.db, DummyHistoryManager)
+    mem.reset()
+    assert isinstance(mem.db, DummyHistoryManager)
+    mem.close()


### PR DESCRIPTION
## Summary
Adds `MemoryConfig.disable_history` (default `False`) so OSS Python SDK/server can skip SQLite history writes, matching TS `disableHistory`.

Closes #6512

## Motivation
Self-hosters with GDPR purge needs cannot currently turn off history. `delete_all` appends DELETE rows rather than erasing history, and teams that treat the vector store as system-of-record want no local audit DB. Node already has `disableHistory`.

## Changes
- `MemoryConfig.disable_history`
- `DummyHistoryManager` no-op backend
- `Memory` / `AsyncMemory` (including `reset`) select backend via `_history_manager_from_config`
- REST server: `DISABLE_HISTORY` env → `disable_history` on MEMORY config
- Tests: `tests/memory/test_disable_history.py` (6 cases)

## Verification
```bash
pytest tests/memory/test_disable_history.py -q
# 6 passed
```

## Notes
Default remains `False` for full backward compatibility. Message retention on the same SQLite path is also no-op'd under the dummy so disabling history does not leave a local transcript store open.
