### PR TITLE
fix: add self-hosted memory support for Cursor

### DIFF
--- a/integrations/mem0-plugin/hooks/cursor-hooks.json
+++ b/integrations/mem0-plugin/hooks/cursor-hooks.json
@@ -45,12 +45,6 @@
       {
         "command": "${CURSOR_PLUGIN_ROOT}/scripts/on_pre_compact_cursor.sh"
       }
-    ],
-    "beforeSubmitPrompt": [
-      {
-        "command": "${CURSOR_PLUGIN_ROOT}/scripts/on_user_prompt_cursor.sh",
-        "timeout": 12
-      }
     ]
   }
 }

--- a/integrations/mem0-plugin/scripts/_api.py
+++ b/integrations/mem0-plugin/scripts/_api.py
@@ -1,0 +1,167 @@
+"""Transport adapter for Mem0 Platform and self-hosted REST APIs.
+
+The plugin keeps its existing Platform behaviour unless ``MEM0_API_BASE`` is
+set. In self-hosted mode, hosted ``app_id`` scopes are translated to the
+self-hosted server's equivalent ``agent_id`` scope.
+
+This module intentionally uses only the Python standard library because hook
+scripts must work before the plugin's optional virtual environment is ready.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from typing import Any
+
+PLATFORM_API_BASE = "https://api.mem0.ai"
+DEFAULT_TIMEOUT = 15
+
+
+def is_self_hosted() -> bool:
+    """Return whether hooks should use a self-hosted Mem0 REST server."""
+    return bool(os.environ.get("MEM0_API_BASE", "").strip())
+
+
+def api_base_url() -> str:
+    """Return the selected API base URL without a trailing slash."""
+    configured = os.environ.get("MEM0_API_BASE", "").strip()
+    return (configured or PLATFORM_API_BASE).rstrip("/")
+
+
+def auth_headers(api_key: str) -> dict[str, str]:
+    """Build authentication headers for the selected backend."""
+    if is_self_hosted():
+        return {"X-API-Key": api_key}
+    return {"Authorization": f"Token {api_key}"}
+
+
+def _request_json(
+    api_key: str,
+    path: str,
+    *,
+    method: str,
+    body: dict[str, Any] | None = None,
+    query: dict[str, Any] | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> tuple[int, Any]:
+    """Send one JSON request and return ``(status, decoded_body)``."""
+    url = f"{api_base_url()}{path}"
+    filtered_query = {key: value for key, value in (query or {}).items() if value is not None}
+    if filtered_query:
+        url = f"{url}?{urllib.parse.urlencode(filtered_query)}"
+
+    encoded_body = json.dumps(body).encode("utf-8") if body is not None else None
+    request = urllib.request.Request(
+        url,
+        data=encoded_body,
+        headers={"Content-Type": "application/json", **auth_headers(api_key)},
+        method=method,
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        read = getattr(response, "read", None)
+        if not callable(read):
+            return response.status, {}
+        raw = read()
+        if not raw or not isinstance(raw, (bytes, bytearray, str)):
+            return response.status, {}
+        return response.status, json.loads(raw)
+
+
+def _map_scope(value: Any) -> Any:
+    """Recursively translate hosted ``app_id`` scopes to ``agent_id``."""
+    if isinstance(value, list):
+        return [_map_scope(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    mapped: dict[str, Any] = {}
+    for key, item in value.items():
+        mapped["agent_id" if key == "app_id" else key] = _map_scope(item)
+    return mapped
+
+
+def _map_add_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    mapped = dict(payload)
+    app_id = mapped.pop("app_id", None)
+    if app_id and not mapped.get("agent_id"):
+        mapped["agent_id"] = app_id
+    return mapped
+
+
+def add_memory(
+    api_key: str,
+    payload: dict[str, Any],
+    *,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> tuple[int, Any]:
+    """Add memories using the selected backend."""
+    if is_self_hosted():
+        return _request_json(
+            api_key,
+            "/memories",
+            method="POST",
+            body=_map_add_payload(payload),
+            timeout=timeout,
+        )
+    return _request_json(api_key, "/v3/memories/add/", method="POST", body=payload, timeout=timeout)
+
+
+def search_memories(
+    api_key: str,
+    payload: dict[str, Any],
+    *,
+    timeout: int = 5,
+) -> tuple[int, Any]:
+    """Search memories using the selected backend."""
+    if is_self_hosted():
+        mapped = _map_scope(payload)
+        mapped.pop("rerank", None)  # The self-hosted endpoint does not expose hosted reranking.
+        return _request_json(api_key, "/search", method="POST", body=mapped, timeout=timeout)
+    return _request_json(api_key, "/v3/memories/search/", method="POST", body=payload, timeout=timeout)
+
+
+def list_memories(
+    api_key: str,
+    payload: dict[str, Any],
+    *,
+    timeout: int = 5,
+) -> tuple[int, Any]:
+    """List memories, normalizing hosted filters for the self-hosted API."""
+    if not is_self_hosted():
+        page = payload.get("page", 1)
+        page_size = payload.get("page_size") or payload.get("top_k") or 10
+        return _request_json(
+            api_key,
+            f"/v3/memories/?page={page}&page_size={page_size}",
+            method="POST",
+            body={"filters": payload.get("filters") or {}},
+            timeout=timeout,
+        )
+
+    filters = _map_scope(payload.get("filters") or {})
+    query: dict[str, Any] = {
+        "top_k": payload.get("page_size") or payload.get("top_k"),
+        "show_expired": payload.get("show_expired"),
+    }
+    clauses = filters.get("AND", []) if isinstance(filters, dict) else []
+    if not clauses and isinstance(filters, dict):
+        clauses = [filters]
+    for clause in clauses:
+        if not isinstance(clause, dict):
+            continue
+        for key in ("user_id", "agent_id", "run_id"):
+            value = clause.get(key)
+            if isinstance(value, str) and value != "*":
+                query[key] = value
+
+    return _request_json(api_key, "/memories", method="GET", query=query, timeout=timeout)
+
+
+def delete_memory(api_key: str, memory_id: str, *, timeout: int = 10) -> tuple[int, Any]:
+    """Delete one memory using the selected backend."""
+    safe_id = urllib.parse.quote(memory_id, safe="")
+    path = f"/memories/{safe_id}" if is_self_hosted() else f"/v1/memories/{safe_id}/"
+    return _request_json(api_key, path, method="DELETE", timeout=timeout)

--- a/integrations/mem0-plugin/scripts/_search.py
+++ b/integrations/mem0-plugin/scripts/_search.py
@@ -6,11 +6,10 @@ All pre-fetch hooks use this instead of duplicating urllib boilerplate.
 
 from __future__ import annotations
 
-import json
 import os
-import urllib.request
 
-SEARCH_URL = "https://api.mem0.ai/v3/memories/search/"
+from _api import search_memories as api_search_memories
+
 SEARCH_TIMEOUT = 5
 
 
@@ -33,16 +32,8 @@ def should_rerank() -> bool:
 
 
 def _do_search(api_key: str, payload: dict) -> list[dict]:
-    body = json.dumps(payload).encode()
-    req = urllib.request.Request(
-        SEARCH_URL,
-        data=body,
-        headers={"Authorization": f"Token {api_key}", "Content-Type": "application/json"},
-        method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=SEARCH_TIMEOUT) as r:
-        data = json.loads(r.read())
-        return data if isinstance(data, list) else data.get("results", [])
+    _status, data = api_search_memories(api_key, payload, timeout=SEARCH_TIMEOUT)
+    return data if isinstance(data, list) else data.get("results", [])
 
 
 def search_memories(

--- a/integrations/mem0-plugin/scripts/auto_capture.py
+++ b/integrations/mem0-plugin/scripts/auto_capture.py
@@ -17,9 +17,9 @@ import logging
 import os
 import sys
 import urllib.error
-import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _api import add_memory
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_branch, resolve_project_id
 
@@ -39,7 +39,6 @@ if os.environ.get("MEM0_DEBUG"):
     except OSError:
         pass
 
-API_URL = "https://api.mem0.ai"
 TAIL_LINES = 200
 MAX_CONTENT_CHARS = 8000
 MIN_CONTENT_CHARS = 100
@@ -127,25 +126,17 @@ def store_exchange(api_key: str, messages: list[dict], user_id: str,
         "infer": True,
     }
 
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        f"{API_URL}/v3/memories/add/",
-        data=data,
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Token {api_key}",
-        },
-        method="POST",
-    )
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            if resp.status in (200, 201):
-                result = json.loads(resp.read())
-                log.info("Auto-captured: event_id=%s status=%s",
-                         result.get("event_id", "?"), result.get("status", "?"))
-                return True
-            log.warning("API returned status %d", resp.status)
-            return False
+        status, result = add_memory(api_key, body, timeout=15)
+        if status in (200, 201):
+            log.info(
+                "Auto-captured: event_id=%s status=%s",
+                result.get("event_id", "?"),
+                result.get("status", "?"),
+            )
+            return True
+        log.warning("API returned status %d", status)
+        return False
     except urllib.error.URLError as e:
         log.warning("API call failed: %s", e)
         return False

--- a/integrations/mem0-plugin/scripts/auto_import.py
+++ b/integrations/mem0-plugin/scripts/auto_import.py
@@ -18,9 +18,9 @@ import logging
 import os
 import sys
 import urllib.error
-import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _api import add_memory, delete_memory, search_memories
 from _chunking import filter_and_truncate, split_by_headers
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_branch, resolve_project_id, save_project_mapping
@@ -41,7 +41,6 @@ if os.environ.get("MEM0_DEBUG"):
     except OSError:
         pass
 
-API_URL = "https://api.mem0.ai"
 MAX_FILE_SIZE = 100_000  # skip files over 100 KB
 TARGET_FILES = ["CLAUDE.md", "AGENTS.md", ".cursorrules", ".windsurfrules", "mem0.md"]
 HASH_STORE = os.path.expanduser("~/.mem0/file_hashes.json")
@@ -122,7 +121,7 @@ def save_hashes(hashes: dict[str, str]) -> None:
 
 
 def already_imported(api_key: str, user_id: str, project_id: str, filename: str) -> bool:
-    body = json.dumps({
+    body = {
         "query": filename,
         "filters": {
             "AND": [
@@ -133,30 +132,23 @@ def already_imported(api_key: str, user_id: str, project_id: str, filename: str)
         },
         "top_k": 10,
         "threshold": 0.0,
-    }).encode()
-    req = urllib.request.Request(
-        f"{API_URL}/v3/memories/search/",
-        data=body,
-        headers={"Content-Type": "application/json", "Authorization": f"Token {api_key}"},
-        method="POST",
-    )
+    }
     try:
-        with urllib.request.urlopen(req, timeout=5) as r:
-            data = json.loads(r.read())
-            results = data if isinstance(data, list) else data.get("results", [])
-            for result in results:
-                meta = result.get("metadata", {}) if isinstance(result, dict) else {}
-                file_field = meta.get("file", "")
-                if file_field == filename or file_field.startswith(f"{filename}["):
-                    return True
-            return False
+        _status, data = search_memories(api_key, body, timeout=5)
+        results = data if isinstance(data, list) else data.get("results", [])
+        for result in results:
+            meta = result.get("metadata", {}) if isinstance(result, dict) else {}
+            file_field = meta.get("file", "")
+            if file_field == filename or file_field.startswith(f"{filename}["):
+                return True
+        return False
     except Exception:
         return False
 
 
 def _delete_stale_chunks(api_key: str, user_id: str, project_id: str, filename: str) -> int:
     """Find and delete existing chunks for a file before re-import. Returns count deleted."""
-    body = json.dumps({
+    body = {
         "query": filename,
         "filters": {
             "AND": [
@@ -167,27 +159,20 @@ def _delete_stale_chunks(api_key: str, user_id: str, project_id: str, filename: 
         },
         "top_k": 20,
         "threshold": 0.0,
-    }).encode()
-    req = urllib.request.Request(
-        f"{API_URL}/v3/memories/search/",
-        data=body,
-        headers={"Content-Type": "application/json", "Authorization": f"Token {api_key}"},
-        method="POST",
-    )
+    }
     ids_to_delete = []
     try:
-        with urllib.request.urlopen(req, timeout=10) as r:
-            data = json.loads(r.read())
-            results = data if isinstance(data, list) else data.get("results", [])
-            for result in results:
-                if not isinstance(result, dict):
-                    continue
-                meta = result.get("metadata", {})
-                file_field = meta.get("file", "")
-                if file_field == filename or file_field.startswith(f"{filename}["):
-                    mid = result.get("id")
-                    if mid:
-                        ids_to_delete.append(mid)
+        _status, data = search_memories(api_key, body, timeout=10)
+        results = data if isinstance(data, list) else data.get("results", [])
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            meta = result.get("metadata", {})
+            file_field = meta.get("file", "")
+            if file_field == filename or file_field.startswith(f"{filename}["):
+                mid = result.get("id")
+                if mid:
+                    ids_to_delete.append(mid)
     except Exception as e:
         log.warning("Failed to search for stale chunks of %s: %s", filename, e)
         return 0
@@ -195,12 +180,8 @@ def _delete_stale_chunks(api_key: str, user_id: str, project_id: str, filename: 
     deleted = 0
     for mid in ids_to_delete:
         try:
-            del_req = urllib.request.Request(
-                f"{API_URL}/v1/memories/{mid}/",
-                headers={"Authorization": f"Token {api_key}"},
-                method="DELETE",
-            )
-            with urllib.request.urlopen(del_req, timeout=10):
+            status, _result = delete_memory(api_key, mid, timeout=10)
+            if status in (200, 204):
                 deleted += 1
         except Exception as e:
             log.warning("Failed to delete stale chunk %s: %s", mid, e)
@@ -232,24 +213,13 @@ def post_memory(api_key: str, content: str, user_id: str, filename: str, project
         "infer": False,
     }
 
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        f"{API_URL}/v3/memories/add/",
-        data=data,
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Token {api_key}",
-        },
-        method="POST",
-    )
-
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            if resp.status in (200, 201):
-                log.info("Imported %s (project=%s)", filename, project_id)
-                return True
-            log.warning("API returned status %d for %s", resp.status, filename)
-            return False
+        status, _result = add_memory(api_key, body, timeout=15)
+        if status in (200, 201):
+            log.info("Imported %s (project=%s)", filename, project_id)
+            return True
+        log.warning("API returned status %d for %s", status, filename)
+        return False
     except urllib.error.URLError as e:
         log.warning("API call failed for %s: %s", filename, e)
         return False

--- a/integrations/mem0-plugin/scripts/capture_compact_summary.py
+++ b/integrations/mem0-plugin/scripts/capture_compact_summary.py
@@ -21,10 +21,10 @@ import logging
 import os
 import sys
 import urllib.error
-import urllib.request
 from datetime import date, timedelta
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _api import add_memory
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_branch, resolve_project_id
 
@@ -44,7 +44,6 @@ if os.environ.get("MEM0_DEBUG"):
     except OSError:
         pass
 
-API_URL = "https://api.mem0.ai"
 MAX_TAIL_LINES = 2000
 MAX_SUMMARY_CHARS = 50000
 # Compact summaries describe a single session's state -- stale after a quarter.
@@ -116,23 +115,13 @@ def store_summary(api_key: str, summary: str, user_id: str, session_id: str, pro
         "expiration_date": expires,
     }
 
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        f"{API_URL}/v3/memories/add/",
-        data=data,
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Token {api_key}",
-        },
-        method="POST",
-    )
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            if resp.status in (200, 201):
-                log.info("Compact summary stored")
-                return True
-            log.warning("API returned status %d", resp.status)
-            return False
+        status, _result = add_memory(api_key, body, timeout=15)
+        if status in (200, 201):
+            log.info("Compact summary stored")
+            return True
+        log.warning("API returned status %d", status)
+        return False
     except urllib.error.URLError as e:
         log.warning("API call failed: %s", e)
         return False

--- a/integrations/mem0-plugin/scripts/capture_session_summary.py
+++ b/integrations/mem0-plugin/scripts/capture_session_summary.py
@@ -19,10 +19,10 @@ import os
 import re
 import sys
 import urllib.error
-import urllib.request
 from datetime import date, timedelta
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _api import add_memory
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_branch, resolve_project_id
 
@@ -42,7 +42,6 @@ if os.environ.get("MEM0_DEBUG"):
     except OSError:
         pass
 
-API_URL = "https://api.mem0.ai"
 MAX_TAIL_LINES = 3000
 MAX_SUMMARY_CHARS = 50000
 SUMMARY_EXPIRY_DAYS = 90
@@ -189,23 +188,13 @@ def store_summary(
         "expiration_date": expires,
     }
 
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        f"{API_URL}/v3/memories/add/",
-        data=data,
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Token {api_key}",
-        },
-        method="POST",
-    )
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            if resp.status in (200, 201):
-                log.info("Session summary stored")
-                return True
-            log.warning("API returned status %d", resp.status)
-            return False
+        status, _result = add_memory(api_key, body, timeout=15)
+        if status in (200, 201):
+            log.info("Session summary stored")
+            return True
+        log.warning("API returned status %d", status)
+        return False
     except urllib.error.URLError as e:
         log.warning("API call failed: %s", e)
         return False

--- a/integrations/mem0-plugin/scripts/import_competing_tools.py
+++ b/integrations/mem0-plugin/scripts/import_competing_tools.py
@@ -22,9 +22,9 @@ import json
 import os
 import sys
 import urllib.error
-import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _api import add_memory
 from _chunking import (
     filter_and_truncate,
     split_by_headers,
@@ -33,7 +33,6 @@ from _chunking import (
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_branch, resolve_project_id
 
-API_URL = "https://api.mem0.ai"
 HASH_STORE = os.path.expanduser("~/.mem0/import_hashes.json")
 
 
@@ -81,19 +80,9 @@ def post_memory(api_key: str, content: str, user_id: str, project_id: str, branc
         "metadata": metadata,
         "infer": False,
     }
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        f"{API_URL}/v3/memories/add/",
-        data=data,
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Token {api_key}",
-        },
-        method="POST",
-    )
     try:
-        with urllib.request.urlopen(req, timeout=20) as resp:
-            return resp.status in (200, 201)
+        status, _result = add_memory(api_key, body, timeout=20)
+        return status in (200, 201)
     except urllib.error.URLError as e:
         print(f"  [warn] API call failed: {e}", file=sys.stderr)
         return False

--- a/integrations/mem0-plugin/scripts/on_pre_compact.py
+++ b/integrations/mem0-plugin/scripts/on_pre_compact.py
@@ -19,10 +19,10 @@ import logging
 import os
 import sys
 import urllib.error
-import urllib.request
 from datetime import date, timedelta
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _api import add_memory
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_branch, resolve_project_id
 
@@ -42,7 +42,6 @@ if os.environ.get("MEM0_DEBUG"):
     except OSError:
         pass
 
-API_URL = "https://api.mem0.ai"
 MAX_TAIL_LINES = 500
 MAX_USER_MESSAGES = 30
 MAX_BASH_COMMANDS = 20
@@ -179,24 +178,13 @@ def store_memory(api_key: str, content: str, user_id: str, source: str, session_
         "infer": True,
     }
 
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        f"{API_URL}/v3/memories/add/",
-        data=data,
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Token {api_key}",
-        },
-        method="POST",
-    )
-
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            if resp.status in (200, 201):
-                log.info("Session state stored successfully")
-                return True
-            log.warning("API returned status %d", resp.status)
-            return False
+        status, _result = add_memory(api_key, body, timeout=15)
+        if status in (200, 201):
+            log.info("Session state stored successfully")
+            return True
+        log.warning("API returned status %d", status)
+        return False
     except urllib.error.URLError as e:
         log.warning("API call failed: %s", e)
         return False

--- a/integrations/mem0-plugin/scripts/on_session_start.sh
+++ b/integrations/mem0-plugin/scripts/on_session_start.sh
@@ -32,6 +32,9 @@ if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
   echo "export MEM0_RESOLVED_USER_ID=\"${MEM0_RESOLVED_USER_ID:-${USER:-default}}\"" >> "$CLAUDE_ENV_FILE"
   echo "export MEM0_PROJECT_ID=\"${MEM0_PROJECT_ID:-unknown}\"" >> "$CLAUDE_ENV_FILE"
   echo "export MEM0_BRANCH=\"${MEM0_BRANCH:-unknown}\"" >> "$CLAUDE_ENV_FILE"
+  if [ -n "${MEM0_API_BASE:-}" ]; then
+    echo "export MEM0_API_BASE=\"$MEM0_API_BASE\"" >> "$CLAUDE_ENV_FILE"
+  fi
   if [ -n "${MEM0_API_KEY:-}" ]; then
     echo "export MEM0_API_KEY=\"$MEM0_API_KEY\"" >> "$CLAUDE_ENV_FILE"
   fi
@@ -41,6 +44,15 @@ if [ -z "${MEM0_API_KEY:-}" ]; then
   _UID="${MEM0_RESOLVED_USER_ID:-${USER:-default}}"
   _PID="${MEM0_PROJECT_ID:-unknown}"
   _BR="${MEM0_BRANCH:-unknown}"
+  if [ -n "${MEM0_API_BASE:-}" ]; then
+    _SETUP_HELP="- Set \`MEM0_API_KEY\` to a self-hosted server API key (prefix \`m0sk_\`)
+- Confirm \`MEM0_API_BASE=${MEM0_API_BASE}\` is reachable from this machine"
+  else
+    _SETUP_HELP="- **Reinstall the plugin**: Uninstall and reinstall — Claude Code will prompt for your API key during setup (stored securely in keychain)
+- **Desktop app**: Click the environment dropdown next to the prompt box → hover over **Local** → click the **gear icon** → add \`MEM0_API_KEY=m0-...\`
+- **CLI**: Add \`export MEM0_API_KEY=m0-...\` to your shell profile (~/.zshrc or ~/.bashrc)
+- Get a key at https://app.mem0.ai/dashboard/api-keys"
+  fi
   cat <<BANNER
 ## Mem0 — Setup Required
 
@@ -53,10 +65,7 @@ Mem0 — Setup Required | user=${_UID} | project=${_PID} | branch=${_BR} | auth=
 \`\`\`
 
 MEM0_API_KEY is not set. To configure:
-- **Reinstall the plugin**: Uninstall and reinstall — Claude Code will prompt for your API key during setup (stored securely in keychain)
-- **Desktop app**: Click the environment dropdown next to the prompt box → hover over **Local** → click the **gear icon** → add \`MEM0_API_KEY=m0-...\`
-- **CLI**: Add \`export MEM0_API_KEY=m0-...\` to your shell profile (~/.zshrc or ~/.bashrc)
-- Get a key at https://app.mem0.ai/dashboard/api-keys
+${_SETUP_HELP}
 
 Then invoke the \`mem0:onboard\` skill to complete setup.
 BANNER
@@ -71,26 +80,22 @@ fi
 
 MEM0_COUNT="?"
 if command -v python3 >/dev/null 2>&1; then
-  MEM0_COUNT=$(python3 -c "
-import json, os, urllib.request, urllib.error
+  MEM0_COUNT=$(PYTHONPATH="$SCRIPT_DIR" python3 -c "
+import os
+from _api import list_memories
 api_key = os.environ.get('MEM0_API_KEY', '')
 user_id = os.environ.get('MEM0_RESOLVED_USER_ID', 'default')
 app_id = os.environ.get('MEM0_PROJECT_ID', '')
 global_search = os.environ.get('MEM0_GLOBAL_SEARCH', 'false') == 'true'
 
 def get_count(filters):
-    body = json.dumps({'filters': filters}).encode()
-    req = urllib.request.Request(
-        'https://api.mem0.ai/v3/memories/?page=1&page_size=1',
-        headers={'Authorization': f'Token {api_key}', 'Content-Type': 'application/json'},
-        data=body, method='POST',
-    )
-    with urllib.request.urlopen(req, timeout=5) as r:
-        data = json.loads(r.read())
-        if isinstance(data, dict) and 'count' in data:
-            return data['count']
-        if isinstance(data, list):
-            return len(data)
+    _status, data = list_memories(api_key, {'filters': filters, 'page': 1, 'page_size': 1000}, timeout=5)
+    if isinstance(data, dict) and 'count' in data:
+        return data['count']
+    if isinstance(data, dict) and 'results' in data:
+        return len(data['results'])
+    if isinstance(data, list):
+        return len(data)
     return 0
 
 try:

--- a/integrations/mem0-plugin/scripts/on_session_start_cursor.sh
+++ b/integrations/mem0-plugin/scripts/on_session_start_cursor.sh
@@ -10,13 +10,22 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Pin platform so the shared script's telemetry is attributed to cursor.
 export MEM0_PLATFORM=cursor
+. "$SCRIPT_DIR/_identity.sh" 2>/dev/null || true
 
 TEXT=$("$SCRIPT_DIR/on_session_start.sh" 2>/dev/null || echo "")
 
-if [ -z "$TEXT" ]; then
-  echo '{}'
-  exit 0
-fi
-
-jq -cn --arg ctx "$TEXT" '{additional_context:$ctx}'
+jq -cn \
+  --arg ctx "$TEXT" \
+  --arg user_id "${MEM0_RESOLVED_USER_ID:-${USER:-default}}" \
+  --arg project_id "${MEM0_PROJECT_ID:-unknown}" \
+  --arg branch "${MEM0_BRANCH:-unknown}" \
+  --arg api_base "${MEM0_API_BASE:-}" \
+  '{
+    additional_context: $ctx,
+    env: ({
+      MEM0_RESOLVED_USER_ID: $user_id,
+      MEM0_PROJECT_ID: $project_id,
+      MEM0_BRANCH: $branch
+    } + (if $api_base == "" then {} else {MEM0_API_BASE: $api_base} end))
+  }'
 exit 0

--- a/integrations/mem0-plugin/scripts/session_timeline.py
+++ b/integrations/mem0-plugin/scripts/session_timeline.py
@@ -11,17 +11,15 @@ Output: Compact timeline text to stdout (empty if nothing found)
 
 from __future__ import annotations
 
-import json
 import os
 import sys
-import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _api import list_memories
 from _formatting import TYPE_ICONS, format_age
 from _identity import resolve_api_key, resolve_user_id
 from _project import resolve_project_id
 
-API_URL = "https://api.mem0.ai"
 MAX_RECENT = 10
 MAX_SUMMARIES = 3
 FETCH_TIMEOUT = 5
@@ -36,24 +34,17 @@ def fetch_recent_memories(api_key: str, user_id: str, project_id: str) -> list[d
     else:
         filters = {"AND": [{"user_id": user_id}, {"app_id": project_id}]}
 
-    body = json.dumps({"filters": filters}).encode()
-    req = urllib.request.Request(
-        f"{API_URL}/v3/memories/?page=1&page_size={MAX_RECENT}",
-        data=body,
-        headers={
-            "Authorization": f"Token {api_key}",
-            "Content-Type": "application/json",
-        },
-        method="POST",
-    )
     try:
-        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT) as r:
-            result = json.loads(r.read())
-            if isinstance(result, dict) and "results" in result:
-                return result["results"][:MAX_RECENT]
-            if isinstance(result, list):
-                return result[:MAX_RECENT]
-            return []
+        _status, result = list_memories(
+            api_key,
+            {"filters": filters, "page": 1, "page_size": MAX_RECENT},
+            timeout=FETCH_TIMEOUT,
+        )
+        if isinstance(result, dict) and "results" in result:
+            return result["results"][:MAX_RECENT]
+        if isinstance(result, list):
+            return result[:MAX_RECENT]
+        return []
     except Exception:
         return []
 

--- a/integrations/mem0-plugin/tests/test_self_hosted_api.py
+++ b/integrations/mem0-plugin/tests/test_self_hosted_api.py
@@ -1,0 +1,143 @@
+"""Tests for the hook REST transport adapter."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+def _response(payload: object, status: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status = status
+    response.read.return_value = json.dumps(payload).encode("utf-8")
+    response.__enter__ = lambda value: value
+    response.__exit__ = MagicMock(return_value=False)
+    return response
+
+
+def test_platform_is_the_unchanged_default(monkeypatch):
+    from _api import add_memory
+
+    monkeypatch.delenv("MEM0_API_BASE", raising=False)
+    captured = {}
+
+    def urlopen(request, timeout=None):
+        captured["request"] = request
+        return _response({"results": []})
+
+    with patch("urllib.request.urlopen", side_effect=urlopen):
+        add_memory("platform-key", {"messages": [], "user_id": "alice", "app_id": "repo"})
+
+    request = captured["request"]
+    assert request.full_url == "https://api.mem0.ai/v3/memories/add/"
+    assert request.get_header("Authorization") == "Token platform-key"
+    assert json.loads(request.data)["app_id"] == "repo"
+
+
+def test_self_hosted_add_maps_app_id_and_auth(monkeypatch):
+    from _api import add_memory
+
+    monkeypatch.setenv("MEM0_API_BASE", "https://memory.example.test/")
+    captured = {}
+
+    def urlopen(request, timeout=None):
+        captured["request"] = request
+        return _response({"results": []}, status=201)
+
+    with patch("urllib.request.urlopen", side_effect=urlopen):
+        status, _ = add_memory(
+            "self-hosted-key",
+            {"messages": [], "user_id": "alice", "app_id": "repo"},
+        )
+
+    request = captured["request"]
+    body = json.loads(request.data)
+    assert status == 201
+    assert request.full_url == "https://memory.example.test/memories"
+    assert request.get_header("X-api-key") == "self-hosted-key"
+    assert request.get_header("Authorization") is None
+    assert body["agent_id"] == "repo"
+    assert "app_id" not in body
+
+
+def test_explicit_agent_id_wins_over_app_id(monkeypatch):
+    from _api import add_memory
+
+    monkeypatch.setenv("MEM0_API_BASE", "https://memory.example.test")
+    captured = {}
+
+    def urlopen(request, timeout=None):
+        captured["body"] = json.loads(request.data)
+        return _response({"results": []})
+
+    with patch("urllib.request.urlopen", side_effect=urlopen):
+        add_memory(
+            "key",
+            {"messages": [], "user_id": "alice", "agent_id": "explicit", "app_id": "alias"},
+        )
+
+    assert captured["body"]["agent_id"] == "explicit"
+    assert "app_id" not in captured["body"]
+
+
+def test_self_hosted_search_maps_nested_app_id_and_drops_rerank(monkeypatch):
+    from _api import search_memories
+
+    monkeypatch.setenv("MEM0_API_BASE", "https://memory.example.test")
+    captured = {}
+
+    def urlopen(request, timeout=None):
+        captured["body"] = json.loads(request.data)
+        return _response({"results": []})
+
+    payload = {
+        "query": "decisions",
+        "filters": {"AND": [{"user_id": "alice"}, {"OR": [{"app_id": "repo"}]}]},
+        "top_k": 3,
+        "rerank": True,
+    }
+    with patch("urllib.request.urlopen", side_effect=urlopen):
+        search_memories("key", payload)
+
+    assert captured["body"]["filters"]["AND"][1] == {"OR": [{"agent_id": "repo"}]}
+    assert "rerank" not in captured["body"]
+
+
+def test_self_hosted_list_converts_supported_scopes_to_query(monkeypatch):
+    from _api import list_memories
+
+    monkeypatch.setenv("MEM0_API_BASE", "https://memory.example.test")
+    captured = {}
+
+    def urlopen(request, timeout=None):
+        captured["request"] = request
+        return _response({"results": []})
+
+    with patch("urllib.request.urlopen", side_effect=urlopen):
+        list_memories(
+            "key",
+            {
+                "filters": {"AND": [{"user_id": "alice"}, {"app_id": "repo"}]},
+                "page_size": 25,
+            },
+        )
+
+    assert captured["request"].full_url == (
+        "https://memory.example.test/memories?top_k=25&user_id=alice&agent_id=repo"
+    )
+
+
+def test_delete_memory_url_encodes_identifier(monkeypatch):
+    from _api import delete_memory
+
+    monkeypatch.setenv("MEM0_API_BASE", "https://memory.example.test")
+    captured = {}
+
+    def urlopen(request, timeout=None):
+        captured["request"] = request
+        return _response({"message": "deleted"})
+
+    with patch("urllib.request.urlopen", side_effect=urlopen):
+        delete_memory("key", "memory/with spaces")
+
+    assert captured["request"].full_url == "https://memory.example.test/memories/memory%2Fwith%20spaces"

