### PR TITLE
fix(ts-oss): feed the reranker the full candidate pool, not the truncated topK

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1531,13 +1531,20 @@ export class Memory {
         payload: mem.payload || {},
       }));
 
-    // Step 8: Score and rank
+    // Step 8: Score and rank. When a reranker will run, keep a larger candidate
+    // pool so it can surface memories the first-stage scorer ranked below topK;
+    // the reranker then narrows it back to topK. Without this, scoreAndRank
+    // truncates to topK before the reranker runs, so reranking could only
+    // reorder the final results and never improve recall — which is the main
+    // reason to run a reranker at all.
+    const rerankActive = Boolean(config.rerank && this.reranker);
+    const rankLimit = rerankActive ? Math.max(topK * 4, 60) : topK;
     const scoredResults = scoreAndRank(
       candidates,
       bm25Scores,
       entityBoosts,
       threshold ?? 0.1,
-      topK,
+      rankLimit,
       explain,
     );
 
@@ -1577,11 +1584,12 @@ export class Memory {
       });
 
     // Step 10: Optionally re-rank with the configured reranker. Opt-in per
-    // search via `rerank: true`; a no-op when no reranker is configured.
-    const invokeReranker = Boolean(
-      config.rerank && this.reranker && results.length > 0,
-    );
-    let finalResults = results;
+    // search via `rerank: true`; a no-op when no reranker is configured. When
+    // reranking, `results` holds the over-fetched pool (see step 8), so default
+    // to the top-`topK` slice — the reranker overrides it on success, and a
+    // rerank failure still returns exactly topK rather than the whole pool.
+    const invokeReranker = Boolean(rerankActive && results.length > 0);
+    let finalResults = rerankActive ? results.slice(0, topK) : results;
     if (invokeReranker) {
       try {
         const ranked = await this.reranker!.rerank(

--- a/mem0-ts/src/oss/tests/memory.rerank.test.ts
+++ b/mem0-ts/src/oss/tests/memory.rerank.test.ts
@@ -10,7 +10,7 @@ import { Memory } from "../src/memory";
 import { CohereReranker } from "../src/rerankers/cohere";
 import type { RerankResult } from "../src/rerankers/base";
 
-jest.setTimeout(15000);
+jest.setTimeout(60000);
 
 jest.mock("../src/embeddings/google", () => ({
   GoogleEmbedder: jest.fn(),
@@ -74,7 +74,82 @@ async function primeSearch(m: any) {
   m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
 }
 
+// Prime with a pool of `n` candidates in descending vector-score order
+// (mem0 best ... mem{n-1} worst), so a small topK truncates the pool.
+async function primeLargePool(m: any, n: number) {
+  await m._ensureInitialized();
+  m.embedder = { embed: jest.fn().mockResolvedValue(mockEmbedding) };
+  const rows = Array.from({ length: n }, (_, i) => ({
+    id: `c${i}`,
+    score: 0.9 - i * 0.01,
+    payload: { data: `mem${i}` },
+  }));
+  m.vectorStore.search = jest.fn().mockResolvedValue(rows);
+  m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
+}
+
 describe("Memory.search reranking", () => {
+  it("feeds the reranker the full candidate pool, not just topK, so it can surface a memory ranked below topK", async () => {
+    const memory = createMemory();
+    const m = memory as any;
+    await primeLargePool(m, 5);
+
+    // The reranker promotes mem4, which the first-stage scorer ranked 5th —
+    // below topK=2. Before the fix, scoreAndRank truncated to topK so mem4
+    // never reached the reranker and could never be surfaced.
+    const rerank = jest
+      .fn<Promise<RerankResult[]>, [string, string[], number?]>()
+      .mockImplementation((_q: string, docs: string[]) =>
+        Promise.resolve([
+          { index: docs.indexOf("mem4"), rerankScore: 0.99 },
+          { index: 0, rerankScore: 0.5 },
+        ]),
+      );
+    m.reranker = { rerank };
+
+    const result = await m.search("recall something", {
+      filters: { user_id: "u1" },
+      topK: 2,
+      rerank: true,
+    });
+
+    // The reranker must have seen all 5 candidates, not the truncated top 2.
+    const docsSeen = rerank.mock.calls[0][1];
+    expect(docsSeen).toHaveLength(5);
+    expect(docsSeen).toContain("mem4");
+
+    // mem4 (ranked 5th by the first stage) is surfaced to the top, and the
+    // final result is still trimmed to topK.
+    expect(result.results[0].memory).toBe("mem4");
+    expect(result.results).toHaveLength(2);
+
+    await memory.reset();
+  });
+
+  it("trims the over-fetched pool back to topK when the reranker fails", async () => {
+    const memory = createMemory();
+    const m = memory as any;
+    await primeLargePool(m, 5);
+    m.reranker = {
+      rerank: jest.fn().mockRejectedValue(new Error("provider down")),
+    };
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await m.search("recall something", {
+      filters: { user_id: "u1" },
+      topK: 2,
+      rerank: true,
+    });
+
+    // Over-fetching for the reranker must not leak the whole pool on failure;
+    // the caller still gets exactly topK (the first-stage top 2).
+    expect(result.results).toHaveLength(2);
+    expect(result.results.map((r: any) => r.memory)).toEqual(["mem0", "mem1"]);
+
+    warnSpy.mockRestore();
+    await memory.reset();
+  });
+
   it("reorders results by the reranker when rerank:true, adding rerankScore while preserving the original vector score", async () => {
     const memory = createMemory();
     const m = memory as any;


### PR DESCRIPTION
### Description

When `search(query, { rerank: true })` is used, the reranker only ever received the already-truncated top-`topK` results, not the larger candidate pool fetched for scoring. So reranking could only **reorder** the final results — it could never surface a relevant memory the first-stage scorer ranked just below `topK`, which is the main reason to run a reranker at all.

Step 3 over-fetches a pool (`internalLimit = max(topK * 4, 60)`), but step 8 truncated it to `topK` via `scoreAndRank(..., topK, ...)` before the reranker ran. The fix: when a reranker will run, score and keep the larger pool and hand it to the reranker, which narrows back to `topK`. A rerank failure trims the pool to `topK` so it never leaks. Non-rerank searches are unchanged (they still truncate to `topK` exactly as before).

This is the TS counterpart of #6448 (the Python SDK has the identical bug, being fixed the same way in #6455 / #6449).

Closes #6575

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`jest src/oss/tests/memory.rerank.test.ts` (run from the `mem0-ts` root), 7 passed.

- Added `feeds the reranker the full candidate pool, not just topK, so it can surface a memory ranked below topK`: with 5 first-stage candidates and `topK: 2`, the reranker now receives all 5 documents and a memory the first stage ranked 5th is surfaced to the top; the final result is still trimmed to `topK`. Reverting the source change fails this — the reranker receives only 2 documents.
- Added `trims the over-fetched pool back to topK when the reranker fails`: a rerank failure returns exactly `topK`, never the whole pool.
- The existing reranking tests (reorder, no-op, graceful failure, config wiring) still pass unchanged.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes