### PR TITLE
fix(storage): add missing lock to SQLiteManager.close()

### DIFF
--- a/mem0/memory/storage.py
+++ b/mem0/memory/storage.py
@@ -339,9 +339,10 @@ class SQLiteManager:
                 raise
 
     def close(self) -> None:
-        if self.connection:
-            self.connection.close()
-            self.connection = None
+        with self._lock:
+            if self.connection:
+                self.connection.close()
+                self.connection = None
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
## Linked Issue

Closes #6619

## Description

SQLiteManager.close() was the only public method that did not acquire self._lock before touching self.connection. Under concurrency, a concurrent close() while another thread is mid-transaction can crash with AttributeError on NoneType connection, and the cascading ROLLBACK failure masks the original error.

The same risk exists via __del__ which calls close() without the lock.

**Fix:** Add `with self._lock:` to close().

## Type of Change

- [x] Bug fix

## Test Coverage

- [x] All 15 tests in tests/memory/test_storage.py pass
- [x] Ruff clean

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally