### PR TITLE
fix(ts-oss/milvus): fall back to dense-only schema on pre-2.5 servers

### DIFF
--- a/mem0-ts/src/oss/src/tests/milvus.test.ts
+++ b/mem0-ts/src/oss/src/tests/milvus.test.ts
@@ -19,6 +19,8 @@ class FakeMilvusClient {
   public searchResponse: any = { results: [] };
   // When true, reject hybrid-schema createCollection calls (Milvus < 2.5).
   public rejectBm25Create = false;
+  // When true with rejectBm25Create, throw with error_code only (legacy SDK path).
+  public rejectBm25LegacyErrorCode = false;
   // When set, createCollection always throws this error (transient failure tests).
   public createCollectionError: any = null;
 
@@ -55,7 +57,11 @@ class FakeMilvusClient {
       // Simulate partial create: collection appears before the server rejects BM25.
       this.collections.add(args.collection_name);
       const err: any = new Error("BM25 function not supported on this server");
-      err.code = 1100;
+      if (this.rejectBm25LegacyErrorCode) {
+        err.error_code = 1100;
+      } else {
+        err.code = 1100;
+      }
       throw err;
     }
     // Mirror Milvus's real server constraint: a FloatVector field's dim must be
@@ -587,6 +593,19 @@ describe("Milvus vector store (TS OSS SDK)", () => {
     await store.insert([[0.1, 0.2, 0.3]], ["a"], [{ data: "dense only" }]);
     const insertCall = client.calls.find((c) => c.method === "insert")!;
     expect(insertCall.args.data[0].text).toBeUndefined();
+  });
+
+  it("falls back when BM25 rejection uses legacy error_code field", async () => {
+    const client = new FakeMilvusClient();
+    client.rejectBm25Create = true;
+    client.rejectBm25LegacyErrorCode = true;
+    const store = makeStore(client);
+    await store.initialize();
+
+    expect(
+      client.calls.filter((c) => c.method === "createCollection"),
+    ).toHaveLength(2);
+    expect(await store.keywordSearch("hello")).toBeNull();
   });
 
   it("re-raises transient create failures instead of falling back", async () => {

--- a/mem0-ts/src/oss/src/tests/milvus.test.ts
+++ b/mem0-ts/src/oss/src/tests/milvus.test.ts
@@ -17,6 +17,10 @@ class FakeMilvusClient {
 
   // Allow tests to script search responses.
   public searchResponse: any = { results: [] };
+  // When true, reject hybrid-schema createCollection calls (Milvus < 2.5).
+  public rejectBm25Create = false;
+  // When set, createCollection always throws this error (transient failure tests).
+  public createCollectionError: any = null;
 
   constructor(opts?: { existing?: string[]; bm25?: string[] }) {
     // Legacy dense-only collections: no text/sparse fields.
@@ -40,6 +44,20 @@ class FakeMilvusClient {
 
   async createCollection(args: any) {
     this.calls.push({ method: "createCollection", args });
+    if (this.createCollectionError) {
+      throw this.createCollectionError;
+    }
+    const fieldNames = (args.fields || []).map((f: any) => f.name);
+    if (
+      this.rejectBm25Create &&
+      (fieldNames.includes("sparse") || fieldNames.includes("text"))
+    ) {
+      // Simulate partial create: collection appears before the server rejects BM25.
+      this.collections.add(args.collection_name);
+      const err: any = new Error("BM25 function not supported on this server");
+      err.code = 1100;
+      throw err;
+    }
     // Mirror Milvus's real server constraint: a FloatVector field's dim must be
     // in [2, 32768]. Vector fields are the ones carrying a numeric `dim`.
     for (const f of args.fields || []) {
@@ -549,5 +567,52 @@ describe("Milvus vector store (TS OSS SDK)", () => {
     await store.insert([[1, 2, 3]], ["a"], [{ data: "d" }]);
     const insertCall = client.calls.find((c) => c.method === "insert")!;
     expect(insertCall.args.data[0].text).toBe("d");
+  });
+
+  it("falls back to dense-only when BM25 hybrid schema is rejected (Milvus < 2.5)", async () => {
+    const client = new FakeMilvusClient();
+    client.rejectBm25Create = true;
+    const store = makeStore(client);
+    await store.initialize();
+
+    const creates = client.calls.filter((c) => c.method === "createCollection");
+    expect(creates).toHaveLength(2);
+    expect(client.calls.some((c) => c.method === "dropCollection")).toBe(true);
+
+    const finalFields = creates[1].args.fields.map((f: any) => f.name);
+    expect(finalFields).toEqual(["id", "vectors", "metadata"]);
+    expect(creates[1].args.functions).toBeUndefined();
+
+    expect(await store.keywordSearch("hello")).toBeNull();
+    await store.insert([[0.1, 0.2, 0.3]], ["a"], [{ data: "dense only" }]);
+    const insertCall = client.calls.find((c) => c.method === "insert")!;
+    expect(insertCall.args.data[0].text).toBeUndefined();
+  });
+
+  it("re-raises transient create failures instead of falling back", async () => {
+    const client = new FakeMilvusClient();
+    const err: any = new Error("connection lost");
+    err.code = 2;
+    client.createCollectionError = err;
+    const store = makeStore(client);
+
+    await expect(store.initialize()).rejects.toThrow(/connection lost/);
+    expect(
+      client.calls.filter((c) => c.method === "createCollection"),
+    ).toHaveLength(1);
+  });
+
+  it("omits text on update for dense-only fallback collections", async () => {
+    const client = new FakeMilvusClient();
+    client.rejectBm25Create = true;
+    const store = makeStore(client);
+    await store.initialize();
+    await store.insert([[1, 0, 0]], ["a"], [{ data: "old" }]);
+
+    await store.update("a", [0, 1, 0], { data: "new" });
+
+    const upsertCall = client.calls.filter((c) => c.method === "upsert").pop()!;
+    expect(upsertCall.args.data[0].text).toBeUndefined();
+    expect(upsertCall.args.data[0].metadata).toEqual({ data: "new" });
   });
 });

--- a/mem0-ts/src/oss/src/vector_stores/milvus.ts
+++ b/mem0-ts/src/oss/src/vector_stores/milvus.ts
@@ -114,13 +114,6 @@ export class Milvus implements VectorStore {
   }
 
   /**
-   * Create the collection if it does not already exist, with an AUTOINDEX
-   * dense-vector index plus a BM25 `text` -> `sparse` full-text index. Idempotent
-   * (mirrors the Python `create_col`). When the collection already exists, detect
-   * whether the BM25 `text`/`sparse` fields are present so keyword search
-   * degrades gracefully on collections created before BM25 support.
-   */
-  /**
    * True when a Milvus server rejected the BM25 hybrid schema (pre-2.5 servers).
    * Mirrors the Python provider's MilvusException code allowlist in #6338.
    */
@@ -170,6 +163,13 @@ export class Milvus implements VectorStore {
     this.hasBm25Schema = false;
   }
 
+  /**
+   * Create the collection if it does not already exist, with an AUTOINDEX
+   * dense-vector index plus a BM25 `text` -> `sparse` full-text index. Idempotent
+   * (mirrors the Python `create_col`). When the collection already exists, detect
+   * whether the BM25 `text`/`sparse` fields are present so keyword search
+   * degrades gracefully on collections created before BM25 support.
+   */
   private async createCol(
     collectionName: string,
     vectorSize: number,

--- a/mem0-ts/src/oss/src/vector_stores/milvus.ts
+++ b/mem0-ts/src/oss/src/vector_stores/milvus.ts
@@ -120,6 +120,56 @@ export class Milvus implements VectorStore {
    * whether the BM25 `text`/`sparse` fields are present so keyword search
    * degrades gracefully on collections created before BM25 support.
    */
+  /**
+   * True when a Milvus server rejected the BM25 hybrid schema (pre-2.5 servers).
+   * Mirrors the Python provider's MilvusException code allowlist in #6338.
+   */
+  private isBm25SchemaRejection(err: unknown): boolean {
+    if (!err || typeof err !== "object") return false;
+    const e = err as { code?: number; error_code?: number };
+    const code = e.code ?? e.error_code;
+    // 1100: unsupported field / BM25 function rejection (issue #6183).
+    // 0: legacy SDK paths may leave code=0 while the real error lives elsewhere.
+    return code === 1100 || code === 0;
+  }
+
+  private async createDenseOnlyCol(
+    collectionName: string,
+    vectorSize: number,
+  ): Promise<void> {
+    const DataType = this.DataType || {};
+    await this.client.createCollection({
+      collection_name: collectionName,
+      fields: [
+        {
+          name: "id",
+          data_type: DataType.VarChar,
+          is_primary_key: true,
+          max_length: 512,
+        },
+        {
+          name: "vectors",
+          data_type: DataType.FloatVector,
+          dim: vectorSize,
+        },
+        {
+          name: "metadata",
+          data_type: DataType.JSON,
+        },
+      ],
+      enable_dynamic_field: true,
+      index_params: [
+        {
+          field_name: "vectors",
+          index_type: "AUTOINDEX",
+          metric_type: this.metricType,
+          index_name: "vector_index",
+        },
+      ],
+    });
+    this.hasBm25Schema = false;
+  }
+
   private async createCol(
     collectionName: string,
     vectorSize: number,
@@ -151,7 +201,7 @@ export class Milvus implements VectorStore {
     }
 
     const DataType = this.DataType || {};
-    const fields = [
+    const hybridFields = [
       {
         name: "id",
         data_type: DataType.VarChar,
@@ -181,38 +231,60 @@ export class Milvus implements VectorStore {
       },
     ];
 
-    await this.client.createCollection({
-      collection_name: collectionName,
-      fields,
-      enable_dynamic_field: true,
-      // BM25 turns the `text` field into `sparse` vectors for full-text search.
-      functions: [
-        {
-          name: "bm25",
-          type: this.FunctionType?.BM25,
-          input_field_names: ["text"],
-          output_field_names: ["sparse"],
-          params: {},
-        },
-      ],
-      index_params: [
-        {
-          field_name: "vectors",
-          index_type: "AUTOINDEX",
-          metric_type: this.metricType,
-          index_name: "vector_index",
-        },
-        {
-          field_name: "sparse",
-          index_type: "SPARSE_INVERTED_INDEX",
-          metric_type: "BM25",
-          index_name: "sparse_index",
-        },
-      ],
-    });
+    try {
+      await this.client.createCollection({
+        collection_name: collectionName,
+        fields: hybridFields,
+        enable_dynamic_field: true,
+        // BM25 turns the `text` field into `sparse` vectors for full-text search.
+        functions: [
+          {
+            name: "bm25",
+            type: this.FunctionType?.BM25,
+            input_field_names: ["text"],
+            output_field_names: ["sparse"],
+            params: {},
+          },
+        ],
+        index_params: [
+          {
+            field_name: "vectors",
+            index_type: "AUTOINDEX",
+            metric_type: this.metricType,
+            index_name: "vector_index",
+          },
+          {
+            field_name: "sparse",
+            index_type: "SPARSE_INVERTED_INDEX",
+            metric_type: "BM25",
+            index_name: "sparse_index",
+          },
+        ],
+      });
+      this.hasBm25Schema = true;
+    } catch (err) {
+      if (!this.isBm25SchemaRejection(err)) throw err;
+
+      console.warn(
+        `Failed to create collection '${collectionName}' with BM25 hybrid search ` +
+          "schema; falling back to dense-only (expected on Milvus < 2.5).",
+      );
+
+      const stillExists = await this.client.hasCollection({
+        collection_name: collectionName,
+      });
+      const partial =
+        typeof stillExists === "object" && stillExists !== null
+          ? stillExists.value
+          : stillExists;
+      if (partial) {
+        await this.client.dropCollection({ collection_name: collectionName });
+      }
+
+      await this.createDenseOnlyCol(collectionName, vectorSize);
+    }
 
     await this.client.loadCollection({ collection_name: collectionName });
-    this.hasBm25Schema = true;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #6183 for the **TypeScript OSS SDK**. Python parity for #6338: on Milvus servers below 2.5, BM25 hybrid collection creation fails at init. This PR tries hybrid first, then falls back to dense-only so semantic search still works.

- Try hybrid BM25 schema on fresh collection create (unchanged happy path on 2.5+).
- On server-side BM25/sparse rejection (code 1100 / legacy code 0), drop any partial collection and create dense-only schema.
- Set `hasBm25Schema = false`; existing insert/update/keywordSearch guards already respect it.
- Re-raise transient errors (non-allowlisted codes) instead of silently degrading.

Related: Python fix in #6338 (salvage of #6184). This closes the TS parity gap called out in #6183 triage.

## Test plan

- [x] `npm test -- --testPathPattern=milvus.test.ts` (28 passed)
- [x] New tests: BM25 rejection fallback, transient error re-raise, dense-only update omits `text`

## Evidence

```bash
cd mem0-ts
npm test -- --testPathPattern=milvus.test.ts
```

```
Test Suites: 1 passed, 1 total
Tests:       28 passed, 28 total
```

New coverage:
- hybrid create success unchanged (existing tests)
- BM25 create failure → dense-only fallback + drop partial collection
- transient failure (code 2) propagates, no fallback
- `update()` omits `text` on dense-only fallback collections
