### PR TITLE
fix: deterministic search ranking ties by recency

### DIFF
--- a/mem0-ts/src/oss/src/utils/scoring.ts
+++ b/mem0-ts/src/oss/src/utils/scoring.ts
@@ -9,6 +9,26 @@
 
 export const ENTITY_BOOST_WEIGHT = 0.5;
 
+const MISSING_TIMESTAMP = -Infinity;
+
+function parseTimestamp(value: unknown): number {
+  if (value == null) {
+    return MISSING_TIMESTAMP;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : MISSING_TIMESTAMP;
+  }
+  const parsed = Date.parse(String(value));
+  return Number.isNaN(parsed) ? MISSING_TIMESTAMP : parsed / 1000;
+}
+
+function resultSortKey(a: ScoredResult): [number, number, number, string] {
+  const payload = a.payload ?? {};
+  const updatedAt = parseTimestamp(payload.updated_at);
+  const createdAt = parseTimestamp(payload.created_at);
+  return [-a.score, -updatedAt, -createdAt, a.id];
+}
+
 /**
  * Get BM25 sigmoid parameters based on query length.
  *
@@ -158,6 +178,14 @@ export function scoreAndRank(
     scored.push(entry);
   }
 
-  scored.sort((a, b) => b.score - a.score);
+  scored.sort((a, b) => {
+    const keyA = resultSortKey(a);
+    const keyB = resultSortKey(b);
+    for (let i = 0; i < keyA.length; i++) {
+      if (keyA[i] < keyB[i]) return -1;
+      if (keyA[i] > keyB[i]) return 1;
+    }
+    return 0;
+  });
   return scored.slice(0, topK);
 }

--- a/mem0-ts/src/oss/tests/scoring.test.ts
+++ b/mem0-ts/src/oss/tests/scoring.test.ts
@@ -46,4 +46,61 @@ describe("scoreAndRank", () => {
     expect(details.maxPossibleScore).toBe(1.0);
     expect(details.finalScore).toBe(0.8);
   });
+
+  it("breaks score ties by updated_at", () => {
+    const tied = [
+      {
+        id: "older",
+        score: 0.5,
+        payload: { updated_at: "2026-01-01T00:00:00Z" },
+      },
+      {
+        id: "newer",
+        score: 0.5,
+        payload: { updated_at: "2026-06-01T00:00:00Z" },
+      },
+    ];
+    const scored = scoreAndRank(tied, {}, {}, 0.1, 10);
+    expect(scored.map((r) => r.id)).toEqual(["newer", "older"]);
+  });
+
+  it("breaks updated_at ties by created_at", () => {
+    const tied = [
+      {
+        id: "older",
+        score: 0.5,
+        payload: { created_at: "2026-01-01T00:00:00Z" },
+      },
+      {
+        id: "newer",
+        score: 0.5,
+        payload: { created_at: "2026-06-01T00:00:00Z" },
+      },
+    ];
+    const scored = scoreAndRank(tied, {}, {}, 0.1, 10);
+    expect(scored.map((r) => r.id)).toEqual(["newer", "older"]);
+  });
+
+  it("breaks timestamp ties by id for stability", () => {
+    const tied = [
+      { id: "b", score: 0.5, payload: { updated_at: "2026-01-01T00:00:00Z" } },
+      { id: "a", score: 0.5, payload: { updated_at: "2026-01-01T00:00:00Z" } },
+    ];
+    const scored = scoreAndRank(tied, {}, {}, 0.1, 10);
+    expect(scored.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("treats missing or malformed timestamps as older than valid ones", () => {
+    const tied = [
+      { id: "bad", score: 0.5, payload: { updated_at: "not-a-date" } },
+      { id: "missing", score: 0.5, payload: {} },
+      {
+        id: "valid",
+        score: 0.5,
+        payload: { updated_at: "2026-01-01T00:00:00Z" },
+      },
+    ];
+    const scored = scoreAndRank(tied, {}, {}, 0.1, 10);
+    expect(scored.map((r) => r.id)).toEqual(["valid", "bad", "missing"]);
+  });
 });

--- a/mem0/utils/scoring.py
+++ b/mem0/utils/scoring.py
@@ -10,6 +10,7 @@ Provides:
 from __future__ import annotations
 
 import math
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 
@@ -55,6 +56,40 @@ def normalize_bm25(raw_score: float, midpoint: float, steepness: float) -> float
 
 
 ENTITY_BOOST_WEIGHT = 0.5
+
+_MISSING_TIMESTAMP = float("-inf")
+
+
+def _parse_timestamp(value: Any) -> float | None:
+    """Parse a timestamp value into seconds since epoch.
+
+    Accepts numeric values and ISO-formatted strings. Returns ``None`` when the
+    value is missing or cannot be parsed so callers can treat malformed
+    timestamps as older than valid ones.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, datetime):
+        return value.timestamp()
+    try:
+        return datetime.fromisoformat(str(value)).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def _result_sort_key(result: Dict[str, Any]) -> tuple[float, float, float, str]:
+    """Stable sort key for scored results.
+
+    Primary: descending combined score. Ties: descending ``updated_at``, then
+    descending ``created_at``, then ascending memory ID for determinism.
+    Missing or malformed timestamps are treated as older than valid ones.
+    """
+    payload = result.get("payload") or {}
+    updated_at = _parse_timestamp(payload.get("updated_at")) or _MISSING_TIMESTAMP
+    created_at = _parse_timestamp(payload.get("created_at")) or _MISSING_TIMESTAMP
+    return (-result["score"], -updated_at, -created_at, result["id"])
 
 
 def score_and_rank(
@@ -135,5 +170,5 @@ def score_and_rank(
             }
         scored.append(scored_result)
 
-    scored.sort(key=lambda x: x["score"], reverse=True)
+    scored.sort(key=_result_sort_key)
     return scored[:top_k]

--- a/tests/utils/test_scoring.py
+++ b/tests/utils/test_scoring.py
@@ -155,6 +155,46 @@ class TestScoreAndRank:
         scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
         assert "score_details" not in scored[0]
 
+    def test_tie_break_prefers_newer_updated_at(self):
+        results = [
+            {"id": "older", "score": 0.5, "payload": {"updated_at": "2026-01-01T00:00:00+00:00"}},
+            {"id": "newer", "score": 0.5, "payload": {"updated_at": "2026-06-01T00:00:00+00:00"}},
+        ]
+        scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
+        assert [r["id"] for r in scored] == ["newer", "older"]
+
+    def test_tie_break_prefers_newer_created_at_when_updated_equal(self):
+        results = [
+            {"id": "older", "score": 0.5, "payload": {"created_at": "2026-01-01T00:00:00+00:00"}},
+            {"id": "newer", "score": 0.5, "payload": {"created_at": "2026-06-01T00:00:00+00:00"}},
+        ]
+        scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
+        assert [r["id"] for r in scored] == ["newer", "older"]
+
+    def test_tie_break_uses_id_when_timestamps_equal(self):
+        results = [
+            {"id": "b", "score": 0.5, "payload": {"updated_at": "2026-01-01T00:00:00+00:00"}},
+            {"id": "a", "score": 0.5, "payload": {"updated_at": "2026-01-01T00:00:00+00:00"}},
+        ]
+        scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
+        assert [r["id"] for r in scored] == ["a", "b"]
+
+    def test_tie_break_treats_missing_timestamps_as_older(self):
+        results = [
+            {"id": "missing", "score": 0.5, "payload": {}},
+            {"id": "valid", "score": 0.5, "payload": {"updated_at": "2026-01-01T00:00:00+00:00"}},
+        ]
+        scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
+        assert [r["id"] for r in scored] == ["valid", "missing"]
+
+    def test_tie_break_treats_malformed_timestamps_as_older(self):
+        results = [
+            {"id": "bad", "score": 0.5, "payload": {"updated_at": "not-a-date"}},
+            {"id": "valid", "score": 0.5, "payload": {"updated_at": "2026-01-01T00:00:00+00:00"}},
+        ]
+        scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
+        assert [r["id"] for r in scored] == ["valid", "bad"]
+
 
 class TestEntityBoostWeight:
     def test_weight_value(self):


### PR DESCRIPTION
## Linked Issue

Closes #5205

## Description

Adds stable tie-breaking to `score_and_rank` (Python) and `scoreAndRank` (TypeScript) so memories with the same hybrid score are ordered deterministically. The tie-break order is:

1. newer `updated_at`
2. newer `created_at`
3. stable memory ID

Missing or malformed timestamps are treated as older than valid ones. This removes backend-order randomness without changing the relevance scoring or adding a general recency boost.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- Added Python tests in `tests/utils/test_scoring.py` and TypeScript tests in `mem0-ts/src/oss/tests/scoring.test.ts` covering equal-score ties, missing/malformed timestamps, and ID stability.
- Ran `MEM0_TELEMETRY=False hatch run pytest tests/utils/test_scoring.py` (26 passed) and `pnpm run test -- scoring.test` (8 passed).
- Ran `hatch run ruff check` and `pnpm run build` successfully.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
