### PR TITLE
fix: resolve vector store bugs and V3 false ADD results

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -93,34 +93,38 @@ def _vector_store_list_rows(listed):
 # Fields that hold runtime auth/connection objects and must be preserved.
 # These are non-serializable objects (e.g. AWSV4SignerAuth, RequestsHttpConnection)
 # needed by clients like OpenSearch — not sensitive strings to redact.
-_RUNTIME_FIELDS = frozenset({
-    "http_auth",
-    "auth",
-    "connection_class",
-    "ssl_context",
-})
+_RUNTIME_FIELDS = frozenset(
+    {
+        "http_auth",
+        "auth",
+        "connection_class",
+        "ssl_context",
+    }
+)
 
 # Fields that are known to contain sensitive secrets and must be redacted.
-_SENSITIVE_FIELDS_EXACT = frozenset({
-    "api_key",
-    "secret_key",
-    "private_key",
-    "access_key",
-    "password",
-    "credentials",
-    "credential",
-    "secret",
-    "token",
-    "access_token",
-    "refresh_token",
-    "auth_token",
-    "session_token",
-    "client_secret",
-    "auth_client_secret",
-    "azure_client_secret",
-    "service_account_json",
-    "aws_session_token",
-})
+_SENSITIVE_FIELDS_EXACT = frozenset(
+    {
+        "api_key",
+        "secret_key",
+        "private_key",
+        "access_key",
+        "password",
+        "credentials",
+        "credential",
+        "secret",
+        "token",
+        "access_token",
+        "refresh_token",
+        "auth_token",
+        "session_token",
+        "client_secret",
+        "auth_client_secret",
+        "azure_client_secret",
+        "service_account_json",
+        "aws_session_token",
+    }
+)
 
 # Suffixes that indicate a field likely holds a secret value.
 _SENSITIVE_SUFFIXES = (
@@ -186,13 +190,9 @@ def _validate_and_trim_entity_id(value: Optional[Any], name: str) -> Optional[st
         value = str(value)
     trimmed = value.strip()
     if trimmed == "":
-        raise ValueError(
-            f"Invalid {name}: cannot be empty or whitespace-only. Provide a valid identifier."
-        )
+        raise ValueError(f"Invalid {name}: cannot be empty or whitespace-only. Provide a valid identifier.")
     if any(c.isspace() for c in trimmed):
-        raise ValueError(
-            f"Invalid {name}: cannot contain whitespace. Provide a valid identifier without spaces."
-        )
+        raise ValueError(f"Invalid {name}: cannot contain whitespace. Provide a valid identifier without spaces.")
     return trimmed
 
 
@@ -211,16 +211,12 @@ def _validate_search_params(threshold: Optional[float] = None, top_k: Optional[i
         if not isinstance(threshold, (int, float)):
             raise ValueError("threshold must be a valid number")
         if threshold < 0 or threshold > 1:
-            raise ValueError(
-                f"Invalid threshold: {threshold}. Must be between 0 and 1 (inclusive)."
-            )
+            raise ValueError(f"Invalid threshold: {threshold}. Must be between 0 and 1 (inclusive).")
     if top_k is not None:
         if not isinstance(top_k, int) or isinstance(top_k, bool):
             raise ValueError("top_k must be a valid integer")
         if top_k < 0:
-            raise ValueError(
-                f"Invalid top_k: {top_k}. Must be a non-negative integer."
-            )
+            raise ValueError(f"Invalid top_k: {top_k}. Must be a non-negative integer.")
 
 
 def _validate_and_trim_search_query(query: str) -> str:
@@ -373,7 +369,7 @@ def _build_filters_and_metadata(
             message="At least one of 'user_id', 'agent_id', or 'run_id' must be provided.",
             error_code="VALIDATION_001",
             details={"provided_ids": {"user_id": user_id, "agent_id": agent_id, "run_id": run_id}},
-            suggestion="Please provide at least one identifier to scope the memory operation."
+            suggestion="Please provide at least one identifier to scope the memory operation.",
         )
 
     # ---------- optional actor filter ----------
@@ -480,10 +476,7 @@ class Memory(MemoryBase):
         # Initialize reranker if configured
         self.reranker = None
         if config.reranker:
-            self.reranker = RerankerFactory.create(
-                config.reranker.provider,
-                config.reranker.config
-            )
+            self.reranker = RerankerFactory.create(config.reranker.provider, config.reranker.config)
 
         # Entity store is initialized lazily on first use
         self._entity_store = None
@@ -491,24 +484,24 @@ class Memory(MemoryBase):
         if MEM0_TELEMETRY:
             # Create telemetry config manually to avoid deepcopy issues with thread locks
             telemetry_config_dict = {}
-            if hasattr(self.config.vector_store.config, 'model_dump'):
+            if hasattr(self.config.vector_store.config, "model_dump"):
                 # For pydantic models
                 telemetry_config_dict = self.config.vector_store.config.model_dump()
             else:
                 # For other objects, manually copy common attributes
-                for attr in ['host', 'port', 'path', 'api_key', 'index_name', 'dimension', 'metric']:
+                for attr in ["host", "port", "path", "api_key", "index_name", "dimension", "metric"]:
                     if hasattr(self.config.vector_store.config, attr):
                         telemetry_config_dict[attr] = getattr(self.config.vector_store.config, attr)
 
             # Override collection name for telemetry
-            telemetry_config_dict['collection_name'] = "mem0migrations"
+            telemetry_config_dict["collection_name"] = "mem0migrations"
 
             # Set path for file-based vector stores
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
             if self.config.vector_store.provider in ["faiss", "qdrant"]:
                 provider_path = f"migrations_{self.config.vector_store.provider}"
-                telemetry_config_dict['path'] = os.path.join(mem0_dir, provider_path)
-                os.makedirs(telemetry_config_dict['path'], exist_ok=True)
+                telemetry_config_dict["path"] = os.path.join(mem0_dir, provider_path)
+                os.makedirs(telemetry_config_dict["path"], exist_ok=True)
 
             # Create the config object using the same class as the original
             telemetry_config = self.config.vector_store.config.__class__(**telemetry_config_dict)
@@ -537,10 +530,10 @@ class Memory(MemoryBase):
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
             entity_collection = _entity_collection_name(self.config.vector_store.provider, self.collection_name)
             # Set collection name on the cloned config
-            if hasattr(entity_config, 'collection_name'):
+            if hasattr(entity_config, "collection_name"):
                 entity_config.collection_name = entity_collection
             elif isinstance(entity_config, dict):
-                entity_config['collection_name'] = entity_collection
+                entity_config["collection_name"] = entity_collection
             # For Qdrant, share the existing client to avoid RocksDB lock contention
             # when using embedded mode (path=...). QdrantConfig.client takes precedence
             # over host/port/path.
@@ -549,9 +542,7 @@ class Memory(MemoryBase):
                     entity_config.client = self.vector_store.client
                 elif isinstance(entity_config, dict):
                     entity_config["client"] = self.vector_store.client
-            self._entity_store = VectorStoreFactory.create(
-                self.config.vector_store.provider, entity_config
-            )
+            self._entity_store = VectorStoreFactory.create(self.config.vector_store.provider, entity_config)
         return self._entity_store
 
     @staticmethod
@@ -803,7 +794,7 @@ class Memory(MemoryBase):
                 message=f"Invalid 'memory_type'. Please pass {MemoryType.PROCEDURAL.value} to create procedural memories.",
                 error_code="VALIDATION_002",
                 details={"provided_type": memory_type, "valid_type": MemoryType.PROCEDURAL.value},
-                suggestion=f"Use '{MemoryType.PROCEDURAL.value}' to create procedural memories."
+                suggestion=f"Use '{MemoryType.PROCEDURAL.value}' to create procedural memories.",
             )
 
         if isinstance(messages, str):
@@ -817,7 +808,7 @@ class Memory(MemoryBase):
                 message="messages must be str, dict, or list[dict]",
                 error_code="VALIDATION_003",
                 details={"provided_type": type(messages).__name__, "valid_types": ["str", "dict", "list[dict]"]},
-                suggestion="Convert your input to a string, dictionary, or list of dictionaries."
+                suggestion="Convert your input to a string, dictionary, or list of dictionaries.",
             )
 
         if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
@@ -836,7 +827,9 @@ class Memory(MemoryBase):
         else:
             messages = parse_vision_messages(messages)
 
-        vector_store_result = self._add_to_vector_store(messages, processed_metadata, effective_filters, infer, prompt=prompt)
+        vector_store_result = self._add_to_vector_store(
+            messages, processed_metadata, effective_filters, infer, prompt=prompt
+        )
         scale_threshold_notice = detect_scale_threshold_from_add_result(self, vector_store_result)
         if temporal_usage_notice:
             display_temporal_usage_notice(self, "sync", "add", *temporal_usage_notice)
@@ -1017,19 +1010,28 @@ class Memory(MemoryBase):
         all_ids = [r[0] for r in records]
         all_payloads = [r[3] for r in records]
 
+        persisted_ids = set()
         try:
             self.vector_store.insert(
                 vectors=all_vectors,
                 ids=all_ids,
                 payloads=all_payloads,
             )
+            persisted_ids = set(all_ids)
         except Exception:
             # Fallback: insert one by one
             for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
                 try:
                     self.vector_store.insert(vectors=[vec], ids=[mid], payloads=[pay])
+                    persisted_ids.add(mid)
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid}: {e}")
+
+        if not persisted_ids:
+            self.db.save_messages(messages, session_scope)
+            return []
+
+        persisted_records = [r for r in records if r[0] in persisted_ids]
 
         # Batch history
         history_records = [
@@ -1041,7 +1043,7 @@ class Memory(MemoryBase):
                 "created_at": r[3].get("created_at"),
                 "is_deleted": 0,
             }
-            for r in records
+            for r in persisted_records
         ]
         try:
             self.db.batch_add_history(history_records)
@@ -1055,12 +1057,12 @@ class Memory(MemoryBase):
 
         # Phase 7: Batch entity linking
         try:
-            all_texts = [r[1] for r in records]
+            all_texts = [r[1] for r in persisted_records]
             all_entities = extract_entities_batch(all_texts)
 
             # 7a: Global dedup — collect unique entities across all memories
             global_entities = {}  # normalized_key -> (entity_type, entity_text, set of memory_ids)
-            for idx, (memory_id, text, embedding, payload) in enumerate(records):
+            for idx, (memory_id, text, embedding, payload) in enumerate(persisted_records):
                 entities = all_entities[idx] if idx < len(all_entities) else []
                 for entity_type, entity_text in entities:
                     key = self._normalize_entity_text(entity_text)
@@ -1084,7 +1086,6 @@ class Memory(MemoryBase):
                             entity_embeddings.append(self.embedding_model.embed(t, "add"))
                         except Exception:
                             entity_embeddings.append(None)
-
 
                 if len(entity_embeddings) != len(ordered_keys):
                     logger.warning(
@@ -1139,12 +1140,14 @@ class Memory(MemoryBase):
                             # New entity — collect for batch insert
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
-                            to_insert_payloads.append({
-                                "data": entity_text,
-                                "entity_type": entity_type,
-                                "linked_memory_ids": sorted(memory_ids),
-                                **search_filters,
-                            })
+                            to_insert_payloads.append(
+                                {
+                                    "data": entity_text,
+                                    "entity_type": entity_type,
+                                    "linked_memory_ids": sorted(memory_ids),
+                                    **search_filters,
+                                }
+                            )
 
                     # 7e: Single batch insert for all new entities
                     if to_insert_vectors:
@@ -1162,10 +1165,7 @@ class Memory(MemoryBase):
         # Phase 8: Save messages + return
         self.db.save_messages(messages, session_scope)
 
-        returned_memories = [
-            {"id": r[0], "memory": r[1], "event": "ADD"}
-            for r in records
-        ]
+        returned_memories = [{"id": r[0], "memory": r[1], "event": "ADD"} for r in persisted_records]
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event(
@@ -1201,7 +1201,16 @@ class Memory(MemoryBase):
             "expiration_date",
         ]
 
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         result_item = MemoryItem(
             id=memory.id,
@@ -1257,23 +1266,16 @@ class Memory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = dict(filters) if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -1318,7 +1320,16 @@ class Memory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         formatted_memories = []
         for mem in actual_memories:
@@ -1413,21 +1424,14 @@ class Memory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -1440,7 +1444,9 @@ class Memory(MemoryBase):
             for logical_key in ("AND", "OR", "NOT"):
                 effective_filters.pop(logical_key, None)
             for fk in list(effective_filters.keys()):
-                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(effective_filters.get(fk), dict):
+                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(
+                    effective_filters.get(fk), dict
+                ):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
@@ -1515,9 +1521,16 @@ class Memory(MemoryBase):
             for operator, value in condition.items():
                 # Map platform operators to universal format that can be translated by each vector store
                 operator_map = {
-                    "eq": "eq", "ne": "ne", "gt": "gt", "gte": "gte",
-                    "lt": "lt", "lte": "lte", "in": "in", "nin": "nin",
-                    "contains": "contains", "icontains": "icontains"
+                    "eq": "eq",
+                    "ne": "ne",
+                    "gt": "gt",
+                    "gte": "gte",
+                    "lt": "lt",
+                    "lte": "lte",
+                    "in": "in",
+                    "nin": "nin",
+                    "contains": "contains",
+                    "icontains": "icontains",
                 }
 
                 if operator in operator_map:
@@ -1571,16 +1584,16 @@ class Memory(MemoryBase):
     def _has_advanced_operators(self, filters: Dict[str, Any]) -> bool:
         """
         Check if filters contain advanced operators that need special processing.
-        
+
         Args:
             filters: Dictionary of filters to check
-            
+
         Returns:
             bool: True if advanced operators are detected
         """
         if not isinstance(filters, dict):
             return False
-            
+
         for key, value in filters.items():
             # Check for platform-style logical operators
             if key in ["AND", "OR", "NOT"]:
@@ -1623,8 +1636,8 @@ class Memory(MemoryBase):
         if keyword_results is not None:
             midpoint, steepness = get_bm25_params(query, lemmatized=query_lemmatized)
             for mem in keyword_results:
-                mem_id = str(mem.id) if hasattr(mem, 'id') else str(mem.get('id', ''))
-                raw_score = mem.score if hasattr(mem, 'score') else mem.get('score', 0)
+                mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+                raw_score = mem.score if hasattr(mem, "score") else mem.get("score", 0)
                 if raw_score and raw_score > 0:
                     bm25_scores[mem_id] = normalize_bm25(raw_score, midpoint, steepness)
 
@@ -1636,15 +1649,17 @@ class Memory(MemoryBase):
         # Step 7: Build candidate set from semantic results
         candidates = []
         for mem in semantic_results:
-            payload = mem.payload if hasattr(mem, 'payload') else {}
+            payload = mem.payload if hasattr(mem, "payload") else {}
             if not show_expired and _payload_is_expired(payload):
                 continue
             mem_id = str(mem.id)
-            candidates.append({
-                "id": mem_id,
-                "score": mem.score,
-                "payload": payload,
-            })
+            candidates.append(
+                {
+                    "id": mem_id,
+                    "score": mem.score,
+                    "payload": payload,
+                }
+            )
 
         # Step 8: Score and rank
         scored_results = score_and_rank(
@@ -1666,7 +1681,16 @@ class Memory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         original_memories = []
         for scored in scored_results:
@@ -1741,15 +1765,10 @@ class Memory(MemoryBase):
             entity_store = self.entity_store
 
             def _search_entity(entity_text, embedding):
-                return entity_store.search(
-                    query=entity_text, vectors=embedding, top_k=500, filters=search_filters
-                )
+                return entity_store.search(query=entity_text, vectors=embedding, top_k=500, filters=search_filters)
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
-                futures = {
-                    pool.submit(_search_entity, text, emb): text
-                    for text, emb in zip(entity_texts, embeddings)
-                }
+                futures = {pool.submit(_search_entity, text, emb): text for text, emb in zip(entity_texts, embeddings)}
 
                 for future in concurrent.futures.as_completed(futures):
                     try:
@@ -1759,11 +1778,11 @@ class Memory(MemoryBase):
                         continue
 
                     for match in matches:
-                        similarity = match.score if hasattr(match, 'score') else 0.0
+                        similarity = match.score if hasattr(match, "score") else 0.0
                         if similarity < 0.5:
                             continue
 
-                        payload = match.payload if hasattr(match, 'payload') else {}
+                        payload = match.payload if hasattr(match, "payload") else {}
                         linked_memory_ids = payload.get("linked_memory_ids", [])
                         if not isinstance(linked_memory_ids, list):
                             continue
@@ -2141,10 +2160,7 @@ class AsyncMemory(MemoryBase):
         # Initialize reranker if configured
         self.reranker = None
         if config.reranker:
-            self.reranker = RerankerFactory.create(
-                config.reranker.provider,
-                config.reranker.config
-            )
+            self.reranker = RerankerFactory.create(config.reranker.provider, config.reranker.config)
 
         if MEM0_TELEMETRY:
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
@@ -2153,7 +2169,9 @@ class AsyncMemory(MemoryBase):
                 provider_path = f"migrations_{self.config.vector_store.provider}"
                 telemetry_config.path = os.path.join(mem0_dir, provider_path)
                 os.makedirs(telemetry_config.path, exist_ok=True)
-            self._telemetry_vector_store = VectorStoreFactory.create(self.config.vector_store.provider, telemetry_config)
+            self._telemetry_vector_store = VectorStoreFactory.create(
+                self.config.vector_store.provider, telemetry_config
+            )
 
         if getattr(type(self.vector_store), "keyword_search", None) is VectorStoreBase.keyword_search:
             logger.warning(
@@ -2176,10 +2194,10 @@ class AsyncMemory(MemoryBase):
         if self._entity_store is None:
             entity_config = _safe_deepcopy_config(self.config.vector_store.config)
             entity_collection = _entity_collection_name(self.config.vector_store.provider, self.collection_name)
-            if hasattr(entity_config, 'collection_name'):
+            if hasattr(entity_config, "collection_name"):
                 entity_config.collection_name = entity_collection
             elif isinstance(entity_config, dict):
-                entity_config['collection_name'] = entity_collection
+                entity_config["collection_name"] = entity_collection
             # For Qdrant, share the existing client to avoid RocksDB lock contention
             # when using embedded mode (path=...). QdrantConfig.client takes precedence
             # over host/port/path.
@@ -2188,9 +2206,7 @@ class AsyncMemory(MemoryBase):
                     entity_config.client = self.vector_store.client
                 elif isinstance(entity_config, dict):
                     entity_config["client"] = self.vector_store.client
-            self._entity_store = VectorStoreFactory.create(
-                self.config.vector_store.provider, entity_config
-            )
+            self._entity_store = VectorStoreFactory.create(self.config.vector_store.provider, entity_config)
         return self._entity_store
 
     @staticmethod
@@ -2221,9 +2237,9 @@ class AsyncMemory(MemoryBase):
         try:
             entity_embedding = await asyncio.to_thread(self.embedding_model.embed, entity_text, "add")
             search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-            exact_match = (
-                await asyncio.to_thread(self._existing_entities_by_text, search_filters)
-            ).get(self._normalize_entity_text(entity_text))
+            exact_match = (await asyncio.to_thread(self._existing_entities_by_text, search_filters)).get(
+                self._normalize_entity_text(entity_text)
+            )
 
             existing = []
             if exact_match is None:
@@ -2443,7 +2459,7 @@ class AsyncMemory(MemoryBase):
                 message="messages must be str, dict, or list[dict]",
                 error_code="VALIDATION_003",
                 details={"provided_type": type(messages).__name__, "valid_types": ["str", "dict", "list[dict]"]},
-                suggestion="Convert your input to a string, dictionary, or list of dictionaries."
+                suggestion="Convert your input to a string, dictionary, or list of dictionaries.",
             )
 
         if agent_id is not None and memory_type == MemoryType.PROCEDURAL.value:
@@ -2464,8 +2480,12 @@ class AsyncMemory(MemoryBase):
         else:
             messages = parse_vision_messages(messages)
 
-        vector_store_result = await self._add_to_vector_store(messages, processed_metadata, effective_filters, infer, prompt=prompt)
-        scale_threshold_notice = await asyncio.to_thread(detect_scale_threshold_from_add_result, self, vector_store_result)
+        vector_store_result = await self._add_to_vector_store(
+            messages, processed_metadata, effective_filters, infer, prompt=prompt
+        )
+        scale_threshold_notice = await asyncio.to_thread(
+            detect_scale_threshold_from_add_result, self, vector_store_result
+        )
         if temporal_usage_notice:
             await display_temporal_usage_notice_async(self, "async", "add", *temporal_usage_notice)
         elif scale_threshold_notice:
@@ -2649,6 +2669,7 @@ class AsyncMemory(MemoryBase):
         all_ids = [r[0] for r in records]
         all_payloads = [r[3] for r in records]
 
+        persisted_ids = set()
         try:
             await asyncio.to_thread(
                 self.vector_store.insert,
@@ -2656,12 +2677,20 @@ class AsyncMemory(MemoryBase):
                 ids=all_ids,
                 payloads=all_payloads,
             )
+            persisted_ids = set(all_ids)
         except Exception:
             for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
                 try:
                     await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
+                    persisted_ids.add(mid)
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid} (async): {e}")
+
+        if not persisted_ids:
+            await asyncio.to_thread(self.db.save_messages, messages, session_scope)
+            return []
+
+        persisted_records = [r for r in records if r[0] in persisted_ids]
 
         # Batch history
         history_records = [
@@ -2673,7 +2702,7 @@ class AsyncMemory(MemoryBase):
                 "created_at": r[3].get("created_at"),
                 "is_deleted": 0,
             }
-            for r in records
+            for r in persisted_records
         ]
         try:
             await asyncio.to_thread(self.db.batch_add_history, history_records)
@@ -2681,20 +2710,24 @@ class AsyncMemory(MemoryBase):
             for hr in history_records:
                 try:
                     await asyncio.to_thread(
-                        self.db.add_history, hr["memory_id"], None, hr["new_memory"], "ADD",
-                        created_at=hr.get("created_at")
+                        self.db.add_history,
+                        hr["memory_id"],
+                        None,
+                        hr["new_memory"],
+                        "ADD",
+                        created_at=hr.get("created_at"),
                     )
                 except Exception as e:
                     logger.error(f"Failed to add history for {hr['memory_id']} (async): {e}")
 
         # Phase 7: Batch entity linking
         try:
-            all_texts = [r[1] for r in records]
+            all_texts = [r[1] for r in persisted_records]
             all_entities = await asyncio.to_thread(extract_entities_batch, all_texts)
 
             # 7a: Global dedup
             global_entities = {}
-            for idx, (memory_id, text, embedding, payload) in enumerate(records):
+            for idx, (memory_id, text, embedding, payload) in enumerate(persisted_records):
                 entities = all_entities[idx] if idx < len(all_entities) else []
                 for entity_type, entity_text in entities:
                     key = self._normalize_entity_text(entity_text)
@@ -2770,12 +2803,14 @@ class AsyncMemory(MemoryBase):
                         else:
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
-                            to_insert_payloads.append({
-                                "data": entity_text,
-                                "entity_type": entity_type,
-                                "linked_memory_ids": sorted(memory_ids),
-                                **search_filters,
-                            })
+                            to_insert_payloads.append(
+                                {
+                                    "data": entity_text,
+                                    "entity_type": entity_type,
+                                    "linked_memory_ids": sorted(memory_ids),
+                                    **search_filters,
+                                }
+                            )
 
                     # 7e: Batch insert new entities
                     if to_insert_vectors:
@@ -2794,10 +2829,7 @@ class AsyncMemory(MemoryBase):
         # Phase 8: Save messages + return
         await asyncio.to_thread(self.db.save_messages, messages, session_scope)
 
-        returned_memories = [
-            {"id": r[0], "memory": r[1], "event": "ADD"}
-            for r in records
-        ]
+        returned_memories = [{"id": r[0], "memory": r[1], "event": "ADD"} for r in persisted_records]
 
         keys, encoded_ids = process_telemetry_filters(effective_filters)
         capture_event(
@@ -2833,7 +2865,16 @@ class AsyncMemory(MemoryBase):
             "expiration_date",
         ]
 
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         result_item = MemoryItem(
             id=memory.id,
@@ -2889,23 +2930,16 @@ class AsyncMemory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = dict(filters) if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -2950,7 +2984,16 @@ class AsyncMemory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         formatted_memories = []
         for mem in actual_memories:
@@ -3032,9 +3075,7 @@ class AsyncMemory(MemoryBase):
                 or if threshold/top_k values are invalid.
         """
         if reference_date is not None:
-            raise ValueError(
-                await get_temporal_feature_error_message_async("async", "search", "reference_date")
-            )
+            raise ValueError(await get_temporal_feature_error_message_async("async", "search", "reference_date"))
 
         # Reject top-level entity params - must use filters instead
         _reject_top_level_entity_params(kwargs, "search")
@@ -3047,23 +3088,16 @@ class AsyncMemory(MemoryBase):
         # Validate and trim entity IDs in filters
         effective_filters = filters.copy() if filters else {}
         if "user_id" in effective_filters:
-            effective_filters["user_id"] = _validate_and_trim_entity_id(
-                effective_filters["user_id"], "user_id"
-            )
+            effective_filters["user_id"] = _validate_and_trim_entity_id(effective_filters["user_id"], "user_id")
         if "agent_id" in effective_filters:
-            effective_filters["agent_id"] = _validate_and_trim_entity_id(
-                effective_filters["agent_id"], "agent_id"
-            )
+            effective_filters["agent_id"] = _validate_and_trim_entity_id(effective_filters["agent_id"], "agent_id")
         if "run_id" in effective_filters:
-            effective_filters["run_id"] = _validate_and_trim_entity_id(
-                effective_filters["run_id"], "run_id"
-            )
+            effective_filters["run_id"] = _validate_and_trim_entity_id(effective_filters["run_id"], "run_id")
 
         # Validate filters contains at least one entity ID
         if not any(key in effective_filters for key in ("user_id", "agent_id", "run_id")):
             raise ValueError(
-                "filters must contain at least one of: user_id, agent_id, run_id. "
-                "Example: filters={'user_id': 'u1'}"
+                "filters must contain at least one of: user_id, agent_id, run_id. Example: filters={'user_id': 'u1'}"
             )
 
         limit = top_k
@@ -3076,7 +3110,9 @@ class AsyncMemory(MemoryBase):
             for logical_key in ("AND", "OR", "NOT"):
                 effective_filters.pop(logical_key, None)
             for fk in list(effective_filters.keys()):
-                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(effective_filters.get(fk), dict):
+                if fk not in ("AND", "OR", "NOT", "user_id", "agent_id", "run_id") and isinstance(
+                    effective_filters.get(fk), dict
+                ):
                     effective_filters.pop(fk, None)
             effective_filters.update(processed_filters)
 
@@ -3106,9 +3142,7 @@ class AsyncMemory(MemoryBase):
         if rerank and self.reranker and original_memories:
             try:
                 # Run reranking in thread pool to avoid blocking async loop
-                reranked_memories = await asyncio.to_thread(
-                    self.reranker.rerank, query, original_memories, limit
-                )
+                reranked_memories = await asyncio.to_thread(self.reranker.rerank, query, original_memories, limit)
                 original_memories = reranked_memories
             except Exception as e:
                 logger.warning(f"Reranking failed, using original results: {e}")
@@ -3154,9 +3188,16 @@ class AsyncMemory(MemoryBase):
             for operator, value in condition.items():
                 # Map platform operators to universal format that can be translated by each vector store
                 operator_map = {
-                    "eq": "eq", "ne": "ne", "gt": "gt", "gte": "gte",
-                    "lt": "lt", "lte": "lte", "in": "in", "nin": "nin",
-                    "contains": "contains", "icontains": "icontains"
+                    "eq": "eq",
+                    "ne": "ne",
+                    "gt": "gt",
+                    "gte": "gte",
+                    "lt": "lt",
+                    "lte": "lte",
+                    "in": "in",
+                    "nin": "nin",
+                    "contains": "contains",
+                    "icontains": "icontains",
                 }
 
                 if operator in operator_map:
@@ -3261,8 +3302,8 @@ class AsyncMemory(MemoryBase):
         if keyword_results is not None:
             midpoint, steepness = get_bm25_params(query, lemmatized=query_lemmatized)
             for mem in keyword_results:
-                mem_id = str(mem.id) if hasattr(mem, 'id') else str(mem.get('id', ''))
-                raw_score = mem.score if hasattr(mem, 'score') else mem.get('score', 0)
+                mem_id = str(mem.id) if hasattr(mem, "id") else str(mem.get("id", ""))
+                raw_score = mem.score if hasattr(mem, "score") else mem.get("score", 0)
                 if raw_score and raw_score > 0:
                     bm25_scores[mem_id] = normalize_bm25(raw_score, midpoint, steepness)
 
@@ -3274,15 +3315,17 @@ class AsyncMemory(MemoryBase):
         # Step 7: Build candidate set from semantic results
         candidates = []
         for mem in semantic_results:
-            payload = mem.payload if hasattr(mem, 'payload') else {}
+            payload = mem.payload if hasattr(mem, "payload") else {}
             if not show_expired and _payload_is_expired(payload):
                 continue
             mem_id = str(mem.id)
-            candidates.append({
-                "id": mem_id,
-                "score": mem.score,
-                "payload": payload,
-            })
+            candidates.append(
+                {
+                    "id": mem_id,
+                    "score": mem.score,
+                    "payload": payload,
+                }
+            )
 
         # Step 8: Score and rank
         scored_results = score_and_rank(
@@ -3304,7 +3347,16 @@ class AsyncMemory(MemoryBase):
             "attributed_to",
             "expiration_date",
         ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
+        core_and_promoted_keys = {
+            "data",
+            "hash",
+            "created_at",
+            "updated_at",
+            "id",
+            "text_lemmatized",
+            "attributed_to",
+            *promoted_payload_keys,
+        }
 
         original_memories = []
         for scored in scored_results:
@@ -3388,11 +3440,11 @@ class AsyncMemory(MemoryBase):
                     continue
 
                 for match in matches:
-                    similarity = match.score if hasattr(match, 'score') else 0.0
+                    similarity = match.score if hasattr(match, "score") else 0.0
                     if similarity < 0.5:
                         continue
 
-                    payload = match.payload if hasattr(match, 'payload') else {}
+                    payload = match.payload if hasattr(match, "payload") else {}
                     linked_memory_ids = payload.get("linked_memory_ids", [])
                     if not isinstance(linked_memory_ids, list):
                         continue
@@ -3632,7 +3684,7 @@ class AsyncMemory(MemoryBase):
             else:
                 procedural_memory = await asyncio.to_thread(self.llm.generate_response, messages=parsed_messages)
                 procedural_memory = remove_code_blocks(procedural_memory)
-        
+
         except Exception as e:
             logger.error(f"Error generating procedural memory summary: {e}")
             raise

--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -131,6 +131,7 @@ class MilvusDB(VectorStoreBase):
             payloads (List[Dict], optional): List of payloads corresponding to vectors.
             ids (List[str], optional): List of IDs corresponding to vectors.
         """
+
         # Batch insert all records at once for better performance and consistency.
         # Only include the `text` field when the collection's schema has it — legacy
         # collections created pre-v3 reject unknown top-level fields.
@@ -138,7 +139,9 @@ class MilvusDB(VectorStoreBase):
             record = {"id": idx, "vectors": embedding, "metadata": metadata}
             if self._has_bm25_schema:
                 # Populate the text field for BM25 sparse search; prefer lemmatized text, fall back to raw data
-                record["text"] = (metadata.get("text_lemmatized") or metadata.get("data", ""))[:65535] if metadata else ""
+                record["text"] = (
+                    (metadata.get("text_lemmatized") or metadata.get("data", ""))[:65535] if metadata else ""
+                )
             return record
 
         data = [_build_record(idx, embedding, metadata) for idx, embedding, metadata in zip(ids, vectors, payloads)]
@@ -169,8 +172,7 @@ class MilvusDB(VectorStoreBase):
                 operands.append(f'(metadata["{key}"] == {value})')
             else:
                 raise ValueError(
-                    f"Filter value for {key!r} must be str, int, float, or bool, "
-                    f"got {type(value).__name__}"
+                    f"Filter value for {key!r} must be str, int, float, or bool, got {type(value).__name__}"
                 )
 
         return " and ".join(operands)

--- a/mem0/vector_stores/opensearch.py
+++ b/mem0/vector_stores/opensearch.py
@@ -23,10 +23,7 @@ def _validate_filter(key: str, value) -> None:
     if not isinstance(key, str) or not _SAFE_FILTER_KEY.match(key):
         raise ValueError(f"Invalid filter key: {key!r}")
     if not isinstance(value, (str, int, float, bool)):
-        raise ValueError(
-            f"Filter value for {key!r} must be str, int, float, or bool, "
-            f"got {type(value).__name__}"
-        )
+        raise ValueError(f"Filter value for {key!r} must be str, int, float, or bool, got {type(value).__name__}")
 
 
 def _build_filter_clauses(filters):
@@ -309,7 +306,7 @@ class OpenSearchDB(VectorStoreBase):
         hits = response.get("hits", {}).get("hits", [])
 
         if not hits:
-            return
+            raise ValueError(f"Vector with id {vector_id} not found in index {self.collection_name}")
 
         opensearch_id = hits[0]["_id"]
 
@@ -335,7 +332,7 @@ class OpenSearchDB(VectorStoreBase):
         hits = response.get("hits", {}).get("hits", [])
 
         if not hits:
-            return
+            raise ValueError(f"Vector with id {vector_id} not found in index {self.collection_name}")
 
         opensearch_id = hits[0]["_id"]  # The actual document ID in OpenSearch
 

--- a/mem0/vector_stores/pinecone.py
+++ b/mem0/vector_stores/pinecone.py
@@ -22,6 +22,13 @@ class OutputData(BaseModel):
     payload: Optional[Dict]  # metadata
 
 
+def _sparse_text_from_payload(payload: Optional[Dict]) -> str:
+    """Return memory text for BM25 sparse encoding (Mem0 stores text in data/text_lemmatized)."""
+    if not payload:
+        return ""
+    return payload.get("text_lemmatized") or payload.get("data") or payload.get("text") or ""
+
+
 class PineconeDB(VectorStoreBase):
     def __init__(
         self,
@@ -144,9 +151,11 @@ class PineconeDB(VectorStoreBase):
 
             vector_record = {"id": item_id, "values": vector, "metadata": payload}
 
-            if self.hybrid_search and self.sparse_encoder and "text" in payload:
-                sparse_vector = self.sparse_encoder.encode_documents(payload["text"])
-                vector_record["sparse_values"] = sparse_vector
+            if self.hybrid_search and self.sparse_encoder:
+                sparse_text = _sparse_text_from_payload(payload)
+                if sparse_text:
+                    sparse_vector = self.sparse_encoder.encode_documents(sparse_text)
+                    vector_record["sparse_values"] = sparse_vector
 
             items.append(vector_record)
 
@@ -323,9 +332,11 @@ class PineconeDB(VectorStoreBase):
         if payload is not None:
             item["metadata"] = payload
 
-            if self.hybrid_search and self.sparse_encoder and "text" in payload:
-                sparse_vector = self.sparse_encoder.encode_documents(payload["text"])
-                item["sparse_values"] = sparse_vector
+            if self.hybrid_search and self.sparse_encoder:
+                sparse_text = _sparse_text_from_payload(payload)
+                if sparse_text:
+                    sparse_vector = self.sparse_encoder.encode_documents(sparse_text)
+                    item["sparse_values"] = sparse_vector
 
         self.index.upsert(vectors=[item], namespace=self.namespace)
 

--- a/mem0/vector_stores/vertex_ai_vector_search.py
+++ b/mem0/vector_stores/vertex_ai_vector_search.py
@@ -69,7 +69,7 @@ class GoogleMatchingEngine(VectorStoreBase):
             "project": self.project_id,
             "location": self.region,
         }
-        
+
         # Support both credentials_path and service_account_json
         if hasattr(config, "credentials_path") and config.credentials_path:
             logger.debug("Using credentials from file: %s", config.credentials_path)
@@ -158,6 +158,35 @@ class GoogleMatchingEngine(VectorStoreBase):
         return aiplatform_v1.types.index.IndexDatapoint(
             datapoint_id=vector_id, feature_vector=vector, restricts=restrictions
         )
+
+    def _fetch_feature_vector(self, vector_id: str) -> List[float]:
+        """Fetch the stored embedding for a datapoint (used for payload-only updates)."""
+        if not self.vector_search_api_endpoint:
+            raise ValueError("vector_search_api_endpoint is required for update operation")
+
+        vector_search_client = aiplatform_v1.MatchServiceClient(
+            client_options={"api_endpoint": self.vector_search_api_endpoint},
+        )
+        datapoint = aiplatform_v1.IndexDatapoint(datapoint_id=vector_id)
+        query = aiplatform_v1.FindNeighborsRequest.Query(datapoint=datapoint, neighbor_count=1)
+        request = aiplatform_v1.FindNeighborsRequest(
+            index_endpoint=(
+                f"projects/{self.project_number}/locations/{self.region}/indexEndpoints/{self.endpoint_id}"
+            ),
+            deployed_index_id=self.deployment_index_id,
+            queries=[query],
+            return_full_datapoint=True,
+        )
+
+        response = vector_search_client.find_neighbors(request)
+        if response and response.nearest_neighbors:
+            nearest = response.nearest_neighbors[0]
+            if nearest.neighbors:
+                feature_vector = list(nearest.neighbors[0].datapoint.feature_vector)
+                if feature_vector:
+                    return feature_vector
+
+        raise ValueError(f"Existing record {vector_id} has no vector data")
 
     def insert(
         self,
@@ -357,9 +386,10 @@ class GoogleMatchingEngine(VectorStoreBase):
                 logger.error("Vector ID not found: %s", vector_id)
                 return False
 
-            datapoint = self._create_datapoint(
-                vector_id=vector_id, vector=vector if vector is not None else [], payload=payload
-            )
+            if vector is None:
+                vector = self._fetch_feature_vector(vector_id)
+
+            datapoint = self._create_datapoint(vector_id=vector_id, vector=vector, payload=payload)
 
             logger.debug("Upserting datapoint: %s", datapoint)
             self.index.upsert_datapoints(datapoints=[datapoint])

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -63,7 +63,9 @@ class TestAddToVectorStoreErrors:
         # Verify — v3 single-pass pipeline makes 1 LLM call, returns [] on parse error
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     def test_empty_llm_response_memory_actions(self, mock_memory, caplog):
         """Test empty response from LLM during memory actions (v3: single-pass, 1 LLM call)"""
@@ -101,6 +103,29 @@ class TestAddToVectorStoreErrors:
         # The documented LLMError contract is honoured, and the original
         # provider exception is preserved as the cause for debugging.
         assert isinstance(exc_info.value.__cause__, _ProviderError)
+
+    def test_insert_failure_does_not_return_add_results(self, mocker, mock_memory, caplog):
+        """Failed vector-store inserts must not be reported as successful ADD events (#5245)."""
+        mock_memory.llm.generate_response.return_value = '{"memory": [{"text": "User loves hiking"}]}'
+        mock_memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+        mock_memory.embedding_model.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+        mock_memory.vector_store.search.return_value = []
+        mock_memory.vector_store.insert.side_effect = Exception("insert failed")
+        mocker.patch("mem0.memory.main.capture_event")
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+        mock_memory.db.batch_add_history = MagicMock()
+
+        with caplog.at_level(logging.ERROR):
+            result = mock_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "I love hiking"}],
+                metadata={"user_id": "alice"},
+                filters={"user_id": "alice"},
+                infer=True,
+            )
+
+        assert result == []
+        assert any("Failed to insert memory" in record.message for record in caplog.records)
+        mock_memory.db.batch_add_history.assert_not_called()
 
 
 class TestPromptOverridesCustomInstructions:
@@ -272,7 +297,9 @@ class TestAsyncAddToVectorStoreErrors:
             )
         assert mock_async_memory.llm.generate_response.call_count == 1
         assert result == []
-        assert any("Error parsing extraction response" in record.message for record in caplog.records), "Expected error message not found in logs"
+        assert any("Error parsing extraction response" in record.message for record in caplog.records), (
+            "Expected error message not found in logs"
+        )
 
     @pytest.mark.asyncio
     async def test_async_empty_llm_response_memory_actions(self, mock_async_memory, caplog, mocker):
@@ -650,6 +677,7 @@ class TestMetadataNotMutated:
         memory = _build_memory_instance(mocker, Memory)
         metadata = {"user_id": "test_user", "tags": ["important", "urgent"], "config": {"key": "val"}}
         import copy
+
         metadata_snapshot = copy.deepcopy(metadata)
 
         memory._create_memory("test data", {"test data": [0.1, 0.2, 0.3]}, metadata=metadata)

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -22,7 +22,7 @@ class TestMilvusDB:
     @pytest.fixture
     def mock_milvus_client(self):
         """Mock MilvusClient to avoid requiring actual Milvus instance."""
-        with patch('mem0.vector_stores.milvus.MilvusClient') as mock_client:
+        with patch("mem0.vector_stores.milvus.MilvusClient") as mock_client:
             mock_instance = MagicMock()
             mock_instance.has_collection.return_value = False
             mock_client.return_value = mock_instance
@@ -37,7 +37,7 @@ class TestMilvusDB:
             collection_name="test_collection",
             embedding_model_dims=1536,  # Should be int, not str
             metric_type=MetricType.COSINE,
-            db_name="test_db"
+            db_name="test_db",
         )
 
     def test_initialization_with_int_dims(self, mock_milvus_client):
@@ -48,9 +48,9 @@ class TestMilvusDB:
             collection_name="test_collection",
             embedding_model_dims=1536,  # Integer
             metric_type=MetricType.COSINE,
-            db_name="test_db"
+            db_name="test_db",
         )
-        
+
         assert db.embedding_model_dims == 1536
         assert isinstance(db.embedding_model_dims, int)
 
@@ -59,53 +59,53 @@ class TestMilvusDB:
         # Collection was already created in __init__, but let's verify the call
         mock_milvus_client.create_collection.assert_called_once()
         call_args = mock_milvus_client.create_collection.call_args
-        
+
         # Verify schema was created properly
         assert call_args is not None
-        
+
     def test_batch_insert(self, milvus_db, mock_milvus_client):
         """Test that insert uses batch operation instead of loop (performance fix)."""
         ids = ["id1", "id2", "id3"]
         vectors = [[0.1] * 1536, [0.2] * 1536, [0.3] * 1536]
         payloads = [{"user_id": "alice"}, {"user_id": "bob"}, {"user_id": "charlie"}]
-        
+
         milvus_db.insert(ids, vectors, payloads)
-        
+
         # Verify insert was called once with all data (batch), not 3 times
         assert mock_milvus_client.insert.call_count == 1
-        
+
         # Verify the data structure
         call_args = mock_milvus_client.insert.call_args
-        inserted_data = call_args[1]['data']
-        
+        inserted_data = call_args[1]["data"]
+
         assert len(inserted_data) == 3
-        assert inserted_data[0]['id'] == 'id1'
-        assert inserted_data[1]['id'] == 'id2'
-        assert inserted_data[2]['id'] == 'id3'
+        assert inserted_data[0]["id"] == "id1"
+        assert inserted_data[1]["id"] == "id2"
+        assert inserted_data[2]["id"] == "id3"
 
     def test_create_filter_string_value(self, milvus_db):
         """Test filter creation for string metadata values."""
         filters = {"user_id": "alice"}
         filter_str = milvus_db._create_filter(filters)
-        
+
         assert filter_str == '(metadata["user_id"] == "alice")'
 
     def test_create_filter_numeric_value(self, milvus_db):
         """Test filter creation for numeric metadata values."""
         filters = {"age": 25}
         filter_str = milvus_db._create_filter(filters)
-        
+
         assert filter_str == '(metadata["age"] == 25)'
 
     def test_create_filter_multiple_conditions(self, milvus_db):
         """Test filter creation with multiple conditions."""
         filters = {"user_id": "alice", "category": "work"}
         filter_str = milvus_db._create_filter(filters)
-        
+
         # Should join with 'and'
         assert 'metadata["user_id"] == "alice"' in filter_str
         assert 'metadata["category"] == "work"' in filter_str
-        assert ' and ' in filter_str
+        assert " and " in filter_str
 
     def test_create_filter_wildcard_conditions(self, milvus_db):
         """Test filter creation with wildcard conditions."""
@@ -118,24 +118,19 @@ class TestMilvusDB:
     def test_search_with_filters(self, milvus_db, mock_milvus_client):
         """Test search with metadata filters (reproduces user's bug scenario)."""
         # Setup mock return value
-        mock_milvus_client.search.return_value = [[
-            {"id": "mem1", "distance": 0.8, "entity": {"metadata": {"user_id": "alice"}}}
-        ]]
-        
+        mock_milvus_client.search.return_value = [
+            [{"id": "mem1", "distance": 0.8, "entity": {"metadata": {"user_id": "alice"}}}]
+        ]
+
         query_vector = [0.1] * 1536
         filters = {"user_id": "alice"}
-        
-        results = milvus_db.search(
-            query="test query",
-            vectors=query_vector,
-            top_k=5,
-            filters=filters
-        )
-        
+
+        results = milvus_db.search(query="test query", vectors=query_vector, top_k=5, filters=filters)
+
         # Verify search was called with correct filter
         call_args = mock_milvus_client.search.call_args
-        assert call_args[1]['filter'] == '(metadata["user_id"] == "alice")'
-        
+        assert call_args[1]["filter"] == '(metadata["user_id"] == "alice")'
+
         # Verify results are parsed correctly
         assert len(results) == 1
         assert results[0].id == "mem1"
@@ -144,20 +139,20 @@ class TestMilvusDB:
     def test_search_different_user_ids(self, milvus_db, mock_milvus_client):
         """Test that search works with different user_ids (reproduces reported bug)."""
         # This test validates the fix for: "Error with different user_ids"
-        
+
         # Mock return for first user
-        mock_milvus_client.search.return_value = [[
-            {"id": "mem1", "distance": 0.9, "entity": {"metadata": {"user_id": "milvus_user"}}}
-        ]]
-        
+        mock_milvus_client.search.return_value = [
+            [{"id": "mem1", "distance": 0.9, "entity": {"metadata": {"user_id": "milvus_user"}}}]
+        ]
+
         results1 = milvus_db.search("test", [0.1] * 1536, filters={"user_id": "milvus_user"})
         assert len(results1) == 1
-        
+
         # Mock return for second user
-        mock_milvus_client.search.return_value = [[
-            {"id": "mem2", "distance": 0.85, "entity": {"metadata": {"user_id": "bob"}}}
-        ]]
-        
+        mock_milvus_client.search.return_value = [
+            [{"id": "mem2", "distance": 0.85, "entity": {"metadata": {"user_id": "bob"}}}]
+        ]
+
         # This should not raise "Unsupported Field type: 0" error
         results2 = milvus_db.search("test", [0.2] * 1536, filters={"user_id": "bob"})
         assert len(results2) == 1
@@ -167,35 +162,72 @@ class TestMilvusDB:
         vector_id = "test_id"
         vector = [0.1] * 1536
         payload = {"user_id": "alice", "data": "Updated memory"}
-        
+
         milvus_db.update(vector_id=vector_id, vector=vector, payload=payload)
-        
+
         # Verify upsert was called (not delete+insert)
         mock_milvus_client.upsert.assert_called_once()
-        
+
         call_args = mock_milvus_client.upsert.call_args
-        assert call_args[1]['collection_name'] == "test_collection"
-        assert call_args[1]['data']['id'] == vector_id
-        assert call_args[1]['data']['vectors'] == vector
-        assert call_args[1]['data']['metadata'] == payload
+        assert call_args[1]["collection_name"] == "test_collection"
+        assert call_args[1]["data"]["id"] == vector_id
+        assert call_args[1]["data"]["vectors"] == vector
+        assert call_args[1]["data"]["metadata"] == payload
+
+    def test_update_legacy_collection_omits_text(self, mock_milvus_client):
+        """Legacy collections without BM25 schema must not receive a text field on update (#6422)."""
+        mock_milvus_client.has_collection.return_value = True
+        mock_milvus_client.describe_collection.return_value = {"fields": [{"name": "vectors"}, {"name": "metadata"}]}
+
+        db = MilvusDB(
+            url="http://localhost:19530",
+            token="test_token",
+            collection_name="legacy_collection",
+            embedding_model_dims=1536,
+            metric_type=MetricType.COSINE,
+            db_name="test_db",
+        )
+
+        payload = {"user_id": "alice", "data": "Updated memory"}
+        db.update(vector_id="test_id", vector=[0.1] * 1536, payload=payload)
+
+        upsert_data = mock_milvus_client.upsert.call_args[1]["data"]
+        assert "text" not in upsert_data
+
+    def test_update_includes_text_for_bm25_schema(self, mock_milvus_client):
+        """update() must include text when the collection has BM25 schema."""
+        mock_milvus_client.has_collection.return_value = True
+        mock_milvus_client.describe_collection.return_value = {
+            "fields": [{"name": "vectors"}, {"name": "metadata"}, {"name": "text"}, {"name": "sparse"}]
+        }
+
+        db = MilvusDB(
+            url="http://localhost:19530",
+            token="test_token",
+            collection_name="existing_collection",
+            embedding_model_dims=1536,
+            metric_type=MetricType.COSINE,
+            db_name="test_db",
+        )
+
+        payload = {"user_id": "alice", "data": "Updated memory", "text_lemmatized": "updated memory"}
+        db.update(vector_id="test_id", vector=[0.1] * 1536, payload=payload)
+
+        upsert_data = mock_milvus_client.upsert.call_args[1]["data"]
+        assert upsert_data["text"] == "updated memory"
 
     def test_delete(self, milvus_db, mock_milvus_client):
         """Test vector deletion."""
         vector_id = "test_id"
         milvus_db.delete(vector_id)
-        
-        mock_milvus_client.delete.assert_called_once_with(
-            collection_name="test_collection",
-            ids=[vector_id]
-        )
+
+        mock_milvus_client.delete.assert_called_once_with(collection_name="test_collection", ids=[vector_id])
 
     def test_get(self, milvus_db, mock_milvus_client):
         """Test retrieving a vector by ID."""
         vector_id = "test_id"
-        mock_milvus_client.get.return_value = [
-            {"id": vector_id, "metadata": {"user_id": "alice"}}
-        ]
-        
+        mock_milvus_client.get.return_value = [{"id": vector_id, "metadata": {"user_id": "alice"}}]
+
         result = milvus_db.get(vector_id)
 
         assert result.id == vector_id
@@ -212,36 +244,28 @@ class TestMilvusDB:
         """Test listing memories with filters."""
         mock_milvus_client.query.return_value = [
             {"id": "mem1", "metadata": {"user_id": "alice"}},
-            {"id": "mem2", "metadata": {"user_id": "alice"}}
+            {"id": "mem2", "metadata": {"user_id": "alice"}},
         ]
-        
+
         results = milvus_db.list(filters={"user_id": "alice"}, top_k=10)
-        
+
         # Verify query was called with filter
         call_args = mock_milvus_client.query.call_args
-        assert call_args[1]['filter'] == '(metadata["user_id"] == "alice")'
-        assert call_args[1]['limit'] == 10
-        
+        assert call_args[1]["filter"] == '(metadata["user_id"] == "alice")'
+        assert call_args[1]["limit"] == 10
+
         # Verify results
         assert len(results[0]) == 2
 
     def test_parse_output(self, milvus_db):
         """Test output data parsing."""
         raw_data = [
-            {
-                "id": "mem1",
-                "distance": 0.9,
-                "entity": {"metadata": {"user_id": "alice"}}
-            },
-            {
-                "id": "mem2",
-                "distance": 0.85,
-                "entity": {"metadata": {"user_id": "bob"}}
-            }
+            {"id": "mem1", "distance": 0.9, "entity": {"metadata": {"user_id": "alice"}}},
+            {"id": "mem2", "distance": 0.85, "entity": {"metadata": {"user_id": "bob"}}},
         ]
-        
+
         parsed = milvus_db._parse_output(raw_data)
-        
+
         assert len(parsed) == 2
         assert parsed[0].id == "mem1"
         assert parsed[0].score == 0.9
@@ -261,12 +285,10 @@ class TestMilvusDB:
 
         milvus_db.update(vector_id=vector_id, vector=None, payload=payload)
 
-        mock_milvus_client.get.assert_called_once_with(
-            collection_name="test_collection", ids=vector_id
-        )
+        mock_milvus_client.get.assert_called_once_with(collection_name="test_collection", ids=vector_id)
         call_args = mock_milvus_client.upsert.call_args
-        assert call_args[1]['data']['vectors'] == existing_vector
-        assert call_args[1]['data']['metadata'] == payload
+        assert call_args[1]["data"]["vectors"] == existing_vector
+        assert call_args[1]["data"]["metadata"] == payload
 
     def test_update_with_none_payload_fetches_existing(self, milvus_db, mock_milvus_client):
         """Test that update with payload=None fetches the existing metadata."""
@@ -281,8 +303,8 @@ class TestMilvusDB:
         milvus_db.update(vector_id=vector_id, vector=vector, payload=None)
 
         call_args = mock_milvus_client.upsert.call_args
-        assert call_args[1]['data']['vectors'] == vector
-        assert call_args[1]['data']['metadata'] == existing_metadata
+        assert call_args[1]["data"]["vectors"] == vector
+        assert call_args[1]["data"]["metadata"] == existing_metadata
 
     def test_update_with_both_none_fetches_existing(self, milvus_db, mock_milvus_client):
         """Test that update with both vector=None and payload=None fetches existing data."""
@@ -299,8 +321,8 @@ class TestMilvusDB:
         # Should only call get once even though both are None
         assert mock_milvus_client.get.call_count == 1
         call_args = mock_milvus_client.upsert.call_args
-        assert call_args[1]['data']['vectors'] == existing_vector
-        assert call_args[1]['data']['metadata'] == existing_metadata
+        assert call_args[1]["data"]["vectors"] == existing_vector
+        assert call_args[1]["data"]["metadata"] == existing_metadata
 
     def test_update_with_none_vector_raises_on_missing_record(self, milvus_db, mock_milvus_client):
         """Test that update raises ValueError when the record doesn't exist."""
@@ -311,9 +333,7 @@ class TestMilvusDB:
 
     def test_update_with_none_vector_raises_on_missing_vector_data(self, milvus_db, mock_milvus_client):
         """Test that update raises ValueError when existing record has no vector."""
-        mock_milvus_client.get.return_value = [
-            {"id": "test_id", "vectors": None, "metadata": {"user_id": "alice"}}
-        ]
+        mock_milvus_client.get.return_value = [{"id": "test_id", "vectors": None, "metadata": {"user_id": "alice"}}]
 
         with pytest.raises(ValueError, match="no vector data"):
             milvus_db.update(vector_id="test_id", vector=None, payload={"data": "test"})
@@ -389,7 +409,7 @@ class TestMilvusDB:
             collection_name="existing_collection",
             embedding_model_dims=1536,
             metric_type=MetricType.L2,
-            db_name="test_db"
+            db_name="test_db",
         )
 
         # create_collection should not be called
@@ -398,4 +418,3 @@ class TestMilvusDB:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-

--- a/tests/vector_stores/test_opensearch.py
+++ b/tests/vector_stores/test_opensearch.py
@@ -330,6 +330,20 @@ class TestOpenSearchDB(unittest.TestCase):
         self.os_db.delete(vector_id="id1")
         self.client_mock.delete.assert_called_once_with(index="test_collection", id="doc1")
 
+    def test_delete_not_found_raises(self):
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+        with self.assertRaises(ValueError) as ctx:
+            self.os_db.delete(vector_id="missing")
+        self.assertIn("not found", str(ctx.exception).lower())
+        self.client_mock.delete.assert_not_called()
+
+    def test_update_not_found_raises(self):
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+        with self.assertRaises(ValueError) as ctx:
+            self.os_db.update("missing", vector=[0.1] * 1536, payload={"key": "value"})
+        self.assertIn("not found", str(ctx.exception).lower())
+        self.client_mock.update.assert_not_called()
+
     def test_delete_col(self):
         self.os_db.delete_col()
         self.client_mock.indices.delete.assert_called_once_with(index="test_collection")

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -101,6 +101,59 @@ def test_update_vector(pinecone_db):
     )
 
 
+def test_hybrid_insert_uses_data_field_for_sparse_vector(mock_pinecone_client):
+    """Hybrid search must index sparse vectors from Mem0's data/text_lemmatized fields."""
+    db = PineconeDB(
+        collection_name="test_index",
+        embedding_model_dims=128,
+        client=mock_pinecone_client,
+        api_key="fake_api_key",
+        environment="us-west1-gcp",
+        serverless_config=None,
+        pod_config=None,
+        hybrid_search=True,
+        metric="cosine",
+        batch_size=100,
+        extra_params=None,
+        namespace="test_namespace",
+    )
+    db.sparse_encoder = MagicMock()
+    db.sparse_encoder.encode_documents.return_value = {"indices": [1], "values": [0.5]}
+
+    payload = {"user_id": "alice", "data": "User loves hiking", "text_lemmatized": "user love hiking"}
+    db.insert([[0.1] * 128], [payload], ["id1"])
+
+    upserted = db.index.upsert.call_args.kwargs["vectors"][0]
+    db.sparse_encoder.encode_documents.assert_called_once_with("user love hiking")
+    assert upserted["sparse_values"] == {"indices": [1], "values": [0.5]}
+
+
+def test_hybrid_update_uses_data_field_for_sparse_vector(mock_pinecone_client):
+    db = PineconeDB(
+        collection_name="test_index",
+        embedding_model_dims=128,
+        client=mock_pinecone_client,
+        api_key="fake_api_key",
+        environment="us-west1-gcp",
+        serverless_config=None,
+        pod_config=None,
+        hybrid_search=True,
+        metric="cosine",
+        batch_size=100,
+        extra_params=None,
+        namespace="test_namespace",
+    )
+    db.sparse_encoder = MagicMock()
+    db.sparse_encoder.encode_documents.return_value = {"indices": [2], "values": [0.7]}
+
+    payload = {"user_id": "alice", "data": "Updated memory text"}
+    db.update("id1", vector=[0.5] * 128, payload=payload)
+
+    upserted = db.index.upsert.call_args.kwargs["vectors"][0]
+    db.sparse_encoder.encode_documents.assert_called_once_with("Updated memory text")
+    assert upserted["sparse_values"] == {"indices": [2], "values": [0.7]}
+
+
 def test_get_vector_found(pinecone_db):
     # Looking at the _parse_output method, it expects a Vector object
     # or a list of dictionaries, not a dictionary with an 'id' field

--- a/tests/vector_stores/test_vertex_ai_vector_search.py
+++ b/tests/vector_stores/test_vertex_ai_vector_search.py
@@ -165,3 +165,34 @@ def test_error_handling(vector_store, mock_vertex_ai):
 
     assert isinstance(exc_info.value, exceptions.InvalidArgument)
     assert "Invalid request" in str(exc_info.value)
+
+
+def test_update_payload_only_fetches_existing_vector(vector_store, mock_vertex_ai):
+    """Payload-only update must reuse the stored embedding, not upsert an empty vector."""
+    existing_vector = [0.1, 0.2, 0.3]
+    mock_datapoint = Mock()
+    mock_datapoint.datapoint_id = "test-id"
+    mock_datapoint.feature_vector = existing_vector
+    mock_datapoint.restricts = []
+
+    mock_neighbor = Mock()
+    mock_neighbor.datapoint = mock_datapoint
+    mock_neighbor.distance = 0.0
+
+    mock_response = Mock()
+    mock_response.nearest_neighbors = [Mock(neighbors=[mock_neighbor])]
+
+    with patch("mem0.vector_stores.vertex_ai_vector_search.aiplatform_v1.MatchServiceClient") as mock_client_cls:
+        mock_client_cls.return_value.find_neighbors.return_value = mock_response
+        vector_store.get = Mock(return_value=Mock(id="test-id", payload={"user_id": "alice"}))
+
+        result = vector_store.update(
+            vector_id="test-id",
+            vector=None,
+            payload={"user_id": "alice", "data": "updated"},
+        )
+
+    assert result is True
+    upserted = mock_vertex_ai["index"].upsert_datapoints.call_args.kwargs["datapoints"][0]
+    assert len(list(upserted.feature_vector)) == len(existing_vector)
+    assert list(upserted.feature_vector) == pytest.approx(existing_vector)


### PR DESCRIPTION
## Linked Issue

Closes #6422
Closes #5245

## Description

Fixes five bugs across the Python SDK:

1. **Milvus `update()` (#6422)** — Guard the `text` field behind `_has_bm25_schema` for legacy collections.
2. **Pinecone hybrid search** — Index sparse vectors from `data` / `text_lemmatized` instead of the missing `text` key.
3. **Vertex AI `update()`** — Fetch existing embedding on payload-only updates instead of upserting an empty vector.
4. **OpenSearch `update()` / `delete()`** — Raise `ValueError` when target ID is not found (no silent no-op).
5. **V3 add pipeline (#5245)** — Return ADD results only for memories successfully persisted to the vector store.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

OpenSearch `update()` and `delete()` now raise `ValueError` when the vector ID is not found.

## Test Coverage

- [x] I added/updated unit tests
- [x] New and existing tests pass locally (1692 passed)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally