### PR TITLE
fix(vector_stores/upstash): escape and validate metadata filter expressions

### DIFF
--- a/mem0/vector_stores/upstash_vector.py
+++ b/mem0/vector_stores/upstash_vector.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel
@@ -92,7 +93,46 @@ class UpstashVector(VectorStoreBase):
         )
 
     def _stringify(self, x):
-        return f'"{x}"' if isinstance(x, str) else x
+        """Render a filter value as an Upstash filter literal.
+
+        String values are quoted, with `\\` and `"` escaped first. Without the
+        escaping a value containing a double quote closes the literal early and
+        the remainder is parsed as filter syntax, so a caller who controls one
+        filter value can append clauses of their own and widen the match set
+        past the scoping filters (e.g. `user_id`).
+        """
+        if isinstance(x, str):
+            escaped = x.replace("\\", "\\\\").replace('"', '\\"')
+            return f'"{escaped}"'
+        return x
+
+    _SAFE_FILTER_KEY = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+    def _build_filter_expression(self, filters: Optional[Dict]) -> Optional[str]:
+        """Build an Upstash metadata filter expression from `filters`.
+
+        Keys are restricted to identifier characters and values to scalars, so
+        neither can contribute unescaped filter syntax.
+
+        Raises:
+            ValueError: If a filter key is not an identifier, or a filter value
+                is not a str, int, float, or bool.
+        """
+        if not filters:
+            return None
+
+        operands = []
+        for key, value in filters.items():
+            if not self._SAFE_FILTER_KEY.match(key):
+                raise ValueError(f"Invalid filter key: {key!r}")
+            if not isinstance(value, (str, int, float, bool)):
+                raise ValueError(
+                    f"Filter value for {key!r} must be str, int, float, or bool, "
+                    f"got {type(value).__name__}"
+                )
+            operands.append(f"{key} = {self._stringify(value)}")
+
+        return " AND ".join(operands)
 
     def search(
         self,
@@ -111,9 +151,12 @@ class UpstashVector(VectorStoreBase):
 
         Returns:
             List[OutputData]: Search results.
+
+        Raises:
+            ValueError: If a filter key or value is invalid.
         """
 
-        filters_str = " AND ".join([f"{k} = {self._stringify(v)}" for k, v in filters.items()]) if filters else None
+        filters_str = self._build_filter_expression(filters)
 
         response = []
 
@@ -159,14 +202,15 @@ class UpstashVector(VectorStoreBase):
 
         Returns:
             List[OutputData]: Search results, or None if sparse/BM25 search is not supported.
-        """
-        try:
-            filters_str = (
-                " AND ".join([f"{k} = {self._stringify(v)}" for k, v in filters.items()])
-                if filters
-                else None
-            )
 
+        Raises:
+            ValueError: If a filter key or value is invalid.
+        """
+        # Built outside the try so an invalid filter raises consistently with
+        # search()/list() instead of being flattened into a `None` result.
+        filters_str = self._build_filter_expression(filters)
+
+        try:
             response = self.client.query(
                 data=query,
                 top_k=top_k,
@@ -251,8 +295,11 @@ class UpstashVector(VectorStoreBase):
             top_k (int, optional): Number of results to return. Defaults to 100.
         Returns:
             List[OutputData]: Search results.
+
+        Raises:
+            ValueError: If a filter key or value is invalid.
         """
-        filters_str = " AND ".join([f"{k} = {self._stringify(v)}" for k, v in filters.items()]) if filters else None
+        filters_str = self._build_filter_expression(filters)
 
         info = self.client.info()
         ns_info = info.namespaces.get(self.collection_name)

--- a/tests/vector_stores/test_upstash_vector.py
+++ b/tests/vector_stores/test_upstash_vector.py
@@ -418,3 +418,87 @@ def test_env_var_only_config_builds_provider(monkeypatch):
         UpstashVector(**dumped)
 
     mock_index.assert_called_once_with("https://example.upstash.io", "tok_123")
+
+
+# --- Filter expression escaping / validation (issue #5977) ---------------------
+#
+# Filter values are interpolated into Upstash's metadata filter DSL. An
+# unescaped double quote closes the string literal early, so the rest of the
+# value is parsed as filter syntax and a caller who controls one value can
+# append clauses that widen the match past the scoping filters.
+
+
+def test_search_escapes_quotes_so_a_filter_value_cannot_inject_clauses(upstash_instance):
+    upstash_instance.client.query_many.return_value = [[]]
+
+    upstash_instance.search(
+        query="q",
+        vectors=[[0.1, 0.2]],
+        top_k=5,
+        filters={"user_id": "alice", "name": 'x" OR user_id = "bob'},
+    )
+
+    sent = upstash_instance.client.query_many.call_args.kwargs["queries"][0]["filter"]
+    # The payload must stay inside its own quoted literal.
+    assert sent == 'user_id = "alice" AND name = "x\\" OR user_id = \\"bob"'
+    # Guard the actual exploit shape rather than only the exact string.
+    assert 'OR user_id = "bob"' not in sent
+
+
+def test_keyword_search_escapes_quotes_in_filter_values(upstash_instance):
+    upstash_instance.client.query.return_value = []
+
+    upstash_instance.keyword_search(query="q", top_k=5, filters={"name": 'x" OR id = "1'})
+
+    sent = upstash_instance.client.query.call_args.kwargs["filter"]
+    assert sent == 'name = "x\\" OR id = \\"1"'
+
+
+def test_list_escapes_quotes_in_filter_values(upstash_instance):
+    upstash_instance.client.info.return_value.dimension = 4
+    upstash_instance.client.info.return_value.namespaces = {"ns": MagicMock(vector_count=1)}
+    handler = MagicMock()
+    upstash_instance.client.resumable_query.return_value = ([], handler)
+    handler.fetch_next.side_effect = [[]]
+
+    upstash_instance.list(filters={"name": 'x" OR id = "1'}, top_k=5)
+
+    sent = upstash_instance.client.resumable_query.call_args.kwargs["filter"]
+    assert sent == 'name = "x\\" OR id = \\"1"'
+
+
+def test_backslash_is_escaped_before_the_quote(upstash_instance):
+    """A pre-escaped payload must not decode back into a bare delimiter."""
+    upstash_instance.client.query_many.return_value = [[]]
+
+    upstash_instance.search(query="q", vectors=[[0.1]], filters={"name": 'a\\" OR x = "1'})
+
+    sent = upstash_instance.client.query_many.call_args.kwargs["queries"][0]["filter"]
+    # The user's backslash is doubled, so it escapes itself and not our quote.
+    assert sent == 'name = "a\\\\\\" OR x = \\"1"'
+
+
+def test_ordinary_filter_values_are_unchanged(upstash_instance):
+    """Values with no `"` or `\\` must serialise exactly as before."""
+    assert upstash_instance._build_filter_expression({"age": 30, "name": "John"}) == 'age = 30 AND name = "John"'
+    assert upstash_instance._build_filter_expression(None) is None
+    assert upstash_instance._build_filter_expression({}) is None
+    assert upstash_instance._build_filter_expression({"ok": True}) == "ok = True"
+
+
+@pytest.mark.parametrize("bad_key", ["user id", "user-id", "1abc", 'a" OR b', "", "a.b"])
+def test_rejects_filter_keys_that_are_not_identifiers(upstash_instance, bad_key):
+    with pytest.raises(ValueError, match="Invalid filter key"):
+        upstash_instance._build_filter_expression({bad_key: "v"})
+
+
+@pytest.mark.parametrize("bad_value", [{"nested": 1}, ["a", "b"], object()])
+def test_rejects_non_scalar_filter_values(upstash_instance, bad_value):
+    with pytest.raises(ValueError, match="must be str, int, float, or bool"):
+        upstash_instance._build_filter_expression({"k": bad_value})
+
+
+def test_keyword_search_raises_on_invalid_filter_instead_of_returning_none(upstash_instance):
+    """keyword_search swallows provider errors into None; validation must still surface."""
+    with pytest.raises(ValueError, match="Invalid filter key"):
+        upstash_instance.keyword_search(query="q", filters={"bad key": "v"})


### PR DESCRIPTION
## Linked Issue

Closes #5977

## Description

`UpstashVector._stringify()` wrapped string filter values in double quotes without escaping them, and the `key = value AND key = value` expression was assembled inline at three separate call sites with no validation of keys or values.

A filter value containing a double quote therefore closed its own string literal early, and the remainder was parsed as Upstash filter syntax. A caller who controls a single filter value could append clauses of their own:

```python
store.search(
    query="q",
    vectors=[[0.1, 0.2]],
    filters={"user_id": "alice", "name": 'x" OR user_id = "bob'},
)
# expression sent to Upstash:
#   user_id = "alice" AND name = "x" OR user_id = "bob"
```

Upstash's filter DSL gives `AND` higher precedence than `OR` when no parentheses are present ([docs](https://upstash.com/docs/vector/features/filtering)), so that parses as `(user_id = "alice" AND name = "x") OR user_id = "bob"` and returns records belonging to another tenant. The same route also breaks non-adversarial input: an honest value such as `note='say "hi"'` produced the malformed `note = "say "hi""`.

This PR:

1. Escapes `\` and `"` in `_stringify()`, backslash first so the escape character cannot itself be forged.
2. Routes `search()`, `keyword_search()` and `list()` through a single `_build_filter_expression()`, which additionally rejects filter keys that are not identifiers (`^[a-zA-Z_][a-zA-Z0-9_]*$`) and values that are not `str`/`int`/`float`/`bool`. This covers the second half of the issue, where dict and list values previously passed through silently.

Both parts mirror the hardening already present in `milvus.py` (`_create_filter`) and `baidu.py`, which use the same `_SAFE_FILTER_KEY` regex, the same escape order and the same scalar-type `ValueError`. `upstash_vector.py` was the remaining store with no escaping of any kind.

Two deliberate scope decisions:

- `"*"` wildcard handling is **not** added here. `upstash_vector.py` has no wildcard support today, and cross-provider wildcard semantics are being handled separately in #6539 / #6540, which do not touch this file.
- `keyword_search()` builds the expression **outside** its `try/except`, so an invalid filter raises consistently with `search()`/`list()` instead of being flattened into the `None` that method returns when sparse search is unavailable. The `Raises:` section was added to all three docstrings.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

Not a breaking change for valid input. Values containing neither `"` nor `\` serialise byte-identically, so existing filter expressions are unchanged. This is covered by a test and by the fact that all 20 pre-existing tests in `test_upstash_vector.py` pass unmodified.

Filter keys that are not identifiers, and non-scalar filter values, now raise `ValueError` instead of being silently interpolated. That input could not have produced a correct Upstash expression before, so it was already broken rather than working.

## Test Coverage

- [x] I added/updated unit tests

15 new tests in `tests/vector_stores/test_upstash_vector.py`:

- injection payload escaped correctly in all three of `search()`, `keyword_search()` and `list()`
- backslash escaped before the quote, so a pre-escaped payload cannot decode back into a bare delimiter
- ordinary values serialise unchanged (regression guard for the compatibility claim above)
- filter keys rejected: `"user id"`, `"user-id"`, `"1abc"`, `'a" OR b'`, `""`, `"a.b"`
- filter values rejected: dict, list, arbitrary object
- `keyword_search()` surfaces the validation error rather than returning `None`

**Proof, red on `upstream/main` and green with the fix** (source file reverted to `upstream/main` with the new tests kept, then restored):

```
# BEFORE (upstream/main source, new tests):
$ pytest tests/vector_stores/test_upstash_vector.py -q
  15 failed, 20 passed

# AFTER (this branch):
$ pytest tests/vector_stores/test_upstash_vector.py -q
  35 passed

# Regression guards on this branch:
$ pytest tests/vector_stores/test_upstash_vector.py tests/vector_stores/test_qdrant.py -q
  131 passed
$ pytest tests/memory/ -q
  352 passed
$ ruff check mem0/vector_stores/upstash_vector.py tests/vector_stores/test_upstash_vector.py
  All checks passed!
```

The 20 pre-existing tests pass in both the red and green runs, which is what establishes that ordinary filter expressions are untouched.

One note for reviewers: `test_ordinary_filter_values_are_unchanged` fails in the red run because `_build_filter_expression` does not exist on `upstream/main`, not because the serialised output differs. It is a forward regression guard for the compatibility claim, not evidence of the bug. The 14 other new tests are load-bearing on the bug itself.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A, no public API or documented behaviour change; docstrings updated in place)
