### PR TITLE
fix(llms): route groq and ollama through shared reasoning-model param gate

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -55,6 +55,9 @@ class LLMBase(ABC):
         if explicit is not None:
             return explicit
 
+        if not isinstance(model, str):
+            return False
+
         reasoning_models = {
             "o1", "o1-preview", "o3-mini", "o3",
             "gpt-5", "gpt-5o", "gpt-5o-mini", "gpt-5o-micro",
@@ -90,6 +93,8 @@ class LLMBase(ABC):
             bool: True if the model requires ``max_completion_tokens``
         """
         # Strip provider prefixes (e.g. "openai/gpt-5.4-mini" -> "gpt-5.4-mini")
+        if not isinstance(model, str):
+            return False
         base_model = (model or "").lower().rsplit("/", 1)[-1]
         return base_model.startswith("gpt-5")
 

--- a/mem0/llms/groq.py
+++ b/mem0/llms/groq.py
@@ -92,13 +92,13 @@ class GroqLLM(LLMBase):
         Returns:
             str: The generated response.
         """
-        params = {
-            "model": self.config.model,
-            "messages": messages,
-            "temperature": self.config.temperature,
-            "max_tokens": self.config.max_tokens,
-            "top_p": self.config.top_p,
-        }
+        params = self._get_supported_params(messages=messages)
+        params.update(
+            {
+                "model": self.config.model,
+                "messages": messages,
+            }
+        )
         if response_format:
             requests_json = isinstance(response_format, dict) and response_format.get("type") in (
                 "json_object",

--- a/mem0/llms/ollama.py
+++ b/mem0/llms/ollama.py
@@ -110,11 +110,25 @@ class OllamaLLM(LLMBase):
         Returns:
             str: The generated response.
         """
-        # Build parameters for Ollama
+        # Build parameters for Ollama via the shared reasoning-model gate so
+        # temperature/top_p/num_predict are omitted for o-series / gpt-5 names.
+        supported = self._get_supported_params(messages=messages)
         params = {
             "model": self.config.model,
             "messages": messages,
         }
+
+        options: Dict[str, Union[int, float]] = {}
+        if "temperature" in supported:
+            options["temperature"] = supported["temperature"]
+        if "top_p" in supported:
+            options["top_p"] = supported["top_p"]
+        if "max_tokens" in supported:
+            options["num_predict"] = supported["max_tokens"]
+        elif "max_completion_tokens" in supported:
+            options["num_predict"] = supported["max_completion_tokens"]
+        if options:
+            params["options"] = options
 
         # Handle JSON response format by using Ollama's native format parameter
         if response_format and response_format.get("type") == "json_object":
@@ -125,17 +139,6 @@ class OllamaLLM(LLMBase):
             else:
                 messages.append({"role": "user", "content": "Please respond with valid JSON only."})
             params["messages"] = messages
-
-        # Add options for Ollama (temperature, num_predict, top_p)
-        options = {
-            "temperature": self.config.temperature,
-            "num_predict": self.config.max_tokens,
-            "top_p": self.config.top_p,
-        }
-        params["options"] = options
-
-        # Remove OpenAI-specific parameters that Ollama doesn't support
-        params.pop("max_tokens", None)  # Ollama uses different parameter names
 
         if tools:
             params["tools"] = tools

--- a/tests/llms/test_groq.py
+++ b/tests/llms/test_groq.py
@@ -182,3 +182,25 @@ def test_generate_response_handles_non_string_model(mock_groq_client):
 
     _, kwargs = mock_groq_client.chat.completions.create.call_args
     assert kwargs["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.parametrize("model", ["o3-mini", "gpt-5", "openai/o3-mini", "o1-2024-12-17"])
+def test_generate_response_omits_sampling_params_for_reasoning_models(mock_groq_client, model):
+    """Reasoning-model names must not receive temperature/top_p/max_tokens (issue #6085)."""
+    config = BaseLlmConfig(model=model, temperature=0.1, max_tokens=100, top_p=0.9)
+    llm = GroqLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_groq_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    _, kwargs = mock_groq_client.chat.completions.create.call_args
+    assert kwargs["model"] == model
+    assert kwargs["messages"] == messages
+    assert "temperature" not in kwargs
+    assert "top_p" not in kwargs
+    assert "max_tokens" not in kwargs
+    assert "max_completion_tokens" not in kwargs

--- a/tests/llms/test_ollama.py
+++ b/tests/llms/test_ollama.py
@@ -140,3 +140,33 @@ def test_parse_response_with_tools_object_style(mock_ollama_client):
     result = llm._parse_response(mock_response, tools)
 
     assert result["tool_calls"] == [{"name": "extract", "arguments": {"entities": ["Alice"]}}]
+
+
+@pytest.mark.parametrize("model", ["o3-mini", "gpt-5", "openai/o3-mini"])
+def test_generate_response_omits_options_for_reasoning_models(mock_ollama_client, model):
+    """Reasoning-model names must not send temperature/top_p/num_predict via options."""
+    config = OllamaConfig(model=model, temperature=0.1, max_tokens=100, top_p=0.9)
+    llm = OllamaLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_ollama_client.chat.return_value = {"message": {"content": "ok"}}
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_ollama_client.chat.call_args.kwargs
+    assert call_kwargs["model"] == model
+    assert call_kwargs["messages"] == messages
+    assert "options" not in call_kwargs
+
+
+def test_generate_response_keeps_options_for_standard_model(mock_ollama_client):
+    config = OllamaConfig(model="llama3.1:70b", temperature=0.2, max_tokens=50, top_p=0.8)
+    llm = OllamaLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_ollama_client.chat.return_value = {"message": {"content": "ok"}}
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_ollama_client.chat.call_args.kwargs
+    assert call_kwargs["options"] == {"temperature": 0.2, "num_predict": 50, "top_p": 0.8}

--- a/tests/llms/test_ollama.py
+++ b/tests/llms/test_ollama.py
@@ -142,7 +142,7 @@ def test_parse_response_with_tools_object_style(mock_ollama_client):
     assert result["tool_calls"] == [{"name": "extract", "arguments": {"entities": ["Alice"]}}]
 
 
-@pytest.mark.parametrize("model", ["o3-mini", "gpt-5", "openai/o3-mini"])
+@pytest.mark.parametrize("model", ["o3-mini", "gpt-5", "openai/o3-mini", "o1-2024-12-17"])
 def test_generate_response_omits_options_for_reasoning_models(mock_ollama_client, model):
     """Reasoning-model names must not send temperature/top_p/num_predict via options."""
     config = OllamaConfig(model=model, temperature=0.1, max_tokens=100, top_p=0.9)


### PR DESCRIPTION
## Summary

Fixes #6241 (Groq + Ollama slice of the #6085 reasoning-param gap). Both providers now build requests through `LLMBase._get_supported_params`, matching `openai.py`.

Related triage: #6085 (default config + reasoning models rejecting temperature).

### Changes

- **groq.py:** use `_get_supported_params(messages=messages)` instead of always sending `temperature` / `top_p` / `max_tokens`.
- **ollama.py:** derive `options` from supported params; omit `options` when the reasoning gate strips sampling params.
- **base.py:** return `False` from `_is_reasoning_model` / `_uses_max_completion_tokens` for non-string model configs (preserves dict-model Groq behavior).

Non-reasoning behavior unchanged: standard models still receive the same temperature/top_p/max_tokens (Groq) or options dict (Ollama).

## Test plan

- [x] `pytest tests/llms/test_groq.py tests/llms/test_ollama.py -q` (21 passed)
- [x] New parametrized tests: `o3-mini`, `gpt-5`, `openai/o3-mini`, `o1-2024-12-17` omit sampling params

## Evidence

```bash
cd /tmp/mem0 && source .venv/bin/activate
python -m pytest tests/llms/test_groq.py tests/llms/test_ollama.py -q
```

```
21 passed in 0.58s
```

New coverage:
- Groq reasoning models: no `temperature` / `top_p` / `max_tokens` in API call
- Ollama reasoning models: no `options` key in `client.chat()` call
- Ollama standard model: `options` unchanged

Note: LiteLLM provider (#6241 original scope) is addressed separately in #6242; this PR closes the Groq/Ollama bypass called out alongside that issue.
