### PR TITLE
docs: remove stale graph-memory references and correct provider counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ This is a **polyglot monorepo** containing Python and TypeScript packages, CLIs,
 
 | Directory | Description |
 |-----------|-------------|
-| `mem0/` | Core Python SDK (`mem0ai` on PyPI) — memory, LLMs, embeddings, vector stores, graphs, rerankers |
+| `mem0/` | Core Python SDK (`mem0ai` on PyPI) — memory, LLMs, embeddings, vector stores, rerankers |
 | `mem0-ts/` | TypeScript SDK (`mem0ai` on npm) — client + OSS memory |
 | `cli/python/` | Python CLI (`mem0-cli` on PyPI) — Typer-based, entry point `mem0` |
 | `cli/node/` | Node CLI (`@mem0/cli` on npm) — Commander-based, entry point `mem0` |
@@ -41,12 +41,18 @@ This is a **polyglot monorepo** containing Python and TypeScript packages, CLIs,
 
 ```
 mem0 (Python SDK)          mem0-ts (TypeScript SDK)
-├── mem0/memory/           ├── src/client/        (MemoryClient — hosted)
-├── mem0/llms/             └── src/oss/           (Memory — self-hosted)
-├── mem0/embeddings/           ├── src/llms/
-├── mem0/vector_stores/        ├── src/embeddings/
-├── mem0/graphs/               ├── src/vector_stores/
-└── mem0/reranker/             └── src/graphs/
+├── mem0/memory/           ├── src/client/            (MemoryClient — hosted)
+├── mem0/llms/             └── src/oss/src/           (Memory — self-hosted)
+├── mem0/embeddings/           ├── memory/
+├── mem0/vector_stores/        ├── llms/
+├── mem0/reranker/             ├── embeddings/
+├── mem0/configs/              ├── vector_stores/
+└── mem0/utils/                ├── rerankers/
+                               ├── prompts/
+                               ├── storage/
+                               ├── config/
+                               ├── types/
+                               └── utils/
 
 cli/python/ ──▶ mem0ai (optional, for OSS mode)
 cli/node/   ──▶ mem0ai (npm, for API calls)
@@ -325,7 +331,7 @@ python -m benchmarks.beam.run --project-name my-test --backend cloud --mem0-api-
 
 ### Python Conventions
 
-- **Provider pattern:** All providers (LLMs, embeddings, vector stores, graphs, rerankers) inherit from a `base.py` abstract class in their directory. Config classes live in `configs.py`.
+- **Provider pattern:** All providers (LLMs, embeddings, vector stores, rerankers) inherit from a `base.py` abstract class in their directory. Config classes live in `configs.py`.
 - **Pydantic v2** for all data models and configuration.
 - **Ruff** is the single linting and formatting tool — no black, no flake8.
   - Root SDK: line length **120**
@@ -359,23 +365,24 @@ cd <package> && pnpm run typecheck    # or: tsc --noEmit
 
 ### Provider Pattern
 
-The SDK uses a consistent plugin architecture across 5 categories. Each category has a `base.py` abstract class and concrete provider implementations:
+The SDK uses a consistent plugin architecture across 4 categories. Each category has a `base.py` abstract class and concrete provider implementations. Counts below reflect the registries in `mem0/utils/factory.py`, which is the source of truth:
 
 | Category | Count | Examples |
 |----------|-------|---------|
-| **LLMs** | 24 | OpenAI, Anthropic, AWS Bedrock, Azure OpenAI, Gemini, Groq, Ollama, Together, DeepSeek, vLLM, LiteLLM, LM Studio, xAI |
-| **Vector Stores** | 30 | Qdrant, Pinecone, Chroma, Weaviate, Milvus, MongoDB, Redis, Elasticsearch, pgvector, Supabase, Faiss, S3 Vectors |
-| **Embeddings** | 15 | OpenAI, Azure OpenAI, Gemini, HuggingFace, FastEmbed, Together, AWS Bedrock, Ollama, Vertex AI |
-| **Graph Stores** | 4 | Neo4j, Memgraph, Kuzu, Apache AGE |
+| **LLMs** | 18 | OpenAI, Anthropic, AWS Bedrock, Azure OpenAI, Gemini, Groq, Ollama, Together, DeepSeek, vLLM, LiteLLM, LM Studio, xAI |
+| **Vector Stores** | 25 | Qdrant, Pinecone, Chroma, Weaviate, Milvus, MongoDB, Redis, Elasticsearch, pgvector, Supabase, Faiss, S3 Vectors |
+| **Embeddings** | 11 | OpenAI, Azure OpenAI, Gemini, HuggingFace, FastEmbed, Together, AWS Bedrock, Ollama, Vertex AI |
 | **Rerankers** | 5 | Cohere, HuggingFace, LLM-based, Sentence Transformer, Zero Entropy |
 
 ### Two Usage Modes
 
 Self-hosted `Memory` / `AsyncMemory` classes and hosted-platform `MemoryClient` — both in Python and TypeScript.
 
-### Graph Memory
+### Entity-Aware Retrieval
 
-Optional layer on top of vector memory for relationship-aware retrieval. Configured via the `graph` section of `MemoryConfig`.
+Relationship-awareness lives inside the vector path, not in a separate graph store. `Memory._add_to_vector_store` extracts entities at write time and links them via an entity store; `_compute_entity_boosts` re-ranks search hits that share entities with the query. Supporting code is in `mem0/utils/entity_extraction.py`, `scoring.py`, and `lemmatization.py`.
+
+> Graph memory (`mem0/graphs/`, `graph_memory.py`, and the TS equivalents) was **removed in #4805** along with the `graph` section of `MemoryConfig`. Do not reintroduce references to it.
 
 ### MCP Integration
 


### PR DESCRIPTION
## Linked Issue

Closes #6591

## Description

`AGENTS.md` (symlinked as `CLAUDE.md`) still documents graph memory as a
supported subsystem, but it was removed from both SDKs in #4805
(*"feat(oss): port v3 pipeline with hybrid search, entity extraction, and
additive scoring"*). That PR deleted:

- **Python:** `mem0/graphs/**` (including `configs.py`, `tools.py`, `utils.py`,
  and `neptune/`), `mem0/memory/graph_memory.py`, `mem0/memory/memgraph_memory.py`
- **TypeScript:** `mem0-ts/src/oss/src/graphs/**`,
  `mem0-ts/src/oss/src/memory/graph_memory.ts`

The commit did not touch `AGENTS.md`, so the file drifted out of sync.

This matters more than a typical stale doc: `AGENTS.md` is the context file
loaded by Claude Code, Cursor, GitHub Copilot, and Codex. An assistant reading
it will suggest configuring a `graph` section of `MemoryConfig` (no such field
exists) or adding a provider under `mem0/graphs/` (no such directory exists).
The file's whole job is to be an accurate map of the repo, so an inaccuracy
here turns directly into broken code suggestions.

### Changes

1. **Removed graph memory** from the "Key Directories" table, the "Core Package
   Dependencies" tree, the provider table (the `Graph Stores | 4` row), and the
   "Provider pattern" bullet under Python Conventions.

2. **Replaced the "Graph Memory" section with "Entity-Aware Retrieval."**
   Relationship-awareness now lives inside the vector path rather than in a
   separate graph store: entities are extracted and linked at write time via
   `_link_entities_for_memory`, and search hits sharing entities with the query
   are re-ranked by `_compute_entity_boosts`, backed by
   `mem0/utils/{entity_extraction,scoring,lemmatization}.py`. Added a short note
   recording that graph memory was removed in #4805, so a future contributor or
   assistant does not reintroduce references to it.

3. **Corrected provider counts**, which had drifted independently of the graph
   removal. Counted from the `provider_to_class` registries in
   `mem0/utils/factory.py`:

   | Category | Was | Now |
   |---|---|---|
   | LLMs | 24 | **18** |
   | Vector Stores | 30 | **25** |
   | Embeddings | 11 | **11** (was documented as 15) |
   | Rerankers | 5 | 5 — already correct |

   Also added a sentence naming `factory.py` as the source of truth, so the next
   person can re-verify in one command instead of re-deriving the numbers.

4. **Fixed the TypeScript dependency tree.** Sub-packages were listed as children
   of `src/oss/`, but they actually live one level deeper at `src/oss/src/`. The
   tree was also missing `memory/`, `rerankers/`, `prompts/`, `storage/`,
   `config/`, `types/`, and `utils/`.

> **Note for reviewers:** `CLAUDE.md` is a symlink to `AGENTS.md`, so only
> `AGENTS.md` appears as modified in the diff. Both are updated.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

Documentation-only change to a root-level Markdown file — no code paths are
touched, and no CI Gate path filter matches `AGENTS.md`. The `docs-llms-txt`
check does not apply either, since its filter covers `docs/**/*.mdx` and
`docs/llms.txt` only.

Rather than tests, every factual claim was verified against the source:

- **Directory removals** — `ls mem0/` and `find mem0-ts/src -iname "*graph*"`
  (the latter returns nothing).
- **Provider counts** — parsed from the `provider_to_class` registries in
  `mem0/utils/factory.py`.
- **Referenced symbols** — `_compute_entity_boosts`, `_link_entities_for_memory`,
  and `lemmatize_for_bm25` confirmed present in `mem0/memory/main.py`, along
  with their import sites.
- **The absent `graph` config** — `MemoryConfig` in `mem0/configs/base.py` has
  fields `vector_store`, `llm`, `embedder`, `history_db_path`, `reranker`,
  `version`, `custom_instructions`, and no `graph`.
- **Every path in the corrected tree** — confirmed to exist via `ls`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works — N/A, documentation only
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed