### PR TITLE
fix(ts-oss): gate entity merges on entityType parity

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -456,6 +456,20 @@ export class Memory {
    * dedup, but still does per-entity "search for existing, update if
    * match >= 0.95 else insert new". Non-fatal errors are swallowed.
    */
+
+  /**
+   * True when both sides declare an entityType and they differ.
+   * Matching Python _upsert_entity gate (#5497): allow merge when either
+   * side lacks a type (backward compatible).
+   */
+  private _entityTypesConflict(
+    newType: string | undefined | null,
+    existingType: string | undefined | null,
+  ): boolean {
+    if (!newType || !existingType) return false;
+    return newType !== existingType;
+  }
+
   private async _linkEntitiesForMemory(
     memoryId: string,
     text: string,
@@ -500,7 +514,25 @@ export class Memory {
               ? matches[0]
               : undefined;
           const match = exactMatch ?? semanticMatch;
-          if (match) {
+          if (
+            match &&
+            this._entityTypesConflict(
+              entity.type,
+              match.payload?.entityType ?? match.payload?.entity_type,
+            )
+          ) {
+            console.debug(
+              `Skipping merge for entity '${entity.text}': stored entityType '${match.payload?.entityType ?? match.payload?.entity_type}' != new entityType '${entity.type}'. Creating a separate entity instead.`,
+            );
+            // Fall through to insert as a new entity record
+          }
+          if (
+            match &&
+            !this._entityTypesConflict(
+              entity.type,
+              match.payload?.entityType ?? match.payload?.entity_type,
+            )
+          ) {
             const payload = match.payload || {};
             const linked = new Set<string>(
               Array.isArray(payload.linkedMemoryIds)
@@ -509,6 +541,10 @@ export class Memory {
             );
             linked.add(memoryId);
             payload.linkedMemoryIds = Array.from(linked).sort();
+            // Backfill type when the stored entity has none
+            if (entity.type && !payload.entityType && !payload.entity_type) {
+              payload.entityType = entity.type;
+            }
             try {
               await entityStore.update(match.id, entityVec, payload);
             } catch (e) {
@@ -1184,12 +1220,22 @@ export class Memory {
                 ? matches[0]
                 : undefined;
             const match = exactMatch ?? semanticMatch;
-            if (match) {
+            const storedType =
+              match?.payload?.entityType ?? match?.payload?.entity_type;
+            if (match && this._entityTypesConflict(entityType, storedType)) {
+              console.debug(
+                `Skipping merge for entity '${entityText}': stored entityType '${storedType}' != new entityType '${entityType}'. Creating a separate entity instead.`,
+              );
+            }
+            if (match && !this._entityTypesConflict(entityType, storedType)) {
               // Update existing entity
               const payload = match.payload || {};
               const linked = new Set<string>(payload.linkedMemoryIds ?? []);
               for (const mid of memoryIds) linked.add(mid);
               payload.linkedMemoryIds = Array.from(linked).sort();
+              if (entityType && !payload.entityType && !payload.entity_type) {
+                payload.entityType = entityType;
+              }
               try {
                 await entityStore.update(match.id, entityVec, payload);
               } catch (e) {

--- a/mem0-ts/src/oss/tests/memory.entity-type-merge-gate.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-type-merge-gate.test.ts
@@ -11,13 +11,11 @@ jest.mock("../src/embeddings/google", () => ({ GoogleEmbedder: jest.fn() }));
 jest.mock("../src/llms/google", () => ({ GoogleLLM: jest.fn() }));
 jest.mock("../src/llms/openai", () => ({
   OpenAILLM: jest.fn().mockImplementation(() => ({
-    generateResponse: jest
-      .fn()
-      .mockResolvedValue(
-        JSON.stringify({
-          memory: [{ id: "0", text: "Python fact", attributed_to: "user" }],
-        }),
-      ),
+    generateResponse: jest.fn().mockResolvedValue(
+      JSON.stringify({
+        memory: [{ id: "0", text: "Python fact", attributed_to: "user" }],
+      }),
+    ),
   })),
 }));
 

--- a/mem0-ts/src/oss/tests/memory.entity-type-merge-gate.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-type-merge-gate.test.ts
@@ -11,9 +11,13 @@ jest.mock("../src/embeddings/google", () => ({ GoogleEmbedder: jest.fn() }));
 jest.mock("../src/llms/google", () => ({ GoogleLLM: jest.fn() }));
 jest.mock("../src/llms/openai", () => ({
   OpenAILLM: jest.fn().mockImplementation(() => ({
-    generateResponse: jest.fn().mockResolvedValue(
-      JSON.stringify({ memory: [{ id: "0", text: "Python fact", attributed_to: "user" }] }),
-    ),
+    generateResponse: jest
+      .fn()
+      .mockResolvedValue(
+        JSON.stringify({
+          memory: [{ id: "0", text: "Python fact", attributed_to: "user" }],
+        }),
+      ),
   })),
 }));
 

--- a/mem0-ts/src/oss/tests/memory.entity-type-merge-gate.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-type-merge-gate.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Entity type merge gate (parity with Python #5497 / issue #6529).
+ * Entities with the same text but different entityType must not merge.
+ */
+/// <reference types="jest" />
+import { Memory } from "../src/memory";
+
+jest.setTimeout(15000);
+
+jest.mock("../src/embeddings/google", () => ({ GoogleEmbedder: jest.fn() }));
+jest.mock("../src/llms/google", () => ({ GoogleLLM: jest.fn() }));
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockResolvedValue(
+      JSON.stringify({ memory: [{ id: "0", text: "Python fact", attributed_to: "user" }] }),
+    ),
+  })),
+}));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 1536,
+  })),
+}));
+
+// Extracted entity helper is pure enough — stub to control types.
+jest.mock("../src/utils/entity_extraction", () => {
+  const actual = jest.requireActual("../src/utils/entity_extraction");
+  return {
+    ...actual,
+    extractEntities: jest.fn(),
+    extractEntitiesBatch: jest.fn(),
+  };
+});
+
+import {
+  extractEntities,
+  extractEntitiesBatch,
+} from "../src/utils/entity_extraction";
+
+describe("entity_type merge gate (#6529)", () => {
+  test("_entityTypesConflict helper: differ only when both typed and unequal", () => {
+    const m = new Memory({
+      version: "v1.1",
+      embedder: {
+        provider: "openai",
+        config: { apiKey: "k", model: "text-embedding-3-small" },
+      },
+      vectorStore: {
+        provider: "memory",
+        config: {
+          collectionName: "et-gate",
+          dimension: 1536,
+          dbPath: ":memory:",
+        },
+      },
+      llm: { provider: "openai", config: { apiKey: "k", model: "gpt-5-mini" } },
+      historyDbPath: ":memory:",
+    }) as any;
+
+    expect(m._entityTypesConflict("language", "animal")).toBe(true);
+    expect(m._entityTypesConflict("language", "language")).toBe(false);
+    expect(m._entityTypesConflict("language", null)).toBe(false);
+    expect(m._entityTypesConflict(null, "language")).toBe(false);
+    expect(m._entityTypesConflict("", "language")).toBe(false);
+  });
+
+  test("_linkEntitiesForMemory inserts instead of merging when types differ", async () => {
+    const m = new Memory({
+      version: "v1.1",
+      embedder: {
+        provider: "openai",
+        config: { apiKey: "k", model: "text-embedding-3-small" },
+      },
+      vectorStore: {
+        provider: "memory",
+        config: {
+          collectionName: "et-gate-link",
+          dimension: 1536,
+          dbPath: ":memory:",
+        },
+      },
+      llm: { provider: "openai", config: { apiKey: "k", model: "gpt-5-mini" } },
+      historyDbPath: ":memory:",
+    }) as any;
+
+    (extractEntities as jest.Mock).mockReturnValue([
+      { text: "Python", type: "animal" },
+    ]);
+
+    const entityStore = {
+      search: jest.fn().mockResolvedValue([
+        {
+          id: "existing-1",
+          score: 0.99,
+          payload: {
+            data: "Python",
+            entityType: "language",
+            linkedMemoryIds: ["mem-A"],
+          },
+        },
+      ]),
+      update: jest.fn().mockResolvedValue(undefined),
+      insert: jest.fn().mockResolvedValue(undefined),
+      list: jest.fn().mockResolvedValue([[]]),
+    };
+
+    m.getEntityStore = jest.fn().mockResolvedValue(entityStore);
+    m._existingEntitiesByText = jest.fn().mockResolvedValue(new Map());
+
+    await m._linkEntitiesForMemory("mem-B", "Python the snake", {
+      user_id: "u1",
+    });
+
+    expect(entityStore.update).not.toHaveBeenCalled();
+    expect(entityStore.insert).toHaveBeenCalledTimes(1);
+    const payloads = entityStore.insert.mock.calls[0][2];
+    expect(payloads[0].entityType).toBe("animal");
+    expect(payloads[0].linkedMemoryIds).toEqual(["mem-B"]);
+  });
+
+  test("_linkEntitiesForMemory merges when existing type is missing (compat)", async () => {
+    const m = new Memory({
+      version: "v1.1",
+      embedder: {
+        provider: "openai",
+        config: { apiKey: "k", model: "text-embedding-3-small" },
+      },
+      vectorStore: {
+        provider: "memory",
+        config: {
+          collectionName: "et-gate-compat",
+          dimension: 1536,
+          dbPath: ":memory:",
+        },
+      },
+      llm: { provider: "openai", config: { apiKey: "k", model: "gpt-5-mini" } },
+      historyDbPath: ":memory:",
+    }) as any;
+
+    (extractEntities as jest.Mock).mockReturnValue([
+      { text: "Python", type: "language" },
+    ]);
+
+    const entityStore = {
+      search: jest.fn().mockResolvedValue([
+        {
+          id: "existing-2",
+          score: 0.99,
+          payload: {
+            data: "Python",
+            linkedMemoryIds: ["mem-A"],
+          },
+        },
+      ]),
+      update: jest.fn().mockResolvedValue(undefined),
+      insert: jest.fn().mockResolvedValue(undefined),
+      list: jest.fn().mockResolvedValue([[]]),
+    };
+
+    m.getEntityStore = jest.fn().mockResolvedValue(entityStore);
+    m._existingEntitiesByText = jest.fn().mockResolvedValue(new Map());
+
+    await m._linkEntitiesForMemory("mem-B", "Python the language", {
+      user_id: "u1",
+    });
+
+    expect(entityStore.insert).not.toHaveBeenCalled();
+    expect(entityStore.update).toHaveBeenCalledTimes(1);
+    const updatedPayload = entityStore.update.mock.calls[0][2];
+    expect(updatedPayload.entityType).toBe("language");
+    expect(updatedPayload.linkedMemoryIds).toEqual(
+      expect.arrayContaining(["mem-A", "mem-B"]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Refuse to merge entity store rows when both sides declare a different `entityType` (camelCase payload; also reads snake_case `entity_type` for mixed clients).
- Keep backward-compatible merge when either side is untyped, and backfill `entityType` onto untyped stored records.
- Covers single-memory `_linkEntitiesForMemory` and batch Phase 7 entity linking.

## Motivation

Closes #6529.

The TypeScript OSS entity linker previously merged solely on text/exact match or ≥0.95 similarity. That conflates homonyms such as “Python” the language vs “Python” the animal — the same class of bug Python #5497 gates with `entity_type`. TS needs the same gate for SDK parity and correct graph linking.

## Verification

- `cd mem0-ts && pnpm exec jest src/oss/tests/memory.entity-type-merge-gate.test.ts --coverage=false` — 3 passed, 0 failed
- Did NOT change: search-time entity boost, embedders, or vector store adapters

## Notes

- Gate policy matches the Python PR #5497 approach (skip merge + insert new when both types present and unequal).
- No labels / no reviewer requests from this bot.