### PR TITLE
fix(embeddings/fastembed): return list[float] from embed()

### DIFF
--- a/mem0/embeddings/fastembed.py
+++ b/mem0/embeddings/fastembed.py
@@ -1,7 +1,7 @@
-from typing import Literal, Optional
+from typing import Optional, Literal
 
-from mem0.configs.embeddings.base import BaseEmbedderConfig
 from mem0.embeddings.base import EmbeddingBase
+from mem0.configs.embeddings.base import BaseEmbedderConfig
 
 try:
     from fastembed import TextEmbedding
@@ -29,4 +29,6 @@ class FastEmbedEmbedding(EmbeddingBase):
         """
         text = text.replace("\n", " ")
         embeddings = list(self.dense_model.embed(text))
-        return embeddings[0].tolist()
+        vector = embeddings[0]
+        # Contract: embedders return list[float], not numpy.ndarray (json-safe).
+        return vector.tolist() if hasattr(vector, "tolist") else list(vector)

--- a/tests/embeddings/test_fastembed_embeddings.py
+++ b/tests/embeddings/test_fastembed_embeddings.py
@@ -29,7 +29,8 @@ def test_embed_with_jina_model(mock_fastembed_client):
     embedding = embedder.embed(text)
     
     mock_fastembed_client.embed.assert_called_once_with(text)
-    assert list(embedding) == [0.1, 0.2, 0.3, 0.4, 0.5]
+    assert isinstance(embedding, list)
+    assert embedding == [0.1, 0.2, 0.3, 0.4, 0.5]
 
 
 def test_embed_removes_newlines(mock_fastembed_client):


### PR DESCRIPTION
Closes #6621

FastEmbed returned numpy arrays; other embedders return plain lists. Normalize with `tolist()` so vectors stay JSON-serializable.

**Tests:** `tests/embeddings/test_fastembed_embeddings.py` asserts `isinstance(..., list)`.