### PR TITLE
fix(memory): paginate delete_all past list() top_k default

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -430,6 +430,10 @@ setup_config()
 logger = logging.getLogger(__name__)
 
 _UNSET = object()
+# Page size for delete_all pagination. Most vector stores default list() to
+# top_k=100, so a single call would silently leave later pages undeleted
+# (a privacy/GDPR hazard). Shared by the sync and async paths so they don't drift.
+_DELETE_ALL_PAGE_SIZE = 1000
 _PROJECT_UPDATE_UNSUPPORTED_ERROR = "Project updates are not supported by the OSS Memory SDK."
 
 
@@ -1887,7 +1891,7 @@ class Memory(MemoryBase):
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
         # Paginate list() — most stores default top_k=100; a single call would
         # silently leave undeleted memories past the first page (privacy risk).
-        page_size = 1000
+        page_size = _DELETE_ALL_PAGE_SIZE
         deleted_count = 0
         while True:
             memories = self.vector_store.list(filters=filters, top_k=page_size)[0]
@@ -3526,7 +3530,7 @@ class AsyncMemory(MemoryBase):
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
         # Paginate list() — most stores default top_k=100; a single call would
         # silently leave undeleted memories past the first page (privacy risk).
-        page_size = 1000
+        page_size = _DELETE_ALL_PAGE_SIZE
         deleted_ids = []
         while True:
             page = await asyncio.to_thread(
@@ -3549,9 +3553,22 @@ class AsyncMemory(MemoryBase):
                 )
                 for err in errors:
                     logger.warning("Delete error: %s", err)
-            deleted_ids.extend(
+            page_deleted = [
                 m.id for m, r in zip(memories, results) if not isinstance(r, BaseException)
-            )
+            ]
+            deleted_ids.extend(page_deleted)
+            # Zero-progress guard: gather(return_exceptions=True) swallows every
+            # failure, so a full page that all fails to delete (dropped
+            # connection, rotated creds, read-only store) would otherwise return
+            # the same rows forever and hang the call. Stop if no row in this page
+            # was actually deleted.
+            if not page_deleted:
+                logger.warning(
+                    "delete_all made no progress on a page of %d memories; "
+                    "stopping to avoid an unbounded loop",
+                    len(memories),
+                )
+                break
             if len(memories) < page_size:
                 break
 

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1885,14 +1885,23 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
-        memories = self.vector_store.list(filters=filters)[0]
-        for memory in memories:
-            self._delete_memory(memory.id)
+        # Paginate list() — most stores default top_k=100; a single call would
+        # silently leave undeleted memories past the first page (privacy risk).
+        page_size = 1000
+        deleted_count = 0
+        while True:
+            memories = self.vector_store.list(filters=filters, top_k=page_size)[0]
+            if not memories:
+                break
+            for memory in memories:
+                self._delete_memory(memory.id)
+            deleted_count += len(memories)
+            if len(memories) < page_size:
+                break
 
-        logger.info(f"Deleted {len(memories)} memories")
+        logger.info(f"Deleted {deleted_count} memories")
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories))
+        decay_usage_notice = detect_decay_usage_from_delete_all(deleted_count)
         if decay_usage_notice:
             display_decay_usage_notice(self, "sync", "delete_all", *decay_usage_notice)
         else:
@@ -3515,26 +3524,43 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
-
-        delete_tasks = []
-        for memory in memories[0]:
-            delete_tasks.append(self._delete_memory(memory.id, skip_entity_cleanup=True))
-
-        results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+        # Paginate list() — most stores default top_k=100; a single call would
+        # silently leave undeleted memories past the first page (privacy risk).
+        page_size = 1000
+        deleted_ids = []
+        while True:
+            page = await asyncio.to_thread(
+                self.vector_store.list, filters=filters, top_k=page_size
+            )
+            memories = page[0]
+            if not memories:
+                break
+            delete_tasks = [
+                self._delete_memory(memory.id, skip_entity_cleanup=True)
+                for memory in memories
+            ]
+            results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+            errors = [r for r in results if isinstance(r, BaseException)]
+            if errors:
+                logger.warning(
+                    "Failed to delete %d out of %d memories in page",
+                    len(errors),
+                    len(results),
+                )
+                for err in errors:
+                    logger.warning("Delete error: %s", err)
+            deleted_ids.extend(
+                m.id for m, r in zip(memories, results) if not isinstance(r, BaseException)
+            )
+            if len(memories) < page_size:
+                break
 
         if self._entity_store is not None:
             await self._bulk_clear_entity_store(filters)
 
-        errors = [r for r in results if isinstance(r, BaseException)]
-        if errors:
-            logger.warning("Failed to delete %d out of %d memories", len(errors), len(results))
-            for err in errors:
-                logger.warning("Delete error: %s", err)
+        logger.info(f"Deleted {len(deleted_ids)} memories")
 
-        logger.info(f"Deleted {len(results) - len(errors)} memories")
-
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories[0]))
+        decay_usage_notice = detect_decay_usage_from_delete_all(len(deleted_ids))
         if decay_usage_notice:
             await display_decay_usage_notice_async(self, "async", "delete_all", *decay_usage_notice)
         else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from mem0.configs.base import MemoryConfig
-from mem0.memory.main import Memory, _validate_and_trim_entity_id
+from mem0.memory.main import AsyncMemory, Memory, _validate_and_trim_entity_id
 
 
 @pytest.fixture(autouse=True)
@@ -307,6 +307,73 @@ def test_delete_all_paginates_beyond_default_top_k(memory_instance):
     memory_instance.vector_store.list.assert_any_call(filters={"user_id": "test_user"}, top_k=1000)
     assert memory_instance._delete_memory.call_count == 1050
     memory_instance.vector_store.reset.assert_not_called()
