### PR TITLE
fix(ts-sdk): restore Elasticsearch hybrid search via keywordSearch and KNN size

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/elasticsearch.ts
+++ b/mem0-ts/src/oss/src/vector_stores/elasticsearch.ts
@@ -205,7 +205,44 @@ export class ElasticsearchDB implements VectorStore {
 
     const response = await this.client.search({
       index: this.collectionName,
+      size: topK,
       ...searchBody,
+    });
+
+    return response.hits.hits.map((hit: any) => ({
+      id: hit._id,
+      score: hit._score,
+      payload: hit._source?.metadata || {},
+    }));
+  }
+
+  async keywordSearch(
+    query: string,
+    topK: number = 5,
+    filters?: SearchFilters,
+  ): Promise<VectorStoreResult[] | null> {
+    await this.initialize();
+    const boolQuery: Record<string, any> = {
+      should: [
+        { match: { "metadata.textLemmatized": query } },
+        { match: { "metadata.text_lemmatized": query } },
+        { match: { "metadata.data": query } },
+      ],
+      minimum_should_match: 1,
+    };
+
+    if (filters && Object.keys(filters).length > 0) {
+      const filterConditions = Object.entries(filters).map(([key, value]) => {
+        validateFilter(key, value);
+        return { term: { [`metadata.${key}`]: value } };
+      });
+      boolQuery.filter = filterConditions;
+    }
+
+    const response = await this.client.search({
+      index: this.collectionName,
+      size: topK,
+      query: { bool: boolQuery },
     });
 
     return response.hits.hits.map((hit: any) => ({

--- a/mem0-ts/src/oss/tests/elasticsearch.unit.test.ts
+++ b/mem0-ts/src/oss/tests/elasticsearch.unit.test.ts
@@ -269,6 +269,7 @@ describe("ElasticsearchDB", () => {
 
       expect(mockSearch).toHaveBeenCalledWith({
         index: "mem0",
+        size: 3,
         knn: {
           field: "vector",
           query_vector: [0.1, 0.2, 0.3, 0.4],
@@ -295,6 +296,7 @@ describe("ElasticsearchDB", () => {
 
       expect(mockSearch).toHaveBeenCalledWith({
         index: "mem0",
+        size: 5,
         knn: {
           field: "vector",
           query_vector: [0.1, 0.2, 0.3, 0.4],
@@ -312,6 +314,24 @@ describe("ElasticsearchDB", () => {
       });
     });
 
+    it("sets size to topK so KNN is not capped at ES default of 10", async () => {
+      const store = new ElasticsearchDB({
+        collectionName: "mem0",
+        embeddingModelDims: 4,
+        host: "localhost",
+      });
+
+      await store.search([0.1, 0.2, 0.3, 0.4], 60);
+
+      expect(mockSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: "mem0",
+          size: 60,
+          knn: expect.objectContaining({ k: 60 }),
+        }),
+      );
+    });
+
     it("rejects filter keys and values that are not safe scalars", async () => {
       const store = new ElasticsearchDB({
         collectionName: "mem0",
@@ -326,6 +346,78 @@ describe("ElasticsearchDB", () => {
         store.search([0.1, 0.2, 0.3, 0.4], 5, { user_id: { $ne: null } }),
       ).rejects.toThrow(/must be string, number, or boolean/);
       expect(mockSearch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("keywordSearch", () => {
+    it("queries metadata.textLemmatized for BM25 keyword search", async () => {
+      mockSearch.mockResolvedValue({
+        hits: {
+          hits: [
+            {
+              _id: "id-1",
+              _score: 1.2,
+              _source: {
+                metadata: { data: "test", textLemmatized: "test" },
+              },
+            },
+          ],
+        },
+      });
+
+      const store = new ElasticsearchDB({
+        collectionName: "mem0",
+        embeddingModelDims: 4,
+        host: "localhost",
+      });
+
+      const results = await store.keywordSearch("test", 5);
+
+      expect(results).toEqual([
+        {
+          id: "id-1",
+          score: 1.2,
+          payload: { data: "test", textLemmatized: "test" },
+        },
+      ]);
+
+      const searchArg = mockSearch.mock.calls[0][0];
+      expect(searchArg.index).toBe("mem0");
+      expect(searchArg.size).toBe(5);
+      expect(searchArg.query.bool.should).toEqual(
+        expect.arrayContaining([
+          { match: { "metadata.textLemmatized": "test" } },
+          { match: { "metadata.text_lemmatized": "test" } },
+          { match: { "metadata.data": "test" } },
+        ]),
+      );
+      expect(searchArg.query.bool.minimum_should_match).toBe(1);
+    });
+
+    it("applies metadata filters to keyword search", async () => {
+      const store = new ElasticsearchDB({
+        collectionName: "mem0",
+        embeddingModelDims: 4,
+        host: "localhost",
+      });
+
+      await store.keywordSearch("test", 3, { user_id: "u1" });
+
+      expect(mockSearch).toHaveBeenCalledWith({
+        index: "mem0",
+        size: 3,
+        query: {
+          bool: {
+            should: [
+              { match: { "metadata.textLemmatized": "test" } },
+              { match: { "metadata.text_lemmatized": "test" } },
+              { match: { "metadata.data": "test" } },
+            ],
+            minimum_should_match: 1,
+            filter: [{ term: { "metadata.user_id": "u1" } }],
+          },
+        },
+      });
     });
   });
 


### PR DESCRIPTION
## Linked Issue

Closes #6611 

## Description

Fixes two silent failures in the TypeScript OSS Elasticsearch adapter that broke `Memory.search()` hybrid retrieval:

1. **Missing `keywordSearch()`** — `Memory.search()` only runs BM25 when the vector store defines `keywordSearch`. The TS `ElasticsearchDB` class did not implement it, so search was semantic-only. Added `keywordSearch()` with `bool`/`match` queries on:
   - `metadata.textLemmatized` (primary TS write path)
   - `metadata.text_lemmatized` (fallback)
   - `metadata.data` (fallback)

2. **KNN capped at 10 hits** — `search()` set `knn.k` but omitted top-level `size`, so Elasticsearch defaulted to 10 results even when `Memory.search()` requested `internalLimit = max(limit * 4, 60)`. Added `size: topK` to the KNN search request.

### Files changed

- `mem0-ts/src/oss/src/vector_stores/elasticsearch.ts`
- `mem0-ts/src/oss/tests/elasticsearch.unit.test.ts`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added/updated unit tests in `elasticsearch.unit.test.ts`:
- KNN `search()` asserts top-level `size` is passed
- `keywordSearch()` asserts match queries on all three metadata text fields
- `size: 60` when `topK=60`

```bash
cd mem0-ts
pnpm run test -- --testPathPattern="elasticsearch.unit" --no-coverage
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
