### PR TITLE
fix(ts-oss): add entity_type merge gate to prevent same-name entity conflation

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -500,21 +500,39 @@ export class Memory {
               ? matches[0]
               : undefined;
           const match = exactMatch ?? semanticMatch;
+          let matched = false;
           if (match) {
             const payload = match.payload || {};
-            const linked = new Set<string>(
-              Array.isArray(payload.linkedMemoryIds)
-                ? payload.linkedMemoryIds
-                : [],
-            );
-            linked.add(memoryId);
-            payload.linkedMemoryIds = Array.from(linked).sort();
-            try {
-              await entityStore.update(match.id, entityVec, payload);
-            } catch (e) {
-              console.debug(`Entity update failed for '${entity.text}': ${e}`);
+            const existingType = payload.entityType;
+            if (entity.type && existingType && existingType !== entity.type) {
+              console.warn(
+                `Skipping merge for entity '${entity.text}': stored entityType ` +
+                  `'${existingType}' != new entityType '${entity.type}'. A duplicate ` +
+                  `entity will be created instead of merging (this can happen after ` +
+                  `an entityType vocabulary change).`,
+              );
+            } else {
+              matched = true;
+              const linked = new Set<string>(
+                Array.isArray(payload.linkedMemoryIds)
+                  ? payload.linkedMemoryIds
+                  : [],
+              );
+              linked.add(memoryId);
+              payload.linkedMemoryIds = Array.from(linked).sort();
+              if (entity.type && !existingType) {
+                payload.entityType = entity.type;
+              }
+              try {
+                await entityStore.update(match.id, entityVec, payload);
+              } catch (e) {
+                console.debug(
+                  `Entity update failed for '${entity.text}': ${e}`,
+                );
+              }
             }
-          } else {
+          }
+          if (!matched) {
             const entityPayload: Record<string, any> = {
               data: entity.text,
               entityType: entity.type,
@@ -1184,18 +1202,36 @@ export class Memory {
                 ? matches[0]
                 : undefined;
             const match = exactMatch ?? semanticMatch;
+            let matched = false;
             if (match) {
               // Update existing entity
               const payload = match.payload || {};
-              const linked = new Set<string>(payload.linkedMemoryIds ?? []);
-              for (const mid of memoryIds) linked.add(mid);
-              payload.linkedMemoryIds = Array.from(linked).sort();
-              try {
-                await entityStore.update(match.id, entityVec, payload);
-              } catch (e) {
-                console.debug(`Entity update failed for '${entityText}': ${e}`);
+              const existingType = payload.entityType;
+              if (entityType && existingType && existingType !== entityType) {
+                console.warn(
+                  `Skipping merge for entity '${entityText}': stored entityType ` +
+                    `'${existingType}' != new entityType '${entityType}'. A duplicate ` +
+                    `entity will be created instead of merging (this can happen after ` +
+                    `an entityType vocabulary change).`,
+                );
+              } else {
+                matched = true;
+                const linked = new Set<string>(payload.linkedMemoryIds ?? []);
+                for (const mid of memoryIds) linked.add(mid);
+                payload.linkedMemoryIds = Array.from(linked).sort();
+                if (entityType && !existingType) {
+                  payload.entityType = entityType;
+                }
+                try {
+                  await entityStore.update(match.id, entityVec, payload);
+                } catch (e) {
+                  console.debug(
+                    `Entity update failed for '${entityText}': ${e}`,
+                  );
+                }
               }
-            } else {
+            }
+            if (!matched) {
               // New entity — collect for batch insert
               const entityPayload: Record<string, any> = {
                 data: entityText,

--- a/mem0-ts/src/oss/tests/memory.entity-type-gate.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-type-gate.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Entity-type merge gate tests (#6529).
+ *
+ * Ports the Python entity_type merge gate (#5497) to the TS OSS SDK. Entities
+ * with the same text but a different entityType must NOT be merged (e.g.
+ * "Python" the language vs the snake); a new entity is inserted instead. When
+ * either side lacks a type the merge is still allowed (backward compat) and a
+ * missing stored type is backfilled from the new entity.
+ *
+ * Covers both merge sites in memory/index.ts:
+ *   - _linkEntitiesForMemory (update() path)
+ *   - Phase 7c/7d batch path (add() path)
+ */
+/// <reference types="jest" />
+import { Memory } from "../src/memory";
+import type { MemoryConfig } from "../src/types";
+
+jest.setTimeout(15000);
+
+// Mock Google modules to prevent @google/genai crash in CI.
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
+
+// Deterministic entity extraction so tests control text + type exactly.
+jest.mock("../src/utils/entity_extraction", () => {
+  const actual = jest.requireActual("../src/utils/entity_extraction");
+  return {
+    ...actual,
+    extractEntities: jest.fn(),
+    extractEntitiesBatch: jest.fn(),
+  };
+});
+import {
+  extractEntities,
+  extractEntitiesBatch,
+} from "../src/utils/entity_extraction";
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 1536,
+  })),
+}));
+
+// LLM mock: echoes the `## New Messages` section back as a single extracted
+// memory so add() produces exactly one ADD record and reaches Phase 7.
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest
+      .fn()
+      .mockImplementation(
+        (messages: Array<{ role: string; content: string }>) => {
+          const userMsg = messages.find((m) => m.role === "user");
+          const content = userMsg?.content ?? "";
+          const newMsgMatch = content.match(
+            /## New Messages\n([\s\S]*?)(?=\n##|$)/,
+          );
+          const extracted = newMsgMatch
+            ? newMsgMatch[1].trim()
+            : "extracted fact";
+          return JSON.stringify({
+            memory: [{ id: "0", text: extracted, attributed_to: "user" }],
+          });
+        },
+      ),
+  })),
+}));
+
+function createMemory(overrides: Partial<MemoryConfig> = {}): Memory {
+  return new Memory({
+    version: "v1.1",
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-etgate-${Date.now()}-${Math.random()}`,
+        dimension: 1536,
+        dbPath: ":memory:",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-5-mini" },
+    },
+    historyDbPath: ":memory:",
+    ...overrides,
+  });
+}
+
+/**
+ * Build a mock entity store where the given payload rows already exist. `list`
+ * feeds the exact-match lookup (_existingEntitiesByText); update/insert are
+ * spies so tests can assert which path ran.
+ */
+function makeEntityStore(existingRows: Array<{ id: string; payload: any }>) {
+  return {
+    list: jest.fn().mockResolvedValue([existingRows]),
+    search: jest.fn().mockResolvedValue([]),
+    update: jest.fn().mockResolvedValue(undefined),
+    insert: jest.fn().mockResolvedValue(undefined),
+    initialize: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("Entity-type merge gate (#6529)", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  describe("_linkEntitiesForMemory (update path)", () => {
+    async function run(
+      newEntity: { type: string; text: string },
+      storedPayload: Record<string, any>,
+    ) {
+      (extractEntities as jest.Mock).mockReturnValue([newEntity]);
+      const memory = createMemory();
+      const m = memory as any;
+      await m._ensureInitialized();
+      const store = makeEntityStore([
+        { id: "entity-1", payload: storedPayload },
+      ]);
+      m._entityStore = store;
+      await m._linkEntitiesForMemory("mem-B", "irrelevant", {
+        user_id: "u1",
+      });
+      await memory.reset();
+      return store;
+    }
+
+    it("merges when stored and new entityType match", async () => {
+      const store = await run(
+        { type: "language", text: "python" },
+        { data: "python", entityType: "language", linkedMemoryIds: ["mem-A"] },
+      );
+      expect(store.update).toHaveBeenCalledTimes(1);
+      expect(store.insert).not.toHaveBeenCalled();
+    });
+
+    it("inserts a new entity when entityType differs", async () => {
+      const store = await run(
+        { type: "animal", text: "python" },
+        { data: "python", entityType: "language", linkedMemoryIds: ["mem-A"] },
+      );
+      expect(store.update).not.toHaveBeenCalled();
+      expect(store.insert).toHaveBeenCalledTimes(1);
+      const insertedPayload = store.insert.mock.calls[0][2][0];
+      expect(insertedPayload.entityType).toBe("animal");
+      expect(insertedPayload.data).toBe("python");
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it("still merges (and backfills type) when the stored entity has no type", async () => {
+      const store = await run(
+        { type: "language", text: "python" },
+        { data: "python", linkedMemoryIds: ["mem-A"] },
+      );
+      expect(store.update).toHaveBeenCalledTimes(1);
+      expect(store.insert).not.toHaveBeenCalled();
+      const updatedPayload = store.update.mock.calls[0][2];
+      expect(updatedPayload.entityType).toBe("language");
+    });
+
+    it("still merges when the new entity has no type", async () => {
+      const store = await run(
+        { type: "", text: "python" },
+        { data: "python", entityType: "language", linkedMemoryIds: ["mem-A"] },
+      );
+      expect(store.update).toHaveBeenCalledTimes(1);
+      expect(store.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Phase 7c/7d batch path (add path)", () => {
+    it("inserts a new entity when entityType differs in the batch path", async () => {
+      (extractEntitiesBatch as jest.Mock).mockReturnValue([
+        [{ type: "animal", text: "python" }],
+      ]);
+      const memory = createMemory();
+      const m = memory as any;
+      await m._ensureInitialized();
+      const store = makeEntityStore([
+        {
+          id: "entity-1",
+          payload: {
+            data: "python",
+            entityType: "language",
+            linkedMemoryIds: ["mem-A"],
+          },
+        },
+      ]);
+      m._entityStore = store;
+
+      await memory.add("python the animal", { userId: "u1" });
+
+      expect(store.update).not.toHaveBeenCalled();
+      expect(store.insert).toHaveBeenCalledTimes(1);
+      const insertedPayload = store.insert.mock.calls[0][2][0];
+      expect(insertedPayload.entityType).toBe("animal");
+      expect(warnSpy).toHaveBeenCalled();
+      await memory.reset();
+    });
+
+    it("merges in the batch path when entityType matches", async () => {
+      (extractEntitiesBatch as jest.Mock).mockReturnValue([
+        [{ type: "language", text: "python" }],
+      ]);
+      const memory = createMemory();
+      const m = memory as any;
+      await m._ensureInitialized();
+      const store = makeEntityStore([
+        {
+          id: "entity-1",
+          payload: {
+            data: "python",
+            entityType: "language",
+            linkedMemoryIds: ["mem-A"],
+          },
+        },
+      ]);
+      m._entityStore = store;
+
+      await memory.add("python the language", { userId: "u1" });
+
+      expect(store.update).toHaveBeenCalledTimes(1);
+      expect(store.insert).not.toHaveBeenCalled();
+      await memory.reset();
+    });
+
+    it("backfills the missing stored type in the batch path", async () => {
+      (extractEntitiesBatch as jest.Mock).mockReturnValue([
+        [{ type: "language", text: "python" }],
+      ]);
+      const memory = createMemory();
+      const m = memory as any;
+      await m._ensureInitialized();
+      const store = makeEntityStore([
+        {
+          id: "entity-1",
+          payload: { data: "python", linkedMemoryIds: ["mem-A"] },
+        },
+      ]);
+      m._entityStore = store;
+
+      await memory.add("python the language", { userId: "u1" });
+
+      expect(store.update).toHaveBeenCalledTimes(1);
+      expect(store.insert).not.toHaveBeenCalled();
+      const updatedPayload = store.update.mock.calls[0][2];
+      expect(updatedPayload.entityType).toBe("language");
+      await memory.reset();
+    });
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6529

## Description

Ports the Python `entity_type` merge gate (#5497) to the TypeScript OSS SDK for parity.

Before this change, the TS OSS entity-merge paths merged entities on exact-text or vector similarity alone, with no `entityType` check. That conflates entities that share text but mean different things (for example "Python" the language vs the snake), the same bug the Python gate fixes.

This adds the gate to both merge sites `@kartik-mem0` identified in the issue:

- `mem0-ts/src/oss/src/memory/index.ts` - `_linkEntitiesForMemory` (the `update()` path)
- `mem0-ts/src/oss/src/memory/index.ts` - Phase 7c/7d batch path (the `add()` path)

Both now mirror the Python behavior in #5497:

- Skip the merge and insert a new entity when both the stored and the new entity have an `entityType` and they differ (a warning is logged).
- Still merge when either side lacks a type (backward compatible).
- Backfill the stored entity's missing type from the new entity on merge.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. Behavior only changes for entities that previously conflated across differing types; when either side has no type, merging is unchanged.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `mem0-ts/src/oss/tests/memory.entity-type-gate.test.ts` with 7 regression tests covering both merge sites: same-type merges, different-type inserts a new entity, no-type-on-either-side still merges, and missing-type backfill.

Verification:

- RED/GREEN proof: with the source fix stashed, the 4 gate-behavior tests fail and the 3 backward-compat tests pass; with the fix applied all 7 pass.
- No regressions: existing `memory.add`, `memory.entity-boost`, `memory.crud`, and `entity-extraction` suites all pass (68 tests).
- `tsup` build succeeds with no new type errors.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed