### PR TITLE
fix(ts-oss): give the entity store its own db file for any memory dbPath

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -301,7 +301,16 @@ export class Memory {
       // For file-based stores (memory/SQLite), always use a separate DB for entities
       if (entityProvider === "memory") {
         const basePath = entityConfig.dbPath || getDefaultVectorStoreDbPath();
-        entityConfig.dbPath = basePath.replace(/\.db$/, "_entities.db");
+        // Insert "_entities" before the file extension so the entity store
+        // gets its own file for ANY dbPath, not just ones ending in ".db".
+        // The old `.replace(/\.db$/, ...)` was a no-op for e.g. ".sqlite" or
+        // extensionless paths, leaving the entity store sharing the main
+        // store's file and leaking entity records into getAll()/search().
+        // ":memory:" is left as-is: each connection is already its own DB.
+        entityConfig.dbPath =
+          basePath === ":memory:"
+            ? basePath
+            : basePath.replace(/(\.[^./\\]+)?$/, "_entities$1");
       }
       if (entityProvider === "databricks") {
         entityConfig.tableName = entityConfig.tableName

--- a/mem0-ts/src/oss/tests/entity-store-dbpath.test.ts
+++ b/mem0-ts/src/oss/tests/entity-store-dbpath.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression: the `memory` provider must give the entity store its OWN db file
+ * for ANY dbPath, not only ones ending in ".db".
+ *
+ * The entity store path was derived with `basePath.replace(/\.db$/, ...)`, a
+ * no-op for e.g. ".sqlite" or extensionless paths. That made the entity store
+ * open the SAME sqlite file as the main store, so extracted entities leaked
+ * into getAll()/search() as phantom memories. The existing entity tests all use
+ * dbPath ":memory:" (two connections are separate DBs by sqlite semantics), so
+ * they never exercised a persistent non-".db" path.
+ */
+/// <reference types="jest" />
+import { Memory } from "../src/memory";
+import type { MemoryConfig } from "../src/types";
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
+
+jest.mock("../src/embeddings/google", () => ({ GoogleEmbedder: jest.fn() }));
+jest.mock("../src/llms/google", () => ({ GoogleLLM: jest.fn() }));
+
+// The LLM extracts one fact rich in proper nouns so real entity extraction
+// produces entity records (Bob, Berlin, ...) that get written to the entity store.
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockResolvedValue(
+      JSON.stringify({
+        memory: [
+          { id: "0", text: "Alice met Bob in Berlin", attributed_to: "user" },
+        ],
+      }),
+    ),
+  })),
+}));
+
+const mockEmbedding = new Array(256).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((t: string[]) =>
+        Promise.resolve(t.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 256,
+  })),
+}));
+
+let tmpRoot: string;
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "mem0-entity-dbpath-"));
+});
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("entity store isolation for the memory provider", () => {
+  // ".db" always worked; the others used to collide.
+  it.each([
+    ["ends in .db", "store.db"],
+    ["ends in .sqlite", "store.sqlite"],
+    ["ends in .sqlite3", "store.sqlite3"],
+    ["no extension", "store"],
+  ])(
+    "keeps entities out of the main store when dbPath %s",
+    async (_label, file) => {
+      // Own directory per case so the file listing is unambiguous.
+      const dir = fs.mkdtempSync(path.join(tmpRoot, "case-"));
+      const m = new Memory({
+        version: "v1.1",
+        embedder: { provider: "openai", config: { apiKey: "k", model: "m" } },
+        vectorStore: {
+          provider: "memory",
+          config: { dbPath: path.join(dir, file), dimension: 256 },
+        },
+        llm: {
+          provider: "openai",
+          config: { apiKey: "k", model: "gpt-4o-mini" },
+        },
+      } as MemoryConfig);
+
+      await m.add("Alice met Bob in Berlin", { userId: "u" });
+
+      const all = await m.getAll({ filters: { user_id: "u" } } as any);
+      const memories = all.results.map((r: any) => r.memory);
+
+      // getAll must return only the stored memory, never the extracted entities.
+      expect(memories).toEqual(["Alice met Bob in Berlin"]);
+
+      // and the entity store must have been given its own separate file.
+      const files = fs.readdirSync(dir);
+      expect(files.some((f) => f.includes("_entities"))).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
## Linked Issue

Closes #6606

## Description

The `memory` provider derived the entity store's db path with `basePath.replace(/\.db$/, "_entities.db")`. That regex only matches paths ending in `.db`, so for a `dbPath` like `store.sqlite` (or no extension) it's a no-op and the entity store opens the *same* sqlite file as the main store. Extracted entities then leak into `getAll()`/`search()` as phantom memories, and in search they can outrank the real ones.

The comment above the line already says "always use a separate DB for entities" — this just makes the derivation actually do that. Now it inserts `_entities` before the extension for any path shape, and leaves `:memory:` alone (each `:memory:` connection is already its own db).

Python isn't affected — it separates the entity store by `collection_name`, not by rewriting the path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

Added `entity-store-dbpath.test.ts` covering `.db`, `.sqlite`, `.sqlite3`, and extensionless paths — asserts `getAll()` returns only the stored memory and that a separate `*_entities*` file is created. Red-green checked: without the fix, `.sqlite`/`.sqlite3`/no-extension fail while the `.db` control passes; with the fix all four pass.

The existing entity tests all use `dbPath: ":memory:"` (two connections are separate DBs by sqlite semantics), which is why this slipped through — the new test uses real files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
