### PR TITLE
fix(ts): add keywordSearch implementation to ElasticsearchDB (fixes #6611)

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/elasticsearch.ts
+++ b/mem0-ts/src/oss/src/vector_stores/elasticsearch.ts
@@ -215,6 +215,46 @@ export class ElasticsearchDB implements VectorStore {
     }));
   }
 
+  async keywordSearch(
+    query: string,
+    topK: number = 5,
+    filters?: SearchFilters,
+  ): Promise<VectorStoreResult[]> {
+    await this.initialize();
+
+    const filterConditions =
+      filters && Object.keys(filters).length > 0
+        ? Object.entries(filters).map(([key, value]) => {
+            validateFilter(key, value);
+            return { term: { [`metadata.${key}`]: value } };
+          })
+        : [];
+
+    const boolQuery: Record<string, any> = {
+      should: [
+        { match: { "metadata.data": query } },
+        { match: { "metadata.text_lemmatized": query } },
+      ],
+      minimum_should_match: 1,
+    };
+
+    if (filterConditions.length > 0) {
+      boolQuery.filter = filterConditions;
+    }
+
+    const response = await this.client.search({
+      index: this.collectionName,
+      size: topK,
+      query: { bool: boolQuery },
+    });
+
+    return response.hits.hits.map((hit: any) => ({
+      id: hit._id,
+      score: hit._score,
+      payload: hit._source?.metadata || {},
+    }));
+  }
+
   async get(vectorId: string): Promise<VectorStoreResult | null> {
     await this.initialize();
     try {

--- a/mem0-ts/src/oss/tests/elasticsearch.unit.test.ts
+++ b/mem0-ts/src/oss/tests/elasticsearch.unit.test.ts
@@ -329,6 +329,81 @@ describe("ElasticsearchDB", () => {
     });
   });
 
+  describe("keywordSearch", () => {
+    it("builds correct match query", async () => {
+      const store = new ElasticsearchDB({
+        collectionName: "mem0",
+        embeddingModelDims: 4,
+        host: "localhost",
+      });
+
+      mockSearch.mockResolvedValueOnce({
+        hits: {
+          hits: [
+            {
+              _id: "id1",
+              _score: 1.5,
+              _source: { metadata: { data: "test memory" } },
+            },
+          ],
+        },
+      });
+
+      const results = await store.keywordSearch("test", 5);
+
+      expect(mockSearch).toHaveBeenCalledWith({
+        index: "mem0",
+        size: 5,
+        query: {
+          bool: {
+            should: [
+              { match: { "metadata.data": "test" } },
+              { match: { "metadata.text_lemmatized": "test" } },
+            ],
+            minimum_should_match: 1,
+          },
+        },
+      });
+
+      expect(results).toEqual([
+        {
+          id: "id1",
+          score: 1.5,
+          payload: { data: "test memory" },
+        },
+      ]);
+    });
+
+    it("applies filters to keywordSearch", async () => {
+      const store = new ElasticsearchDB({
+        collectionName: "mem0",
+        embeddingModelDims: 4,
+        host: "localhost",
+      });
+
+      mockSearch.mockResolvedValueOnce({
+        hits: { hits: [] },
+      });
+
+      await store.keywordSearch("test", 5, { user_id: "u1" });
+
+      expect(mockSearch).toHaveBeenCalledWith({
+        index: "mem0",
+        size: 5,
+        query: {
+          bool: {
+            should: [
+              { match: { "metadata.data": "test" } },
+              { match: { "metadata.text_lemmatized": "test" } },
+            ],
+            minimum_should_match: 1,
+            filter: [{ term: { "metadata.user_id": "u1" } }],
+          },
+        },
+      });
+    });
+  });
+
   describe("get", () => {
     it("returns document by id", async () => {
       const store = new ElasticsearchDB({


### PR DESCRIPTION
## Summary
Fixes #6611.

## Changes
- Implemented `keywordSearch` method on `ElasticsearchDB` in `mem0-ts/src/oss/src/vector_stores/elasticsearch.ts`.
- Added query matching against `metadata.data` and `metadata.text_lemmatized` with filter support.
- Added comprehensive unit test coverage in `elasticsearch.unit.test.ts`.