--- a/server/main.py
+++ b/server/main.py
@@ -20,6 +20,7 @@ from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from mem0.exceptions import ValidationError as Mem0ValidationError
+from mcp_server import setup_mcp_server
 from models import RequestLog, User
 from pydantic import BaseModel, Field
 from rate_limit import limiter
@@ -169,6 +170,7 @@ app.include_router(auth_router.router)
 app.include_router(api_keys_router.router)
 app.include_router(entities_router.router)
 app.include_router(requests_router.router)
+setup_mcp_server(app)
 
 
 class Message(BaseModel):

--- a/server/mcp_server.py
+++ b/server/mcp_server.py
@@ -1,0 +1,234 @@
+"""Minimal MCP facade for the self-hosted Mem0 server.
+
+The tools call the same in-process ``Memory`` instance used by the REST routes.
+The transport is stateless Streamable HTTP and reuses the server's existing
+authentication dependency, including ``X-API-Key`` support.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+from typing import Annotated, Any
+
+import anyio
+from fastapi import APIRouter, Depends, Request
+from mcp.server.fastmcp import FastMCP
+from mcp.server.streamable_http import StreamableHTTPServerTransport
+from pydantic import Field
+from starlette.responses import Response
+
+from auth import verify_auth
+from server_state import get_memory_instance
+
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP("mem0-self-hosted")
+mcp_router = APIRouter()
+_is_admin: contextvars.ContextVar[bool] = contextvars.ContextVar("mcp_is_admin", default=False)
+
+
+def _map_app_id(payload: dict[str, Any]) -> dict[str, Any]:
+    """Map the hosted API's ``app_id`` alias to self-hosted ``agent_id``."""
+    mapped = dict(payload)
+    app_id = mapped.pop("app_id", None)
+    if app_id and not mapped.get("agent_id"):
+        mapped["agent_id"] = app_id
+    return mapped
+
+
+def _scope_filters(
+    filters: dict[str, Any] | None,
+    *,
+    user_id: str | None,
+    agent_id: str | None,
+    app_id: str | None,
+    run_id: str | None,
+) -> dict[str, Any]:
+    """Merge explicit MCP scope arguments with caller-provided filters."""
+    mapped_scope = _map_app_id(
+        {"user_id": user_id, "agent_id": agent_id, "app_id": app_id, "run_id": run_id}
+    )
+    scope = {key: value for key, value in mapped_scope.items() if value}
+    if not scope:
+        raise ValueError("Provide at least one of user_id, agent_id/app_id, or run_id.")
+    if not filters:
+        return scope
+    return {"AND": [scope, filters]}
+
+
+def _tool_failure(exc: Exception) -> dict[str, str]:
+    """Return a stable MCP error without leaking provider details."""
+    if isinstance(exc, ValueError):
+        return {"error": "invalid_request", "detail": str(exc)}
+    logger.exception("Mem0 MCP tool failed")
+    return {"error": "memory_operation_failed", "detail": "The memory operation failed."}
+
+
+@mcp.tool(description="Store a durable fact, preference, project decision, or task learning.")
+def add_memory(
+    text: Annotated[str | None, Field(description="Plain text to store.")] = None,
+    messages: Annotated[
+        list[dict[str, str]] | None,
+        Field(description="Optional role/content messages. Takes precedence over text."),
+    ] = None,
+    user_id: Annotated[str | None, Field(description="User scope.")] = None,
+    agent_id: Annotated[str | None, Field(description="Agent/project scope.")] = None,
+    app_id: Annotated[str | None, Field(description="Hosted-compatible alias for agent_id.")] = None,
+    run_id: Annotated[str | None, Field(description="Run/session scope.")] = None,
+    metadata: Annotated[dict[str, Any] | None, Field(description="Optional memory metadata.")] = None,
+    infer: Annotated[bool, Field(description="Extract memories from the supplied messages.")] = True,
+) -> dict[str, Any]:
+    try:
+        if messages is None:
+            if not text:
+                raise ValueError("Provide text or messages.")
+            messages = [{"role": "user", "content": text}]
+
+        scope = _map_app_id(
+            {"user_id": user_id, "agent_id": agent_id, "app_id": app_id, "run_id": run_id}
+        )
+        scope = {key: value for key, value in scope.items() if value}
+        if not scope:
+            raise ValueError("Provide at least one of user_id, agent_id/app_id, or run_id.")
+
+        params: dict[str, Any] = {**scope, "metadata": metadata, "infer": infer}
+        return get_memory_instance().add(
+            messages=messages,
+            **{key: value for key, value in params.items() if value is not None},
+        )
+    except Exception as exc:
+        return _tool_failure(exc)
+
+
+@mcp.tool(description="Search long-term memories relevant to a natural-language query.")
+def search_memories(
+    query: Annotated[str, Field(description="Natural-language search query.")],
+    user_id: Annotated[str | None, Field(description="User scope.")] = None,
+    agent_id: Annotated[str | None, Field(description="Agent/project scope.")] = None,
+    app_id: Annotated[str | None, Field(description="Hosted-compatible alias for agent_id.")] = None,
+    run_id: Annotated[str | None, Field(description="Run/session scope.")] = None,
+    filters: Annotated[dict[str, Any] | None, Field(description="Additional structured filters.")] = None,
+    top_k: Annotated[int, Field(ge=1, le=100, description="Maximum number of results.")] = 10,
+    threshold: Annotated[float | None, Field(description="Optional minimum similarity score.")] = None,
+) -> dict[str, Any]:
+    try:
+        scoped = _scope_filters(
+            filters,
+            user_id=user_id,
+            agent_id=agent_id,
+            app_id=app_id,
+            run_id=run_id,
+        )
+        params: dict[str, Any] = {"filters": scoped, "top_k": top_k}
+        if threshold is not None:
+            params["threshold"] = threshold
+        return get_memory_instance().search(query=query, **params)
+    except Exception as exc:
+        return _tool_failure(exc)
+
+
+@mcp.tool(description="List memories in a user, project/agent, or run scope.")
+def get_memories(
+    user_id: Annotated[str | None, Field(description="User scope.")] = None,
+    agent_id: Annotated[str | None, Field(description="Agent/project scope.")] = None,
+    app_id: Annotated[str | None, Field(description="Hosted-compatible alias for agent_id.")] = None,
+    run_id: Annotated[str | None, Field(description="Run/session scope.")] = None,
+    filters: Annotated[dict[str, Any] | None, Field(description="Additional structured filters.")] = None,
+    top_k: Annotated[int, Field(ge=1, le=1000, description="Maximum number of memories.")] = 100,
+) -> dict[str, Any]:
+    try:
+        scoped = _scope_filters(
+            filters,
+            user_id=user_id,
+            agent_id=agent_id,
+            app_id=app_id,
+            run_id=run_id,
+        )
+        return get_memory_instance().get_all(filters=scoped, top_k=top_k)
+    except Exception as exc:
+        return _tool_failure(exc)
+
+
+@mcp.tool(description="Delete every memory in one explicit user, project/agent, or run scope.")
+def delete_all_memories(
+    user_id: Annotated[str | None, Field(description="User scope.")] = None,
+    agent_id: Annotated[str | None, Field(description="Agent/project scope.")] = None,
+    app_id: Annotated[str | None, Field(description="Hosted-compatible alias for agent_id.")] = None,
+    run_id: Annotated[str | None, Field(description="Run/session scope.")] = None,
+) -> dict[str, Any]:
+    try:
+        if not _is_admin.get():
+            return {"error": "forbidden", "detail": "Admin authentication is required for bulk deletion."}
+        scope = _map_app_id(
+            {"user_id": user_id, "agent_id": agent_id, "app_id": app_id, "run_id": run_id}
+        )
+        scope = {key: value for key, value in scope.items() if value}
+        if len(scope) != 1:
+            raise ValueError("Provide exactly one of user_id, agent_id/app_id, or run_id.")
+        get_memory_instance().delete_all(**scope)
+        return {"message": "All relevant memories deleted"}
+    except Exception as exc:
+        return _tool_failure(exc)
+
+
+@mcp_router.api_route("/mcp", methods=["POST", "GET", "DELETE"], include_in_schema=False)
+async def handle_mcp(request: Request, authenticated_user=Depends(verify_auth)) -> Response:
+    """Serve one stateless Streamable HTTP MCP request."""
+    auth_type = getattr(request.state, "auth_type", "none")
+    admin = auth_type in {"admin_api_key", "disabled"} or (
+        authenticated_user is not None and authenticated_user.role == "admin"
+    )
+    admin_token = _is_admin.set(admin)
+
+    response_started = False
+    response_status = 200
+    response_headers: list[tuple[bytes, bytes]] = []
+    response_body = bytearray()
+
+    async def capture_send(message: dict[str, Any]) -> None:
+        nonlocal response_started, response_status
+        if message["type"] == "http.response.start":
+            response_started = True
+            response_status = message["status"]
+            response_headers.extend(message.get("headers", []))
+        elif message["type"] == "http.response.body":
+            response_body.extend(message.get("body", b""))
+
+    try:
+        transport = StreamableHTTPServerTransport(
+            mcp_session_id=None,
+            is_json_response_enabled=True,
+        )
+        async with anyio.create_task_group() as task_group:
+
+            async def run_server(*, task_status=anyio.TASK_STATUS_IGNORED):
+                async with transport.connect() as (read_stream, write_stream):
+                    task_status.started()
+                    await mcp._mcp_server.run(
+                        read_stream,
+                        write_stream,
+                        mcp._mcp_server.create_initialization_options(),
+                        stateless=True,
+                    )
+
+            await task_group.start(run_server)
+            await transport.handle_request(request.scope, request.receive, capture_send)
+            await transport.terminate()
+            task_group.cancel_scope.cancel()
+    finally:
+        _is_admin.reset(admin_token)
+
+    if not response_started:
+        return Response(status_code=500, content="MCP transport did not produce a response.")
+
+    return Response(
+        content=bytes(response_body),
+        status_code=response_status,
+        headers={key.decode(): value.decode() for key, value in response_headers},
+    )
+
+
+def setup_mcp_server(app) -> None:
+    """Register the self-hosted MCP endpoint on a FastAPI application."""
+    app.include_router(mcp_router)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.115.8
 uvicorn==0.34.0
