### PR TITLE
fix(ts-oss/together): honor TOGETHER_API_BASE in the embedder

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/together.ts
+++ b/mem0-ts/src/oss/src/embeddings/together.ts
@@ -17,7 +17,14 @@ export class TogetherEmbedder extends OpenAIEmbedder {
     super({
       ...openAICompatibleConfig,
       apiKey,
-      baseURL: config.baseURL || config.url || DEFAULT_BASE_URL,
+      // Honor TOGETHER_API_BASE like the Together LLM does, so a user behind a
+      // gateway who sets it gets it for embeddings too instead of silently
+      // hitting api.together.ai.
+      baseURL:
+        config.baseURL ||
+        config.url ||
+        process.env.TOGETHER_API_BASE ||
+        DEFAULT_BASE_URL,
       model: config.model || DEFAULT_MODEL,
     });
   }

--- a/mem0-ts/src/oss/tests/together-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/together-embedder.test.ts
@@ -20,6 +20,7 @@ describe("TogetherEmbedder (unit)", () => {
     jest.resetModules();
     process.env = { ...originalEnv };
     delete process.env.TOGETHER_API_KEY;
+    delete process.env.TOGETHER_API_BASE;
     mockOpenAI.mockClear();
     mockEmbeddingsCreate.mockReset();
     mockEmbeddingsCreate.mockResolvedValue({
@@ -78,6 +79,35 @@ describe("TogetherEmbedder (unit)", () => {
       model: "custom-together-embed",
       input: "hello",
       encoding_format: "float",
+    });
+  });
+
+  it("honors TOGETHER_API_BASE when no baseURL is configured", async () => {
+    process.env.TOGETHER_API_BASE = "https://gateway.example/v1";
+
+    const embedder = new TogetherEmbedder({ apiKey: "test-key" });
+
+    await embedder.embed("hello");
+
+    expect(mockOpenAI).toHaveBeenCalledWith({
+      apiKey: "test-key",
+      baseURL: "https://gateway.example/v1",
+    });
+  });
+
+  it("prefers an explicit baseURL over TOGETHER_API_BASE", async () => {
+    process.env.TOGETHER_API_BASE = "https://gateway.example/v1";
+
+    const embedder = new TogetherEmbedder({
+      apiKey: "test-key",
+      baseURL: "https://explicit.example/v1",
+    });
+
+    await embedder.embed("hello");
+
+    expect(mockOpenAI).toHaveBeenCalledWith({
+      apiKey: "test-key",
+      baseURL: "https://explicit.example/v1",
     });
   });
 


### PR DESCRIPTION
### Description

The Together LLM resolves its base URL as `config.baseURL || process.env.TOGETHER_API_BASE || default`, but the Together embedder skipped the env var (`config.baseURL || config.url || default`). So a user who runs Together behind a gateway and sets `TOGETHER_API_BASE` gets it honored for chat but silently ignored for embeddings, which keep hitting `https://api.together.ai/v1`. Within one provider the LLM and embedder disagreed on base-URL resolution.

The fix adds `TOGETHER_API_BASE` to the embedder base-URL precedence (`config.baseURL || config.url || TOGETHER_API_BASE || default`), matching the LLM.

Closes #6571

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`jest src/oss/tests/together-embedder.test.ts` (run from the `mem0-ts` root), 8 passed.

- Added `honors TOGETHER_API_BASE when no baseURL is configured` and `prefers an explicit baseURL over TOGETHER_API_BASE`.
- Reverting the source change fails the first.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes