### PR TITLE
feat(ts-oss): optional retry with backoff for LLM and embedding provider calls

### DIFF
--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -26,6 +26,16 @@ export interface EmbeddingConfig {
   awsAccessKeyId?: string;
   awsSecretAccessKey?: string;
   awsSessionToken?: string;
+  /**
+   * mem0-level retries on transient errors (rate-limit / network / timeout /
+   * 5xx) using exponential backoff with jitter. Default `0` (disabled), which
+   * keeps the previous single-attempt behavior.
+   */
+  maxRetries?: number;
+  /** Base backoff delay in ms, doubled each attempt. Default `500`. */
+  retryInitialDelayMs?: number;
+  /** Ceiling for any single backoff delay in ms. Default `30000`. */
+  retryMaxDelayMs?: number;
 }
 
 export interface VertexAIConfig extends EmbeddingConfig {
@@ -80,6 +90,16 @@ export interface LLMConfig {
   awsSessionToken?: string;
   // Optional pre-constructed client (e.g. BedrockRuntimeClient) for DI/testing.
   client?: any;
+  /**
+   * mem0-level retries on transient errors (rate-limit / network / timeout /
+   * 5xx) using exponential backoff with jitter. Default `0` (disabled), which
+   * keeps the previous single-attempt behavior.
+   */
+  maxRetries?: number;
+  /** Base backoff delay in ms, doubled each attempt. Default `500`. */
+  retryInitialDelayMs?: number;
+  /** Ceiling for any single backoff delay in ms. Default `30000`. */
+  retryMaxDelayMs?: number;
 }
 
 export interface RerankerConfig {
@@ -207,6 +227,9 @@ export const MemoryConfigSchema = z.object({
       awsAccessKeyId: z.string().optional(),
       awsSecretAccessKey: z.string().optional(),
       awsSessionToken: z.string().optional(),
+      maxRetries: z.number().optional(),
+      retryInitialDelayMs: z.number().optional(),
+      retryMaxDelayMs: z.number().optional(),
     }),
   }),
   vectorStore: z.object({
@@ -241,6 +264,9 @@ export const MemoryConfigSchema = z.object({
         awsSecretAccessKey: z.string().optional(),
         awsSessionToken: z.string().optional(),
         client: z.any().optional(),
+        maxRetries: z.number().optional(),
+        retryInitialDelayMs: z.number().optional(),
+        retryMaxDelayMs: z.number().optional(),
       })
       .passthrough(),
   }),

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -18,6 +18,7 @@ import {
 } from "../types";
 import { Reranker } from "../rerankers/base";
 import { CohereReranker } from "../rerankers/cohere";
+import { withEmbedderRetry, withLLMRetry } from "./retryWrappers";
 import { LLMReranker } from "../rerankers/llm";
 import { ZeroEntropyReranker } from "../rerankers/zeroentropy";
 import { CrossEncoderReranker } from "../rerankers/cross_encoder";
@@ -74,6 +75,14 @@ import { WeaviateDB } from "../vector_stores/weaviate";
 
 export class EmbedderFactory {
   static create(provider: string, config: EmbeddingConfig): Embedder {
+    // Wrap with the optional retry layer (no-op unless config.maxRetries > 0).
+    return withEmbedderRetry(this.instantiate(provider, config), config);
+  }
+
+  private static instantiate(
+    provider: string,
+    config: EmbeddingConfig,
+  ): Embedder {
     switch (provider.toLowerCase()) {
       case "openai":
         return new OpenAIEmbedder(config);
@@ -106,6 +115,11 @@ export class EmbedderFactory {
 
 export class LLMFactory {
   static create(provider: string, config: LLMConfig): LLM {
+    // Wrap with the optional retry layer (no-op unless config.maxRetries > 0).
+    return withLLMRetry(this.instantiate(provider, config), config);
+  }
+
+  private static instantiate(provider: string, config: LLMConfig): LLM {
     switch (provider.toLowerCase()) {
       case "openai":
         return new OpenAILLM(config);

--- a/mem0-ts/src/oss/src/utils/retry.ts
+++ b/mem0-ts/src/oss/src/utils/retry.ts
@@ -1,0 +1,194 @@
+/**
+ * Optional retry layer for transient provider failures.
+ *
+ * LLM and embedding calls fail intermittently in production — provider rate
+ * limits (429), gateway/5xx blips, and network resets — and a single failure
+ * otherwise fails the whole `add()` / `search()`. `retryCall` wraps a
+ * zero-argument async callable with bounded exponential backoff and full
+ * jitter, honoring a server-directed `Retry-After` when present. It is opt-in
+ * (see `maxRetries` in the LLM/embedder config; `0` keeps the old
+ * single-attempt behavior) and dependency-free, so it can live in the core SDK.
+ */
+
+/** HTTP status codes worth retrying: rate limit, request timeout, and 5xx. */
+const TRANSIENT_STATUS = new Set([408, 409, 425, 429, 500, 502, 503, 504]);
+
+/** Node socket/DNS error codes that indicate a transient network failure. */
+const TRANSIENT_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "EPIPE",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+]);
+
+/** Provider SDK error class names that map to transient conditions. */
+const TRANSIENT_NAMES = new Set([
+  "APIConnectionError",
+  "APIConnectionTimeoutError",
+  "APITimeoutError",
+  "InternalServerError",
+  "RateLimitError",
+]);
+
+/**
+ * Best-effort classification of an error as a transient (retryable) provider
+ * failure. Recognizes an HTTP status (`status`/`statusCode`), a Node network
+ * error `code`, a provider SDK error class `name`, and unwraps a nested
+ * `cause` (the OpenAI SDK wraps socket errors in `APIConnectionError`).
+ */
+export function isTransientError(err: unknown, depth = 0): boolean {
+  if (!err || typeof err !== "object" || depth > 3) return false;
+  const e = err as Record<string, any>;
+
+  const status = e.status ?? e.statusCode ?? e.response?.status;
+  if (typeof status === "number" && TRANSIENT_STATUS.has(status)) return true;
+  if (typeof e.code === "string" && TRANSIENT_CODES.has(e.code)) return true;
+  if (typeof e.name === "string" && TRANSIENT_NAMES.has(e.name)) return true;
+
+  if (e.cause && e.cause !== e) return isTransientError(e.cause, depth + 1);
+  return false;
+}
+
+/** Read a header off either a `Headers`-like object or a plain record. */
+function readHeader(headers: any, key: string): string | undefined {
+  if (!headers) return undefined;
+  if (typeof headers.get === "function") {
+    const v = headers.get(key);
+    return v == null ? undefined : String(v);
+  }
+  const v = headers[key] ?? headers[key.toLowerCase()];
+  return v == null ? undefined : String(v);
+}
+
+/**
+ * Server-directed retry delay in milliseconds from a provider error, or `null`
+ * when absent/unparseable. Mirrors the OpenAI SDK precedence: `retry-after-ms`
+ * (milliseconds) first, then `retry-after` as either numeric seconds or an
+ * HTTP-date.
+ */
+export function getRetryAfterMs(
+  err: unknown,
+  now: () => number = Date.now,
+): number | null {
+  const headers = (err as any)?.headers ?? (err as any)?.response?.headers;
+  if (!headers) return null;
+
+  const ms = readHeader(headers, "retry-after-ms");
+  if (ms !== undefined) {
+    const n = Number(ms);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+
+  const ra = readHeader(headers, "retry-after");
+  if (ra !== undefined) {
+    const secs = Number(ra);
+    if (Number.isFinite(secs) && secs >= 0) return secs * 1000;
+    const date = Date.parse(ra);
+    if (!Number.isNaN(date)) return Math.max(0, date - now());
+  }
+  return null;
+}
+
+export interface RetryOptions {
+  /** Number of retries after the first attempt. Must be >= 1 to have effect. */
+  maxRetries: number;
+  /** Base backoff delay in ms (doubled each attempt). Default 500. */
+  initialDelayMs?: number;
+  /** Ceiling for any single backoff delay in ms. Default 30000. */
+  maxDelayMs?: number;
+  /** Override transient-error classification (testing / custom providers). */
+  isTransient?: (e: unknown) => boolean;
+  /** Override the server `Retry-After` extractor. */
+  retryAfterMs?: (e: unknown) => number | null;
+  /** Injectable sleep (testing). */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable RNG in [0, 1) for jitter (testing). */
+  random?: () => number;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `fn`, retrying on transient errors with exponential backoff and full
+ * jitter. A server `Retry-After` (capped at `maxDelayMs`) takes precedence over
+ * computed backoff. Non-transient errors, and the final attempt's error, are
+ * rethrown unchanged so callers see the original provider exception.
+ */
+export async function retryCall<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions,
+): Promise<T> {
+  const initialDelayMs = options.initialDelayMs ?? 500;
+  const maxDelayMs = options.maxDelayMs ?? 30_000;
+  const isTransient = options.isTransient ?? isTransientError;
+  const retryAfterMs = options.retryAfterMs ?? getRetryAfterMs;
+  const sleep = options.sleep ?? defaultSleep;
+  const random = options.random ?? Math.random;
+
+  let attempt = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= options.maxRetries || !isTransient(err)) {
+        throw err;
+      }
+
+      const serverDelay = retryAfterMs(err);
+      let delay: number;
+      if (serverDelay != null && serverDelay >= 0) {
+        delay = Math.min(serverDelay, maxDelayMs);
+      } else {
+        // Exponential backoff (initialDelay * 2^attempt) with full jitter,
+        // i.e. a random point in [0, backoff], to avoid synchronized retries.
+        const backoff = Math.min(maxDelayMs, initialDelayMs * 2 ** attempt);
+        delay = random() * backoff;
+      }
+
+      await sleep(delay);
+      attempt += 1;
+    }
+  }
+}
+
+/**
+ * Resolve retry settings from a provider config, or `null` when retries are
+ * disabled. `maxRetries` is opt-in: `undefined`/`0` disables the layer; a
+ * defined value that is not a non-negative integer is a configuration error.
+ */
+export function resolveRetryOptions(config: {
+  maxRetries?: number;
+  retryInitialDelayMs?: number;
+  retryMaxDelayMs?: number;
+}): RetryOptions | null {
+  const { maxRetries } = config;
+  if (maxRetries === undefined || maxRetries === null) return null;
+  if (
+    typeof maxRetries !== "number" ||
+    !Number.isInteger(maxRetries) ||
+    maxRetries < 0
+  ) {
+    throw new Error(
+      `maxRetries must be a non-negative integer, got ${JSON.stringify(maxRetries)}`,
+    );
+  }
+  if (maxRetries === 0) return null;
+
+  return {
+    maxRetries,
+    initialDelayMs: positiveOr(config.retryInitialDelayMs, 500),
+    maxDelayMs: positiveOr(config.retryMaxDelayMs, 30_000),
+  };
+}
+
+function positiveOr(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}

--- a/mem0-ts/src/oss/src/utils/retryWrappers.ts
+++ b/mem0-ts/src/oss/src/utils/retryWrappers.ts
@@ -1,0 +1,85 @@
+/**
+ * Factory-level retry wrappers. When a provider config sets `maxRetries > 0`,
+ * the created LLM/embedder is wrapped so its network-facing methods retry
+ * transient failures (see ./retry). When retries are disabled the original
+ * instance is returned untouched, so the default behavior is unchanged.
+ */
+import { LLM, LLMResponse } from "../llms/base";
+import { Embedder } from "../embeddings/base";
+import { Message } from "../types";
+import { resolveRetryOptions, retryCall, RetryOptions } from "./retry";
+
+interface RetryConfig {
+  maxRetries?: number;
+  retryInitialDelayMs?: number;
+  retryMaxDelayMs?: number;
+}
+
+/**
+ * Wrap `llm` so `generateResponse` / `generateChat` retry transient provider
+ * errors, or return it unchanged when retries are disabled.
+ */
+export function withLLMRetry(llm: LLM, config: RetryConfig): LLM {
+  const options = resolveRetryOptions(config);
+  if (!options) return llm;
+  return new RetryingLLM(llm, options);
+}
+
+/**
+ * Wrap `embedder` so `embed` / `embedBatch` retry transient provider errors, or
+ * return it unchanged when retries are disabled.
+ */
+export function withEmbedderRetry(
+  embedder: Embedder,
+  config: RetryConfig,
+): Embedder {
+  const options = resolveRetryOptions(config);
+  if (!options) return embedder;
+  return new RetryingEmbedder(embedder, options);
+}
+
+class RetryingLLM implements LLM {
+  constructor(
+    private readonly inner: LLM,
+    private readonly options: RetryOptions,
+  ) {}
+
+  generateResponse(
+    messages: Array<{ role: string; content: string }>,
+    responseFormat?: { type: string },
+    tools?: any[],
+  ): Promise<any> {
+    return retryCall(
+      () => this.inner.generateResponse(messages, responseFormat, tools),
+      this.options,
+    );
+  }
+
+  generateChat(messages: Message[]): Promise<LLMResponse> {
+    return retryCall(() => this.inner.generateChat(messages), this.options);
+  }
+}
+
+class RetryingEmbedder implements Embedder {
+  constructor(
+    private readonly inner: Embedder,
+    private readonly options: RetryOptions,
+  ) {}
+
+  embed(
+    text: string,
+    memoryAction?: "add" | "update" | "search",
+  ): Promise<number[]> {
+    return retryCall(() => this.inner.embed(text, memoryAction), this.options);
+  }
+
+  embedBatch(
+    texts: string[],
+    memoryAction?: "add" | "update" | "search",
+  ): Promise<number[][]> {
+    return retryCall(
+      () => this.inner.embedBatch(texts, memoryAction),
+      this.options,
+    );
+  }
+}

--- a/mem0-ts/src/oss/tests/retry.factory.test.ts
+++ b/mem0-ts/src/oss/tests/retry.factory.test.ts
@@ -1,0 +1,96 @@
+/// <reference types="jest" />
+/**
+ * Integration tests for the factory-level retry wrappers (utils/retryWrappers).
+ * Verifies that an LLM/embedder created with maxRetries retries transient
+ * provider errors, and that maxRetries:0 (or unset) returns the raw instance.
+ */
+import { withLLMRetry, withEmbedderRetry } from "../src/utils/retryWrappers";
+import type { LLM } from "../src/llms/base";
+import type { Embedder } from "../src/embeddings/base";
+
+const transient = (status: number) =>
+  Object.assign(new Error(`HTTP ${status}`), { status });
+
+// Patch the module's sleep by using zero-delay real timers is flaky; instead we
+// rely on retryCall's default sleep (setTimeout) with tiny backoff via config.
+const fastRetry = {
+  maxRetries: 3,
+  retryInitialDelayMs: 1,
+  retryMaxDelayMs: 2,
+};
+
+describe("withLLMRetry", () => {
+  it("returns the same instance when retries are disabled", () => {
+    const llm = { generateResponse: jest.fn(), generateChat: jest.fn() } as LLM;
+    expect(withLLMRetry(llm, {})).toBe(llm);
+    expect(withLLMRetry(llm, { maxRetries: 0 })).toBe(llm);
+  });
+
+  it("wraps and retries generateResponse on a transient error", async () => {
+    const generateResponse = jest
+      .fn()
+      .mockRejectedValueOnce(transient(429))
+      .mockResolvedValue("done");
+    const llm = { generateResponse, generateChat: jest.fn() } as unknown as LLM;
+
+    const wrapped = withLLMRetry(llm, fastRetry);
+    await expect(
+      wrapped.generateResponse([{ role: "user", content: "hi" }]),
+    ).resolves.toBe("done");
+    expect(generateResponse).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards all arguments to the wrapped generateResponse", async () => {
+    const generateResponse = jest.fn().mockResolvedValue("ok");
+    const llm = { generateResponse, generateChat: jest.fn() } as unknown as LLM;
+    const wrapped = withLLMRetry(llm, fastRetry);
+
+    const messages = [{ role: "user", content: "hi" }];
+    const format = { type: "json_object" };
+    const tools = [{ name: "t" }];
+    await wrapped.generateResponse(messages, format, tools);
+
+    expect(generateResponse).toHaveBeenCalledWith(messages, format, tools);
+  });
+
+  it("surfaces a non-transient error without retrying", async () => {
+    const generateChat = jest.fn().mockRejectedValue(transient(401));
+    const llm = {
+      generateResponse: jest.fn(),
+      generateChat,
+    } as unknown as LLM;
+    const wrapped = withLLMRetry(llm, fastRetry);
+
+    await expect(wrapped.generateChat([])).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(generateChat).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("withEmbedderRetry", () => {
+  it("returns the same instance when retries are disabled", () => {
+    const emb = { embed: jest.fn(), embedBatch: jest.fn() } as Embedder;
+    expect(withEmbedderRetry(emb, {})).toBe(emb);
+  });
+
+  it("retries embed and embedBatch on transient errors", async () => {
+    const embed = jest
+      .fn()
+      .mockRejectedValueOnce(transient(503))
+      .mockResolvedValue([0.1, 0.2]);
+    const embedBatch = jest
+      .fn()
+      .mockRejectedValueOnce(transient(500))
+      .mockResolvedValue([[0.1]]);
+    const emb = { embed, embedBatch } as unknown as Embedder;
+
+    const wrapped = withEmbedderRetry(emb, fastRetry);
+    await expect(wrapped.embed("x", "add")).resolves.toEqual([0.1, 0.2]);
+    await expect(wrapped.embedBatch(["x"], "search")).resolves.toEqual([[0.1]]);
+    expect(embed).toHaveBeenCalledTimes(2);
+    expect(embed).toHaveBeenLastCalledWith("x", "add");
+    expect(embedBatch).toHaveBeenCalledTimes(2);
+    expect(embedBatch).toHaveBeenLastCalledWith(["x"], "search");
+  });
+});

--- a/mem0-ts/src/oss/tests/retry.unit.test.ts
+++ b/mem0-ts/src/oss/tests/retry.unit.test.ts
@@ -1,0 +1,200 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for the dependency-free retry core (utils/retry.ts).
+ */
+import {
+  isTransientError,
+  getRetryAfterMs,
+  retryCall,
+  resolveRetryOptions,
+} from "../src/utils/retry";
+
+// A deterministic harness: no real timers, fixed jitter.
+function harness(overrides: Partial<Parameters<typeof retryCall>[1]> = {}) {
+  const slept: number[] = [];
+  return {
+    slept,
+    options: {
+      maxRetries: 3,
+      initialDelayMs: 100,
+      maxDelayMs: 10_000,
+      sleep: async (ms: number) => {
+        slept.push(ms);
+      },
+      random: () => 0.5, // full jitter picks the midpoint
+      ...overrides,
+    },
+  };
+}
+
+const httpError = (status: number, headers?: Record<string, string>) =>
+  Object.assign(new Error(`HTTP ${status}`), { status, headers });
+
+describe("isTransientError", () => {
+  it("treats rate-limit and 5xx statuses as transient", () => {
+    expect(isTransientError(httpError(429))).toBe(true);
+    expect(isTransientError(httpError(500))).toBe(true);
+    expect(isTransientError(httpError(503))).toBe(true);
+    expect(isTransientError(httpError(408))).toBe(true);
+  });
+
+  it("does not retry client errors like 400/401/404", () => {
+    expect(isTransientError(httpError(400))).toBe(false);
+    expect(isTransientError(httpError(401))).toBe(false);
+    expect(isTransientError(httpError(404))).toBe(false);
+  });
+
+  it("treats network error codes as transient", () => {
+    expect(
+      isTransientError(Object.assign(new Error(), { code: "ECONNRESET" })),
+    ).toBe(true);
+    expect(
+      isTransientError(Object.assign(new Error(), { code: "ETIMEDOUT" })),
+    ).toBe(true);
+    expect(
+      isTransientError(Object.assign(new Error(), { code: "ENOENT" })),
+    ).toBe(false);
+  });
+
+  it("recognizes provider SDK error class names and nested causes", () => {
+    expect(
+      isTransientError(
+        Object.assign(new Error(), { name: "APIConnectionError" }),
+      ),
+    ).toBe(true);
+    const wrapped = Object.assign(new Error("outer"), {
+      cause: Object.assign(new Error("inner"), { code: "ECONNRESET" }),
+    });
+    expect(isTransientError(wrapped)).toBe(true);
+  });
+
+  it("returns false for non-error values", () => {
+    expect(isTransientError(null)).toBe(false);
+    expect(isTransientError("boom")).toBe(false);
+    expect(isTransientError(undefined)).toBe(false);
+  });
+});
+
+describe("getRetryAfterMs", () => {
+  it("prefers retry-after-ms (milliseconds)", () => {
+    expect(getRetryAfterMs(httpError(429, { "retry-after-ms": "1500" }))).toBe(
+      1500,
+    );
+  });
+
+  it("reads retry-after as seconds", () => {
+    expect(getRetryAfterMs(httpError(429, { "retry-after": "2" }))).toBe(2000);
+  });
+
+  it("reads retry-after as an HTTP-date relative to now", () => {
+    const now = () => 1_000_000;
+    const when = new Date(1_000_000 + 3000).toUTCString();
+    const ms = getRetryAfterMs(httpError(503, { "retry-after": when }), now);
+    // HTTP-date has 1s resolution, so allow a small window.
+    expect(ms).toBeGreaterThanOrEqual(2000);
+    expect(ms).toBeLessThanOrEqual(3000);
+  });
+
+  it("returns null when absent or unparseable", () => {
+    expect(getRetryAfterMs(httpError(429))).toBeNull();
+    expect(
+      getRetryAfterMs(httpError(429, { "retry-after": "soon" })),
+    ).toBeNull();
+  });
+});
+
+describe("retryCall", () => {
+  it("returns immediately on success without sleeping", async () => {
+    const { options, slept } = harness();
+    const fn = jest.fn().mockResolvedValue("ok");
+    await expect(retryCall(fn, options)).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(slept).toEqual([]);
+  });
+
+  it("retries a transient error and eventually succeeds", async () => {
+    const { options, slept } = harness();
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(httpError(503))
+      .mockRejectedValueOnce(httpError(429))
+      .mockResolvedValue("ok");
+    await expect(retryCall(fn, options)).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+    // full jitter at random()=0.5: 0.5 * (100 * 2^attempt) = 50, 100
+    expect(slept).toEqual([50, 100]);
+  });
+
+  it("does not retry a non-transient error", async () => {
+    const { options, slept } = harness();
+    const fn = jest.fn().mockRejectedValue(httpError(400));
+    await expect(retryCall(fn, options)).rejects.toMatchObject({ status: 400 });
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(slept).toEqual([]);
+  });
+
+  it("rethrows the original error after exhausting maxRetries", async () => {
+    const { options, slept } = harness({ maxRetries: 2 });
+    const fn = jest.fn().mockRejectedValue(httpError(500));
+    await expect(retryCall(fn, options)).rejects.toMatchObject({ status: 500 });
+    expect(fn).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+    expect(slept).toHaveLength(2);
+  });
+
+  it("honors a server Retry-After over computed backoff, capped at maxDelayMs", async () => {
+    const { options, slept } = harness({ maxDelayMs: 5000 });
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(httpError(429, { "retry-after-ms": "999999" }))
+      .mockResolvedValue("ok");
+    await expect(retryCall(fn, options)).resolves.toBe("ok");
+    expect(slept).toEqual([5000]); // 999999 capped to maxDelayMs
+  });
+
+  it("caps exponential backoff at maxDelayMs", async () => {
+    const { options, slept } = harness({
+      maxRetries: 5,
+      initialDelayMs: 1000,
+      maxDelayMs: 3000,
+      random: () => 1, // no jitter reduction, so delay == backoff
+    });
+    const fn = jest.fn().mockRejectedValue(httpError(503));
+    await expect(retryCall(fn, options)).rejects.toBeDefined();
+    // 1000, 2000, 3000(capped), 3000, 3000
+    expect(slept).toEqual([1000, 2000, 3000, 3000, 3000]);
+  });
+});
+
+describe("resolveRetryOptions", () => {
+  it("returns null (disabled) for undefined or 0", () => {
+    expect(resolveRetryOptions({})).toBeNull();
+    expect(resolveRetryOptions({ maxRetries: 0 })).toBeNull();
+  });
+
+  it("returns options for a positive integer", () => {
+    expect(resolveRetryOptions({ maxRetries: 3 })).toMatchObject({
+      maxRetries: 3,
+      initialDelayMs: 500,
+      maxDelayMs: 30_000,
+    });
+  });
+
+  it("carries custom delays through", () => {
+    expect(
+      resolveRetryOptions({
+        maxRetries: 2,
+        retryInitialDelayMs: 250,
+        retryMaxDelayMs: 5000,
+      }),
+    ).toMatchObject({ initialDelayMs: 250, maxDelayMs: 5000 });
+  });
+
+  it("throws on a negative or non-integer maxRetries", () => {
+    expect(() => resolveRetryOptions({ maxRetries: -1 })).toThrow(
+      /non-negative integer/,
+    );
+    expect(() => resolveRetryOptions({ maxRetries: 1.5 })).toThrow(
+      /non-negative integer/,
+    );
+  });
+});


### PR DESCRIPTION
### Description

Adds an **opt-in retry layer** for the TS OSS SDK's LLM and embedding provider calls. Today every path in `llms/*` and `embeddings/*` makes a single bare SDK call, so one transient `429` / `5xx` / socket blip fails the whole `add()` or `search()`. This adds `maxRetries` (default `0`, behavior unchanged) so those calls retry transient failures with **exponential backoff + full jitter**, honoring a server-directed `Retry-After`, and rethrow the original provider error once retries are exhausted.

This is the TypeScript counterpart of the Python request #6270.

Closes #6599

### Architecture

Opt-in, non-invasive, dependency-free. Wrapped at the **factory boundary**, so none of the ~19 LLM / ~12 embedder provider classes change.

```
LLMFactory.create(provider, config)
   ├─ instantiate(provider, config)   ← existing switch, unchanged
   ▼
   withLLMRetry(llm, config)  ──►  maxRetries>0 ? RetryingLLM(llm) : llm
                                        │
   RetryingLLM.generateResponse(...) ──► retryCall(() => inner.generateResponse(...), opts)
```

- **`utils/retry.ts`** — dependency-free core:
  - `isTransientError` — HTTP `{408,409,425,429,500,502,503,504}` (via `status`/`statusCode`/`response.status`), Node socket/DNS codes (`ECONNRESET`, `ETIMEDOUT`, …), provider SDK error names (`APIConnectionError`, `RateLimitError`, …), and unwraps a nested `cause`.
  - `getRetryAfterMs` — `retry-after-ms` (ms) then `retry-after` (seconds or HTTP-date), reading a `Headers`-like or plain-record header bag.
  - `retryCall` — `min(maxDelay, initialDelay · 2^attempt)` with full jitter, or a capped `Retry-After`; non-transient / final errors rethrown unchanged. `sleep`/`random` injectable for deterministic tests.
  - `resolveRetryOptions` — `undefined`/`0` ⇒ disabled; negative/non-integer throws.
- **`utils/retryWrappers.ts`** — `withLLMRetry` / `withEmbedderRetry`: raw instance when disabled, else a thin `RetryingLLM` / `RetryingEmbedder`.
- **`utils/factory.ts`** — factories wrap the instantiated provider (switch moved to a private `instantiate`).
- **Config** — `maxRetries`, `retryInitialDelayMs`, `retryMaxDelayMs` on `LLMConfig`/`EmbeddingConfig` + zod schema.

```ts
new Memory({
  llm:      { provider: "openai", config: { apiKey, maxRetries: 3 } },
  embedder: { provider: "openai", config: { apiKey, maxRetries: 3 } },
});
```

### Backward compatibility

`maxRetries` defaults to `0`, so the wrappers return the **exact same instance** — the call path is unchanged for anyone who doesn't opt in. No dependency added.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

`jest src/oss/tests/retry.unit.test.ts src/oss/tests/retry.factory.test.ts` — **25 passed**. Full build (`tsup`, incl. DTS) succeeds.

- `retry.unit.test.ts` (19): transient vs client-error classification, network codes, nested cause, `Retry-After` (ms / seconds / HTTP-date / absent), success-without-sleep, retry-then-succeed with exact jittered delays, no-retry on 4xx, exhaustion rethrow, `Retry-After` precedence + cap, backoff cap, and `resolveRetryOptions` (disabled/enabled/custom/validation).
- `retry.factory.test.ts` (6): `withLLMRetry`/`withEmbedderRetry` return the same instance when disabled, retry `generateResponse`/`embed`/`embedBatch` on transient errors, forward all args, and surface non-transient errors without retrying.
- Existing `LLMFactory.create` tests (vllm) and provider tests still pass, confirming the factory refactor is transparent.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
