### PR TITLE
fix(ts-oss): enforce the '*' wildcard as field-exists in Redis and Azure AI Search

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/azure_ai_search.ts
+++ b/mem0-ts/src/oss/src/vector_stores/azure_ai_search.ts
@@ -316,7 +316,13 @@ export class AzureAISearch implements VectorStore {
     for (const [key, value] of Object.entries(filters)) {
       const safeKey = this.sanitizeKey(key);
 
-      if (typeof value === "string") {
+      if (value === "*") {
+        // The documented '*' filter value means "the field exists"
+        // (mem0ai/mem0#6539); a literal eq '*' comparison would match
+        // nothing. Fields absent from a document are null in Azure AI
+        // Search, so 'ne null' expresses exactly field-exists.
+        filterConditions.push(`${safeKey} ne null`);
+      } else if (typeof value === "string") {
         // Escape single quotes in string values
         const safeValue = value.replace(/'/g, "''");
         filterConditions.push(`${safeKey} eq '${safeValue}'`);

--- a/mem0-ts/src/oss/src/vector_stores/redis.ts
+++ b/mem0-ts/src/oss/src/vector_stores/redis.ts
@@ -22,6 +22,23 @@ function escapeRedisTagValue(value: unknown): string {
   );
 }
 
+/**
+ * Translate a single metadata filter into a RediSearch condition.
+ *
+ * The documented `*` filter value means "the field exists, regardless of
+ * value" (mem0ai/mem0#6539). Tag equality would escape the star into a
+ * literal `\*` tag that matches nothing, so build a tag wildcard query
+ * instead — it matches any record with a non-empty value for the field
+ * (RediSearch does not index missing or empty tag values). The w'...'
+ * wildcard syntax requires query DIALECT 2.
+ */
+function redisFilterCondition(key: string, value: unknown): string {
+  if (value === "*") {
+    return `@${key}:{w'*'}`;
+  }
+  return `@${key}:{${escapeRedisTagValue(value)}}`;
+}
+
 interface RedisConfig extends VectorStoreConfig {
   redisUrl: string;
   collectionName: string;
@@ -407,12 +424,15 @@ export class RedisDB implements VectorStore {
   ): Promise<VectorStoreResult[]> {
     await this.initialize();
     const snakeFilters = filters ? toSnakeCase(filters) : undefined;
-    const filterExpr = snakeFilters
+    const conditions = snakeFilters
       ? Object.entries(snakeFilters)
           .filter(([_, value]) => value !== null && value !== undefined)
-          .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`)
-          .join(" ")
-      : "*";
+          .map(([key, value]) => redisFilterCondition(key, value))
+      : [];
+    // Parenthesize the prefilter: RediSearch rejects a space-joined
+    // multi-condition prefilter placed directly before =>[KNN ...] with a
+    // syntax error, so any search with two or more filters failed outright.
+    const filterExpr = conditions.length ? `(${conditions.join(" ")})` : "*";
 
     const queryVector = new Float32Array(query).buffer;
 
@@ -659,7 +679,7 @@ export class RedisDB implements VectorStore {
     const filterExpr = snakeFilters
       ? Object.entries(snakeFilters)
           .filter(([_, value]) => value !== null && value !== undefined)
-          .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`)
+          .map(([key, value]) => redisFilterCondition(key, value))
           .join(" ")
       : "*";
 
@@ -670,6 +690,10 @@ export class RedisDB implements VectorStore {
         from: 0,
         size: topK,
       },
+      // The w'...' wildcard syntax needs query DIALECT 2; node-redis does
+      // not send DIALECT unless asked (search() above already passes it).
+      ...(snakeFilters &&
+        Object.values(snakeFilters).includes("*") && { DIALECT: 2 }),
     };
 
     const results = (await this.client.ft.search(

--- a/mem0-ts/src/oss/src/vector_stores/redis.ts
+++ b/mem0-ts/src/oss/src/vector_stores/redis.ts
@@ -23,6 +23,23 @@ function escapeRedisTagValue(value: unknown): string {
   );
 }
 
+/**
+ * Translate a single metadata filter into a RediSearch condition.
+ *
+ * The documented `*` filter value means "the field exists, regardless of
+ * value" (mem0ai/mem0#6539). Tag equality would escape the star into a
+ * literal `\*` tag that matches nothing, so build a tag wildcard query
+ * instead — it matches any record with a non-empty value for the field
+ * (RediSearch does not index missing or empty tag values). The w'...'
+ * wildcard syntax requires query DIALECT 2.
+ */
+function redisFilterCondition(key: string, value: unknown): string {
+  if (value === "*") {
+    return `@${key}:{w'*'}`;
+  }
+  return `@${key}:{${escapeRedisTagValue(value)}}`;
+}
+
 interface RedisConfig extends VectorStoreConfig {
   redisUrl: string;
   collectionName: string;
@@ -138,12 +155,30 @@ function toSnakeCase(obj: Record<string, any>): Record<string, any> {
 // all) when there are no usable conditions — including an empty filters object
 // or one whose values are all null/undefined — since an empty expression is an
 // invalid RediSearch query (e.g. ` =>[KNN ...]`).
-export function buildRedisFilterExpr(filters?: SearchFilters): string {
+//
+// Pass `group: true` for the vector-search pre-filter: RediSearch rejects a
+// space-joined multi-condition prefilter placed directly before `=>[KNN ...]`
+// with a syntax error, so any search with two or more filters failed outright.
+export function buildRedisFilterExpr(
+  filters?: SearchFilters,
+  options: { group?: boolean } = {},
+): string {
   if (!filters) return "*";
   const conditions = Object.entries(toSnakeCase(filters))
     .filter(([, value]) => value !== null && value !== undefined)
-    .map(([key, value]) => `@${key}:{${escapeRedisTagValue(value)}}`);
-  return conditions.length > 0 ? conditions.join(" ") : "*";
+    .map(([key, value]) => redisFilterCondition(key, value));
+  if (conditions.length === 0) return "*";
+  const expr = conditions.join(" ");
+  return options.group ? `(${expr})` : expr;
+}
+
+/**
+ * Whether any filter uses the `*` wildcard, which is emitted as the `w'...'`
+ * tag syntax and therefore requires query DIALECT 2. Snake-casing rewrites
+ * keys only, so the raw values are enough to answer this.
+ */
+function hasWildcardFilter(filters?: SearchFilters): boolean {
+  return !!filters && Object.values(filters).includes("*");
 }
 
 export class RedisDB implements VectorStore {
@@ -407,7 +442,7 @@ export class RedisDB implements VectorStore {
     filters?: SearchFilters,
   ): Promise<VectorStoreResult[]> {
     await this.initialize();
-    const filterExpr = buildRedisFilterExpr(filters);
+    const filterExpr = buildRedisFilterExpr(filters, { group: true });
 
     const queryVector = new Float32Array(query).buffer;
 
@@ -659,6 +694,9 @@ export class RedisDB implements VectorStore {
         from: 0,
         size: topK,
       },
+      // The w'...' wildcard syntax needs query DIALECT 2; node-redis does
+      // not send DIALECT unless asked (search() above already passes it).
+      ...(hasWildcardFilter(filters) && { DIALECT: 2 }),
     };
 
     const results = (await this.client.ft.search(

--- a/mem0-ts/src/oss/tests/azure-ai-search.unit.test.ts
+++ b/mem0-ts/src/oss/tests/azure-ai-search.unit.test.ts
@@ -1,0 +1,32 @@
+import { AzureAISearch } from "../src/vector_stores/azure_ai_search";
+
+/**
+ * buildFilterExpression is pure (no client interaction), so instantiate via
+ * the prototype to avoid the constructor's initialize() reaching for the
+ * optional @azure/search-documents peer.
+ */
+function bareStore(): any {
+  return Object.create(AzureAISearch.prototype);
+}
+
+describe("AzureAISearch – buildFilterExpression", () => {
+  test("string values become quoted equality comparisons", () => {
+    const expr = bareStore().buildFilterExpression({ user_id: "alice" });
+    expect(expr).toBe("user_id eq 'alice'");
+  });
+
+  test("'*' means field-exists, not a literal comparison (mem0ai/mem0#6539)", () => {
+    // Fields absent from a document are null in Azure AI Search, so
+    // 'ne null' expresses exactly field-exists; eq '*' matched nothing.
+    const expr = bareStore().buildFilterExpression({ agent_id: "*" });
+    expect(expr).toBe("agent_id ne null");
+  });
+
+  test("wildcard combines with equality", () => {
+    const expr = bareStore().buildFilterExpression({
+      user_id: "alice",
+      agent_id: "*",
+    });
+    expect(expr).toBe("user_id eq 'alice' and agent_id ne null");
+  });
+});

--- a/mem0-ts/src/oss/tests/redis.unit.test.ts
+++ b/mem0-ts/src/oss/tests/redis.unit.test.ts
@@ -210,3 +210,92 @@ describe("RedisDB – entity payload handling", () => {
     expect(items[0].payload).not.toHaveProperty("runId");
   });
 });
+
+describe("RedisDB – '*' wildcard filter means field-exists (mem0ai/mem0#6539)", () => {
+  let store: RedisDB;
+  let mockClient: any;
+
+  beforeAll(async () => {
+    store = createStore();
+    await store.initialize();
+    mockClient = (store as any).client;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient.ft.search.mockResolvedValue({ documents: [], total: 0 });
+  });
+
+  test("search translates '*' into a tag wildcard, not a literal tag", async () => {
+    await store.search([0.1, 0.2, 0.3, 0.4], 5, { agentId: "*" });
+
+    const [, queryString] = mockClient.ft.search.mock.calls[0];
+    expect(queryString).toContain("@agent_id:{w'*'}");
+    expect(queryString).not.toContain("\\*");
+  });
+
+  test("search combines wildcard with tag equality", async () => {
+    await store.search([0.1, 0.2, 0.3, 0.4], 5, {
+      userId: "alice",
+      agentId: "*",
+    });
+
+    const [, queryString] = mockClient.ft.search.mock.calls[0];
+    expect(queryString).toContain("@user_id:{alice}");
+    expect(queryString).toContain("@agent_id:{w'*'}");
+  });
+
+  test("list translates '*' into a tag wildcard and sends DIALECT 2", async () => {
+    await store.list({ agentId: "*" });
+
+    const [, queryString, options] = mockClient.ft.search.mock.calls[0];
+    expect(queryString).toBe("@agent_id:{w'*'}");
+    // The w'...' syntax requires DIALECT 2 and node-redis does not send
+    // DIALECT unless asked.
+    expect(options.DIALECT).toBe(2);
+  });
+
+  test("list without wildcard keeps its previous query shape", async () => {
+    await store.list({ userId: "alice" });
+
+    const [, queryString, options] = mockClient.ft.search.mock.calls[0];
+    expect(queryString).toBe("@user_id:{alice}");
+    expect(options.DIALECT).toBeUndefined();
+  });
+});
+
+describe("RedisDB – KNN prefilter parenthesization", () => {
+  let store: RedisDB;
+  let mockClient: any;
+
+  beforeAll(async () => {
+    store = createStore();
+    await store.initialize();
+    mockClient = (store as any).client;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient.ft.search.mockResolvedValue({ documents: [], total: 0 });
+  });
+
+  test("multi-filter search wraps the prefilter in parentheses", async () => {
+    // RediSearch rejects a space-joined multi-condition prefilter placed
+    // directly before =>[KNN ...] with a syntax error, so any search with
+    // two or more filters failed outright.
+    await store.search([0.1, 0.2, 0.3, 0.4], 5, {
+      userId: "alice",
+      agentId: "a1",
+    });
+
+    const [, queryString] = mockClient.ft.search.mock.calls[0];
+    expect(queryString).toMatch(/^\(.+\) =>\[KNN /);
+  });
+
+  test("unfiltered search keeps the match-all prefilter", async () => {
+    await store.search([0.1, 0.2, 0.3, 0.4], 5);
+
+    const [, queryString] = mockClient.ft.search.mock.calls[0];
+    expect(queryString).toMatch(/^\* =>\[KNN /);
+  });
+});

--- a/mem0-ts/src/oss/tests/redis.unit.test.ts
+++ b/mem0-ts/src/oss/tests/redis.unit.test.ts
@@ -126,3 +126,92 @@ describe("RedisDB – entity payload handling", () => {
     expect(Number.isNaN(entry.created_at)).toBe(false);
   });
 });
+
+describe("RedisDB – '*' wildcard filter means field-exists (mem0ai/mem0#6539)", () => {
+  let store: RedisDB;
+  let mockClient: any;
+
+  beforeAll(async () => {
+    store = createStore();
+    await store.initialize();
+    mockClient = (store as any).client;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient.ft.search.mockResolvedValue({ documents: [], total: 0 });
+  });
+
+  test("search translates '*' into a tag wildcard, not a literal tag", async () => {
+    await store.search([0.1, 0.2, 0.3, 0.4], 5, { agentId: "*" });
+
+    const [, queryString] = mockClient.ft.search.mock.calls[0];
+    expect(queryString).toContain("@agent_id:{w'*'}");
+    expect(queryString).not.toContain("\\*");
+  });
+
+  test("search combines wildcard with tag equality", async () => {
+    await store.search([0.1, 0.2, 0.3, 0.4], 5, {
+      userId: "alice",
+      agentId: "*",
+    });
+
+    const [, queryString] = mockClient.ft.search.mock.calls[0];
+    expect(queryString).toContain("@user_id:{alice}");
+    expect(queryString).toContain("@agent_id:{w'*'}");
+  });
+
+  test("list translates '*' into a tag wildcard and sends DIALECT 2", async () => {
+    await store.list({ agentId: "*" });
+
+    const [, queryString, options] = mockClient.ft.search.mock.calls[0];
+    expect(queryString).toBe("@agent_id:{w'*'}");
+    // The w'...' syntax requires DIALECT 2 and node-redis does not send
+    // DIALECT unless asked.
+    expect(options.DIALECT).toBe(2);
+  });
+
+  test("list without wildcard keeps its previous query shape", async () => {
+    await store.list({ userId: "alice" });
+
+    const [, queryString, options] = mockClient.ft.search.mock.calls[0];
+    expect(queryString).toBe("@user_id:{alice}");
+    expect(options.DIALECT).toBeUndefined();
+  });
+});
+
+describe("RedisDB – KNN prefilter parenthesization", () => {
+  let store: RedisDB;
+  let mockClient: any;
+
+  beforeAll(async () => {
+    store = createStore();
+    await store.initialize();
+    mockClient = (store as any).client;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient.ft.search.mockResolvedValue({ documents: [], total: 0 });
+  });
+
+  test("multi-filter search wraps the prefilter in parentheses", async () => {
+    // RediSearch rejects a space-joined multi-condition prefilter placed
+    // directly before =>[KNN ...] with a syntax error, so any search with
+    // two or more filters failed outright.
+    await store.search([0.1, 0.2, 0.3, 0.4], 5, {
+      userId: "alice",
+      agentId: "a1",
+    });
+
+    const [, queryString] = mockClient.ft.search.mock.calls[0];
+    expect(queryString).toMatch(/^\(.+\) =>\[KNN /);
+  });
+
+  test("unfiltered search keeps the match-all prefilter", async () => {
+    await store.search([0.1, 0.2, 0.3, 0.4], 5);
+
+    const [, queryString] = mockClient.ft.search.mock.calls[0];
+    expect(queryString).toMatch(/^\* =>\[KNN /);
+  });
+});


### PR DESCRIPTION
## Linked Issue

Related to #6539. TypeScript counterpart of #6566 — together with #6553 (which covered the other six TS OSS stores) this completes the wildcard contract on the TS side. (#6540 carries the `Closes` reference for the issue.)

## Description

Both stores compiled the documented "field exists" wildcard into an equality comparison against the literal string `*`, matching nothing — the same literal-match variant #6566 fixes in the Python SDK:

- **redis.ts**: `escapeRedisTagValue` turns the star into a literal `\*` tag. Now translated into a tag wildcard query `{w'*'}` on both query paths. `search()` already sends `DIALECT: 2`; `list()` sends no DIALECT at all (node-redis only sends it when asked) while the `w'...'` syntax requires dialect 2, so `list()` now passes `DIALECT: 2` when a wildcard filter is present — non-wildcard `list()` queries are byte-identical to before.
- **azure_ai_search.ts**: `buildFilterExpression` produced `field eq '*'`. Now translated into OData `field ne null` — absent fields are null in Azure AI Search, so this expresses exactly field-exists.

Semantics match #6540/#6553/#6566: present with a real value (missing/empty excluded).

### Pre-existing bug found while verifying

`redis.ts` `search()` with **two or more filters of any kind** failed outright: a space-joined multi-condition prefilter placed directly before `=>[KNN ...]` is a RediSearch syntax error (`Syntax error at offset ... near >[`). Reproducible on main with e.g. `{ userId, agentId }`. The prefilter is now parenthesized (`(A B) =>[KNN ...]`), which RediSearch accepts for single and multiple conditions alike; the unfiltered `* =>[KNN ...]` form is unchanged. Happy to split this into its own PR if preferred, but it blocks verifying the combined wildcard case, so it's included here.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — `filters = { field: '*' }` previously returned no results on these stores, and multi-filter Redis search previously threw, so no working behavior changes.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Unit tests assert the compiled filter/query strings on both Redis query paths plus the DIALECT flag, the parenthesized prefilter regression, and the Azure OData expressions (`src/oss/tests/redis.unit.test.ts`, new `src/oss/tests/azure-ai-search.unit.test.ts`).

Manual verification against a real `redis/redis-stack-server` (RediSearch 2.10.20) with three records (agentId=a1 / absent / agentId=a2): `search`/`list` with `{ agentId: '*' }` return exactly the two records that have the field (previously zero); `{ agentId: '*', userId: 'u1' }` returns the intersection (previously a syntax error); plain tag equality unchanged.

`pnpm exec jest --coverage=false`: 1390 passed, 42 skipped. `pnpm run build` and `prettier --check` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed