### PR TITLE
fix(together): honor TOGETHER_API_BASE for LLM and embedder clients

### DIFF
--- a/docs/components/llms/models/together.mdx
+++ b/docs/components/llms/models/together.mdx
@@ -4,7 +4,7 @@ description: "Configure Together AI as an LLM provider in Mem0 with API key setu
 ---
 
 To use Together LLM models, you have to set the `TOGETHER_API_KEY` environment variable. You can obtain the Together API key from their [Account settings page](https://api.together.ai/settings/projects/~current/api-keys).
-In the TypeScript SDK, you can optionally set `TOGETHER_API_BASE` or pass `baseURL` in the config (defaults to `https://api.together.ai/v1`).
+You can optionally point Together at a custom endpoint (e.g. an OpenAI-compatible gateway or proxy) by setting the `TOGETHER_API_BASE` environment variable, or by passing `together_base_url` (Python) / `baseURL` (TypeScript) in the config. Defaults to `https://api.together.ai/v1`.
 
 ## Usage
 

--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -20,6 +20,8 @@ class BaseEmbedderConfig(ABC):
         ollama_base_url: Optional[str] = None,
         # Openai specific
         openai_base_url: Optional[str] = None,
+        # Together specific
+        together_base_url: Optional[str] = None,
         # Huggingface specific
         model_kwargs: Optional[dict] = None,
         huggingface_base_url: Optional[str] = None,
@@ -77,6 +79,7 @@ class BaseEmbedderConfig(ABC):
         self.model = model
         self.api_key = api_key
         self.openai_base_url = openai_base_url
+        self.together_base_url = together_base_url
         self.embedding_dims = embedding_dims
 
         # AzureOpenAI specific

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -26,6 +26,9 @@ class BaseLlmConfig(ABC):
         reasoning_effort: Optional[str] = None,
         http_client_proxies: Optional[Union[Dict, str]] = None,
         is_reasoning_model: Optional[bool] = None,
+        # OpenAI-compatible / Together specific
+        openai_base_url: Optional[str] = None,
+        together_base_url: Optional[str] = None,
     ):
         """
         Initialize a base configuration class instance for the LLM.
@@ -74,5 +77,7 @@ class BaseLlmConfig(ABC):
         self.vision_details = vision_details
         self.reasoning_effort = reasoning_effort
         self.is_reasoning_model = is_reasoning_model
+        self.openai_base_url = openai_base_url
+        self.together_base_url = together_base_url
         self.http_client_proxies = http_client_proxies
         self.http_client = build_http_client(http_client_proxies)

--- a/mem0/embeddings/together.py
+++ b/mem0/embeddings/together.py
@@ -18,7 +18,6 @@ class TogetherEmbedding(EmbeddingBase):
             getattr(self.config, "together_base_url", None)
             or getattr(self.config, "openai_base_url", None)
             or os.getenv("TOGETHER_API_BASE")
-            or os.getenv("TOGETHER_BASE_URL")
         )
         client_kwargs = {"api_key": api_key}
         if base_url:

--- a/mem0/embeddings/together.py
+++ b/mem0/embeddings/together.py
@@ -14,7 +14,16 @@ class TogetherEmbedding(EmbeddingBase):
         self.config.model = self.config.model or "intfloat/multilingual-e5-large-instruct"
         api_key = self.config.api_key or os.getenv("TOGETHER_API_KEY")
         self.config.embedding_dims = self.config.embedding_dims or 1024
-        self.client = Together(api_key=api_key)
+        base_url = (
+            getattr(self.config, "together_base_url", None)
+            or getattr(self.config, "openai_base_url", None)
+            or os.getenv("TOGETHER_API_BASE")
+            or os.getenv("TOGETHER_BASE_URL")
+        )
+        client_kwargs = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self.client = Together(**client_kwargs)
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """

--- a/mem0/llms/together.py
+++ b/mem0/llms/together.py
@@ -26,7 +26,6 @@ class TogetherLLM(LLMBase):
             getattr(self.config, "together_base_url", None)
             or getattr(self.config, "openai_base_url", None)
             or os.getenv("TOGETHER_API_BASE")
-            or os.getenv("TOGETHER_BASE_URL")
         )
         client_kwargs = {"api_key": api_key}
         if base_url:

--- a/mem0/llms/together.py
+++ b/mem0/llms/together.py
@@ -20,7 +20,18 @@ class TogetherLLM(LLMBase):
             self.config.model = "MiniMaxAI/MiniMax-M3"
 
         api_key = self.config.api_key or os.getenv("TOGETHER_API_KEY")
-        self.client = Together(api_key=api_key)
+        # Prefer explicit config (openai_base_url common for OpenAI-compatible),
+        # then TOGETHER_API_BASE — parity with TS TogetherLLM and other providers.
+        base_url = (
+            getattr(self.config, "together_base_url", None)
+            or getattr(self.config, "openai_base_url", None)
+            or os.getenv("TOGETHER_API_BASE")
+            or os.getenv("TOGETHER_BASE_URL")
+        )
+        client_kwargs = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self.client = Together(**client_kwargs)
 
     def _parse_response(self, response, tools):
         """

--- a/tests/embeddings/test_together_embeddings.py
+++ b/tests/embeddings/test_together_embeddings.py
@@ -85,3 +85,23 @@ def test_explicit_config_overrides_defaults(mock_together_client):
     mock_together_client.embeddings.create.return_value = Mock(data=[Mock(embedding=[0.0] * 768)])
     embedder.embed("hello")
     mock_together_client.embeddings.create.assert_called_once_with(model="BAAI/bge-base-en-v1.5", input="hello")
+
+
+def test_together_embedder_base_url_from_env(mock_together_client, monkeypatch):
+    monkeypatch.setenv("TOGETHER_API_BASE", "https://proxy.example/v1")
+    monkeypatch.delenv("TOGETHER_BASE_URL", raising=False)
+    config = BaseEmbedderConfig(model=DEFAULT_MODEL, api_key="test-key")
+    with patch("mem0.embeddings.together.Together") as mock_together:
+        mock_together.return_value = mock_together_client
+        TogetherEmbedding(config)
+        mock_together.assert_called_once_with(api_key="test-key", base_url="https://proxy.example/v1")
+
+
+def test_together_embedder_base_url_from_openai_base_url(mock_together_client, monkeypatch):
+    monkeypatch.delenv("TOGETHER_API_BASE", raising=False)
+    monkeypatch.delenv("TOGETHER_BASE_URL", raising=False)
+    config = BaseEmbedderConfig(model=DEFAULT_MODEL, api_key="test-key", openai_base_url="https://cfg.example/v1")
+    with patch("mem0.embeddings.together.Together") as mock_together:
+        mock_together.return_value = mock_together_client
+        TogetherEmbedding(config)
+        mock_together.assert_called_once_with(api_key="test-key", base_url="https://cfg.example/v1")

--- a/tests/embeddings/test_together_embeddings.py
+++ b/tests/embeddings/test_together_embeddings.py
@@ -105,3 +105,20 @@ def test_together_embedder_base_url_from_openai_base_url(mock_together_client, m
         mock_together.return_value = mock_together_client
         TogetherEmbedding(config)
         mock_together.assert_called_once_with(api_key="test-key", base_url="https://cfg.example/v1")
+
+
+def test_together_embedder_base_url_from_together_base_url(mock_together_client, monkeypatch):
+    """together_base_url on BaseEmbedderConfig wins over openai_base_url and env."""
+    monkeypatch.delenv("TOGETHER_API_BASE", raising=False)
+    monkeypatch.delenv("TOGETHER_BASE_URL", raising=False)
+    monkeypatch.setenv("TOGETHER_API_BASE", "https://env-should-lose.example/v1")
+    config = BaseEmbedderConfig(
+        model=DEFAULT_MODEL,
+        api_key="test-key",
+        openai_base_url="https://openai-cfg-should-lose.example/v1",
+        together_base_url="https://together-cfg.example/v1",
+    )
+    with patch("mem0.embeddings.together.Together") as mock_together:
+        mock_together.return_value = mock_together_client
+        TogetherEmbedding(config)
+        mock_together.assert_called_once_with(api_key="test-key", base_url="https://together-cfg.example/v1")

--- a/tests/llms/test_together.py
+++ b/tests/llms/test_together.py
@@ -102,3 +102,25 @@ def test_generate_response_forwards_extra_kwargs(mock_together_client):
     assert response == "Hi"
     call_kwargs = mock_together_client.chat.completions.create.call_args.kwargs
     assert call_kwargs["frequency_penalty"] == 0.5
+
+
+def test_together_base_url_from_env(mock_together_client, monkeypatch):
+    """TOGETHER_API_BASE is forwarded to the Together client constructor."""
+    monkeypatch.setenv("TOGETHER_API_BASE", "https://proxy.example/v1")
+    monkeypatch.delenv("TOGETHER_BASE_URL", raising=False)
+    config = BaseLlmConfig(model="test-model", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    with patch("mem0.llms.together.Together") as mock_together:
+        mock_together.return_value = mock_together_client
+        TogetherLLM(config)
+        mock_together.assert_called_once_with(api_key="test-key", base_url="https://proxy.example/v1")
+
+
+def test_together_base_url_from_openai_base_url_config(mock_together_client, monkeypatch):
+    monkeypatch.delenv("TOGETHER_API_BASE", raising=False)
+    monkeypatch.delenv("TOGETHER_BASE_URL", raising=False)
+    config = BaseLlmConfig(model="test-model", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
+    config.openai_base_url = "https://cfg.example/v1"
+    with patch("mem0.llms.together.Together") as mock_together:
+        mock_together.return_value = mock_together_client
+        TogetherLLM(config)
+        mock_together.assert_called_once_with(api_key="test-key", base_url="https://cfg.example/v1")

--- a/tests/llms/test_together.py
+++ b/tests/llms/test_together.py
@@ -118,8 +118,14 @@ def test_together_base_url_from_env(mock_together_client, monkeypatch):
 def test_together_base_url_from_openai_base_url_config(mock_together_client, monkeypatch):
     monkeypatch.delenv("TOGETHER_API_BASE", raising=False)
     monkeypatch.delenv("TOGETHER_BASE_URL", raising=False)
-    config = BaseLlmConfig(model="test-model", api_key="test-key", temperature=0.7, max_tokens=100, top_p=1.0)
-    config.openai_base_url = "https://cfg.example/v1"
+    config = BaseLlmConfig(
+        model="test-model",
+        api_key="test-key",
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        openai_base_url="https://cfg.example/v1",
+    )
     with patch("mem0.llms.together.Together") as mock_together:
         mock_together.return_value = mock_together_client
         TogetherLLM(config)

--- a/tests/llms/test_together.py
+++ b/tests/llms/test_together.py
@@ -130,3 +130,23 @@ def test_together_base_url_from_openai_base_url_config(mock_together_client, mon
         mock_together.return_value = mock_together_client
         TogetherLLM(config)
         mock_together.assert_called_once_with(api_key="test-key", base_url="https://cfg.example/v1")
+
+
+def test_together_base_url_from_together_base_url_config(mock_together_client, monkeypatch):
+    """together_base_url on BaseLlmConfig wins over openai_base_url and env."""
+    monkeypatch.delenv("TOGETHER_API_BASE", raising=False)
+    monkeypatch.delenv("TOGETHER_BASE_URL", raising=False)
+    monkeypatch.setenv("TOGETHER_API_BASE", "https://env-should-lose.example/v1")
+    config = BaseLlmConfig(
+        model="test-model",
+        api_key="test-key",
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1.0,
+        openai_base_url="https://openai-cfg-should-lose.example/v1",
+        together_base_url="https://together-cfg.example/v1",
+    )
+    with patch("mem0.llms.together.Together") as mock_together:
+        mock_together.return_value = mock_together_client
+        TogetherLLM(config)
+        mock_together.assert_called_once_with(api_key="test-key", base_url="https://together-cfg.example/v1")

--- a/       1
+++ b/       1
@@ -1,2 +1,0 @@
-/Users/bartokmoltbot/clawd/repos/top10/mem0/.venv/bin/python: No module named pip
-/Users/bartokmoltbot/clawd/repos/top10/mem0/.venv/bin/python: No module named pip

--- a/       1
+++ b/       1
@@ -1,0 +1,2 @@
+/Users/bartokmoltbot/clawd/repos/top10/mem0/.venv/bin/python: No module named pip
+/Users/bartokmoltbot/clawd/repos/top10/mem0/.venv/bin/python: No module named pip


### PR DESCRIPTION
Closes #6587

Together Python LLM/embedder ignored TOGETHER_API_BASE (and config base URL); TS LLM already forwards it.

Pass base_url from config/env when set so proxies and gateways work.

Verification: pytest tests/llms/test_together.py tests/embeddings/test_together_embeddings.py — 13 passed.