### PR TITLE
fix(ts-oss): close hash-dedup TOCTOU race in add() with per-scope lock

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -205,6 +205,20 @@ export class Memory {
   private _initError?: Error;
   private _entityStore?: VectorStore;
 
+  // Per-session-scope mutex for the dedup-recheck + insert step in
+  // addToVectorStore, so concurrent add() calls extracting the same fact can't
+  // both pass a stale dedup snapshot and both insert (the hash-dedup TOCTOU
+  // race). Keyed by session scope (user_id/agent_id/run_id) so add() calls for
+  // different scopes — which can never hash-collide — don't serialize against
+  // each other; only same-scope callers do. Each map value is the tail of a
+  // promise chain; a caller awaits the current tail, then installs its own.
+  //
+  // Scope of protection: this map lives on the Memory instance, so it only
+  // serializes callers sharing one instance in one process. It does NOT
+  // coordinate across multiple processes/workers — that would need a
+  // shared/distributed lock and is out of scope here.
+  private addLocks: Map<string, Promise<void>> = new Map();
+
   constructor(config: Partial<MemoryConfig> = {}) {
     // Merge and validate config
     this.config = ConfigManager.mergeConfig(config);
@@ -563,6 +577,38 @@ export class Memory {
       if (val) parts.push(`${key}=${val}`);
     }
     return parts.join("&");
+  }
+
+  /**
+   * Serialize `fn` against all other callers sharing the same session scope.
+   * Runs `fn` only after the previous same-scope holder has released, so the
+   * dedup-recheck + insert step is atomic per scope. Different scopes run
+   * concurrently. The map entry is cleaned up once the chain drains, so it
+   * doesn't grow unbounded across distinct scopes.
+   */
+  private async withAddLock<T>(
+    scope: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.addLocks.get(scope) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => gate);
+    this.addLocks.set(scope, tail);
+
+    await previous;
+    try {
+      return await fn();
+    } finally {
+      release();
+      // If no later caller chained onto our tail, drop the entry so the map
+      // doesn't retain a lock object per distinct scope forever.
+      if (this.addLocks.get(scope) === tail) {
+        this.addLocks.delete(scope);
+      }
+    }
   }
 
   private async _initializeTelemetry() {
@@ -976,14 +1022,9 @@ export class Memory {
       }
     }
 
-    // Phase 4-5: CPU processing + hash dedup
-    const existingHashes = new Set<string>();
-    for (const mem of existingResults) {
-      const h = mem.payload?.hash;
-      if (h) existingHashes.add(h);
-    }
-
-    const records: Array<{
+    // Phase 4: CPU processing (intra-batch dedup only; the against-existing
+    // dedup is re-checked under the lock right before insert, see Phase 5/6).
+    let records: Array<{
       memoryId: string;
       text: string;
       embedding: number[];
@@ -996,7 +1037,7 @@ export class Memory {
       if (!text || !(text in embedMap)) continue;
 
       const memHash = createHash("md5").update(text).digest("hex");
-      if (existingHashes.has(memHash) || seenHashes.has(memHash)) {
+      if (seenHashes.has(memHash)) {
         continue;
       }
       seenHashes.add(memHash);
@@ -1043,26 +1084,66 @@ export class Memory {
       return [];
     }
 
-    // Phase 6: Batch persist
-    const allVectors = records.map((r) => r.embedding);
-    const allIds = records.map((r) => r.memoryId);
-    const allPayloads = records.map((r) => r.payload);
+    // Phase 5: Hash dedup + Phase 6: Batch persist, serialized per scope.
+    // The Phase 1 snapshot (existingResults) can go stale by the time we get
+    // here — an LLM round-trip plus embedding calls have happened since. Under
+    // the session-scoped lock we re-fetch existing hashes fresh and drop any
+    // record that now collides, then insert. This closes the TOCTOU window:
+    // two concurrent add() calls extracting the same fact can no longer both
+    // pass dedup and both insert a permanent duplicate. Only same-scope callers
+    // serialize here.
+    const inserted = await this.withAddLock(sessionScope, async () => {
+      const freshExisting = await this.vectorStore.search(
+        queryEmbedding,
+        10,
+        filters,
+      );
+      const freshHashes = new Set<string>();
+      for (const mem of freshExisting) {
+        const h = mem.payload?.hash;
+        if (h) freshHashes.add(h);
+      }
+      records = records.filter((r) => !freshHashes.has(r.payload.hash));
+      if (records.length === 0) return false;
 
-    try {
-      await this.vectorStore.insert(allVectors, allIds, allPayloads);
-    } catch {
-      // Fallback: insert one by one
-      for (let i = 0; i < allIds.length; i++) {
-        try {
-          await this.vectorStore.insert(
-            [allVectors[i]],
-            [allIds[i]],
-            [allPayloads[i]],
-          );
-        } catch (e) {
-          console.error(`Failed to insert memory ${allIds[i]}: ${e}`);
+      const allVectors = records.map((r) => r.embedding);
+      const allIds = records.map((r) => r.memoryId);
+      const allPayloads = records.map((r) => r.payload);
+
+      try {
+        await this.vectorStore.insert(allVectors, allIds, allPayloads);
+      } catch {
+        // Fallback: insert one by one
+        for (let i = 0; i < allIds.length; i++) {
+          try {
+            await this.vectorStore.insert(
+              [allVectors[i]],
+              [allIds[i]],
+              [allPayloads[i]],
+            );
+          } catch (e) {
+            console.error(`Failed to insert memory ${allIds[i]}: ${e}`);
+          }
         }
       }
+      return true;
+    });
+
+    if (!inserted) {
+      // Everything we extracted was already persisted by a concurrent same-scope
+      // add() that won the race; nothing new to store.
+      if (typeof this.db.saveMessages === "function") {
+        try {
+          await this.db.saveMessages(
+            messages.map((m) => ({
+              role: m.role,
+              content: m.content as string,
+            })),
+            sessionScope,
+          );
+        } catch {}
+      }
+      return [];
     }
 
     // Batch history

--- a/mem0-ts/src/oss/tests/memory.dedup-race.test.ts
+++ b/mem0-ts/src/oss/tests/memory.dedup-race.test.ts
@@ -1,0 +1,108 @@
+/**
+ * OSS Memory unit tests — hash-dedup TOCTOU race in add().
+ *
+ * Two concurrent add() calls that extract the identical fact for the same scope
+ * take their Phase-1 "existing memories" snapshot before either has inserted.
+ * Without a fresh recheck under a per-scope lock right before insert, both pass
+ * dedup against the same stale snapshot and both insert, producing a permanent
+ * duplicate. The LLM mock is intentionally delayed to widen the race window.
+ */
+/// <reference types="jest" />
+import { Memory } from "../src/memory";
+import type { MemoryConfig, SearchResult } from "../src/types";
+
+jest.setTimeout(15000);
+
+// Mock Google modules to prevent @google/genai crash in CI
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
+
+// LLM always extracts the SAME fact, after a delay that widens the race window.
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return JSON.stringify({
+        memory: [{ id: "0", text: "User likes coffee", attributed_to: "user" }],
+      });
+    }),
+  })),
+}));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 1536,
+  })),
+}));
+
+function createMemory(overrides: Partial<MemoryConfig> = {}): Memory {
+  return new Memory({
+    version: "v1.1",
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-dedup-race-${Date.now()}`,
+        dimension: 1536,
+        dbPath: ":memory:",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-5-mini" },
+    },
+    historyDbPath: ":memory:",
+    ...overrides,
+  });
+}
+
+describe("Memory - add() hash-dedup TOCTOU race", () => {
+  test("two concurrent add() calls for the same fact persist only one memory", async () => {
+    const memory = createMemory();
+    const userId = `race_same_${Date.now()}`;
+
+    await Promise.all([
+      memory.add("I really like coffee", { userId }),
+      memory.add("I really like coffee", { userId }),
+    ]);
+
+    const all: SearchResult = await memory.getAll({
+      filters: { user_id: userId },
+    });
+    expect(all.results.length).toBe(1);
+
+    await memory.reset();
+  });
+
+  test("concurrent add() for different scopes each persist (no false cross-scope dedup)", async () => {
+    const memory = createMemory();
+    const u1 = `race_u1_${Date.now()}`;
+    const u2 = `race_u2_${Date.now()}`;
+
+    await Promise.all([
+      memory.add("I really like coffee", { userId: u1 }),
+      memory.add("I really like coffee", { userId: u2 }),
+    ]);
+
+    const a1: SearchResult = await memory.getAll({ filters: { user_id: u1 } });
+    const a2: SearchResult = await memory.getAll({ filters: { user_id: u2 } });
+    expect(a1.results.length).toBe(1);
+    expect(a2.results.length).toBe(1);
+
+    await memory.reset();
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6531

## Description

TypeScript twin of #6516 (Python). `addToVectorStore` (`mem0-ts/src/oss/src/memory/index.ts`) takes a snapshot of existing memories in Phase 1 (`existingResults = await this.vectorStore.search(...)`), then checks the hash-dedup guard against that same snapshot in Phase 4/5 — after an LLM extraction round-trip and embedding calls. Two `add()` calls extracting the identical fact for the same scope, awaited concurrently (`Promise.all`, a retried request, two parallel agent turns), both take their snapshot before either inserts, both pass dedup, and both insert — creating a permanent duplicate memory (same `hash`, different `id`), silently.

Node's single event loop does **not** prevent this: the interleaving `await`s between the snapshot and the insert are exactly the race window — a purely-async TOCTOU, not a thread race.

This PR serializes the dedup-recheck + insert step with a **per-session-scope async mutex** — a lazily-populated promise-chain keyed by session scope (`user_id`/`agent_id`/`run_id`), so `add()` calls for **different** scopes (which can never hash-collide) don't serialize against each other; only same-scope callers do. Inside the lock it re-fetches existing hashes fresh and drops any record that now collides, then inserts. The map entry is cleaned up once its chain drains, so it doesn't grow unbounded across distinct scopes.

### Scope / limitation

The lock map lives on the `Memory` instance, so it only serializes callers sharing one instance in one process. It does **not** coordinate across multiple processes/workers — that would need a shared/distributed lock and is out of scope here. Documented inline. Matches the Python fix's stated guarantee in #6516.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — no public API changes. One extra `vectorStore.search()` runs per `add()` that produces at least one record (same cost class as the existing Phase 1 search), only when there's something to persist.

## Test Coverage

- [x] I added/updated unit tests

New `mem0-ts/src/oss/tests/memory.dedup-race.test.ts`:
- `two concurrent add() calls for the same fact persist only one memory` — `Promise.all` of two same-scope adds, deterministic delayed LLM mock to widen the race window, real in-memory vector store; asserts `getAll` returns 1.
- `concurrent add() for different scopes each persist (no false cross-scope dedup)` — two different-user adds concurrently; asserts each scope keeps its own memory.

**Proof — red on `upstream/main`, green with the fix** (`index.ts` reverted to `upstream/main`, then restored):

```
# BEFORE (raw upstream/main index.ts — dedup only vs the stale Phase 1 snapshot):
$ npx jest --config jest.config.js src/oss/tests/memory.dedup-race.test.ts
  ✕ two concurrent add() calls for the same fact persist only one memory
    expect(received).toBe(expected)  Expected: 1  Received: 2
  ✓ concurrent add() for different scopes each persist (no false cross-scope dedup)
  Tests: 1 failed, 1 passed

# AFTER (this branch — per-scope async mutex + fresh in-lock recheck):
$ npx jest --config jest.config.js src/oss/tests/memory.dedup-race.test.ts
  ✓ two concurrent add() calls for the same fact persist only one memory
  ✓ concurrent add() for different scopes each persist (no false cross-scope dedup)
  Tests: 2 passed

# Related suites + build, clean on this branch:
$ npx jest --config jest.config.js memory.add memory.crud memory.dedup-race
  Tests: 65 passed
$ npx prettier --check <changed files>   # All matched files use Prettier code style!
$ npx tsc --noEmit                       # 26 errors, all pre-existing on main, none in changed files
$ pnpm run build                         # Build success
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A — internal concurrency fix, no public API/doc change; scope limitation documented inline)
