### PR TITLE
fix(llms/lmstudio): honor `LMSTUDIO_BASE_URL` env var

### DIFF
--- a/mem0/configs/llms/lmstudio.py
+++ b/mem0/configs/llms/lmstudio.py
@@ -55,5 +55,7 @@ class LMStudioConfig(BaseLlmConfig):
         )
 
         # LM Studio-specific parameters
-        self.lmstudio_base_url = lmstudio_base_url or "http://localhost:1234/v1"
+        # Do NOT default here: keep `None` so LMStudioLLM can resolve
+        # config > LMSTUDIO_BASE_URL env > default (see #6526).
+        self.lmstudio_base_url = lmstudio_base_url
         self.lmstudio_response_format = lmstudio_response_format

--- a/mem0/llms/lmstudio.py
+++ b/mem0/llms/lmstudio.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Dict, List, Optional, Union
 
 from openai import OpenAI
@@ -38,7 +39,9 @@ class LMStudioLLM(LLMBase):
         )
         self.config.api_key = self.config.api_key or "lm-studio"
 
-        self.client = OpenAI(base_url=self.config.lmstudio_base_url, api_key=self.config.api_key)
+        # Precedence: explicit config > LMSTUDIO_BASE_URL env > default (#6526).
+        base_url = self.config.lmstudio_base_url or os.getenv("LMSTUDIO_BASE_URL") or "http://localhost:1234/v1"
+        self.client = OpenAI(base_url=base_url, api_key=self.config.api_key)
 
     def _parse_response(self, response, tools):
         """

--- a/tests/llms/test_lmstudio.py
+++ b/tests/llms/test_lmstudio.py
@@ -1,0 +1,20 @@
+from mem0.configs.llms.lmstudio import LMStudioConfig
+from mem0.llms.lmstudio import LMStudioLLM
+
+
+def test_lmstudio_llm_base_url(monkeypatch):
+    # case1: default is used when neither config nor env sets a base URL
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    llm = LMStudioLLM(LMStudioConfig(model="test-model"))
+    assert str(llm.client.base_url) == "http://localhost:1234/v1/"
+
+    # case2: LMSTUDIO_BASE_URL env is honored when config leaves it unset (#6526)
+    env_base_url = "http://192.168.1.5:1234/v1/"
+    monkeypatch.setenv("LMSTUDIO_BASE_URL", env_base_url)
+    llm = LMStudioLLM(LMStudioConfig(model="test-model"))
+    assert str(llm.client.base_url) == env_base_url
+
+    # case3: explicit config base URL wins over the env var
+    config_base_url = "http://config-host:9999/v1/"
+    llm = LMStudioLLM(LMStudioConfig(model="test-model", lmstudio_base_url=config_base_url))
+    assert str(llm.client.base_url) == config_base_url


### PR DESCRIPTION
# fix(llms/lmstudio): honor LMSTUDIO_BASE_URL env var

## Linked Issue

Closes #6526

## Description

`LMStudioConfig` baked the default base URL in the config layer
(`self.lmstudio_base_url = lmstudio_base_url or "http://localhost:1234/v1"`), so by the time
`LMStudioLLM` built the OpenAI client the value was never `None` and the `LMSTUDIO_BASE_URL`
environment variable was never consulted — users who set it (or expected the same
`config > env > default` precedence the other OpenAI-compatible providers follow) always hit
`localhost:1234`.

This moves the default out of the config and resolves precedence in `LMStudioLLM.__init__`,
mirroring the existing **DeepSeek** provider (`mem0/llms/deepseek.py`):

- `mem0/configs/llms/lmstudio.py`: `self.lmstudio_base_url = lmstudio_base_url` (no default; the
  docstring already documented `defaults to None`).
- `mem0/llms/lmstudio.py`: `base_url = self.config.lmstudio_base_url or os.getenv("LMSTUDIO_BASE_URL") or "http://localhost:1234/v1"`.

Precedence is now: explicit `lmstudio_base_url` config **>** `LMSTUDIO_BASE_URL` env **>**
`http://localhost:1234/v1`.

Note: I scoped this to the LLM provider (the subject of the issue). The embeddings LM Studio
config (`mem0/configs/embeddings/base.py` + `mem0/embeddings/lmstudio.py`) has a similar
default-baked-in pattern; happy to file/fix that separately if you'd like, but kept it out to
keep this change focused.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — behavior is unchanged when neither env nor config is set (still `localhost:1234`) and when
config is set (still honored). The only new behavior is the intended env fallback.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed

Added `tests/llms/test_lmstudio.py::test_lmstudio_llm_base_url` (mirrors
`tests/llms/test_deepseek.py`) covering all three cases — default, `LMSTUDIO_BASE_URL` env, and
explicit config (wins over env). It fails on `main` (env case returns `localhost`) and passes with
this change. Run locally:

```
$ python -m pytest tests/llms/test_lmstudio.py -q
1 passed
```
`ruff format --check` and `isort` are clean on the changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (no doc claimed the env var worked; none needed)
