### PR TITLE
fix(vector_stores): enforce the '*' wildcard as field-exists in Redis and Azure AI Search

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -196,7 +196,13 @@ class AzureAISearch(VectorStoreBase):
         filter_conditions = []
         for key, value in filters.items():
             safe_key = self._sanitize_key(key)
-            if isinstance(value, str):
+            if value == "*":
+                # The documented '*' filter value means "the field exists"; a
+                # literal eq '*' comparison would match nothing. Fields absent
+                # from a document are null in Azure AI Search, so 'ne null'
+                # expresses exactly field-exists.
+                condition = f"{safe_key} ne null"
+            elif isinstance(value, str):
                 safe_value = value.replace("'", "''")
                 condition = f"{safe_key} eq '{safe_value}'"
             elif isinstance(value, bool):

--- a/mem0/vector_stores/redis.py
+++ b/mem0/vector_stores/redis.py
@@ -9,7 +9,7 @@ import redis
 from redis.commands.search.query import Query
 from redisvl.index import SearchIndex
 from redisvl.query import TextQuery, VectorQuery
-from redisvl.query.filter import Tag
+from redisvl.query.filter import FilterExpression, Tag
 
 from mem0.memory.utils import extract_json
 from mem0.vector_stores.base import VectorStoreBase
@@ -36,6 +36,21 @@ DEFAULT_FIELDS = [
 ]
 
 excluded_keys = {"user_id", "agent_id", "run_id", "hash", "data", "created_at", "updated_at"}
+
+
+def _filter_condition(key, value):
+    """Translate a single metadata filter into a redisvl filter expression.
+
+    The documented '*' filter value means "the field exists, regardless of
+    value". Tag equality escapes the star into a literal '\\*' tag that
+    matches nothing, so build a tag wildcard query instead — it matches any
+    record with a non-empty value for the field (RediSearch does not index
+    missing or empty tag values). The w'...' wildcard syntax requires query
+    dialect 2, redisvl's default.
+    """
+    if value == "*":
+        return FilterExpression(f"@{key}:{{w'*'}}")
+    return Tag(key) == value
 
 
 class MemoryResult:
@@ -148,7 +163,7 @@ class RedisDB(VectorStoreBase):
     def search(self, query: str, vectors: list, top_k: int = 5, filters: dict = None):
         filter = None
         if filters:
-            conditions = [Tag(key) == value for key, value in filters.items() if value is not None]
+            conditions = [_filter_condition(key, value) for key, value in filters.items() if value is not None]
             if conditions:
                 filter = reduce(lambda x, y: x & y, conditions)
 
@@ -202,7 +217,7 @@ class RedisDB(VectorStoreBase):
         """
         filter_expression = None
         if filters:
-            conditions = [Tag(key) == value for key, value in filters.items() if value is not None]
+            conditions = [_filter_condition(key, value) for key, value in filters.items() if value is not None]
             if conditions:
                 filter_expression = reduce(lambda x, y: x & y, conditions)
 
@@ -327,10 +342,15 @@ class RedisDB(VectorStoreBase):
         """
         filter = None
         if filters:
-            conditions = [Tag(key) == value for key, value in filters.items() if value is not None]
+            conditions = [_filter_condition(key, value) for key, value in filters.items() if value is not None]
             if conditions:
                 filter = reduce(lambda x, y: x & y, conditions)
         query = Query(str(filter) if filter is not None else "*").sort_by("created_at", asc=False)
+        if filters and any(value == "*" for value in filters.values()):
+            # The w'...' wildcard syntax needs query dialect 2. redisvl queries
+            # default to it, but redis-py's raw Query does not send DIALECT at
+            # all in the supported <6.0 range, leaving the server default (1).
+            query = query.dialect(2)
         if top_k is not None:
             query = query.paging(0, top_k)
 

--- a/tests/vector_stores/test_azure_ai_search.py
+++ b/tests/vector_stores/test_azure_ai_search.py
@@ -719,3 +719,20 @@ def test_build_filter_escapes_quotes(azure_ai_search_instance):
     instance, _, _ = azure_ai_search_instance
     expr = instance._build_filter_expression({"name": "O'Brien"})
     assert "name eq 'O''Brien'" in expr
+
+
+def test_build_filter_wildcard_means_field_exists(azure_ai_search_instance):
+    """The documented '*' filter value means "the field exists" (#6539).
+    A literal eq '*' comparison would match nothing; absent fields are null
+    in Azure AI Search, so it must translate to 'ne null'."""
+    instance, _, _ = azure_ai_search_instance
+    expr = instance._build_filter_expression({"agent_id": "*"})
+    assert expr == "agent_id ne null"
+
+
+def test_build_filter_wildcard_combines_with_equality(azure_ai_search_instance):
+    instance, _, _ = azure_ai_search_instance
+    expr = instance._build_filter_expression({"user_id": "alice", "agent_id": "*"})
+    assert "user_id eq 'alice'" in expr
+    assert "agent_id ne null" in expr
+    assert " and " in expr

--- a/tests/vector_stores/test_redis.py
+++ b/tests/vector_stores/test_redis.py
@@ -228,3 +228,52 @@ def test_update_entity_payload_without_hash_and_timestamps():
     assert data_dict["hash"] == ""
     assert data_dict["created_at"] == 0
     assert data_dict["updated_at"] == 0
+
+
+def test_search_wildcard_filter_means_field_exists():
+    """The documented '*' filter value means "the field exists" (#6539).
+    Tag equality escapes the star into a literal '\\*' tag that matches
+    nothing; it must become a tag wildcard query instead."""
+    db, mock_index = _make_redis_db()
+    mock_index.query.return_value = []
+
+    db.search("query", [0.1, 0.2, 0.3, 0.4], filters={"agent_id": "*"})
+
+    vector_query = mock_index.query.call_args[0][0]
+    assert str(vector_query.filter) == "@agent_id:{w'*'}"
+
+
+def test_search_wildcard_combines_with_tag_equality():
+    db, mock_index = _make_redis_db()
+    mock_index.query.return_value = []
+
+    db.search("query", [0.1, 0.2, 0.3, 0.4], filters={"user_id": "alice", "agent_id": "*"})
+
+    vector_query = mock_index.query.call_args[0][0]
+    assert str(vector_query.filter) == "(@user_id:{alice} @agent_id:{w'*'})"
+
+
+def test_keyword_search_wildcard_filter_means_field_exists():
+    db, mock_index = _make_redis_db()
+    mock_index.query.return_value = []
+
+    db.keyword_search("query", filters={"agent_id": "*"})
+
+    text_query = mock_index.query.call_args[0][0]
+    assert str(text_query.filter) == "@agent_id:{w'*'}"
+
+
+def test_list_wildcard_filter_means_field_exists():
+    """list() builds a raw redis-py Query, which does not send DIALECT by
+    default; the w'...' wildcard syntax requires dialect 2."""
+    db, mock_index = _make_redis_db()
+    mock_index.search.return_value = MagicMock(docs=[])
+
+    db.list(filters={"agent_id": "*"})
+
+    query = mock_index.search.call_args[0][0]
+    assert query.query_string() == "@agent_id:{w'*'}"
+    args = query.get_args()
+    assert "DIALECT" in args
+    assert args[args.index("DIALECT") + 1] == 2
+


### PR DESCRIPTION
## Linked Issue

Related to #6539 — follow-up to #6540, covering the two providers flagged in [this comment](https://github.com/mem0ai/mem0/issues/6539#issuecomment-5067432678) as having the same literal-match bug. (#6540 carries the `Closes` reference.)

## Description

Both stores compiled the documented "field exists" wildcard into an equality comparison against the literal string `*`, matching nothing:

- **redis**: `Tag(key) == "*"` escapes the star into a literal `{\*}` tag query. Now translated into a tag wildcard query `{w'*'}`, which matches any record with a non-empty value for the field — applied on all three query paths (`search`, `keyword_search`, `list`). One subtlety: `list()` builds a raw redis-py `Query`, which does **not** send `DIALECT` in the supported `redis>=5.0,<6.0` range (verified on 5.0.0 and 5.1.0), while the `w'...'` syntax requires dialect 2 — so it is set explicitly on that path. The redisvl `VectorQuery`/`TextQuery` paths already default to dialect 2.
  - `ismissing()` was considered but requires the index schema to declare `INDEXMISSING` (RediSearch ≥ 2.10), which mem0's schema doesn't; the tag wildcard works without schema changes.
- **azure_ai_search**: `_build_filter_expression` produced `field eq '*'`. Now translated into OData `field ne null` — absent fields are null in Azure AI Search, so this expresses exactly field-exists.

Semantics match the providers fixed in #6540: present with a real value (missing/empty excluded).

No docs changes here to avoid conflicting with the per-provider note added in #6540; I'll extend that note with these two providers once it lands.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — `filters={field: '*'}` previously returned no results on these two stores, so no working behavior changes.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Unit tests assert the compiled filter expressions on all query paths (`tests/vector_stores/test_redis.py`, `tests/vector_stores/test_azure_ai_search.py`).

Manual verification against a real `redis/redis-stack-server` (RediSearch 2.10.20): with three records (agent_id=a1 / absent / agent_id=a2), `search`/`keyword_search`/`list` with `{'agent_id': '*'}` return exactly the two records that have the field, before the fix they returned none; combined `{'agent_id': '*', 'user_id': 'u1'}` returns only the intersection; plain tag equality is unchanged.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed