### PR TITLE
fix(vector_stores/elasticsearch): treat '*' filter as field-exists

### DIFF
--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -35,6 +35,25 @@ def _validate_filter(key: str, value: Any) -> None:
         )
 
 
+def _build_filter_conditions(filters: Optional[Dict]) -> List[Dict[str, Any]]:
+    """Build ES filter clauses.
+
+    The documented ``"*"`` metadata filter means field-exists (same contract as
+    OpenSearch), not a literal term match on the string ``"*"``.
+    """
+    conditions: List[Dict[str, Any]] = []
+    for key, value in (filters or {}).items():
+        if value is None:
+            continue
+        _validate_filter(key, value)
+        field = f"metadata.{key}"
+        if value == "*":
+            conditions.append({"exists": {"field": field}})
+        else:
+            conditions.append({"term": {field: value}})
+    return conditions
+
+
 class ElasticsearchDB(VectorStoreBase):
     def __init__(self, **kwargs):
         config = ElasticsearchConfig(**kwargs)
@@ -166,11 +185,9 @@ class ElasticsearchDB(VectorStoreBase):
                 "knn": {"field": "vector", "query_vector": vectors, "k": top_k, "num_candidates": top_k * 2}
             }
             if filters:
-                filter_conditions = []
-                for key, value in filters.items():
-                    _validate_filter(key, value)
-                    filter_conditions.append({"term": {f"metadata.{key}": value}})
-                search_query["knn"]["filter"] = {"bool": {"must": filter_conditions}}
+                filter_conditions = _build_filter_conditions(filters)
+                if filter_conditions:
+                    search_query["knn"]["filter"] = {"bool": {"must": filter_conditions}}
 
         response = self.client.search(index=self.collection_name, body=search_query)
 
@@ -205,11 +222,9 @@ class ElasticsearchDB(VectorStoreBase):
         }
 
         if filters:
-            filter_conditions = []
-            for key, value in filters.items():
-                _validate_filter(key, value)
-                filter_conditions.append({"term": {f"metadata.{key}": value}})
-            bool_query["filter"] = filter_conditions
+            filter_conditions = _build_filter_conditions(filters)
+            if filter_conditions:
+                bool_query["filter"] = filter_conditions
 
         search_query = {
             "size": top_k,
@@ -276,11 +291,9 @@ class ElasticsearchDB(VectorStoreBase):
         query: Dict[str, Any] = {"query": {"match_all": {}}}
 
         if filters:
-            filter_conditions = []
-            for key, value in filters.items():
-                _validate_filter(key, value)
-                filter_conditions.append({"term": {f"metadata.{key}": value}})
-            query["query"] = {"bool": {"must": filter_conditions}}
+            filter_conditions = _build_filter_conditions(filters)
+            if filter_conditions:
+                query["query"] = {"bool": {"must": filter_conditions}}
 
         if top_k:
             query["size"] = top_k

--- a/tests/vector_stores/test_elasticsearch.py
+++ b/tests/vector_stores/test_elasticsearch.py
@@ -390,3 +390,26 @@ class TestElasticsearchDB(unittest.TestCase):
     def test_list_with_dict_filter_raises(self):
         with self.assertRaises(ValueError):
             self.es_db.list(filters={"user_id": {"$ne": ""}})
+
+
+    def test_star_filter_uses_exists_on_search(self):
+        """"*" must be field-exists, not a literal term on "*"."""
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+        self.es_db.search("q", [0.1] * 1536, top_k=5, filters={"agent_id": "*", "user_id": "u1"})
+        body = self.client_mock.search.call_args.kwargs.get("body") or self.client_mock.search.call_args[1]["body"]
+        knn_filter = body["knn"]["filter"]["bool"]["must"]
+        self.assertIn({"exists": {"field": "metadata.agent_id"}}, knn_filter)
+        self.assertIn({"term": {"metadata.user_id": "u1"}}, knn_filter)
+        # Must not literal-match the string "*"
+        self.assertNotIn({"term": {"metadata.agent_id": "*"}}, knn_filter)
+
+    def test_star_filter_uses_exists_on_list(self):
+        self.client_mock.search.return_value = {"hits": {"hits": []}}
+        self.es_db.list(filters={"run_id": "*"}, top_k=10)
+        body = self.client_mock.search.call_args.kwargs.get("body") or self.client_mock.search.call_args[1]["body"]
+        must = body["query"]["bool"]["must"]
+        self.assertEqual(must, [{"exists": {"field": "metadata.run_id"}}])
+
+    def test_star_filter_allowed_by_validate(self):
+        # "*" is a valid scalar filter value
+        _validate_filter("agent_id", "*")


### PR DESCRIPTION
Closes #6595

Elasticsearch built every metadata filter as a `term` query, so `"*"` literal-matched and returned no rows. Map `"*"` to `exists` on `metadata.<key>` (OpenSearch parity). Tests cover search + list.