### PR TITLE
fix(vector_stores): FAISS/MongoDB '*' filter as field-exists

### DIFF
--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -434,6 +434,10 @@ class FAISS(VectorStoreBase):
             if key not in payload:
                 return False
 
+            # Documented "*" wildcard: field must exist (value already present).
+            if value == "*":
+                continue
+
             if isinstance(value, list):
                 if payload[key] not in value:
                     return False

--- a/mem0/vector_stores/mongodb.py
+++ b/mem0/vector_stores/mongodb.py
@@ -149,6 +149,14 @@ class MongoDB(VectorStoreBase):
             logger.error(f"Error inserting data: {e}")
 
     @staticmethod
+    def _payload_filter_clause(key: str, value: Any) -> dict:
+        """Build a payload field match; documented "*" means field-exists."""
+        field = "payload." + key
+        if value == "*":
+            return {field: {"$exists": True}}
+        return {field: value}
+
+    @staticmethod
     def _validate_filter_value(key: str, value: Any) -> None:
         """Reject values that could inject MongoDB query operators (e.g. $ne, $gt)."""
         if isinstance(value, dict):
@@ -208,7 +216,7 @@ class MongoDB(VectorStoreBase):
             if filters:
                 filter_conditions = []
                 for key, value in filters.items():
-                    filter_conditions.append({"payload." + key: value})
+                    filter_conditions.append(self._payload_filter_clause(key, value))
 
                 if filter_conditions:
                     # Add a $match stage after vector search to apply filters
@@ -260,7 +268,7 @@ class MongoDB(VectorStoreBase):
             if filters:
                 filter_conditions = []
                 for key, value in filters.items():
-                    filter_conditions.append({"payload." + key: value})
+                    filter_conditions.append(self._payload_filter_clause(key, value))
                 if filter_conditions:
                     pipeline.insert(1, {"$match": {"$and": filter_conditions}})
 
@@ -401,7 +409,7 @@ class MongoDB(VectorStoreBase):
                 # Apply filters to the payload field
                 filter_conditions = []
                 for key, value in filters.items():
-                    filter_conditions.append({"payload." + key: value})
+                    filter_conditions.append(self._payload_filter_clause(key, value))
                 if filter_conditions:
                     query = {"$and": filter_conditions}
 

--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -754,3 +754,13 @@ class TestCosineNormalization:
 
             assert results[0].id == "x"
             assert results[0].score == pytest.approx(1.0, abs=1e-5)
+
+
+def test_apply_filters_star_means_field_exists(faiss_instance):
+    """Documented "*" is field-exists, not equality to the string "*"."""
+    payload = {"user_id": "u1", "agent_id": "a1", "category": "work"}
+    assert faiss_instance._apply_filters(payload, {"agent_id": "*"}) is True
+    assert faiss_instance._apply_filters(payload, {"missing_key": "*"}) is False
+    # Combined: star + equality
+    assert faiss_instance._apply_filters(payload, {"agent_id": "*", "category": "work"}) is True
+    assert faiss_instance._apply_filters(payload, {"agent_id": "*", "category": "home"}) is False

--- a/tests/vector_stores/test_mongodb.py
+++ b/tests/vector_stores/test_mongodb.py
@@ -427,3 +427,30 @@ def test_search_allows_scalar_filter_values(mongo_vector_fixture):
     mock_collection.list_search_indexes.return_value = ["test_collection_vector_index"]
 
     mongo_vector.search("q", [0.1] * 1536, top_k=2, filters={"user_id": "alice", "count": 5})
+
+
+def test_payload_filter_clause_star_means_exists():
+    clause = MongoDB._payload_filter_clause("agent_id", "*")
+    assert clause == {"payload.agent_id": {"$exists": True}}
+    assert MongoDB._payload_filter_clause("user_id", "u1") == {"payload.user_id": "u1"}
+
+
+def test_star_filter_means_field_exists(mongo_vector_fixture):
+    mongo_vector, mock_collection, _ = mongo_vector_fixture
+    query_vector = [0.1] * 1536
+    mock_collection.list_search_indexes.return_value = ["test_collection_vector_index"]
+    mock_collection.aggregate.return_value = []
+
+    mongo_vector.search("q", query_vector, top_k=5, filters={"agent_id": "*", "user_id": "u1"})
+    pipeline = mock_collection.aggregate.call_args[0][0]
+    match_stage = next(stage for stage in pipeline if "$match" in stage)
+    assert {"payload.agent_id": {"$exists": True}} in match_stage["$match"]["$and"]
+    assert {"payload.user_id": "u1"} in match_stage["$match"]["$and"]
+
+    # list path
+    mock_cursor = MagicMock()
+    mock_cursor.limit.return_value = []
+    mock_collection.find.return_value = mock_cursor
+    mongo_vector.list(filters={"run_id": "*"}, top_k=10)
+    find_query = mock_collection.find.call_args[0][0]
+    assert find_query == {"$and": [{"payload.run_id": {"$exists": True}}]}


### PR DESCRIPTION
Closes #6596

FAISS and MongoDB treated metadata filter "*" as equality to the string "*". Map it to field-exists (FAISS: key present; Mongo: $exists) to match the docs/OpenSearch contract. Tests included.