### PR TITLE
fix(vector_stores): enforce the '*' wildcard as field-exists across providers

### DIFF
--- a/docs/open-source/features/metadata-filtering.mdx
+++ b/docs/open-source/features/metadata-filtering.mdx
@@ -129,7 +129,7 @@ results = m.search(
 ```
 
 <Warning>
-Wildcard semantics differ by vector store. pgvector requires the key to exist in the payload (a real "field exists" check). Qdrant and Chroma have no native "field exists" filter, so `*` is a no-op there: the field condition is dropped and every record passes, including ones where the field is missing entirely. Do not rely on `*` to exclude records with a missing field unless you have confirmed your store's behavior in `mem0/vector_stores/<provider>.py`.
+Wildcard semantics differ by vector store. pgvector, OpenSearch, Qdrant, Milvus, Pinecone, and Cassandra enforce `*` as a real "field exists" check, so records missing the field are excluded. Chroma and Databricks Vector Search have no field-exists operator, so `*` is a no-op there: the field condition is dropped and every record passes, including ones where the field is missing entirely. Do not rely on `*` to exclude records with a missing field on those two stores.
 </Warning>
 
 ### Logical combinations

--- a/docs/open-source/features/metadata-filtering.mdx
+++ b/docs/open-source/features/metadata-filtering.mdx
@@ -124,6 +124,13 @@ results = m.search(
 )
 ```
 
+<Note>
+  OpenSearch, Qdrant, Milvus, Pinecone, and Cassandra enforce the wildcard as a
+  field-exists condition. Chroma and Databricks Vector Search have no
+  field-exists operator, so on those stores the wildcard leaves the field
+  unconstrained and matches records with or without it.
+</Note>
+
 ### Logical combinations
 
 Combine filters with `AND`, `OR`, and `NOT` to express complex decision trees. Nest logical operators to encode multi-branch workflows.

--- a/mem0/vector_stores/cassandra.py
+++ b/mem0/vector_stores/cassandra.py
@@ -32,6 +32,21 @@ def _validate_identifier(name: str, label: str = "identifier") -> str:
     return name
 
 
+def _payload_matches(payload: Dict, filters: Dict) -> bool:
+    """Check a payload against filters, honoring the '*' any-value wildcard.
+
+    '*' means "the field must exist (and not be null)" rather than a literal
+    match on the string '*', consistent with the other vector stores.
+    """
+    for k, v in filters.items():
+        if v == "*":
+            if payload.get(k) is None:
+                return False
+        elif payload.get(k) != v:
+            return False
+    return True
+
+
 class OutputData(BaseModel):
     id: Optional[str]
     score: Optional[float]
@@ -265,8 +280,7 @@ class CassandraDB(VectorStoreBase):
                 if filters:
                     try:
                         payload = json.loads(row.payload) if row.payload else {}
-                        match = all(payload.get(k) == v for k, v in filters.items())
-                        if not match:
+                        if not _payload_matches(payload, filters):
                             continue
                     except json.JSONDecodeError:
                         continue
@@ -460,8 +474,7 @@ class CassandraDB(VectorStoreBase):
                 if filters:
                     try:
                         payload = json.loads(row.payload) if row.payload else {}
-                        match = all(payload.get(k) == v for k, v in filters.items())
-                        if not match:
+                        if not _payload_matches(payload, filters):
                             continue
                     except json.JSONDecodeError:
                         continue

--- a/mem0/vector_stores/chroma.py
+++ b/mem0/vector_stores/chroma.py
@@ -295,7 +295,10 @@ class ChromaDB(VectorStoreBase):
         def convert_condition(key: str, value: any) -> list:
             """Convert one field condition to a list of single-field ChromaDB clauses."""
             if value == "*":
-                # Wildcard - match any value (ChromaDB doesn't have direct wildcard, so we skip this filter)
+                # "Any value" wildcard. ChromaDB has no exists operator, and $ne
+                # matches documents that lack the key entirely, so a sentinel $ne
+                # can't emulate "field exists" either. Best available translation
+                # is to not constrain the field (match all), same as chroma.ts.
                 return []
             if isinstance(value, dict):
                 # One clause per operator: ChromaDB rejects field expressions

--- a/mem0/vector_stores/databricks.py
+++ b/mem0/vector_stores/databricks.py
@@ -460,6 +460,29 @@ class Databricks(VectorStoreBase):
             logger.error(f"Insert operation failed: {e}")
             raise
 
+    @staticmethod
+    def _filters_to_json(filters: Optional[dict]) -> Optional[str]:
+        """Serialize filters for filters_json, dropping '*' wildcard entries.
+
+        Databricks Vector Search has no "field exists" operator, so the best
+        available translation for the "any value" wildcard is to not constrain
+        the field at all. Passing '*' through would build a literal string
+        match that returns nothing.
+        """
+        if not filters:
+            return None
+        effective = {}
+        for key, value in filters.items():
+            if value == "*":
+                logger.debug(
+                    "Dropping '*' wildcard filter for key %r: Databricks Vector Search "
+                    "cannot express 'field exists', so the wildcard matches all rows.",
+                    key,
+                )
+                continue
+            effective[key] = value
+        return json.dumps(effective) if effective else None
+
     def search(self, query: str, vectors: list, top_k: int = 5, filters: dict = None) -> List[MemoryResult]:
         """
         Search for similar vectors or text using the Databricks Vector Search index.
@@ -474,7 +497,7 @@ class Databricks(VectorStoreBase):
             List of MemoryResult objects.
         """
         try:
-            filters_json = json.dumps(filters) if filters else None
+            filters_json = self._filters_to_json(filters)
 
             # Choose query mode per Databricks SDK contract:
             # - query_text: for Delta Sync Index with model endpoint
@@ -540,7 +563,7 @@ class Databricks(VectorStoreBase):
             return None
 
         try:
-            filters_json = json.dumps(filters) if filters else None
+            filters_json = self._filters_to_json(filters)
 
             sdk_results = self.client.vector_search_indexes.query_index(
                 index_name=self.fully_qualified_index_name,
@@ -794,7 +817,7 @@ class Databricks(VectorStoreBase):
             List containing list of MemoryResult objects.
         """
         try:
-            filters_json = json.dumps(filters) if filters else None
+            filters_json = self._filters_to_json(filters)
             num_results = top_k or 100
             columns = self.column_names
             # Use query_text for Delta Sync with model endpoint, query_vector otherwise

--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -160,7 +160,10 @@ class MilvusDB(VectorStoreBase):
             if not self._SAFE_FILTER_KEY.match(key):
                 raise ValueError(f"Invalid filter key: {key!r}")
             if value == "*":
-                # Wildcard - match any value (MilvusDB doesn't have direct wildcard, so we skip this filter)
+                # "Any value" wildcard: the field must exist. Milvus treats a
+                # missing JSON key and an explicit null the same way, so exists
+                # matches the field-must-exist semantics of the other stores.
+                operands.append(f'(exists metadata["{key}"])')
                 continue
             elif isinstance(value, str):
                 escaped = value.replace("\\", "\\\\").replace('"', '\\"')

--- a/mem0/vector_stores/pinecone.py
+++ b/mem0/vector_stores/pinecone.py
@@ -216,6 +216,11 @@ class PineconeDB(VectorStoreBase):
                     else:
                         condition[f"${op}"] = operand
                 pinecone_filter[key] = condition
+            elif value == "*":
+                # "Any value" wildcard: the field must exist. Without this,
+                # the wildcard becomes a literal {"$eq": "*"} that matches
+                # (almost) nothing.
+                pinecone_filter[key] = {"$exists": True}
             else:
                 pinecone_filter[key] = {"$eq": value}
 

--- a/mem0/vector_stores/qdrant.py
+++ b/mem0/vector_stores/qdrant.py
@@ -8,10 +8,12 @@ from qdrant_client.models import (
     Distance,
     FieldCondition,
     Filter,
+    IsEmptyCondition,
     MatchAny,
     MatchExcept,
     MatchText,
     MatchValue,
+    PayloadField,
     PointIdsList,
     PointStruct,
     PointVectors,
@@ -262,7 +264,7 @@ class Qdrant(VectorStoreBase):
             for v in range_kwargs.values()
         )
 
-    def _build_field_condition(self, key: str, value) -> Optional[FieldCondition]:
+    def _build_field_condition(self, key: str, value):
         """
         Build a single FieldCondition from a key-value filter pair.
 
@@ -274,14 +276,17 @@ class Qdrant(VectorStoreBase):
             value: A scalar for simple equality, or a dict with one operator key.
 
         Returns:
-            Optional[FieldCondition]: The Qdrant field condition, or None if the
-            value is the wildcard '*' (match any / field exists — skip filter).
+            Optional[Condition]: The Qdrant condition (a FieldCondition, or a
+            nested Filter for the '*' wildcard), or None if the value builds
+            no condition.
         """
         if not isinstance(value, dict):
             if value == "*":
-                # Wildcard: match any value. Qdrant has no direct "field exists"
-                # condition via FieldCondition, so we skip this filter (match all).
-                return None
+                # "Any value" wildcard: the field must exist. Qdrant expresses
+                # this as must_not(IsEmpty), which excludes points where the
+                # field is missing, null, or an empty array — matching the
+                # exists semantics OpenSearch and the platform API use.
+                return Filter(must_not=[IsEmptyCondition(is_empty=PayloadField(key=key))])
             if isinstance(value, list):
                 # List shorthand: {"field": ["a", "b"]} treated as in-operator.
                 return FieldCondition(key=key, match=MatchAny(any=value))

--- a/tests/vector_stores/test_cassandra.py
+++ b/tests/vector_stores/test_cassandra.py
@@ -275,6 +275,54 @@ def test_search_with_filters(cassandra_instance):
         assert result.payload.get("category") == "A"
 
 
+def test_search_with_wildcard_filter(cassandra_instance):
+    """'*' should match any present value, not the literal string '*'."""
+    mock_row1 = Mock()
+    mock_row1.id = 'id1'
+    mock_row1.vector = [0.1, 0.2, 0.3]
+    mock_row1.payload = json.dumps({"text": "test1", "agent_id": "agent-a"})
+
+    mock_row2 = Mock()
+    mock_row2.id = 'id2'
+    mock_row2.vector = [0.4, 0.5, 0.6]
+    mock_row2.payload = json.dumps({"text": "test2"})
+
+    mock_row3 = Mock()
+    mock_row3.id = 'id3'
+    mock_row3.vector = [0.5, 0.6, 0.7]
+    mock_row3.payload = json.dumps({"text": "test3", "agent_id": None})
+
+    cassandra_instance.session.execute = Mock(return_value=[mock_row1, mock_row2, mock_row3])
+
+    results = cassandra_instance.search(
+        query="test",
+        vectors=[0.2, 0.3, 0.4],
+        top_k=5,
+        filters={"agent_id": "*"}
+    )
+
+    assert [r.id for r in results] == ['id1']
+
+
+def test_list_with_wildcard_filter(cassandra_instance):
+    """list() should honor the '*' wildcard the same way as search()."""
+    mock_row1 = Mock()
+    mock_row1.id = 'id1'
+    mock_row1.vector = [0.1, 0.2, 0.3]
+    mock_row1.payload = json.dumps({"text": "test1", "agent_id": "agent-a"})
+
+    mock_row2 = Mock()
+    mock_row2.id = 'id2'
+    mock_row2.vector = [0.4, 0.5, 0.6]
+    mock_row2.payload = json.dumps({"text": "test2"})
+
+    cassandra_instance.session.execute = Mock(return_value=[mock_row1, mock_row2])
+
+    results = cassandra_instance.list(filters={"agent_id": "*"}, top_k=10)
+
+    assert [r.id for r in results[0]] == ['id1']
+
+
 def test_output_data_model():
     """Test OutputData model."""
     data = OutputData(

--- a/tests/vector_stores/test_databricks.py
+++ b/tests/vector_stores/test_databricks.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -197,6 +198,25 @@ def test_search_delta_sync_text(db_instance_delta, mock_workspace_client):
     assert results[0].id == "id1"
     assert results[0].score == 0.42
     assert results[0].payload["data"] == "memory text"
+
+
+def test_search_wildcard_filter_dropped(db_instance_delta, mock_workspace_client):
+    """'*' wildcard entries are dropped from filters_json instead of literal-matching '*'."""
+    mock_workspace_client.vector_search_indexes.query_index.return_value = SimpleNamespace(
+        result=SimpleNamespace(data_array=[])
+    )
+    db_instance_delta.search(query="hello", vectors=None, top_k=1, filters={"agent_id": "*", "user_id": "u1"})
+    kwargs = mock_workspace_client.vector_search_indexes.query_index.call_args.kwargs
+    assert json.loads(kwargs["filters_json"]) == {"user_id": "u1"}
+
+
+def test_search_only_wildcard_filters_yields_no_filters_json(db_instance_delta, mock_workspace_client):
+    mock_workspace_client.vector_search_indexes.query_index.return_value = SimpleNamespace(
+        result=SimpleNamespace(data_array=[])
+    )
+    db_instance_delta.search(query="hello", vectors=None, top_k=1, filters={"agent_id": "*"})
+    kwargs = mock_workspace_client.vector_search_indexes.query_index.call_args.kwargs
+    assert kwargs["filters_json"] is None
 
 
 def test_search_direct_access_vector(db_instance_direct, mock_workspace_client):

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -108,12 +108,18 @@ class TestMilvusDB:
         assert ' and ' in filter_str
 
     def test_create_filter_wildcard_conditions(self, milvus_db):
-        """Test filter creation with wildcard conditions."""
+        """Wildcard '*' should become an exists condition, not a literal match."""
         filters = {"user_id": "alice", "run_id": "*"}
         filter_str = milvus_db._create_filter(filters)
 
         assert 'metadata["user_id"] == "alice"' in filter_str
         assert 'metadata["run_id"] == "*"' not in filter_str
+        assert '(exists metadata["run_id"])' in filter_str
+
+    def test_create_filter_only_wildcard(self, milvus_db):
+        """A lone wildcard filter should still require the field to exist."""
+        filter_str = milvus_db._create_filter({"agent_id": "*"})
+        assert filter_str == '(exists metadata["agent_id"])'
 
     def test_search_with_filters(self, milvus_db, mock_milvus_client):
         """Test search with metadata filters (reproduces user's bug scenario)."""

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -263,3 +263,13 @@ def test_create_filter_in_operator(pinecone_db):
 def test_create_filter_ne_operator(pinecone_db):
     result = pinecone_db._create_filter({"status": {"ne": "deleted"}})
     assert result == {"status": {"$ne": "deleted"}}
+
+
+def test_create_filter_wildcard_becomes_exists(pinecone_db):
+    result = pinecone_db._create_filter({"agent_id": "*"})
+    assert result == {"agent_id": {"$exists": True}}
+
+
+def test_create_filter_wildcard_mixed_with_equality(pinecone_db):
+    result = pinecone_db._create_filter({"agent_id": "*", "user_id": "alice"})
+    assert result == {"agent_id": {"$exists": True}, "user_id": {"$eq": "alice"}}

--- a/tests/vector_stores/test_qdrant.py
+++ b/tests/vector_stores/test_qdrant.py
@@ -10,6 +10,7 @@ from qdrant_client.models import (
     Distance,
     FieldCondition,
     Filter,
+    IsEmptyCondition,
     MatchAny,
     MatchExcept,
     MatchText,
@@ -735,22 +736,32 @@ class TestQdrantEnhancedFilters(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.qdrant._build_field_condition("score", {"gt": 0.5, "eq": 1.0})
 
-    def test_wildcard_returns_none(self):
-        """Wildcard '*' should return None (skip filter — match any)."""
+    def test_wildcard_returns_exists_condition(self):
+        """Wildcard '*' should build a must_not(IsEmpty) exists condition."""
         result = self.qdrant._build_field_condition("category", "*")
-        self.assertIsNone(result)
+        self.assertIsInstance(result, Filter)
+        self.assertIsNone(result.must)
+        self.assertEqual(len(result.must_not), 1)
+        self.assertIsInstance(result.must_not[0], IsEmptyCondition)
+        self.assertEqual(result.must_not[0].is_empty.key, "category")
 
-    def test_create_filter_with_wildcard_skips_it(self):
-        """Wildcard fields should be skipped in the final filter."""
+    def test_create_filter_with_wildcard_builds_exists(self):
+        """Wildcard fields should become exists conditions alongside other filters."""
         result = self.qdrant._create_filter({"category": "*", "user_id": "alice"})
         self.assertIsInstance(result, Filter)
-        self.assertEqual(len(result.must), 1)
-        self.assertEqual(result.must[0].key, "user_id")
+        self.assertEqual(len(result.must), 2)
+        exists = [c for c in result.must if isinstance(c, Filter)]
+        self.assertEqual(len(exists), 1)
+        self.assertEqual(exists[0].must_not[0].is_empty.key, "category")
+        equality = [c for c in result.must if isinstance(c, FieldCondition)]
+        self.assertEqual(equality[0].key, "user_id")
 
-    def test_create_filter_only_wildcard_returns_none(self):
-        """Filter with only wildcard should return None."""
+    def test_create_filter_only_wildcard_builds_exists(self):
+        """Filter with only a wildcard should still require the field to exist."""
         result = self.qdrant._create_filter({"category": "*"})
-        self.assertIsNone(result)
+        self.assertIsInstance(result, Filter)
+        self.assertEqual(len(result.must), 1)
+        self.assertIsInstance(result.must[0].must_not[0], IsEmptyCondition)
 
     def test_and_with_non_list_raises_error(self):
         """AND with non-list value should raise ValueError."""
@@ -829,14 +840,15 @@ class TestQdrantEnhancedFilters(unittest.TestCase):
         self.assertEqual(cond.match.any, [1, 2, 3])
 
     def test_wildcard_inside_and(self):
-        """Wildcard inside AND should be skipped, other conditions preserved."""
+        """Wildcard inside AND should become an exists condition alongside the others."""
         result = self.qdrant._create_filter({
             "AND": [{"category": "*"}, {"user_id": "alice"}]
         })
         self.assertIsInstance(result, Filter)
-        # AND produces nested Filters; the wildcard sub-filter returns None and is skipped
-        # Only the user_id sub-filter remains
-        self.assertEqual(len(result.must), 1)
+        self.assertEqual(len(result.must), 2)
+        exists = result.must[0].must[0]
+        self.assertIsInstance(exists.must_not[0], IsEmptyCondition)
+        self.assertEqual(exists.must_not[0].is_empty.key, "category")
 
     def test_list_value_treated_as_match_any(self):
         """List value shorthand should be treated as in-operator (MatchAny)."""


### PR DESCRIPTION
## Linked Issue

Closes #6539

## Description

Follow-up to #6522. The `*` filter value is documented as "require that the field exists, regardless of value", but only OpenSearch enforced it. Qdrant, Milvus, and Chroma silently skipped the condition (so the wildcard also matched records *without* the field), while Pinecone, Cassandra, and Databricks built a literal match on the string `"*"` that matches nothing — the same bug #6522 fixed for OpenSearch.

Per-provider changes:

| Provider | Before | After |
|---|---|---|
| Qdrant | condition skipped | `must_not(IsEmptyCondition)` (excludes missing / null / empty-array) |
| Milvus | condition skipped | `exists metadata["key"]` |
| Pinecone | literal `{"$eq": "*"}` | `{"$exists": true}` |
| Cassandra | literal `payload.get(k) == "*"` | client-side key-present-and-not-null |
| Databricks | literal `"*"` in `filters_json` | wildcard entries dropped (grammar has no exists operator), debug-logged |
| Chroma | condition skipped | unchanged, with the why documented |

Chroma and Databricks cannot express field-exists: Databricks Vector Search's filter grammar has no exists / `IS NOT NULL` operator for either endpoint type, and Chroma has no `$exists` while `$ne` matches documents that lack the key entirely (verified empirically on chromadb 1.5.9), so a sentinel `$ne` can't emulate it. For those two the wildcard now consistently means "don't constrain this field" instead of a match-nothing literal, and the docs note the difference.

The docs page (`metadata-filtering.mdx`) gains a note describing which stores enforce field-exists.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — behavior only changes for filters containing the `*` wildcard, moving them onto the documented contract.

## Test Coverage

- [x] I added/updated unit tests
- [x] I tested manually (describe below)

Manual verification:

- **Qdrant**: end-to-end through `Qdrant.search()` against qdrant-client local mode — `{"agent_id": "*"}` returns only the point whose `agent_id` is present and non-null (missing key and explicit `null` both excluded)
- **Milvus**: end-to-end through `MilvusDB.search()` against a dockerized Milvus standalone v2.5.12 — same result; also confirmed `exists metadata["key"]` composes with `and`
- **Chroma**: confirmed on chromadb 1.5.9 that `$ne` matches documents lacking the key, ruling out a sentinel-based exists
- `pytest` across the seven touched provider suites: 318 passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
