### PR TITLE
fix(ts-oss/lmstudio): honor LMSTUDIO_BASE_URL env var

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/lmstudio.ts
+++ b/mem0-ts/src/oss/src/embeddings/lmstudio.ts
@@ -12,7 +12,12 @@ export class LMStudioEmbedder implements Embedder {
   private model: string;
 
   constructor(config: EmbeddingConfig) {
-    const baseURL = config.baseURL ?? config.url ?? DEFAULT_BASE_URL;
+    // Precedence: explicit config > LMSTUDIO_BASE_URL env > default (#6526).
+    const baseURL =
+      config.baseURL ||
+      config.url ||
+      process.env.LMSTUDIO_BASE_URL ||
+      DEFAULT_BASE_URL;
     const apiKey = config.apiKey || DEFAULT_LMSTUDIO_API_KEY;
     this.openai = new OpenAI({ apiKey, baseURL: String(baseURL) });
     this.model = config.model || DEFAULT_MODEL;

--- a/mem0-ts/src/oss/src/llms/lmstudio.ts
+++ b/mem0-ts/src/oss/src/llms/lmstudio.ts
@@ -12,7 +12,10 @@ export class LMStudioLLM extends OpenAILLM {
     super({
       ...config,
       apiKey: config.apiKey || DEFAULT_LMSTUDIO_API_KEY,
-      baseURL: config.baseURL ?? DEFAULT_BASE_URL,
+      // Precedence: explicit config > LMSTUDIO_BASE_URL env > default (#6526),
+      // matching the vllm/deepseek/sarvam/minimax/together providers.
+      baseURL:
+        config.baseURL || process.env.LMSTUDIO_BASE_URL || DEFAULT_BASE_URL,
       model: config.model || DEFAULT_MODEL,
     });
   }

--- a/mem0-ts/src/oss/tests/lmstudio-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/lmstudio-embedder.test.ts
@@ -3,6 +3,7 @@
  * LM Studio Embedder — unit tests (mocked OpenAI).
  */
 
+import OpenAI from "openai";
 import { LMStudioEmbedder } from "../src/embeddings/lmstudio";
 
 const mockEmbedding = [0.1, 0.2, 0.3, 0.4, 0.5];
@@ -16,8 +17,45 @@ jest.mock("openai", () => {
   }));
 });
 
+const MockOpenAI = OpenAI as unknown as jest.Mock;
+
 describe("LMStudioEmbedder (unit)", () => {
-  beforeEach(() => mockCreate.mockClear());
+  beforeEach(() => {
+    mockCreate.mockClear();
+    MockOpenAI.mockClear();
+    delete process.env.LMSTUDIO_BASE_URL;
+  });
+
+  it("honors LMSTUDIO_BASE_URL when no baseURL is configured", () => {
+    process.env.LMSTUDIO_BASE_URL = "http://lmstudio.example:9999/v1";
+
+    new LMStudioEmbedder({ model: "test-model" });
+
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "http://lmstudio.example:9999/v1" }),
+    );
+  });
+
+  it("prefers an explicit baseURL over LMSTUDIO_BASE_URL", () => {
+    process.env.LMSTUDIO_BASE_URL = "http://env.example/v1";
+
+    new LMStudioEmbedder({
+      model: "test-model",
+      baseURL: "http://explicit.example/v1",
+    });
+
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "http://explicit.example/v1" }),
+    );
+  });
+
+  it("falls back to the localhost default when neither is set", () => {
+    new LMStudioEmbedder({ model: "test-model" });
+
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "http://localhost:1234/v1" }),
+    );
+  });
 
   it("embed() calls OpenAI with encoding_format float and returns vector", async () => {
     const embedder = new LMStudioEmbedder({

--- a/mem0-ts/src/oss/tests/lmstudio-llm.test.ts
+++ b/mem0-ts/src/oss/tests/lmstudio-llm.test.ts
@@ -3,6 +3,7 @@
  * LM Studio LLM — unit tests (mocked OpenAI).
  */
 
+import OpenAI from "openai";
 import { LMStudioLLM } from "../src/llms/lmstudio";
 
 const mockCreate = jest.fn();
@@ -13,8 +14,14 @@ jest.mock("openai", () => {
   }));
 });
 
+const MockOpenAI = OpenAI as unknown as jest.Mock;
+
 describe("LMStudioLLM (unit)", () => {
-  beforeEach(() => mockCreate.mockClear());
+  beforeEach(() => {
+    mockCreate.mockClear();
+    MockOpenAI.mockClear();
+    delete process.env.LMSTUDIO_BASE_URL;
+  });
 
   it("generateResponse() returns a text response", async () => {
     mockCreate.mockResolvedValueOnce({
@@ -36,6 +43,34 @@ describe("LMStudioLLM (unit)", () => {
 
     expect(mockCreate).toHaveBeenCalledTimes(1);
     expect(result).toBe("Hello, world!");
+  });
+
+  it("honors LMSTUDIO_BASE_URL when no baseURL is configured", () => {
+    process.env.LMSTUDIO_BASE_URL = "http://lmstudio.example:9999/v1";
+
+    new LMStudioLLM({});
+
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "http://lmstudio.example:9999/v1" }),
+    );
+  });
+
+  it("prefers an explicit baseURL over LMSTUDIO_BASE_URL", () => {
+    process.env.LMSTUDIO_BASE_URL = "http://env.example/v1";
+
+    new LMStudioLLM({ baseURL: "http://explicit.example/v1" });
+
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "http://explicit.example/v1" }),
+    );
+  });
+
+  it("falls back to the localhost default when neither is set", () => {
+    new LMStudioLLM({});
+
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "http://localhost:1234/v1" }),
+    );
   });
 
   it("generateResponse() handles tool calls", async () => {


### PR DESCRIPTION
### Description

The TS LM Studio LLM and embedder resolved the base URL from config-or-default only, with no env fallback, so a user who set `LMSTUDIO_BASE_URL` always hit `http://localhost:1234/v1`. Every sibling OpenAI-compatible provider in this SDK already reads its base-URL env var (`VLLM_BASE_URL`, `DEEPSEEK_API_BASE`, `SARVAM_API_BASE`, `MINIMAX_API_BASE`, `TOGETHER_API_BASE`); LM Studio was the only one that did not.

The fix resolves the base URL as explicit config > `LMSTUDIO_BASE_URL` env > default in both the LLM and the embedder. This is the TS counterpart of #6526 (the Python config has the same gap).

Closes #6542

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`jest src/oss/tests/lmstudio-llm.test.ts src/oss/tests/lmstudio-embedder.test.ts` (run from the `mem0-ts` root), 15 passed.

Added to both suites:
- `honors LMSTUDIO_BASE_URL when no baseURL is configured`
- `prefers an explicit baseURL over LMSTUDIO_BASE_URL`
- `falls back to the localhost default when neither is set`

Reverting the two source changes fails exactly the two `honors LMSTUDIO_BASE_URL` tests.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes