### PR TITLE
fix(ts-oss): enforce '*' metadata filter as field-exists

### DIFF
--- a/mem0-ts/src/oss/src/tests/milvus.test.ts
+++ b/mem0-ts/src/oss/src/tests/milvus.test.ts
@@ -267,34 +267,34 @@ describe("Milvus vector store (TS OSS SDK)", () => {
     });
   });
 
-  it("skips a wildcard '*' filter value and keeps the rest", async () => {
+  it("treats wildcard '*' as field-exists and keeps the rest", async () => {
     const client = new FakeMilvusClient({ existing: ["mem0"] });
     client.searchResponse = { results: [] };
     const store = makeStore(client, { metricType: "COSINE" });
     await store.initialize();
 
-    // "*" means match-any: it must be dropped, not emitted as `== "*"` (which
-    // matches nothing), leaving only the real agent_id clause.
+    // "*" means field-exists (not drop, not literal == "*").
     await store.search([0.1, 0.2, 0.3], 5, {
       user_id: "*",
       agent_id: "a1",
     });
 
     const searchCall = client.calls.find((c) => c.method === "search")!;
-    expect(searchCall.args.filter).toBe('(metadata["agent_id"] == "a1")');
+    expect(searchCall.args.filter).toBe(
+      'exists metadata["user_id"] and (metadata["agent_id"] == "a1")',
+    );
   });
 
-  it("omits the filter entirely when every value is a wildcard", async () => {
+  it("emits exists when every value is a wildcard", async () => {
     const client = new FakeMilvusClient({ existing: ["mem0"] });
     const store = makeStore(client);
     await store.initialize();
 
     await store.list({ user_id: "*" });
 
-    // All clauses dropped, so list() falls back to its match-all "" filter
-    // rather than a literal `(metadata["user_id"] == "*")` that matches nothing.
+    // Field-exists for the wildcard key rather than empty match-all or == "*".
     const queryCall = client.calls.filter((c) => c.method === "query").pop()!;
-    expect(queryCall.args.filter).toBe("");
+    expect(queryCall.args.filter).toBe('exists metadata["user_id"]');
   });
 
   it("normalises L2 distances into a 0..1 similarity score", async () => {

--- a/mem0-ts/src/oss/src/tests/pinecone.test.ts
+++ b/mem0-ts/src/oss/src/tests/pinecone.test.ts
@@ -304,11 +304,11 @@ describe("search", () => {
     );
   });
 
-  it("omits wildcard '*' from filter", async () => {
+  it("treats wildcard '*' as field-exists on filter", async () => {
     const db = await initDb();
     await db.search([1, 2, 3, 4], 5, { user_id: "*" });
     const call = __mocks__.query.mock.calls[0][0];
-    expect(call.filter).toBeUndefined();
+    expect(call.filter).toEqual({ user_id: { $exists: true } });
   });
 
   it("translates OR filter", async () => {

--- a/mem0-ts/src/oss/src/vector_stores/cassandra.ts
+++ b/mem0-ts/src/oss/src/vector_stores/cassandra.ts
@@ -445,8 +445,9 @@ export class CassandraDB implements VectorStore {
     const payloadValue = payload[key];
 
     if (typeof value !== "object" || value === null) {
+      // "*" = field-exists (docs contract). Must not match missing/undefined fields.
       if (value === "*") {
-        return true;
+        return payloadValue !== undefined && payloadValue !== null;
       }
       return payloadValue === value;
     }

--- a/mem0-ts/src/oss/src/vector_stores/chroma.ts
+++ b/mem0-ts/src/oss/src/vector_stores/chroma.ts
@@ -274,7 +274,9 @@ export class ChromaDB implements VectorStore {
     key: string,
     value: any,
   ): Array<Record<string, any>> {
-    // Wildcard - ChromaDB has no direct wildcard, so skip this filter.
+    // Field-exists wildcard: Chroma has no exists/$exists operator that excludes
+    // missing keys ($ne and peers still match absent keys). Skip rather than
+    // emit a literal equality on "*" (which matched nothing).
     if (value === "*") {
       return [];
     }

--- a/mem0-ts/src/oss/src/vector_stores/memory.ts
+++ b/mem0-ts/src/oss/src/vector_stores/memory.ts
@@ -98,9 +98,9 @@ export class MemoryVectorStore implements VectorStore {
 
     // Handle non-dict values
     if (typeof value !== "object" || value === null) {
-      // Wildcard: match any value
+      // "*" = field-exists; do not match missing/null/undefined values.
       if (value === "*") {
-        return true;
+        return payloadValue !== undefined && payloadValue !== null;
       }
       // Simple equality
       return payloadValue === value;

--- a/mem0-ts/src/oss/src/vector_stores/milvus.ts
+++ b/mem0-ts/src/oss/src/vector_stores/milvus.ts
@@ -236,10 +236,8 @@ export class Milvus implements VectorStore {
         throw new Error(`Invalid filter key: ${JSON.stringify(key)}`);
       }
       if (value === "*") {
-        // Wildcard - match any value. Milvus has no direct wildcard, so skip
-        // the clause rather than emitting a literal `== "*"` that matches
-        // nothing. Mirrors the Python provider (#6187) and the chroma/pinecone
-        // stores.
+        // Field-exists (docs contract). Milvus 2.x supports exists() on JSON keys.
+        operands.push(`exists metadata["${key}"]`);
         continue;
       }
       if (typeof value === "string") {

--- a/mem0-ts/src/oss/src/vector_stores/pinecone.ts
+++ b/mem0-ts/src/oss/src/vector_stores/pinecone.ts
@@ -182,7 +182,11 @@ export class PineconeDB implements VectorStore {
         continue;
       }
 
-      if (value === "*") continue;
+      // Documented contract: "*" means the field must exist (any value).
+      if (value === "*") {
+        result[key] = { $exists: true };
+        continue;
+      }
 
       if (Array.isArray(value)) {
         result[key] = { $in: value };

--- a/mem0-ts/src/oss/src/vector_stores/qdrant.ts
+++ b/mem0-ts/src/oss/src/vector_stores/qdrant.ts
@@ -121,7 +121,7 @@ export class Qdrant implements VectorStore {
   private buildFieldCondition(key: string, value: any): QdrantCondition | null {
     // Handle non-dict values
     if (typeof value !== "object" || value === null) {
-      // Wildcard: match any value - skip this filter
+      // "*" is handled in createFilter (must_not is_empty) — should not reach here.
       if (value === "*") {
         return null;
       }
@@ -258,6 +258,11 @@ export class Qdrant implements VectorStore {
           }
         }
       } else {
+        // Field-exists wildcard: require the payload key (must_not is_empty).
+        if (value === "*") {
+          mustNot.push({ is_empty: { key } } as any);
+          continue;
+        }
         // Regular field condition
         const condition = this.buildFieldCondition(key, value);
         if (condition !== null) {

--- a/mem0-ts/src/oss/tests/wildcard-field-exists.test.ts
+++ b/mem0-ts/src/oss/tests/wildcard-field-exists.test.ts
@@ -1,0 +1,63 @@
+/**
+ * "*" filter value = field-exists across TS vector stores (issue #6539).
+ */
+/// <reference types="jest" />
+import { MemoryVectorStore } from "../src/vector_stores/memory";
+import { CassandraDB } from "../src/vector_stores/cassandra";
+import { PineconeDB } from "../src/vector_stores/pinecone";
+import { Qdrant } from "../src/vector_stores/qdrant";
+import { Milvus } from "../src/vector_stores/milvus";
+
+describe("field-exists wildcard (*)", () => {
+  test("MemoryVectorStore rejects missing fields for *", () => {
+    const store = new MemoryVectorStore({
+      collectionName: "wc",
+      dimension: 3,
+      dbPath: ":memory:",
+    }) as any;
+    expect(store.matchFieldCondition({ agent_id: "a" }, "agent_id", "*")).toBe(
+      true,
+    );
+    expect(store.matchFieldCondition({}, "agent_id", "*")).toBe(false);
+    expect(store.matchFieldCondition({ agent_id: null }, "agent_id", "*")).toBe(
+      false,
+    );
+  });
+
+  test("CassandraDB rejects missing fields for *", () => {
+    const store = Object.create(CassandraDB.prototype) as any;
+    expect(store.matchFieldCondition({ agent_id: "a" }, "agent_id", "*")).toBe(
+      true,
+    );
+    expect(store.matchFieldCondition({}, "agent_id", "*")).toBe(false);
+  });
+
+  test("PineconeDB emits $exists for *", () => {
+    const store = Object.create(PineconeDB.prototype) as any;
+    expect(store.createFilter({ agent_id: "*" })).toEqual({
+      agent_id: { $exists: true },
+    });
+    expect(store.createFilter({ agent_id: "x" })).toEqual({
+      agent_id: { $eq: "x" },
+    });
+  });
+
+  test("Qdrant uses must_not is_empty for *", () => {
+    const store = Object.create(Qdrant.prototype) as any;
+    expect(store.createFilter({ agent_id: "*" })).toEqual({
+      must: undefined,
+      should: undefined,
+      must_not: [{ is_empty: { key: "agent_id" } }],
+    });
+  });
+
+  test("Milvus emits exists metadata[key] for *", () => {
+    const store = Object.create(Milvus.prototype) as any;
+    expect(store.createFilter({ agent_id: "*" })).toBe(
+      'exists metadata["agent_id"]',
+    );
+    expect(store.createFilter({ agent_id: "bot" })).toBe(
+      '(metadata["agent_id"] == "bot")',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Enforce documented `filters[field] = "*"` **field-exists** semantics across TypeScript OSS vector stores that could express it.
- Client-side matchers (memory, Cassandra) no longer treat missing/`null` payload keys as matches.
- Pinecone emits `{ $exists: true }`; Qdrant uses `must_not: is_empty`; Milvus emits `exists metadata["key"]`.
- Chroma still skips `*` (no exists operator that excludes missing keys) but no longer risks a silent precisamente-wrong path; comment clarifies.

## Motivation

Related to #6539 (does **not** close it alone — Python providers are covered by #6540).

Same cross-provider contract failure called out after OpenSearch #6522: `"*"` must mean “field is present,” not “ignore this filter” or “literal star.”

## Differential value

#6540 by @microbluey fixes the **Python** providers for #6539. This PR is the complementary **TypeScript OSS** surface (`mem0-ts/src/oss/src/vector_stores/*`) so both SDKs share the contract.

## Verification

- `cd mem0-ts && pnpm exec jest src/oss/tests/wildcard-field-exists.test.ts --coverage=false` — 5 passed, 0 failed
- Did NOT change: OpenSearch adapter (already correct), server REST, Python packages

## Notes

- No reviewer requests / no labels from this bot.