### PR TITLE
fix(llms/lmstudio): honor LMSTUDIO_BASE_URL when config url is unset

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/lmstudio.ts
+++ b/mem0-ts/src/oss/src/embeddings/lmstudio.ts
@@ -12,7 +12,12 @@ export class LMStudioEmbedder implements Embedder {
   private model: string;
 
   constructor(config: EmbeddingConfig) {
-    const baseURL = config.baseURL ?? config.url ?? DEFAULT_BASE_URL;
+    // config > LMSTUDIO_BASE_URL env > localhost default (mirror LLM path / Python)
+    const baseURL =
+      config.baseURL ||
+      config.url ||
+      process.env.LMSTUDIO_BASE_URL ||
+      DEFAULT_BASE_URL;
     const apiKey = config.apiKey || DEFAULT_LMSTUDIO_API_KEY;
     this.openai = new OpenAI({ apiKey, baseURL: String(baseURL) });
     this.model = config.model || DEFAULT_MODEL;

--- a/mem0-ts/src/oss/src/llms/lmstudio.ts
+++ b/mem0-ts/src/oss/src/llms/lmstudio.ts
@@ -9,10 +9,13 @@ const DEFAULT_LMSTUDIO_API_KEY = "lm-studio";
 
 export class LMStudioLLM extends OpenAILLM {
   constructor(config: LLMConfig) {
+    // config > LMSTUDIO_BASE_URL env > localhost default (mirror deepseek.ts / Python LMStudioLLM)
+    const baseURL =
+      config.baseURL || process.env.LMSTUDIO_BASE_URL || DEFAULT_BASE_URL;
     super({
       ...config,
       apiKey: config.apiKey || DEFAULT_LMSTUDIO_API_KEY,
-      baseURL: config.baseURL ?? DEFAULT_BASE_URL,
+      baseURL,
       model: config.model || DEFAULT_MODEL,
     });
   }

--- a/mem0-ts/src/oss/tests/lmstudio-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/lmstudio-embedder.test.ts
@@ -3,12 +3,14 @@
  * LM Studio Embedder — unit tests (mocked OpenAI).
  */
 
+import OpenAI from "openai";
 import { LMStudioEmbedder } from "../src/embeddings/lmstudio";
 
 const mockEmbedding = [0.1, 0.2, 0.3, 0.4, 0.5];
 const mockCreate = jest.fn().mockResolvedValue({
   data: [{ embedding: mockEmbedding }],
 });
+const MockOpenAI = OpenAI as unknown as jest.Mock;
 
 jest.mock("openai", () => {
   return jest.fn().mockImplementation(() => ({
@@ -17,7 +19,47 @@ jest.mock("openai", () => {
 });
 
 describe("LMStudioEmbedder (unit)", () => {
-  beforeEach(() => mockCreate.mockClear());
+  const originalEnv = process.env.LMSTUDIO_BASE_URL;
+
+  beforeEach(() => {
+    mockCreate.mockClear();
+    MockOpenAI.mockClear();
+    delete process.env.LMSTUDIO_BASE_URL;
+  });
+
+  afterAll(() => {
+    if (originalEnv === undefined) {
+      delete process.env.LMSTUDIO_BASE_URL;
+    } else {
+      process.env.LMSTUDIO_BASE_URL = originalEnv;
+    }
+  });
+
+  it("honors LMSTUDIO_BASE_URL when config baseURL is unset", () => {
+    process.env.LMSTUDIO_BASE_URL = "http://remote-lms:1234/v1";
+    new LMStudioEmbedder({ model: "nomic-embed-text" });
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "http://remote-lms:1234/v1" }),
+    );
+  });
+
+  it("prefers config baseURL over LMSTUDIO_BASE_URL", () => {
+    process.env.LMSTUDIO_BASE_URL = "http://env-host:1234/v1";
+    new LMStudioEmbedder({
+      model: "nomic-embed-text",
+      baseURL: "http://cfg-host:1234/v1",
+    });
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "http://cfg-host:1234/v1" }),
+    );
+  });
+
+  it("defaults to localhost when config and env are unset", () => {
+    new LMStudioEmbedder({ model: "nomic-embed-text" });
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "http://localhost:1234/v1" }),
+    );
+  });
 
   it("embed() calls OpenAI with encoding_format float and returns vector", async () => {
     const embedder = new LMStudioEmbedder({

--- a/mem0-ts/src/oss/tests/lmstudio-llm.test.ts
+++ b/mem0-ts/src/oss/tests/lmstudio-llm.test.ts
@@ -3,9 +3,11 @@
  * LM Studio LLM — unit tests (mocked OpenAI).
  */
 
+import OpenAI from "openai";
 import { LMStudioLLM } from "../src/llms/lmstudio";
 
 const mockCreate = jest.fn();
+const MockOpenAI = OpenAI as unknown as jest.Mock;
 
 jest.mock("openai", () => {
   return jest.fn().mockImplementation(() => ({
@@ -14,7 +16,44 @@ jest.mock("openai", () => {
 });
 
 describe("LMStudioLLM (unit)", () => {
-  beforeEach(() => mockCreate.mockClear());
+  const originalEnv = process.env.LMSTUDIO_BASE_URL;
+
+  beforeEach(() => {
+    mockCreate.mockClear();
+    MockOpenAI.mockClear();
+    delete process.env.LMSTUDIO_BASE_URL;
+  });
+
+  afterAll(() => {
+    if (originalEnv === undefined) {
+      delete process.env.LMSTUDIO_BASE_URL;
+    } else {
+      process.env.LMSTUDIO_BASE_URL = originalEnv;
+    }
+  });
+
+  it("honors LMSTUDIO_BASE_URL when config baseURL is unset", () => {
+    process.env.LMSTUDIO_BASE_URL = "http://remote-lms:1234/v1";
+    new LMStudioLLM({});
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "http://remote-lms:1234/v1" }),
+    );
+  });
+
+  it("prefers config baseURL over LMSTUDIO_BASE_URL", () => {
+    process.env.LMSTUDIO_BASE_URL = "http://env-host:1234/v1";
+    new LMStudioLLM({ baseURL: "http://cfg-host:1234/v1" });
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "http://cfg-host:1234/v1" }),
+    );
+  });
+
+  it("defaults to localhost when config and env are unset", () => {
+    new LMStudioLLM({});
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "http://localhost:1234/v1" }),
+    );
+  });
 
   it("generateResponse() returns a text response", async () => {
     mockCreate.mockResolvedValueOnce({

--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -33,8 +33,8 @@ class BaseEmbedderConfig(ABC):
         memory_search_embedding_type: Optional[str] = None,
         # Gemini specific
         output_dimensionality: Optional[str] = None,
-        # LM Studio specific
-        lmstudio_base_url: Optional[str] = "http://localhost:1234/v1",
+        # LM Studio specific — default resolved in LMStudioEmbedding (config > env > localhost)
+        lmstudio_base_url: Optional[str] = None,
         # AWS Bedrock specific
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
@@ -70,7 +70,7 @@ class BaseEmbedderConfig(ABC):
         :type memory_update_embedding_type: Optional[str], optional
         :param memory_search_embedding_type: The type of embedding to use for the search memory action, defaults to None
         :type memory_search_embedding_type: Optional[str], optional
-        :param lmstudio_base_url: LM Studio base URL to be use, defaults to "http://localhost:1234/v1"
+        :param lmstudio_base_url: LM Studio base URL; when unset, LMStudioEmbedding applies LMSTUDIO_BASE_URL env then localhost
         :type lmstudio_base_url: Optional[str], optional
         """
 

--- a/mem0/configs/llms/lmstudio.py
+++ b/mem0/configs/llms/lmstudio.py
@@ -55,6 +55,6 @@ class LMStudioConfig(BaseLlmConfig):
         )
 
         # LM Studio-specific parameters
-        # Keep unset so LMStudioLLM can apply config > env > default (see VLLM #6256).
+        # Keep unset so LMStudioLLM can apply config > env > default (mirror DeepSeek).
         self.lmstudio_base_url = lmstudio_base_url
         self.lmstudio_response_format = lmstudio_response_format

--- a/mem0/configs/llms/lmstudio.py
+++ b/mem0/configs/llms/lmstudio.py
@@ -55,5 +55,6 @@ class LMStudioConfig(BaseLlmConfig):
         )
 
         # LM Studio-specific parameters
-        self.lmstudio_base_url = lmstudio_base_url or "http://localhost:1234/v1"
+        # Keep unset so LMStudioLLM can apply config > env > default (see VLLM #6256).
+        self.lmstudio_base_url = lmstudio_base_url
         self.lmstudio_response_format = lmstudio_response_format

--- a/mem0/embeddings/lmstudio.py
+++ b/mem0/embeddings/lmstudio.py
@@ -17,7 +17,6 @@ class LMStudioEmbedding(EmbeddingBase):
 
         # config > LMSTUDIO_BASE_URL env > localhost default (mirror DeepSeek / LLM path)
         base_url = self.config.lmstudio_base_url or os.getenv("LMSTUDIO_BASE_URL") or "http://localhost:1234/v1"
-        self.config.lmstudio_base_url = base_url
         self.client = OpenAI(base_url=base_url, api_key=self.config.api_key)
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):

--- a/mem0/embeddings/lmstudio.py
+++ b/mem0/embeddings/lmstudio.py
@@ -1,3 +1,4 @@
+import os
 from typing import Literal, Optional
 
 from openai import OpenAI
@@ -14,7 +15,10 @@ class LMStudioEmbedding(EmbeddingBase):
         self.config.embedding_dims = self.config.embedding_dims or 1536
         self.config.api_key = self.config.api_key or "lm-studio"
 
-        self.client = OpenAI(base_url=self.config.lmstudio_base_url, api_key=self.config.api_key)
+        # config > LMSTUDIO_BASE_URL env > localhost default (mirror DeepSeek / LLM path)
+        base_url = self.config.lmstudio_base_url or os.getenv("LMSTUDIO_BASE_URL") or "http://localhost:1234/v1"
+        self.config.lmstudio_base_url = base_url
+        self.client = OpenAI(base_url=base_url, api_key=self.config.api_key)
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """

--- a/mem0/llms/lmstudio.py
+++ b/mem0/llms/lmstudio.py
@@ -39,12 +39,8 @@ class LMStudioLLM(LLMBase):
         )
         self.config.api_key = self.config.api_key or "lm-studio"
 
-        # config > LMSTUDIO_BASE_URL env > localhost default (mirror DeepSeek/VLLM)
-        base_url = (
-            self.config.lmstudio_base_url
-            or os.getenv("LMSTUDIO_BASE_URL")
-            or "http://localhost:1234/v1"
-        )
+        # config > LMSTUDIO_BASE_URL env > localhost default (mirror DeepSeek)
+        base_url = self.config.lmstudio_base_url or os.getenv("LMSTUDIO_BASE_URL") or "http://localhost:1234/v1"
         self.config.lmstudio_base_url = base_url
         self.client = OpenAI(base_url=base_url, api_key=self.config.api_key)
 

--- a/mem0/llms/lmstudio.py
+++ b/mem0/llms/lmstudio.py
@@ -41,7 +41,6 @@ class LMStudioLLM(LLMBase):
 
         # config > LMSTUDIO_BASE_URL env > localhost default (mirror DeepSeek)
         base_url = self.config.lmstudio_base_url or os.getenv("LMSTUDIO_BASE_URL") or "http://localhost:1234/v1"
-        self.config.lmstudio_base_url = base_url
         self.client = OpenAI(base_url=base_url, api_key=self.config.api_key)
 
     def _parse_response(self, response, tools):

--- a/mem0/llms/lmstudio.py
+++ b/mem0/llms/lmstudio.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Dict, List, Optional, Union
 
 from openai import OpenAI
@@ -38,7 +39,14 @@ class LMStudioLLM(LLMBase):
         )
         self.config.api_key = self.config.api_key or "lm-studio"
 
-        self.client = OpenAI(base_url=self.config.lmstudio_base_url, api_key=self.config.api_key)
+        # config > LMSTUDIO_BASE_URL env > localhost default (mirror DeepSeek/VLLM)
+        base_url = (
+            self.config.lmstudio_base_url
+            or os.getenv("LMSTUDIO_BASE_URL")
+            or "http://localhost:1234/v1"
+        )
+        self.config.lmstudio_base_url = base_url
+        self.client = OpenAI(base_url=base_url, api_key=self.config.api_key)
 
     def _parse_response(self, response, tools):
         """

--- a/tests/embeddings/test_lm_studio_embeddings.py
+++ b/tests/embeddings/test_lm_studio_embeddings.py
@@ -6,24 +6,44 @@ from mem0.configs.embeddings.base import BaseEmbedderConfig
 from mem0.embeddings.lmstudio import LMStudioEmbedding
 
 
-
 @pytest.fixture
 def mock_lm_studio_client():
     with patch("mem0.embeddings.lmstudio.OpenAI") as mock_openai:
         mock_client = Mock()
         mock_client.embeddings.create.return_value = Mock(data=[Mock(embedding=[0.1, 0.2, 0.3, 0.4, 0.5])])
         mock_openai.return_value = mock_client
-        yield mock_client
+        yield mock_openai
+
+
+def test_lmstudio_embed_honors_env_base_url(mock_lm_studio_client, monkeypatch):
+    monkeypatch.setenv("LMSTUDIO_BASE_URL", "http://remote-lms:1234/v1")
+    LMStudioEmbedding(BaseEmbedderConfig(model="nomic-embed-text"))
+    assert mock_lm_studio_client.call_args.kwargs["base_url"] == "http://remote-lms:1234/v1"
+
+
+def test_lmstudio_embed_config_overrides_env(mock_lm_studio_client, monkeypatch):
+    monkeypatch.setenv("LMSTUDIO_BASE_URL", "http://env-host:1234/v1")
+    LMStudioEmbedding(
+        BaseEmbedderConfig(model="nomic-embed-text", lmstudio_base_url="http://cfg-host:1234/v1")
+    )
+    assert mock_lm_studio_client.call_args.kwargs["base_url"] == "http://cfg-host:1234/v1"
+
+
+def test_lmstudio_embed_default_base_url(mock_lm_studio_client, monkeypatch):
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    LMStudioEmbedding(BaseEmbedderConfig(model="nomic-embed-text"))
+    assert mock_lm_studio_client.call_args.kwargs["base_url"] == "http://localhost:1234/v1"
 
 
 def test_embed_text(mock_lm_studio_client):
+    mock_client = mock_lm_studio_client.return_value
     config = BaseEmbedderConfig(model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf", embedding_dims=512)
     embedder = LMStudioEmbedding(config)
 
     text = "Sample text to embed."
     embedding = embedder.embed(text)
 
-    mock_lm_studio_client.embeddings.create.assert_called_once_with(
+    mock_client.embeddings.create.assert_called_once_with(
         input=["Sample text to embed."], model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf"
     )
 
@@ -31,52 +51,56 @@ def test_embed_text(mock_lm_studio_client):
 
 
 def test_embed_batch_single_call(mock_lm_studio_client):
+    mock_client = mock_lm_studio_client.return_value
     config = BaseEmbedderConfig(model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf", embedding_dims=512)
     embedder = LMStudioEmbedding(config)
 
     mock_item0 = Mock(index=0, embedding=[0.1, 0.2, 0.3])
     mock_item1 = Mock(index=1, embedding=[0.4, 0.5, 0.6])
-    mock_lm_studio_client.embeddings.create.return_value = Mock(data=[mock_item0, mock_item1])
+    mock_client.embeddings.create.return_value = Mock(data=[mock_item0, mock_item1])
 
     texts = ["First text.", "Second text."]
     embeddings = embedder.embed_batch(texts)
 
-    mock_lm_studio_client.embeddings.create.assert_called_once_with(
+    mock_client.embeddings.create.assert_called_once_with(
         input=texts, model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf"
     )
     assert embeddings == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
 
 
 def test_embed_batch_empty_list(mock_lm_studio_client):
+    mock_client = mock_lm_studio_client.return_value
     config = BaseEmbedderConfig(model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf", embedding_dims=512)
     embedder = LMStudioEmbedding(config)
 
     result = embedder.embed_batch([])
 
     assert result == []
-    mock_lm_studio_client.embeddings.create.assert_not_called()
+    mock_client.embeddings.create.assert_not_called()
 
 
 def test_embed_batch_strips_newlines(mock_lm_studio_client):
+    mock_client = mock_lm_studio_client.return_value
     config = BaseEmbedderConfig(model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf", embedding_dims=512)
     embedder = LMStudioEmbedding(config)
 
     mock_item0 = Mock(index=0, embedding=[0.1, 0.2, 0.3])
-    mock_lm_studio_client.embeddings.create.return_value = Mock(data=[mock_item0])
+    mock_client.embeddings.create.return_value = Mock(data=[mock_item0])
 
     embedder.embed_batch(["line one\nline two"])
 
-    mock_lm_studio_client.embeddings.create.assert_called_once_with(
+    mock_client.embeddings.create.assert_called_once_with(
         input=["line one line two"], model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf"
     )
 
 
 def test_embed_batch_count_mismatch_raises(mock_lm_studio_client):
+    mock_client = mock_lm_studio_client.return_value
     config = BaseEmbedderConfig(model="nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf", embedding_dims=512)
     embedder = LMStudioEmbedding(config)
 
     mock_item0 = Mock(index=0, embedding=[0.1, 0.2, 0.3])
-    mock_lm_studio_client.embeddings.create.return_value = Mock(data=[mock_item0])
+    mock_client.embeddings.create.return_value = Mock(data=[mock_item0])
 
     with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
         embedder.embed_batch(["first text", "second text"])

--- a/tests/llms/test_lmstudio.py
+++ b/tests/llms/test_lmstudio.py
@@ -1,6 +1,5 @@
 from unittest.mock import Mock, patch
 
-import os
 
 import pytest
 

--- a/tests/llms/test_lmstudio.py
+++ b/tests/llms/test_lmstudio.py
@@ -1,0 +1,35 @@
+from unittest.mock import Mock, patch
+
+import os
+
+import pytest
+
+from mem0.configs.llms.base import BaseLlmConfig
+from mem0.configs.llms.lmstudio import LMStudioConfig
+from mem0.llms.lmstudio import LMStudioLLM
+
+
+@pytest.fixture
+def mock_openai():
+    with patch("mem0.llms.lmstudio.OpenAI") as mock_cls:
+        mock_cls.return_value = Mock()
+        yield mock_cls
+
+
+def test_lmstudio_honors_env_base_url(mock_openai, monkeypatch):
+    monkeypatch.setenv("LMSTUDIO_BASE_URL", "http://remote-lms:1234/v1")
+    # BaseLlmConfig path (no provider-specific url set)
+    LMStudioLLM(BaseLlmConfig(model="local-model"))
+    assert mock_openai.call_args.kwargs["base_url"] == "http://remote-lms:1234/v1"
+
+
+def test_lmstudio_config_overrides_env(mock_openai, monkeypatch):
+    monkeypatch.setenv("LMSTUDIO_BASE_URL", "http://env-host:1234/v1")
+    LMStudioLLM(LMStudioConfig(model="local-model", lmstudio_base_url="http://cfg-host:1234/v1"))
+    assert mock_openai.call_args.kwargs["base_url"] == "http://cfg-host:1234/v1"
+
+
+def test_lmstudio_default_base_url(mock_openai, monkeypatch):
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    LMStudioLLM(BaseLlmConfig(model="local-model"))
+    assert mock_openai.call_args.kwargs["base_url"] == "http://localhost:1234/v1"


### PR DESCRIPTION
Honors LMSTUDIO_BASE_URL when the config url is unset across the Python LLM + embedder and both TypeScript surfaces, with the localhost fallback chain and the dead write-back removed.

Closes #6692
Supersedes #6693