### PR TITLE
fix(memory): chain the real cause when vision image description fails

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -8,6 +8,7 @@ from mem0.configs.prompts import (
     FACT_RETRIEVAL_PROMPT,
     USER_MEMORY_EXTRACTION_PROMPT,
 )
+from mem0.exceptions import LLMError
 
 logger = logging.getLogger(__name__)
 
@@ -213,8 +214,8 @@ def parse_vision_messages(messages, llm=None, vision_details="auto"):
             try:
                 description = get_image_description(image_url, llm, vision_details)
                 returned_messages.append({"role": role, "content": description})
-            except Exception:
-                raise Exception(f"Error while downloading {image_url}.")
+            except Exception as e:
+                raise LLMError(f"Failed to describe image {image_url}: {e}") from e
         else:
             # Regular text content
             returned_messages.append(msg)

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import Mock
 
+from mem0.exceptions import LLMError
 from mem0.memory.utils import (
     parse_messages,
     parse_vision_messages,
@@ -113,6 +114,19 @@ class TestParseVisionMessages:
         with pytest.raises(ValueError, match=r"missing image_url\.url"):
             parse_vision_messages(messages, llm=mock_llm)
         mock_llm.generate_response.assert_not_called()
+
+    def test_image_description_failure_chains_original_cause(self):
+        # A failing vision LLM call (auth, rate-limit, timeout, ...) must not be
+        # swallowed as a generic download error: the raised LLMError has to chain
+        # the real cause so callers can inspect and handle it.
+        original = RuntimeError("401 invalid api key")
+        mock_llm = Mock()
+        mock_llm.generate_response.side_effect = original
+        messages = [{"role": "user", "content": {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}}}]
+        with pytest.raises(LLMError) as exc_info:
+            parse_vision_messages(messages, llm=mock_llm)
+        assert exc_info.value.__cause__ is original
+        assert "401 invalid api key" in str(exc_info.value)
 
 
 class TestRemoveSpacesFromEntities:


### PR DESCRIPTION
## Linked Issue

Closes #6544

## Description

In `mem0/memory/utils.py`, `parse_vision_messages` wrapped the vision LLM call in a bare `except` that re-raised a generic `Exception("Error while downloading ...")`. Since `get_image_description` calls `llm.generate_response(...)`, this swallowed the real cause and type of any vision failure (auth, rate limit, timeout, provider error) and mislabeled it as a download problem, so callers of `add()` with image content could not inspect or handle the underlying error.

This raises `LLMError(f"Failed to describe image {image_url}: {e}") from e` instead, matching how the rest of `memory/main.py` surfaces LLM failures (`raise LLMError(...) from e`). The original exception is preserved on `__cause__`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. The success path is unchanged; only the exception raised on failure changes from a generic `Exception` to `mem0.exceptions.LLMError` (a `MemoryError` subclass), now carrying the original cause.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added a regression test in `tests/memory/test_memory_utils.py` that makes the mocked vision LLM raise a distinctive error and asserts the raised `LLMError` chains it (`exc.__cause__ is original`) and keeps the message. It fails against the old code (generic un-chained `Exception`) and passes with the fix. Ran `ruff check` and the full `tests/memory/test_memory_utils.py` suite locally: 20 passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed