### PR TITLE
fix(ts-oss): give the reranker the full candidate pool, not the truncated topK

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1548,13 +1548,21 @@ export class Memory {
         payload: mem.payload || {},
       }));
 
-    // Step 8: Score and rank
+    // Step 8: Score and rank.
+    // When a reranker will run, return the full over-fetched pool (internalLimit)
+    // instead of truncating to `topK` here, so the reranker can surface relevant
+    // memories the first-stage scorer ranked below `topK`. Without this,
+    // scoreAndRank truncates to `topK` before Step 10, so reranking could only
+    // reorder the final results, never improve recall. The DB fetch is NOT
+    // re-widened — internalLimit is still computed once from `topK`.
+    const rerankActive = Boolean(config.rerank && this.reranker);
+    const returnK = rerankActive ? internalLimit : topK;
     const scoredResults = scoreAndRank(
       candidates,
       bm25Scores,
       entityBoosts,
       threshold ?? 0.1,
-      topK,
+      returnK,
       explain,
     );
 
@@ -1594,11 +1602,15 @@ export class Memory {
       });
 
     // Step 10: Optionally re-rank with the configured reranker. Opt-in per
-    // search via `rerank: true`; a no-op when no reranker is configured.
+    // search via `rerank: true`; a no-op when no reranker is configured. The
+    // reranker receives the full candidate pool (Step 8) and narrows it back to
+    // `topK`.
     const invokeReranker = Boolean(
       config.rerank && this.reranker && results.length > 0,
     );
-    let finalResults = results;
+    // When reranking, `results` holds the full over-fetched pool; if the rerank
+    // call fails we must trim back to `topK` rather than leak the whole pool.
+    let finalResults = rerankActive ? results.slice(0, topK) : results;
     if (invokeReranker) {
       try {
         const ranked = await this.reranker!.rerank(

--- a/mem0-ts/src/oss/tests/memory.rerank.test.ts
+++ b/mem0-ts/src/oss/tests/memory.rerank.test.ts
@@ -181,4 +181,79 @@ describe("Memory.search reranking", () => {
 
     expect((memory as any).reranker).toBeInstanceOf(CohereReranker);
   });
+
+  // Prime the store with `n` semantic results (descending score), so the
+  // candidate pool is larger than a small topK.
+  async function primeSearchN(m: any, n: number) {
+    await m._ensureInitialized();
+    m.embedder = { embed: jest.fn().mockResolvedValue(mockEmbedding) };
+    m.vectorStore.search = jest.fn().mockResolvedValue(
+      Array.from({ length: n }, (_, i) => ({
+        id: `m${i}`,
+        score: 1 - i * 0.01,
+        payload: { data: `doc${i}` },
+      })),
+    );
+    m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
+  }
+
+  it("hands the reranker the full candidate pool, not the truncated topK", async () => {
+    const memory = createMemory();
+    const m = memory as any;
+    const POOL = 8;
+    const FINAL = 3;
+    await primeSearchN(m, POOL);
+
+    const rerank = jest
+      .fn<Promise<RerankResult[]>, [string, string[], number?]>()
+      .mockImplementation(async (_q, memories, topK) =>
+        // Narrow whatever pool we received down to the final topK.
+        memories
+          .slice(0, topK)
+          .map((_mem, index) => ({ index, rerankScore: 1 - index * 0.1 })),
+      );
+    m.reranker = { rerank };
+
+    const result = await m.search("q", {
+      filters: { user_id: "u1" },
+      topK: FINAL,
+      rerank: true,
+    });
+
+    // Reranker must have seen the full over-fetched pool (> final topK)...
+    const pooledInput = rerank.mock.calls[0][1];
+    expect(pooledInput.length).toBeGreaterThan(FINAL);
+    expect(pooledInput.length).toBe(POOL);
+    // ...been asked to narrow to the final topK...
+    expect(rerank.mock.calls[0][2]).toBe(FINAL);
+    // ...and the final results still respect topK.
+    expect(result.results.length).toBe(FINAL);
+
+    await memory.reset();
+  });
+
+  it("trims the over-fetched pool back to topK when the reranker throws", async () => {
+    const memory = createMemory();
+    const m = memory as any;
+    const POOL = 8;
+    const FINAL = 3;
+    await primeSearchN(m, POOL);
+    m.reranker = {
+      rerank: jest.fn().mockRejectedValue(new Error("provider down")),
+    };
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await m.search("q", {
+      filters: { user_id: "u1" },
+      topK: FINAL,
+      rerank: true,
+    });
+
+    // Failure must not leak the whole over-fetched pool.
+    expect(result.results.length).toBe(FINAL);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    await memory.reset();
+  });
 });


### PR DESCRIPTION
## Linked Issue

Closes #6536

## Description

TypeScript twin of #6449 (Python). `Memory.search()` (`mem0-ts/src/oss/src/memory/index.ts`) over-fetches a candidate pool (`internalLimit = Math.max(topK * 4, 60)`), but `scoreAndRank(..., topK, ...)` truncates the ranked output to `topK` **before** the reranker runs (Step 10). So the reranker only ever receives the already-truncated top-`topK` set — it can reorder those, but can never surface a relevant memory that the first-stage scorer ranked at `topK+1..N`, defeating the two-stage retrieve-then-rerank design. With reranking on, recall ends up identical to reranking off.

This PR: when a reranker will run, `scoreAndRank` returns the full over-fetched pool (`internalLimit`) instead of truncating to `topK`; the reranker then narrows it back to `topK`. If the rerank call fails, the fallback trims to `topK` so a failure doesn't leak the whole pool. The DB fetch is **not** re-widened — `internalLimit` is still computed once from `topK` (no double-widening; the single-method TS `search()` doesn't have the caller/callee split that #6449 had to untangle on the Python side).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — no public API change. Non-rerank path is unchanged (`returnK === topK`).

## Test Coverage

- [x] I added/updated unit tests

Two new cases in `mem0-ts/src/oss/tests/memory.rerank.test.ts`:
- `hands the reranker the full candidate pool, not the truncated topK` — primes an 8-item pool with `topK: 3`; asserts the reranker receives the full 8 (> topK), is asked to narrow to 3, and the final result is 3.
- `trims the over-fetched pool back to topK when the reranker throws` — same pool; a failing reranker must yield exactly `topK`, not the whole pool.

**Proof — red on `upstream/main`, green with the fix** (`index.ts` reverted to `upstream/main`, then restored):

```
# BEFORE (raw upstream/main — scoreAndRank truncates to topK before rerank):
$ npx jest --config jest.config.js src/oss/tests/memory.rerank.test.ts
  ✕ hands the reranker the full candidate pool, not the truncated topK
  (6 others pass)
  Tests: 1 failed, 6 passed

# AFTER (this branch):
$ npx jest --config jest.config.js src/oss/tests/memory.rerank.test.ts
  Tests: 7 passed

# Related suites + build, clean on this branch:
$ npx jest ... memory.rerank memory.add memory.crud memory.dedup-race   # 68 passed
$ npx prettier --check <changed files>   # All matched files use Prettier code style!
$ npx tsc --noEmit                       # 26 errors, all pre-existing on main, none in changed files
$ pnpm run build                         # Build success
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A — internal retrieval fix, no public API/doc change)
