### PR TITLE
Use UTF-8 for CLI and state file reads

### DIFF
--- a/cli/python/src/mem0_cli/commands/memory.py
+++ b/cli/python/src/mem0_cli/commands/memory.py
@@ -76,7 +76,7 @@ def cmd_add(
     # Read from file
     if file:
         try:
-            raw = Path(file).read_text()
+            raw = Path(file).read_text(encoding="utf-8")
             msgs = json.loads(raw)
         except (FileNotFoundError, json.JSONDecodeError) as e:
             print_error(err_console, f"Failed to read file: {e}")

--- a/cli/python/src/mem0_cli/commands/utils.py
+++ b/cli/python/src/mem0_cli/commands/utils.py
@@ -116,7 +116,7 @@ def cmd_import(
         output = "agent"
 
     try:
-        data = json.loads(Path(file_path).read_text())
+        data = json.loads(Path(file_path).read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError) as e:
         print_error(err_console, f"Failed to read file: {e}")
         raise typer.Exit(1) from None

--- a/integrations/mem0-plugin/scripts/install_codex_hooks.py
+++ b/integrations/mem0-plugin/scripts/install_codex_hooks.py
@@ -44,7 +44,7 @@ OWNER_MARKER = "mem0-plugin"
 
 
 def load_template() -> dict:
-    raw = TEMPLATE_FILE.read_text()
+    raw = TEMPLATE_FILE.read_text(encoding="utf-8")
     raw = raw.replace("${PLUGIN_ROOT}", str(PLUGIN_ROOT))
     return json.loads(raw)
 
@@ -53,7 +53,7 @@ def load_existing() -> dict:
     if not HOOKS_FILE.exists():
         return {"hooks": {}}
     try:
-        return json.loads(HOOKS_FILE.read_text())
+        return json.loads(HOOKS_FILE.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as e:
         print(f"error: failed to read {HOOKS_FILE}: {e}", file=sys.stderr)
         sys.exit(1)
@@ -85,13 +85,13 @@ def merge_template(config: dict, template: dict) -> dict:
 
 def write_config(config: dict) -> None:
     CODEX_DIR.mkdir(parents=True, exist_ok=True)
-    HOOKS_FILE.write_text(json.dumps(config, indent=2) + "\n")
+    HOOKS_FILE.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
 
 
 def feature_flag_enabled() -> bool:
     if not CONFIG_FILE.exists():
         return False
-    content = CONFIG_FILE.read_text()
+    content = CONFIG_FILE.read_text(encoding="utf-8")
     for line in content.splitlines():
         stripped = line.split("#", 1)[0].strip().replace(" ", "")
         if stripped == "codex_hooks=true":

--- a/scripts/check-llms-txt-coverage.py
+++ b/scripts/check-llms-txt-coverage.py
@@ -42,7 +42,7 @@ def load_ignore_prefixes() -> list[str]:
     if not IGNORE_FILE.exists():
         return []
     prefixes: list[str] = []
-    for raw in IGNORE_FILE.read_text().splitlines():
+    for raw in IGNORE_FILE.read_text(encoding="utf-8").splitlines():
         line = raw.strip()
         if line and not line.startswith("#"):
             prefixes.append(line)
@@ -105,7 +105,7 @@ def main() -> int:
 
     ignore_prefixes = load_ignore_prefixes()
     all_pages, included_pages = canonical_repo_pages(ignore_prefixes)
-    text = LLMS_TXT.read_text()
+    text = LLMS_TXT.read_text(encoding="utf-8")
     linked = indexed_urls(text)
 
     missing = sorted(included_pages - linked)

--- a/server/telemetry.py
+++ b/server/telemetry.py
@@ -36,7 +36,7 @@ def _load_state() -> dict[str, Any]:
     if not STATE_PATH.exists():
         return {}
     try:
-        return json.loads(STATE_PATH.read_text())
+        return json.loads(STATE_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return {}
 
@@ -44,7 +44,7 @@ def _load_state() -> dict[str, Any]:
 def _save_state(state: dict[str, Any]) -> None:
     try:
         STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        STATE_PATH.write_text(json.dumps(state))
+        STATE_PATH.write_text(json.dumps(state), encoding="utf-8")
     except OSError:
         logging.exception("telemetry: failed to persist state")
 


### PR DESCRIPTION
## Summary
- Read CLI JSON input/import files with explicit UTF-8 encoding.
- Use explicit UTF-8 for Codex hook installer template/config files.
- Read docs coverage files and server telemetry state with explicit UTF-8, and persist telemetry state with the same encoding.

## Problem
Several JSON/text files are read or written with `Path.read_text()` / `write_text()` without an explicit encoding. On Windows or other non-UTF-8 locales, user-provided CLI files, generated hook config, docs coverage checks, or telemetry state can become locale-dependent.

## Before / After
Before: these CLI/state/helper files used the platform default text encoding.

After: the same file paths consistently use UTF-8.

## Verification
- `python -m py_compile cli/python/src/mem0_cli/commands/memory.py cli/python/src/mem0_cli/commands/utils.py integrations/mem0-plugin/scripts/install_codex_hooks.py scripts/check-llms-txt-coverage.py server/telemetry.py`
- `python -m pytest tests/test_telemetry_aliasing.py -q` (`28 passed`)