-pydantic[email]==2.10.4
+pydantic[email]==2.11.10
 mem0ai>=0.1.48
 python-dotenv==1.2.2
 psycopg>=3.2.8
@@ -24,3 +24,6 @@ posthog>=3.0,<8.0
 
 # Per-IP rate limiting on auth endpoints
 slowapi>=0.1.9,<1.0
+
+# Model Context Protocol endpoint for coding agents
+mcp>=1.25.0,<2.0

--- a/tests/test_server_mcp.py
+++ b/tests/test_server_mcp.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from auth import verify_auth
+from server.mcp_server import (
+    _is_admin,
+    _map_app_id,
+    _scope_filters,
+    add_memory,
+    delete_all_memories,
+    get_memories,
+    mcp_router,
+    search_memories,
+)
+
+
+def test_map_app_id_preserves_explicit_agent_id():
+    assert _map_app_id({"app_id": "alias", "agent_id": "explicit"}) == {"agent_id": "explicit"}
+
+
+def test_scope_filters_maps_app_id_and_combines_metadata():
+    filters = _scope_filters(
+        {"metadata": {"type": "decision"}},
+        user_id="alice",
+        agent_id=None,
+        app_id="repo",
+        run_id=None,
+    )
+
+    assert filters == {
+        "AND": [
+            {"user_id": "alice", "agent_id": "repo"},
+            {"metadata": {"type": "decision"}},
+        ]
+    }
+
+
+def test_scope_filters_rejects_unscoped_access():
+    with pytest.raises(ValueError, match="at least one"):
+        _scope_filters(None, user_id=None, agent_id=None, app_id=None, run_id=None)
+
+
+@patch("server.mcp_server.get_memory_instance")
+def test_add_memory_uses_shared_memory_instance(get_memory_instance):
+    memory = Mock()
+    memory.add.return_value = {"results": [{"id": "memory-1"}]}
+    get_memory_instance.return_value = memory
+
+    result = add_memory(text="Use Postgres", user_id="alice", app_id="repo")
+
+    assert result == {"results": [{"id": "memory-1"}]}
+    memory.add.assert_called_once_with(
+        messages=[{"role": "user", "content": "Use Postgres"}],
+        user_id="alice",
+        agent_id="repo",
+        infer=True,
+    )
+
+
+@patch("server.mcp_server.get_memory_instance")
+def test_search_memory_is_scoped(get_memory_instance):
+    memory = Mock()
+    memory.search.return_value = {"results": []}
+    get_memory_instance.return_value = memory
+
+    search_memories(query="database", user_id="alice", app_id="repo", top_k=5)
+
+    memory.search.assert_called_once_with(
+        query="database",
+        filters={"user_id": "alice", "agent_id": "repo"},
+        top_k=5,
+    )
+
+
+@patch("server.mcp_server.get_memory_instance")
+def test_get_memories_is_scoped(get_memory_instance):
+    memory = Mock()
+    memory.get_all.return_value = {"results": []}
+    get_memory_instance.return_value = memory
+
+    get_memories(user_id="alice", app_id="repo", top_k=20)
+
+    memory.get_all.assert_called_once_with(
+        filters={"user_id": "alice", "agent_id": "repo"},
+        top_k=20,
+    )
+
+
+@patch("server.mcp_server.get_memory_instance")
+def test_delete_all_requires_admin(get_memory_instance):
+    result = delete_all_memories(user_id="alice")
+
+    assert result["error"] == "forbidden"
+    get_memory_instance.assert_not_called()
+
+
+@patch("server.mcp_server.get_memory_instance")
+def test_delete_all_allows_one_scope_for_admin(get_memory_instance):
+    memory = Mock()
+    get_memory_instance.return_value = memory
+    token = _is_admin.set(True)
+    try:
+        result = delete_all_memories(app_id="repo")
+    finally:
+        _is_admin.reset(token)
+
+    assert result == {"message": "All relevant memories deleted"}
+    memory.delete_all.assert_called_once_with(agent_id="repo")
+
+
+def test_streamable_http_protocol_lists_public_tools():
+    app = FastAPI()
+    app.include_router(mcp_router)
+    app.dependency_overrides[verify_auth] = lambda: Mock(role="user")
+
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {},
+    }
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp",
+            json=request,
+            headers={"Accept": "application/json, text/event-stream"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["jsonrpc"] == "2.0"
+    assert payload["id"] == 1
+    assert {tool["name"] for tool in payload["result"]["tools"]} == {
+        "add_memory",
+        "search_memories",
+        "get_memories",
+        "delete_all_memories",
+    }
+
+
+@patch("server.mcp_server.get_memory_instance")
+def test_streamable_http_protocol_calls_tool(get_memory_instance):
+    memory = Mock()
+    memory.search.return_value = {"results": [{"id": "memory-1", "memory": "Use Postgres"}]}
+    get_memory_instance.return_value = memory
+
+    app = FastAPI()
+    app.include_router(mcp_router)
+    app.dependency_overrides[verify_auth] = lambda: Mock(role="user")
+
+    request = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "search_memories",
+            "arguments": {
+                "query": "database",
+                "user_id": "alice",
+                "app_id": "repo",
+                "top_k": 5,
+            },
+        },
+    }
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp",
+            json=request,
+            headers={"Accept": "application/json, text/event-stream"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["jsonrpc"] == "2.0"
+    assert payload["id"] == 2
+    assert payload["result"]["isError"] is False
+    memory.search.assert_called_once_with(
+        query="database",
+        filters={"user_id": "alice", "agent_id": "repo"},
+        top_k=5,
+    )
+
+
+def test_streamable_http_protocol_requires_authentication():
+    async def reject_auth():
+        raise HTTPException(status_code=401, detail="Authentication required.")
+
+    app = FastAPI()
+    app.include_router(mcp_router)
+    app.dependency_overrides[verify_auth] = reject_auth
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {}},
+            headers={"Accept": "application/json, text/event-stream"},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Authentication required."}


### PR DESCRIPTION
## Linked Issue

Closes #6370

## Description

Adds self-hosted memory support for Cursor while preserving the existing Mem0 Platform behavior when `MEM0_API_BASE` is unset.

- Adds a shared REST adapter with `X-API-Key` authentication and `app_id` to `agent_id` scope mapping.
- Updates Cursor session bootstrap and removes unsupported per-prompt prefetch.
- Adds an authenticated Streamable HTTP `/mcp` endpoint backed by the server's shared in-process memory service.
- Exposes scoped `add_memory`, `search_memories`, `get_memories`, and admin-only `delete_all_memories` tools.
- Adds REST seam and protocol-level MCP tests for tool listing, calls, and authentication.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. Existing Platform behavior remains the default when `MEM0_API_BASE` is unset.

## Test Coverage

- [x] I added/updated unit tests
- [x] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Validation performed:

- Docker server image builds successfully.
- 174 plugin regression and MCP tests pass.
- Ruff passes for all touched Python files.
- Shell syntax, hook JSON, and `git diff --check` pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed