### PR TITLE
fix(ts-oss/gemini): send the system prompt via systemInstruction

### DIFF
--- a/mem0-ts/src/oss/src/llms/google.ts
+++ b/mem0-ts/src/oss/src/llms/google.ts
@@ -23,18 +23,39 @@ export class GoogleLLM implements LLM {
     this.google = new sdk.GoogleGenAI({ apiKey: this.apiKey });
   }
 
-  private formatContents(messages: Message[]) {
-    return messages.map((msg) => ({
-      parts: [
-        {
-          text:
-            typeof msg.content === "string"
-              ? msg.content
-              : JSON.stringify(msg.content),
-        },
-      ],
-      role: msg.role === "system" ? "model" : "user",
-    }));
+  private formatContents(messages: Message[]): {
+    systemInstruction?: string;
+    contents: Array<{ parts: Array<{ text: string }>; role: string }>;
+  } {
+    let systemInstruction: string | undefined;
+    const contents: Array<{ parts: Array<{ text: string }>; role: string }> =
+      [];
+
+    for (const msg of messages) {
+      const text =
+        typeof msg.content === "string"
+          ? msg.content
+          : JSON.stringify(msg.content);
+
+      // Gemini takes the system prompt via `systemInstruction`, not as a
+      // content turn. Mapping it to a "model" turn (as this used to) mislabels
+      // the extraction instructions as something the model already said, and
+      // leaves the conversation without a leading user turn. Mirrors the Python
+      // SDK's _reformat_messages (mem0/llms/gemini.py); last system wins.
+      if (msg.role === "system") {
+        systemInstruction = text;
+        continue;
+      }
+
+      // Gemini's content roles are "user" and "model"; assistant turns are
+      // "model". Previously assistant was mislabeled "user".
+      contents.push({
+        parts: [{ text }],
+        role: msg.role === "assistant" ? "model" : "user",
+      });
+    }
+
+    return { systemInstruction, contents };
   }
 
   async generateResponse(
@@ -43,10 +64,13 @@ export class GoogleLLM implements LLM {
     tools?: any[],
   ): Promise<string | LLMResponse> {
     await this.ensureClient();
-    const contents = this.formatContents(messages);
+    const { systemInstruction, contents } = this.formatContents(messages);
 
     // Build config with tools if provided
     const config: Record<string, any> = {};
+    if (systemInstruction) {
+      config.systemInstruction = systemInstruction;
+    }
     if (tools && tools.length > 0) {
       config.tools = [
         {
@@ -95,9 +119,15 @@ export class GoogleLLM implements LLM {
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {
     await this.ensureClient();
+    const { systemInstruction, contents } = this.formatContents(messages);
+    const config: Record<string, any> = {};
+    if (systemInstruction) {
+      config.systemInstruction = systemInstruction;
+    }
     const completion = await this.google.models.generateContent({
-      contents: this.formatContents(messages),
+      contents,
       model: this.model,
+      config,
     });
     const response = completion.candidates?.[0]?.content;
     const content =

--- a/mem0-ts/src/oss/tests/google-llm.test.ts
+++ b/mem0-ts/src/oss/tests/google-llm.test.ts
@@ -234,15 +234,60 @@ describe("GoogleLLM (unit)", () => {
       { role: "user", content: "Say hello" },
     ]);
 
+    // The system message goes to systemInstruction (not a "model" content
+    // turn), leaving only the user turn in contents.
     expect(mockGenerateContent).toHaveBeenCalledWith(
       expect.objectContaining({
-        contents: [
-          { role: "model", parts: [{ text: "Be concise" }] },
-          { role: "user", parts: [{ text: "Say hello" }] },
-        ],
+        contents: [{ role: "user", parts: [{ text: "Say hello" }] }],
+        config: expect.objectContaining({ systemInstruction: "Be concise" }),
       }),
     );
     expect(result).toEqual({ content: "Hello, world", role: "model" });
+  });
+
+  // Regression: the system prompt (which carries the extraction instructions)
+  // must be sent via systemInstruction, not as a "model" content turn. Parity
+  // with the Python SDK's _reformat_messages (mem0/llms/gemini.py).
+  it("extracts the system prompt into config.systemInstruction", async () => {
+    mockGenerateContent.mockResolvedValueOnce({
+      text: "ok",
+      functionCalls: null,
+    });
+
+    const llm = new GoogleLLM({ apiKey: "test-key" });
+    await llm.generateResponse([
+      { role: "system", content: "You extract facts." },
+      { role: "user", content: "I like coffee." },
+    ]);
+
+    const callArgs = mockGenerateContent.mock.calls[0][0];
+    expect(callArgs.config.systemInstruction).toBe("You extract facts.");
+    // The system message must not leak into contents.
+    expect(callArgs.contents).toEqual([
+      { role: "user", parts: [{ text: "I like coffee." }] },
+    ]);
+  });
+
+  // Regression: assistant turns map to Gemini's "model" role, not "user".
+  it("maps assistant turns to the model role in contents", async () => {
+    mockGenerateContent.mockResolvedValueOnce({
+      text: "ok",
+      functionCalls: null,
+    });
+
+    const llm = new GoogleLLM({ apiKey: "test-key" });
+    await llm.generateResponse([
+      { role: "user", content: "Hi" },
+      { role: "assistant", content: "Hello there" },
+      { role: "user", content: "How are you?" },
+    ]);
+
+    const callArgs = mockGenerateContent.mock.calls[0][0];
+    expect(callArgs.contents).toEqual([
+      { role: "user", parts: [{ text: "Hi" }] },
+      { role: "model", parts: [{ text: "Hello there" }] },
+      { role: "user", parts: [{ text: "How are you?" }] },
+    ]);
   });
 
   it("returns an empty assistant response when generateChat has no candidates", async () => {


### PR DESCRIPTION
### Description

`formatContents()` in the TS Gemini provider turned every message into a content turn, mapping `system` to role `"model"` and `assistant` to `"user"`. As a result:

1. The system prompt (which carries the fact-extraction instructions) was sent as a `"model"` turn, i.e. as if the model had already said it, leaving the conversation without a leading user turn.
2. Prior `assistant` turns were relabeled as `"user"`, corrupting multi-turn calls.

The fix mirrors the Python SDK's `_reformat_messages` (`mem0/llms/gemini.py`): system messages are pulled into `config.systemInstruction`, only real turns stay in `contents`, and `user`→`"user"` / `assistant`→`"model"`. Applied to both `generateResponse` and `generateChat`.

Context: #6468 recently made this same file honor `responseFormat` for Python parity but did not touch the role mapping. (The stale, conflicting #4390 flips assistant to `"model"` but still leaves the system prompt as a `"model"` content turn rather than `systemInstruction`.)

Closes #6569

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`jest src/oss/tests/google-llm.test.ts` (run from the `mem0-ts` root), 11 passed.

- Added `extracts the system prompt into config.systemInstruction`: the system message lands in `config.systemInstruction` and no longer leaks into `contents`.
- Added `maps assistant turns to the model role in contents`.
- Updated the existing generateChat test, which asserted the old behavior (system as a `"model"` content turn), to expect the corrected `systemInstruction` handling.
- Reverting the source change fails all three.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes