### PR TITLE
fix(vector_stores/weaviate): apply custom metadata filters on search/list

### DIFF
--- a/mem0/vector_stores/weaviate.py
+++ b/mem0/vector_stores/weaviate.py
@@ -188,7 +188,9 @@ class Weaviate(VectorStoreBase):
         filter_conditions = []
         if filters:
             for key, value in filters.items():
-                if value and key in ["user_id", "agent_id", "run_id"]:
+                # Apply equality filters for all scalar metadata keys (not just
+                # user_id/agent_id/run_id). Operator-dict and list filters are a follow-up.
+                if value is not None and not isinstance(value, (dict, list)):
                     filter_conditions.append(Filter.by_property(key).equal(value))
         combined_filter = Filter.all_of(filter_conditions) if filter_conditions else None
         response = collection.query.hybrid(
@@ -239,7 +241,9 @@ class Weaviate(VectorStoreBase):
         filter_conditions = []
         if filters:
             for key, value in filters.items():
-                if value and key in ["user_id", "agent_id", "run_id"]:
+                # Apply equality filters for all scalar metadata keys (not just
+                # user_id/agent_id/run_id). Operator-dict and list filters are a follow-up.
+                if value is not None and not isinstance(value, (dict, list)):
                     filter_conditions.append(Filter.by_property(key).equal(value))
         combined_filter = Filter.all_of(filter_conditions) if filter_conditions else None
         response = collection.query.bm25(
@@ -362,7 +366,9 @@ class Weaviate(VectorStoreBase):
         filter_conditions = []
         if filters:
             for key, value in filters.items():
-                if value and key in ["user_id", "agent_id", "run_id"]:
+                # Apply equality filters for all scalar metadata keys (not just
+                # user_id/agent_id/run_id). Operator-dict and list filters are a follow-up.
+                if value is not None and not isinstance(value, (dict, list)):
                     filter_conditions.append(Filter.by_property(key).equal(value))
         combined_filter = Filter.all_of(filter_conditions) if filter_conditions else None
         response = collection.query.fetch_objects(

--- a/tests/vector_stores/test_weaviate.py
+++ b/tests/vector_stores/test_weaviate.py
@@ -265,5 +265,37 @@ class TestWeaviateDB(unittest.TestCase):
         self.assertNotIn("properties", vector_updates[0].kwargs)
 
 
+    def test_search_builds_conditions_for_custom_metadata_filters(self):
+        mock_response = MagicMock()
+        mock_response.objects = []
+        mock_hybrid = MagicMock(return_value=mock_response)
+        self.client_mock.collections.get.return_value.query.hybrid = mock_hybrid
+
+        with patch("mem0.vector_stores.weaviate.Filter") as mock_filter:
+            self.weaviate_db.search(
+                query="",
+                vectors=[0.1] * 1536,
+                top_k=5,
+                filters={"user_id": "u1", "category": "work"},
+            )
+
+        called_keys = {call.args[0] for call in mock_filter.by_property.call_args_list}
+        self.assertIn("user_id", called_keys)
+        self.assertIn("category", called_keys)
+
+    def test_list_builds_conditions_for_custom_metadata_filters(self):
+        mock_response = MagicMock()
+        mock_response.objects = []
+        mock_fetch = MagicMock(return_value=mock_response)
+        self.client_mock.collections.get.return_value.query.fetch_objects = mock_fetch
+
+        with patch("mem0.vector_stores.weaviate.Filter") as mock_filter:
+            self.weaviate_db.list(filters={"agent_id": "a1", "category": "personal"}, top_k=10)
+
+        called_keys = {call.args[0] for call in mock_filter.by_property.call_args_list}
+        self.assertIn("agent_id", called_keys)
+        self.assertIn("category", called_keys)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #6423

Weaviate search/list/keyword_search only equality-filtered user_id/agent_id/run_id, dropping custom metadata keys and allowing cross-scope results.

Now every scalar filter key becomes an equality condition (dict/list ops left for a follow-up). Reimplements the approach from closed #6402.

Verification: pytest tests/vector_stores/test_weaviate.py — 14 passed.