### PR TITLE
fix(llms+embeddings/together): honor TOGETHER_API_BASE and custom base_url configuration (#6587)

### DIFF
--- a/mem0/embeddings/together.py
+++ b/mem0/embeddings/together.py
@@ -14,7 +14,17 @@ class TogetherEmbedding(EmbeddingBase):
         self.config.model = self.config.model or "intfloat/multilingual-e5-large-instruct"
         api_key = self.config.api_key or os.getenv("TOGETHER_API_KEY")
         self.config.embedding_dims = self.config.embedding_dims or 1024
-        self.client = Together(api_key=api_key)
+        base_url = (
+            getattr(self.config, "openai_base_url", None)
+            or getattr(self.config, "together_base_url", None)
+            or getattr(self.config, "base_url", None)
+            or os.getenv("TOGETHER_API_BASE")
+            or os.getenv("TOGETHER_BASE_URL")
+        )
+        kwargs = {"api_key": api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+        self.client = Together(**kwargs)
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """

--- a/mem0/llms/together.py
+++ b/mem0/llms/together.py
@@ -20,7 +20,17 @@ class TogetherLLM(LLMBase):
             self.config.model = "MiniMaxAI/MiniMax-M3"
 
         api_key = self.config.api_key or os.getenv("TOGETHER_API_KEY")
-        self.client = Together(api_key=api_key)
+        base_url = (
+            getattr(self.config, "openai_base_url", None)
+            or getattr(self.config, "together_base_url", None)
+            or getattr(self.config, "base_url", None)
+            or os.getenv("TOGETHER_API_BASE")
+            or os.getenv("TOGETHER_BASE_URL")
+        )
+        kwargs = {"api_key": api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+        self.client = Together(**kwargs)
 
     def _parse_response(self, response, tools):
         """

--- a/tests/embeddings/test_together_embeddings.py
+++ b/tests/embeddings/test_together_embeddings.py
@@ -85,3 +85,10 @@ def test_explicit_config_overrides_defaults(mock_together_client):
     mock_together_client.embeddings.create.return_value = Mock(data=[Mock(embedding=[0.0] * 768)])
     embedder.embed("hello")
     mock_together_client.embeddings.create.assert_called_once_with(model="BAAI/bge-base-en-v1.5", input="hello")
+
+def test_init_with_base_url(mock_together_client):
+    import os
+    with patch.dict(os.environ, {"TOGETHER_API_BASE": "https://custom.together.endpoint/v1"}):
+        TogetherEmbedding(BaseEmbedderConfig(model=DEFAULT_MODEL))
+        from mem0.embeddings.together import Together
+        Together.assert_called_with(api_key=None, base_url="https://custom.together.endpoint/v1")

--- a/tests/llms/test_together.py
+++ b/tests/llms/test_together.py
@@ -102,3 +102,10 @@ def test_generate_response_forwards_extra_kwargs(mock_together_client):
     assert response == "Hi"
     call_kwargs = mock_together_client.chat.completions.create.call_args.kwargs
     assert call_kwargs["frequency_penalty"] == 0.5
+
+def test_init_with_base_url(mock_together_client):
+    import os
+    with patch.dict(os.environ, {"TOGETHER_API_BASE": "https://custom.together.endpoint/v1"}):
+        TogetherLLM(BaseLlmConfig(model="mistralai/Mixtral-8x7B-Instruct-v0.1"))
+        from mem0.llms.together import Together
+        Together.assert_called_with(api_key=None, base_url="https://custom.together.endpoint/v1")


### PR DESCRIPTION
Fixes #6587.

## Summary
Updates `TogetherLLM` and `TogetherEmbedding` in the Python SDK to accept custom base URLs via environment variables (`TOGETHER_API_BASE` / `TOGETHER_BASE_URL`) or model configuration attributes (`openai_base_url` / `together_base_url` / `base_url`). This aligns Python SDK behavior with the TypeScript SDK (`llms/together.ts`), enabling seamless compatibility with self-hosted gateways and proxy deployments for both chat and embeddings.

## Changes
- Updated `mem0/llms/together.py` to resolve custom `base_url` from config or env variables and pass it to `Together(api_key=..., base_url=...)`.
- Updated `mem0/embeddings/together.py` with identical `base_url` resolution logic for embedding provider initialization.
- Added unit tests in `tests/llms/test_together.py` and `tests/embeddings/test_together_embeddings.py` verifying that custom endpoints are correctly forwarded to the Together client.

## Testing
- Ran pytest suite for Together LLM and embeddings (`pytest tests/llms/test_together.py tests/embeddings/test_together_embeddings.py`); all tests passed.