+    assert result["message"] == "Memories deleted successfully!"
+
+
+@pytest.fixture
+def async_memory_instance():
+    with (
+        patch("mem0.utils.factory.EmbedderFactory") as mock_embedder,
+        patch("mem0.memory.main.VectorStoreFactory") as mock_vector_store,
+        patch("mem0.utils.factory.LlmFactory") as mock_llm,
+        patch("mem0.memory.telemetry.capture_event"),
+    ):
+        mock_embedder.create.return_value = Mock()
+        mock_vector_store.create.return_value = Mock()
+        mock_vector_store.create.return_value.search.return_value = []
+        mock_llm.create.return_value = Mock()
+
+        config = MemoryConfig(version="v1.1")
+        instance = AsyncMemory(config)
+        instance._entity_store = None
+        return instance
+
+
+@pytest.mark.asyncio
+async def test_async_delete_all_paginates_beyond_default_top_k(async_memory_instance):
+    """AsyncMemory.delete_all must page through list() past the default top_k."""
+    page1 = [Mock(id=str(i)) for i in range(1000)]
+    page2 = [Mock(id=str(i)) for i in range(1000, 1050)]
+    async_memory_instance.vector_store.list = Mock(side_effect=[(page1, None), (page2, None)])
+    async_memory_instance.vector_store.reset = Mock()
+
+    async def _ok_delete(memory_id, skip_entity_cleanup=False):
+        return None
+
+    async_memory_instance._delete_memory = Mock(side_effect=_ok_delete)
+
+    result = await async_memory_instance.delete_all(user_id="test_user")
+
+    assert async_memory_instance.vector_store.list.call_count == 2
+    assert async_memory_instance._delete_memory.call_count == 1050
+    async_memory_instance.vector_store.reset.assert_not_called()
+    assert result["message"] == "Memories deleted successfully!"
+
+
+@pytest.mark.asyncio
+async def test_async_delete_all_stops_when_page_makes_no_progress(async_memory_instance):
+    """A full page that all fails to delete must not loop forever.
+
+    gather(return_exceptions=True) swallows every failure, so without a
+    zero-progress guard list() would keep returning the same 1000 rows and
+    the call would hang. The guard must break after one non-progressing page.
+    """
+    page = [Mock(id=str(i)) for i in range(1000)]
+    # list() would return the same full page forever if we didn't stop.
+    async_memory_instance.vector_store.list = Mock(return_value=(page, None))
+    async_memory_instance.vector_store.reset = Mock()
+
+    async def _always_fail(memory_id, skip_entity_cleanup=False):
+        raise ConnectionError("store went read-only")
+
+    async_memory_instance._delete_memory = Mock(side_effect=_always_fail)
+
+    result = await async_memory_instance.delete_all(user_id="test_user")
+
+    # One page attempted, then bail — not an unbounded loop.
+    assert async_memory_instance.vector_store.list.call_count == 1
+    assert async_memory_instance._delete_memory.call_count == 1000
+    async_memory_instance.vector_store.reset.assert_not_called()
     assert result["message"] == "Memories deleted successfully!"
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -293,6 +293,23 @@ def test_delete_all(memory_instance):
     assert result["message"] == "Memories deleted successfully!"
 
 
+def test_delete_all_paginates_beyond_default_top_k(memory_instance):
+    """delete_all must page through list(); default top_k=100 must not cap deletes."""
+    page1 = [Mock(id=str(i)) for i in range(1000)]
+    page2 = [Mock(id=str(i)) for i in range(1000, 1050)]
+    memory_instance.vector_store.list = Mock(side_effect=[(page1, None), (page2, None)])
+    memory_instance.vector_store.reset = Mock()
+    memory_instance._delete_memory = Mock()
+
+    result = memory_instance.delete_all(user_id="test_user")
+
+    assert memory_instance.vector_store.list.call_count == 2
+    memory_instance.vector_store.list.assert_any_call(filters={"user_id": "test_user"}, top_k=1000)
+    assert memory_instance._delete_memory.call_count == 1050
+    memory_instance.vector_store.reset.assert_not_called()
+    assert result["message"] == "Memories deleted successfully!"
+
+
 def test_get_all(memory_instance):
     mock_memories = [Mock(id="1", payload={"data": "Memory 1", "user_id": "test_user"})]
     memory_instance.vector_store.list = Mock(return_value=(mock_memories, None))
@@ -431,7 +448,9 @@ class TestEntityIdValidation:
 
         memory_instance.delete_all(user_id="  alice  ")
 
-        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "alice"})
+        memory_instance.vector_store.list.assert_called_once_with(
+            filters={"user_id": "alice"}, top_k=1000
+        )
 
     def test_validate_coerces_non_string_entity_id(self):
         """Integer (and other non-string) ids are coerced to str, not crashed on."""
@@ -444,7 +463,9 @@ class TestEntityIdValidation:
 
         memory_instance.delete_all(user_id=42)
 
-        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "42"})
+        memory_instance.vector_store.list.assert_called_once_with(
+            filters={"user_id": "42"}, top_k=1000
+        )
 
     def test_get_all_coerces_integer_user_id(self, memory_instance):
         """get_all should accept an integer user_id in filters and scope by its str form."""


### PR DESCRIPTION
## Summary
`delete_all()` only deleted the first page of `vector_store.list()` (default `top_k=100`) but still returned success.

## Motivation
Closes #6627. Silent partial delete is a data-retention/privacy hazard.

## Fix
Page `list(filters=..., top_k=1000)` until a short/empty page in sync and async `Memory.delete_all`.

## Verification
`pytest tests/test_main.py::test_delete_all tests/test_main.py::test_delete_all_paginates_beyond_default_top_k` (+ entity-id delete_all cases) — passed.