### PR TITLE
fix(server): restore env precedence over persisted config overrides

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -60,6 +60,8 @@ SKIPPED_REQUEST_LOG_PREFIXES = ("/requests",)
 
 BUNDLED_LLM_PROVIDERS = ("openai", "anthropic", "gemini")
 BUNDLED_EMBEDDER_PROVIDERS = ("openai", "gemini")
+DEFAULT_LLM_MODEL = "gpt-4.1-nano-2025-04-14"
+DEFAULT_EMBEDDER_MODEL = "text-embedding-3-small"
 
 
 def _warn_if_unconfigured() -> None:
@@ -111,35 +113,63 @@ POSTGRES_USER = os.environ.get("POSTGRES_USER", "postgres")
 POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "postgres")
 POSTGRES_COLLECTION_NAME = os.environ.get("POSTGRES_COLLECTION_NAME", "memories")
 
-OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
-HISTORY_DB_PATH = os.environ.get("HISTORY_DB_PATH", "/app/history/history.db")
-DEFAULT_LLM_MODEL = os.environ.get("MEM0_DEFAULT_LLM_MODEL", "gpt-4.1-nano-2025-04-14")
-DEFAULT_EMBEDDER_MODEL = os.environ.get("MEM0_DEFAULT_EMBEDDER_MODEL", "text-embedding-3-small")
+
+def _set_nested_value(config: Dict[str, Any], path: tuple[str, ...], value: Any) -> None:
+    current = config
+    for key in path[:-1]:
+        current = current.setdefault(key, {})
+    current[path[-1]] = value
+
+
+def _build_env_config_overrides() -> Dict[str, Any]:
+    overrides: Dict[str, Any] = {}
+    env_fields = (
+        ("POSTGRES_HOST", ("vector_store", "config", "host"), str),
+        ("POSTGRES_PORT", ("vector_store", "config", "port"), int),
+        ("POSTGRES_DB", ("vector_store", "config", "dbname"), str),
+        ("POSTGRES_USER", ("vector_store", "config", "user"), str),
+        ("POSTGRES_PASSWORD", ("vector_store", "config", "password"), str),
+        ("POSTGRES_COLLECTION_NAME", ("vector_store", "config", "collection_name"), str),
+        ("OPENAI_API_KEY", ("llm", "config", "api_key"), str),
+        ("OPENAI_API_KEY", ("embedder", "config", "api_key"), str),
+        ("HISTORY_DB_PATH", ("history_db_path",), str),
+        ("MEM0_DEFAULT_LLM_MODEL", ("llm", "config", "model"), str),
+        ("MEM0_DEFAULT_EMBEDDER_MODEL", ("embedder", "config", "model"), str),
+    )
+
+    for env_name, path, cast in env_fields:
+        if env_name not in os.environ:
+            continue
+        _set_nested_value(overrides, path, cast(os.environ[env_name]))
+
+    return overrides
+
 
 DEFAULT_CONFIG = {
     "version": "v1.1",
     "vector_store": {
         "provider": "pgvector",
         "config": {
-            "host": POSTGRES_HOST,
-            "port": int(POSTGRES_PORT),
-            "dbname": POSTGRES_DB,
-            "user": POSTGRES_USER,
-            "password": POSTGRES_PASSWORD,
-            "collection_name": POSTGRES_COLLECTION_NAME,
+            "host": "postgres",
+            "port": 5432,
+            "dbname": "postgres",
+            "user": "postgres",
+            "password": "postgres",
+            "collection_name": "memories",
         },
     },
     "llm": {
         "provider": "openai",
-        "config": {"api_key": OPENAI_API_KEY, "temperature": 0.2, "model": DEFAULT_LLM_MODEL},
+        "config": {"api_key": None, "temperature": 0.2, "model": DEFAULT_LLM_MODEL},
     },
-    "embedder": {"provider": "openai", "config": {"api_key": OPENAI_API_KEY, "model": DEFAULT_EMBEDDER_MODEL}},
-    "history_db_path": HISTORY_DB_PATH,
+    "embedder": {"provider": "openai", "config": {"api_key": None, "model": DEFAULT_EMBEDDER_MODEL}},
+    "history_db_path": "/app/history/history.db",
 }
+ENV_CONFIG_OVERRIDES = _build_env_config_overrides()
 
 
 set_session_factory(SessionLocal)
-initialize_state(DEFAULT_CONFIG)
+initialize_state(DEFAULT_CONFIG, ENV_CONFIG_OVERRIDES)
 
 
 app = FastAPI(
@@ -382,7 +412,16 @@ def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
 
 
 ALL_MEMORIES_LIMIT = 1000
-_RESERVED_PAYLOAD_KEYS = {"data", "user_id", "agent_id", "run_id", "hash", "created_at", "updated_at", "expiration_date"}
+_RESERVED_PAYLOAD_KEYS = {
+    "data",
+    "user_id",
+    "agent_id",
+    "run_id",
+    "hash",
+    "created_at",
+    "updated_at",
+    "expiration_date",
+}
 
 
 def _serialize_memory(row: Any) -> Dict[str, Any]:
@@ -425,9 +464,7 @@ def get_all_memories(
                 raise HTTPException(status_code=403, detail="Admin role required to list all memories.")
             # Admin all-memory listing is intentionally raw; scoped get_all below applies expiry visibility.
             return _list_all_memories(limit=top_k if top_k is not None else ALL_MEMORIES_LIMIT)
-        filters = {
-            k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v
-        }
+        filters = {k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v}
         params = {"filters": filters}
         if top_k is not None:
             params["top_k"] = top_k
@@ -534,9 +571,7 @@ def delete_all_memories(
     if not any([user_id, run_id, agent_id]):
         raise HTTPException(status_code=400, detail="At least one identifier is required.")
     try:
-        params = {
-            k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v
-        }
+        params = {k: v for k, v in {"user_id": user_id, "run_id": run_id, "agent_id": agent_id}.items() if v}
         get_memory_instance().delete_all(**params)
         return MessageResponse(message="All relevant memories deleted")
     except Exception:

--- a/server/server_state.py
+++ b/server/server_state.py
@@ -7,7 +7,9 @@ from typing import Any, Callable, Dict
 from mem0 import Memory
 
 _state_lock = threading.RLock()
+_base_config: Dict[str, Any] = {}
 _current_config: Dict[str, Any] = {}
+_env_overrides: Dict[str, Any] = {}
 _memory_instance: Memory | None = None
 _session_factory: Callable | None = None
 
@@ -73,25 +75,32 @@ def _merge_config(base: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, An
     return merged
 
 
-def initialize_state(default_config: Dict[str, Any]) -> None:
-    global _current_config, _memory_instance
+def _compose_config(
+    base_config: Dict[str, Any],
+    persisted_overrides: Dict[str, Any],
+    env_overrides: Dict[str, Any],
+) -> Dict[str, Any]:
+    return _merge_config(_merge_config(base_config, persisted_overrides), env_overrides)
+
+
+def initialize_state(default_config: Dict[str, Any], env_overrides: Dict[str, Any] | None = None) -> None:
+    global _base_config, _current_config, _env_overrides, _memory_instance
     with _state_lock:
-        _current_config = deepcopy(default_config)
+        _base_config = deepcopy(default_config)
+        _env_overrides = deepcopy(env_overrides or {})
         overrides = _load_overrides()
-        if overrides:
-            _current_config = _merge_config(_current_config, overrides)
+        _current_config = _compose_config(_base_config, overrides, _env_overrides)
         _memory_instance = Memory.from_config(_current_config)
 
 
 def update_config(updates: Dict[str, Any]) -> Dict[str, Any]:
     global _current_config, _memory_instance
     with _state_lock:
-        next_config = _merge_config(_current_config, updates)
-        _current_config = next_config
-        _memory_instance = Memory.from_config(next_config)
         overrides = _load_overrides()
         overrides = _merge_config(overrides, updates)
         _save_overrides(overrides)
+        _current_config = _compose_config(_base_config, overrides, _env_overrides)
+        _memory_instance = Memory.from_config(_current_config)
         return deepcopy(_current_config)
 
 

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1,0 +1,207 @@
+import importlib
+import os
+import sys
+import types
+from contextlib import contextmanager
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+_SERVER_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "server")
+if _SERVER_DIR not in sys.path:
+    sys.path.insert(0, _SERVER_DIR)
+
+
+def _reloaded_module(name: str):
+    module = importlib.import_module(name)
+    return importlib.reload(module)
+
+
+def _fake_main_modules():
+    fake_db = types.ModuleType("db")
+    fake_db.SessionLocal = MagicMock()
+
+    fake_auth = types.ModuleType("auth")
+    fake_auth.ADMIN_API_KEY = ""
+    fake_auth.AUTH_DISABLED = True
+    fake_auth.JWT_SECRET = ""
+
+    async def _allow(*args, **kwargs):
+        return None
+
+    fake_auth.require_admin = _allow
+    fake_auth.verify_auth = _allow
+
+    fake_models = types.ModuleType("models")
+    fake_models.RequestLog = type("RequestLog", (), {})
+    fake_models.User = type("User", (), {})
+
+    fake_schemas = types.ModuleType("schemas")
+
+    class MessageResponse(BaseModel):
+        message: str
+
+    fake_schemas.MessageResponse = MessageResponse
+
+    class _Limiter:
+        def limit(self, *args, **kwargs):
+            def _decorator(func):
+                return func
+
+            return _decorator
+
+    fake_rate_limit = types.ModuleType("rate_limit")
+    fake_rate_limit.limiter = _Limiter()
+
+    fake_telemetry = types.ModuleType("telemetry")
+    fake_telemetry.log_status = lambda: None
+
+    fake_errors = types.ModuleType("errors")
+
+    class UpstreamError(Exception):
+        pass
+
+    fake_errors.UpstreamError = UpstreamError
+    fake_errors.install_request_id_logging = lambda: None
+    fake_errors.new_request_id = lambda: "req-test"
+    fake_errors.request_id_var = object()
+    fake_errors.upstream_error = lambda exc: exc
+
+    async def _upstream_error_handler(*args, **kwargs):
+        return None
+
+    fake_errors.upstream_error_handler = _upstream_error_handler
+
+    fake_slowapi = types.ModuleType("slowapi")
+    fake_slowapi._rate_limit_exceeded_handler = lambda *args, **kwargs: None
+    fake_slowapi_errors = types.ModuleType("slowapi.errors")
+    fake_slowapi_errors.RateLimitExceeded = type("RateLimitExceeded", (Exception,), {})
+
+    fake_routers = types.ModuleType("routers")
+    fake_routers.__path__ = []
+    fake_router_modules = {}
+    for name in ("api_keys", "auth", "entities", "requests"):
+        module = types.ModuleType(f"routers.{name}")
+        module.router = APIRouter()
+        fake_router_modules[f"routers.{name}"] = module
+
+    modules = {
+        "auth": fake_auth,
+        "db": fake_db,
+        "errors": fake_errors,
+        "models": fake_models,
+        "rate_limit": fake_rate_limit,
+        "routers": fake_routers,
+        "schemas": fake_schemas,
+        "slowapi": fake_slowapi,
+        "slowapi.errors": fake_slowapi_errors,
+        "telemetry": fake_telemetry,
+    }
+    modules.update(fake_router_modules)
+    return modules
+
+
+@contextmanager
+def _patched_relevant_env(overrides=None):
+    overrides = overrides or {}
+    relevant = {
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
+        "POSTGRES_DB",
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_COLLECTION_NAME",
+        "OPENAI_API_KEY",
+        "HISTORY_DB_PATH",
+        "MEM0_DEFAULT_LLM_MODEL",
+        "MEM0_DEFAULT_EMBEDDER_MODEL",
+    }
+    with patch.dict(os.environ, {}, clear=False):
+        for key in relevant:
+            os.environ.pop(key, None)
+        for key, value in overrides.items():
+            os.environ[key] = value
+        yield
+
+
+@contextmanager
+def _server_runtime(*, initial_overrides=None, env=None):
+    stored_overrides = deepcopy(initial_overrides or {})
+
+    def _load():
+        return deepcopy(stored_overrides)
+
+    def _save(overrides):
+        stored_overrides.clear()
+        stored_overrides.update(deepcopy(overrides))
+
+    with (
+        patch("mem0.Memory.from_config", return_value=MagicMock()),
+        _patched_relevant_env(env),
+        patch.dict(sys.modules, _fake_main_modules()),
+    ):
+        sys.modules.pop("server.main", None)
+        server_state = _reloaded_module("server_state")
+        with (
+            patch.object(server_state, "_load_overrides", side_effect=_load),
+            patch.object(server_state, "_save_overrides", side_effect=_save),
+        ):
+            server_main = _reloaded_module("server.main")
+            yield server_main, stored_overrides
+
+
+def test_startup_env_api_key_beats_persisted_override():
+    with _server_runtime(
+        initial_overrides={"llm": {"config": {"api_key": "db-bad-key"}}},
+        env={"OPENAI_API_KEY": "env-good-key"},
+    ) as (server_main, _):
+        current_config = server_main.get_current_config()
+
+    assert current_config["llm"]["config"]["api_key"] == "env-good-key"
+
+
+def test_startup_persisted_without_env_beats_default():
+    with _server_runtime(
+        initial_overrides={"llm": {"config": {"api_key": "db-good-key"}}},
+    ) as (server_main, _):
+        current_config = server_main.get_current_config()
+
+    assert current_config["llm"]["config"]["api_key"] == "db-good-key"
+
+
+def test_update_preserves_env_owned_field():
+    with _server_runtime(
+        initial_overrides={"llm": {"config": {"api_key": "db-bad-key"}}},
+        env={"OPENAI_API_KEY": "env-good-key"},
+    ) as (server_main, stored_overrides):
+        updated = server_main.update_config({"llm": {"config": {"api_key": "db-new-key"}}})
+
+    assert updated["llm"]["config"]["api_key"] == "env-good-key"
+    assert stored_overrides["llm"]["config"]["api_key"] == "db-new-key"
+
+
+def test_update_non_env_owned_field():
+    with _server_runtime(env={"OPENAI_API_KEY": "env-good-key"}) as (server_main, stored_overrides):
+        updated = server_main.update_config({"llm": {"config": {"temperature": 0.7}}})
+
+    assert updated["llm"]["config"]["api_key"] == "env-good-key"
+    assert updated["llm"]["config"]["temperature"] == 0.7
+    assert stored_overrides["llm"]["config"]["temperature"] == 0.7
+
+
+def test_restart_after_env_removal():
+    persisted_overrides = {"llm": {"config": {"api_key": "db-good-key"}}}
+
+    with _server_runtime(
+        initial_overrides=persisted_overrides,
+        env={"OPENAI_API_KEY": "env-good-key"},
+    ) as (server_main, _):
+        with_env = server_main.get_current_config()
+
+    with _server_runtime(initial_overrides=persisted_overrides) as (server_main, _):
+        without_env = server_main.get_current_config()
+
+    assert with_env["llm"]["config"]["api_key"] == "env-good-key"
+    assert without_env["llm"]["config"]["api_key"] == "db-good-key"


### PR DESCRIPTION
## Linked Issue

Closes #4984

## Description

The dashboard half of issue `#4984` merged in PR `#6475`, but the remaining server-state half is still live on `main`: an explicit `.env` value cannot override a conflicting persisted server override on restart. This change restores env precedence for fields that are explicitly present in the environment, while keeping persisted overrides effective for fields whose environment variable is absent.

## Root cause

The server currently collapses built-in defaults and explicit environment values into one `DEFAULT_CONFIG`, then merges persisted overrides on top of that single blob during startup and later mutates the already-composed runtime config during `POST /configure`. Once those ownership layers are flattened together, the runtime can no longer tell which fields were explicitly set by environment and must remain authoritative.

## Scope

This PR touches only `server/main.py`, `server/server_state.py`, and a new focused regression file `tests/test_server_config.py`. It leaves the merged dashboard fix from `#6475`, the provider-switch overwrite work from `#5523`, auth middleware, endpoint shapes, docs, and `VECTOR_STORE_CONFIG` unchanged.

## Attribution

The remaining-slice direction comes from the maintainer follow-up in https://github.com/mem0ai/mem0/issues/4984#issuecomment-5055415449 after the dashboard half merged in https://github.com/mem0ai/mem0/pull/6475 .

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed

Verification:
- [x] `hatch run pytest tests/test_server_config.py -q`
- [x] `hatch run ruff check server/main.py server/server_state.py tests/test_server_config.py`
- [x] `hatch run ruff format --check server/main.py server/server_state.py tests/test_server_config.py`
- [ ] `make lint`
- [ ] `make test`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
