### PR TITLE
fix(ts-oss/valkey): preserve entity ID casing in docToResult

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/valkey.ts
+++ b/mem0-ts/src/oss/src/vector_stores/valkey.ts
@@ -45,14 +45,39 @@ function toSnakeCase(obj: Record<string, any>): Record<string, any> {
   );
 }
 
-function toCamelCase(obj: Record<string, any>): Record<string, any> {
+/**
+ * Keys that must remain in snake_case — memory/index.ts reads these directly.
+ */
+const ENTITY_ID_KEYS = new Set(["user_id", "agent_id", "run_id"]);
+
+/**
+ * Timestamp keys stored as snake_case in Valkey but expected as camelCase by
+ * the rest of the SDK (memory/index.ts reads payload.createdAt / updatedAt).
+ */
+const TIMESTAMP_RENAMES: Record<string, string> = {
+  created_at: "createdAt",
+  updated_at: "updatedAt",
+};
+
+/**
+ * Selectively normalize a result payload to the canonical format expected by
+ * memory/index.ts: entity IDs in snake_case, timestamps in camelCase, and all
+ * other keys (metadata spillover) in camelCase.
+ */
+function normalizeResultPayload(obj: Record<string, any>): Record<string, any> {
   if (typeof obj !== "object" || obj === null) return obj;
-  return Object.fromEntries(
-    Object.entries(obj).map(([key, value]) => [
-      key.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase()),
-      value,
-    ]),
-  );
+  const result: Record<string, any> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (ENTITY_ID_KEYS.has(key)) {
+      result[key] = value;
+    } else if (Object.hasOwn(TIMESTAMP_RENAMES, key)) {
+      result[TIMESTAMP_RENAMES[key]] = value;
+    } else {
+      const camelKey = key.replace(/_([a-z])/g, (_, l) => l.toUpperCase());
+      result[camelKey] = value;
+    }
+  }
+  return result;
 }
 
 interface ValkeySearchDoc {
@@ -380,7 +405,12 @@ export class ValkeyDB implements VectorStore {
 
     if (doc.metadata) {
       try {
-        Object.assign(resultPayload, JSON.parse(doc.metadata));
+        const parsed = JSON.parse(doc.metadata);
+        // Defense-in-depth: prevent crafted metadata from overwriting entity IDs
+        for (const key of ENTITY_ID_KEYS) {
+          delete parsed[key];
+        }
+        Object.assign(resultPayload, parsed);
       } catch {
         console.warn("Failed to parse Valkey metadata:", doc.metadata);
       }
@@ -388,7 +418,7 @@ export class ValkeyDB implements VectorStore {
 
     return {
       id: doc.memory_id ?? "",
-      payload: toCamelCase(resultPayload),
+      payload: normalizeResultPayload(resultPayload),
       score,
     };
   }

--- a/mem0-ts/src/oss/tests/manual-memory-e2e.ts
+++ b/mem0-ts/src/oss/tests/manual-memory-e2e.ts
@@ -1,0 +1,159 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/**
+ * Manual integration test #2: End-to-end through memory/index.ts
+ * 
+ * This test pre-inserts data into Valkey via ValkeyDB directly, then
+ * uses Memory.search() and Memory.getAll() to verify the final MemoryItem
+ * output shape is correct (entity IDs in snake_case, timestamps in camelCase,
+ * no metadata leakage).
+ * 
+ * Requires: Valkey 8.x at 127.0.0.2:6379 with search module.
+ * 
+ * Run from mem0-ts/:
+ *   npx ts-node --transpile-only --compiler-options '{"module":"commonjs","moduleResolution":"node"}' \
+ *     src/oss/tests/manual-memory-e2e.ts
+ */
+
+// Disable telemetry BEFORE importing Memory — prevents network calls that hang
+process.env.MEM0_TELEMETRY = "false";
+
+const { ValkeyDB } = require("../src/vector_stores/valkey") as { ValkeyDB: any };
+
+// Monkey-patch factories BEFORE importing Memory
+const factory = require("../src/utils/factory");
+const FIXED_VEC = [0.25, 0.5, 0.75, 1.0];
+
+factory.EmbedderFactory.create = () => ({
+  embed: async () => FIXED_VEC,
+  embedBatch: async (texts: string[]) => texts.map(() => FIXED_VEC),
+});
+
+factory.LLMFactory.create = () => ({
+  generateResponse: async () => "[]",
+});
+
+// Stub getOrCreateMem0UserId to prevent network call
+try {
+  const clientConfig = require("../../../client/config");
+  if (clientConfig.getOrCreateMem0UserId) {
+    clientConfig.getOrCreateMem0UserId = async () => "test-user-id";
+  }
+} catch { /* ignore if module not found */ }
+
+// Stub captureClientEvent to prevent network telemetry
+try {
+  const telemetry = require("../src/utils/telemetry");
+  if (telemetry.captureClientEvent) {
+    telemetry.captureClientEvent = async () => {};
+  }
+} catch { /* ignore */ }
+
+const { Memory } = require("../src/memory/index") as { Memory: any };
+
+const VALKEY_URL = "valkey://127.0.0.2:6379";
+const COLLECTION = `e2e_test_${Date.now()}`;
+const DIMS = 4;
+
+function assert(condition: boolean, msg: string) {
+  if (!condition) throw new Error(`ASSERTION FAILED: ${msg}`);
+}
+
+async function main() {
+  console.log("=== Integration Test #2: End-to-end through memory/index.ts ===\n");
+
+  // --- Pre-insert data via ValkeyDB directly ---
+  const store = new ValkeyDB({
+    collectionName: COLLECTION,
+    embeddingModelDims: DIMS,
+    valkeyUrl: VALKEY_URL,
+  });
+  await store.initialize();
+
+  await store.insert(
+    [FIXED_VEC, FIXED_VEC],
+    ["mem-e2e-1", "mem-e2e-2"],
+    [
+      {
+        data: "Alice likes cats",
+        hash: "h1",
+        created_at: "2024-06-01T12:00:00.000Z",
+        user_id: "alice",
+        agent_id: "bot1",
+        run_id: "run1",
+      },
+      {
+        data: "Bob likes dogs",
+        hash: "h2",
+        created_at: "2024-06-02T12:00:00.000Z",
+        user_id: "bob",
+      },
+    ],
+  );
+  console.log("✓ Pre-inserted 2 memories into Valkey\n");
+
+  // --- Create Memory instance with explicit dimension to skip probe ---
+  const memory = new Memory({
+    embedder: { provider: "openai", config: {} },
+    llm: { provider: "openai", config: {} },
+    vectorStore: {
+      provider: "valkey",
+      config: {
+        collectionName: COLLECTION,
+        embeddingModelDims: DIMS,
+        dimension: DIMS,  // explicit — skips dimension probe
+        valkeyUrl: VALKEY_URL,
+      },
+    },
+  });
+
+  // Wait for async init to complete
+  await new Promise((r) => setTimeout(r, 1000));
+  console.log("✓ Memory instance created\n");
+
+  // --- Test search() ---
+  console.log("--- memory.search() ---");
+  const searchResult = await memory.search("cats", {
+    filters: { user_id: "alice" },
+  });
+  console.log("Search results:", JSON.stringify(searchResult, null, 2));
+
+  assert(searchResult.results.length > 0, "search should return results");
+  const sr = searchResult.results[0];
+  assert(sr.user_id === "alice", `search result user_id should be 'alice', got '${sr.user_id}'`);
+  assert(sr.agent_id === "bot1", `search result agent_id should be 'bot1', got '${sr.agent_id}'`);
+  assert(sr.run_id === "run1", `search result run_id should be 'run1', got '${sr.run_id}'`);
+  assert(sr.createdAt !== undefined, "search result createdAt should exist");
+  assert(sr.memory === "Alice likes cats", `memory text should match, got '${sr.memory}'`);
+  // Verify NO leakage into metadata
+  assert(sr.metadata?.userId === undefined, "userId should NOT be in metadata");
+  assert(sr.metadata?.agentId === undefined, "agentId should NOT be in metadata");
+  assert(sr.metadata?.runId === undefined, "runId should NOT be in metadata");
+  assert(sr.metadata?.user_id === undefined, "user_id should NOT be in metadata (it's top-level)");
+  console.log("✓ SEARCH assertions passed\n");
+
+  // --- Test getAll() ---
+  console.log("--- memory.getAll() ---");
+  const allResult = await memory.getAll({
+    filters: { user_id: "alice" },
+  });
+  console.log("GetAll results:", JSON.stringify(allResult, null, 2));
+
+  assert(allResult.results.length > 0, "getAll should return results");
+  const ar = allResult.results[0];
+  assert(ar.user_id === "alice", `getAll result user_id should be 'alice', got '${ar.user_id}'`);
+  assert(ar.createdAt !== undefined, "getAll result createdAt should exist");
+  assert(ar.metadata?.userId === undefined, "userId should NOT be in metadata (getAll)");
+  console.log("✓ GETALL assertions passed\n");
+
+  // --- Cleanup ---
+  await store.deleteCol();
+  await store.close();
+
+  console.log("=== ALL E2E ASSERTIONS PASSED ===");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("FAILED:", err);
+  process.exit(1);
+});

--- a/mem0-ts/src/oss/tests/manual-valkey-integration.ts
+++ b/mem0-ts/src/oss/tests/manual-valkey-integration.ts
@@ -1,0 +1,111 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/**
+ * Manual integration test #1: ValkeyDB direct — insert/search/get/update/delete cycle.
+ * Run from mem0-ts/: npx ts-node --project tsconfig.test.json src/oss/tests/manual-valkey-integration.ts
+ */
+
+const { ValkeyDB } = require("../src/vector_stores/valkey") as { ValkeyDB: any };
+
+const VALKEY_URL = "valkey://127.0.0.2:6379";
+const COLLECTION = `integ_test_${Date.now()}`;
+const DIMS = 4;
+
+function assert(condition: boolean, msg: string) {
+  if (!condition) throw new Error(`ASSERTION FAILED: ${msg}`);
+}
+
+async function main() {
+  console.log("=== Integration Test #1: ValkeyDB direct ===\n");
+
+  const store = new ValkeyDB({
+    collectionName: COLLECTION,
+    embeddingModelDims: DIMS,
+    valkeyUrl: VALKEY_URL,
+  });
+  await store.initialize();
+  console.log("✓ Store initialized\n");
+
+  // --- INSERT ---
+  const vec = [0.1, 0.2, 0.3, 0.4];
+  await store.insert(
+    [vec],
+    ["mem-integ-1"],
+    [
+      {
+        data: "Alice likes cats",
+        hash: "h1",
+        created_at: "2024-06-01T12:00:00.000Z",
+        user_id: "u1",
+        agent_id: "a1",
+        run_id: "r1",
+      },
+    ],
+  );
+  console.log("✓ Inserted mem-integ-1\n");
+
+  // --- GET ---
+  const getResult = await store.get("mem-integ-1");
+  console.log("GET result payload:", JSON.stringify(getResult?.payload, null, 2));
+  assert(getResult !== null, "get() returned null");
+  assert(getResult!.payload.user_id === "u1", "user_id should be 'u1'");
+  assert(getResult!.payload.agent_id === "a1", "agent_id should be 'a1'");
+  assert(getResult!.payload.run_id === "r1", "run_id should be 'r1'");
+  assert(getResult!.payload.userId === undefined, "userId should NOT exist");
+  assert(getResult!.payload.agentId === undefined, "agentId should NOT exist");
+  assert(getResult!.payload.runId === undefined, "runId should NOT exist");
+  assert(getResult!.payload.createdAt !== undefined, "createdAt should exist");
+  assert(getResult!.payload.created_at === undefined, "created_at should NOT exist");
+  console.log("✓ GET assertions passed\n");
+
+  // --- SEARCH ---
+  const searchResults = await store.search(vec, 5, { user_id: "u1" });
+  console.log("SEARCH results:", searchResults.length, "hits");
+  console.log("SEARCH first payload:", JSON.stringify(searchResults[0]?.payload, null, 2));
+  assert(searchResults.length > 0, "search should return at least 1 result");
+  assert(searchResults[0].payload.user_id === "u1", "search result user_id should be 'u1'");
+  assert(searchResults[0].payload.userId === undefined, "search result should NOT have userId");
+  assert(searchResults[0].payload.createdAt !== undefined, "search result createdAt should exist");
+  console.log("✓ SEARCH assertions passed\n");
+
+  // --- SEARCH with non-matching filter ---
+  const emptyResults = await store.search(vec, 5, { user_id: "nonexistent" });
+  assert(emptyResults.length === 0, "search with non-matching filter should return empty");
+  console.log("✓ SEARCH with non-matching filter returned empty\n");
+
+  // --- UPDATE ---
+  await store.update("mem-integ-1", vec, {
+    data: "Alice likes cats and dogs",
+    hash: "h1-updated",
+    created_at: "2024-06-01T12:00:00.000Z",
+    updated_at: "2024-06-02T14:00:00.000Z",
+    user_id: "u1",
+    agent_id: "a1",
+    run_id: "r1",
+  });
+  console.log("✓ Updated mem-integ-1\n");
+
+  const updatedResult = await store.get("mem-integ-1");
+  console.log("GET after update payload:", JSON.stringify(updatedResult?.payload, null, 2));
+  assert(updatedResult!.payload.user_id === "u1", "after update user_id should be 'u1'");
+  assert(updatedResult!.payload.updatedAt !== undefined, "updatedAt should exist after update");
+  assert(updatedResult!.payload.updated_at === undefined, "updated_at should NOT exist");
+  assert(updatedResult!.payload.data === "Alice likes cats and dogs", "data should be updated");
+  console.log("✓ UPDATE assertions passed\n");
+
+  // --- DELETE ---
+  await store.delete("mem-integ-1");
+  const deletedResult = await store.get("mem-integ-1");
+  assert(deletedResult === null, "get() after delete should return null");
+  console.log("✓ DELETE assertions passed\n");
+
+  // --- CLEANUP ---
+  await store.deleteCol();
+  await store.close();
+
+  console.log("=== ALL ASSERTIONS PASSED ===");
+}
+
+main().catch((err) => {
+  console.error("FAILED:", err);
+  process.exit(1);
+});

--- a/mem0-ts/src/oss/tests/valkey.test.ts
+++ b/mem0-ts/src/oss/tests/valkey.test.ts
@@ -166,7 +166,7 @@ describe("Valkey – mocked iovalkey client", () => {
     const result = await store.get("mem-1");
     expect(result?.id).toBe("mem-1");
     expect(result?.payload.data).toBe("hello valkey");
-    expect(result?.payload.userId).toBe("alice");
+    expect(result?.payload.user_id).toBe("alice");
     // created_at is persisted as unix seconds and rendered back to its ISO instant.
     expect(result?.payload.createdAt).toBe("2024-01-01T00:00:00.000Z");
   });
@@ -272,5 +272,154 @@ describe("Valkey – mocked iovalkey client", () => {
     expect(unhandled).toHaveLength(0);
     expect(errorSpy).toHaveBeenCalled();
     errorSpy.mockRestore();
+  });
+
+  // --- GH-6266: Payload shape normalization tests ---
+
+  describe("GH-6266: docToResult payload normalization", () => {
+    it("preserves entity IDs in snake_case (user_id, agent_id, run_id)", async () => {
+      const store = new ValkeyDB({
+        collectionName: "test",
+        embeddingModelDims: 4,
+        valkeyUrl: "valkey://localhost:6379",
+      });
+      await store.initialize();
+
+      await store.insert(
+        [[0.1, 0.2, 0.3, 0.4]],
+        ["mem-aea588"],
+        [
+          {
+            data: "entity id test",
+            hash: "h1",
+            created_at: "2024-06-01T00:00:00.000Z",
+            user_id: "u1",
+            agent_id: "a1",
+            run_id: "r1",
+          },
+        ],
+      );
+
+      const result = await store.get("mem-aea588");
+      expect(result).not.toBeNull();
+      // Entity IDs MUST be snake_case
+      expect(result?.payload.user_id).toBe("u1");
+      expect(result?.payload.agent_id).toBe("a1");
+      expect(result?.payload.run_id).toBe("r1");
+      // camelCase variants MUST NOT exist
+      expect(result?.payload.userId).toBeUndefined();
+      expect(result?.payload.agentId).toBeUndefined();
+      expect(result?.payload.runId).toBeUndefined();
+    });
+
+    it("does not leak entity IDs into metadata", async () => {
+      const store = new ValkeyDB({
+        collectionName: "test",
+        embeddingModelDims: 4,
+        valkeyUrl: "valkey://localhost:6379",
+      });
+      await store.initialize();
+
+      await store.insert(
+        [[0.1, 0.2, 0.3, 0.4]],
+        ["mem-leak"],
+        [
+          {
+            data: "leak test",
+            hash: "h2",
+            created_at: "2024-06-01T00:00:00.000Z",
+            user_id: "u2",
+            agent_id: "a2",
+            run_id: "r2",
+            metadata: JSON.stringify({ custom_key: "custom_value" }),
+          },
+        ],
+      );
+
+      const result = await store.get("mem-leak");
+      expect(result).not.toBeNull();
+      // Entity IDs must NOT appear inside metadata spillover
+      const payloadKeys = Object.keys(result!.payload);
+      // The payload should have user_id at top level, not userId
+      expect(payloadKeys).toContain("user_id");
+      expect(payloadKeys).not.toContain("userId");
+      expect(payloadKeys).toContain("agent_id");
+      expect(payloadKeys).not.toContain("agentId");
+    });
+
+    it("renders timestamps in camelCase (createdAt, updatedAt)", async () => {
+      const store = new ValkeyDB({
+        collectionName: "test",
+        embeddingModelDims: 4,
+        valkeyUrl: "valkey://localhost:6379",
+      });
+      await store.initialize();
+
+      await store.insert(
+        [[0.1, 0.2, 0.3, 0.4]],
+        ["mem-ts"],
+        [
+          {
+            data: "timestamp test",
+            hash: "h3",
+            created_at: "2024-06-01T12:00:00.000Z",
+            user_id: "u3",
+          },
+        ],
+      );
+
+      // Set updated_at via update() since insert() doesn't store it
+      await store.update("mem-ts", [0.1, 0.2, 0.3, 0.4], {
+        data: "timestamp test",
+        hash: "h3",
+        created_at: "2024-06-01T12:00:00.000Z",
+        updated_at: "2024-06-02T12:00:00.000Z",
+        user_id: "u3",
+      });
+
+      const result = await store.get("mem-ts");
+      expect(result).not.toBeNull();
+      // Timestamps MUST be camelCase
+      expect(result?.payload.createdAt).toBeDefined();
+      expect(result?.payload.updatedAt).toBeDefined();
+      // snake_case timestamp keys MUST NOT exist
+      expect(result?.payload.created_at).toBeUndefined();
+      expect(result?.payload.updated_at).toBeUndefined();
+    });
+
+    it("camelCases arbitrary metadata keys", async () => {
+      const store = new ValkeyDB({
+        collectionName: "test",
+        embeddingModelDims: 4,
+        valkeyUrl: "valkey://localhost:6379",
+      });
+      await store.initialize();
+
+      // Custom fields passed at top level end up in the metadata JSON blob
+      // after EXCLUDED_KEYS are filtered out during insert.
+      await store.insert(
+        [[0.1, 0.2, 0.3, 0.4]],
+        ["mem-meta"],
+        [
+          {
+            data: "metadata test",
+            hash: "h4",
+            created_at: "2024-06-01T00:00:00.000Z",
+            user_id: "u4",
+            some_custom_field: "value1",
+            another_key: "value2",
+          },
+        ],
+      );
+
+      const result = await store.get("mem-meta");
+      expect(result).not.toBeNull();
+      // Metadata keys should be camelCased
+      expect(result?.payload.someCustomField).toBe("value1");
+      expect(result?.payload.anotherKey).toBe("value2");
+      // Original snake_case metadata keys should NOT exist
+      expect(result?.payload.some_custom_field).toBeUndefined();
+      expect(result?.payload.another_key).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the Valkey vector store's `docToResult` method which ran a blanket `toCamelCase()` on the result payload, converting entity IDs (`user_id`, `agent_id`, `run_id`) to camelCase. The rest of the SDK (`memory/index.ts`) expects entity IDs in snake_case and timestamps in camelCase.

### Consequences of the bug (for Valkey users):
- `search()`, `getAll()`, `get()` dropped `user_id`/`agent_id`/`run_id` from results
- Entity IDs leaked into `metadata` as camelCase keys
- Entity-store cleanup on delete/update read `undefined` and ran unscoped

## Changes

**`mem0-ts/src/oss/src/vector_stores/valkey.ts`:**
- Replaced `toCamelCase` with `normalizeResultPayload` — a selective transformer that:
  - Preserves entity IDs in snake_case (`user_id`, `agent_id`, `run_id`)
  - Renames timestamps to camelCase (`created_at` → `createdAt`, `updated_at` → `updatedAt`)
  - CamelCases all other keys (metadata spillover)
- Defense-in-depth: strips entity ID keys from parsed metadata before `Object.assign` (prevents spoofing from crafted metadata)
- Uses `Object.hasOwn()` instead of `in` operator for prototype safety

**`mem0-ts/src/oss/tests/valkey.test.ts`:**
- Fixed existing assertion that tested buggy behavior (`userId` → `user_id`)
- Added 4 regression tests covering: entity ID preservation, metadata leak prevention, timestamp casing, metadata key camelCasing

## Testing

- Full test suite: 87 suites, 1385 tests, 0 failures
- Manual integration test against real Valkey 8.x (insert/search/get/update/delete cycle)
- End-to-end through `memory/index.ts`: `search()` and `getAll()` produce correct `MemoryItem` output

Closes #6266