### PR TITLE
fix(memory): delete_all() now enumerates the full ID set, not just the first page

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1885,8 +1885,11 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
-        memories = self.vector_store.list(filters=filters)[0]
+        # delete all vector memories and reset the collections.
+        # `list()` defaults to top_k=100 on most vector stores, which would
+        # silently leave memories beyond the first page undeleted. Pass the
+        # same large cap used elsewhere for full enumeration (#6627).
+        memories = self.vector_store.list(filters=filters, top_k=10000)[0]
         for memory in memories:
             self._delete_memory(memory.id)
 
@@ -3515,7 +3518,10 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
+        # `list()` defaults to top_k=100 on most vector stores, which would
+        # silently leave memories beyond the first page undeleted. Pass the
+        # same large cap used elsewhere for full enumeration (#6627).
+        memories = await asyncio.to_thread(self.vector_store.list, filters=filters, top_k=10000)
 
         delete_tasks = []
         for memory in memories[0]:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1005,6 +1005,60 @@ async def test_async_delete_all_continues_on_partial_failure(mock_sqlite, mock_l
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')
 @patch('mem0.memory.storage.SQLiteManager')
+def test_delete_all_enumerates_beyond_default_page(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+    """Regression test for #6627.
+
+    delete_all() must request the full ID set from the vector store, not the
+    default first page (top_k=100 on most stores), or memories beyond the page
+    are silently left undeleted.
+    """
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+    config = MemoryConfig()
+    memory = MemoryClass(config)
+
+    mock_vector_store.list.return_value = [[]]
+
+    memory.delete_all(user_id="test-user")
+
+    _, kwargs = mock_vector_store.list.call_args
+    assert kwargs.get("top_k") == 10000
+
+
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+async def test_async_delete_all_enumerates_beyond_default_page(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+    """Async counterpart of the #6627 regression test."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import AsyncMemory
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+
+    mock_vector_store.list.return_value = ([],)
+
+    await memory.delete_all(user_id="test-user")
+
+    _, kwargs = mock_vector_store.list.call_args
+    assert kwargs.get("top_k") == 10000
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
 class TestProcessMetadataFiltersMerge:
     """Regression tests for issue #3952: multiple operators on the same key must be merged."""
 


### PR DESCRIPTION
## Summary

Fixes #6627

`Memory.delete_all()` and `AsyncMemory.delete_all()` fetched the IDs to delete via `vector_store.list(filters=filters)` **without passing `top_k`**. Most vector stores default `list(top_k)` to 100, so `delete_all()` silently deleted only the first 100 memories for a scope and left the rest behind — while still returning `{"message": "Memories deleted successfully!"}`.

This is a data-retention / privacy hazard: a GDPR right-to-be-forgotten request can appear to succeed while personal data remains in the store.

## Fix

Pass `top_k=10000` to `vector_store.list()`, matching the full-enumeration cap already used for `entity_store.list()` in five other places in this module:

```python
# sync
memories = self.vector_store.list(filters=filters, top_k=10000)[0]
# async
memories = await asyncio.to_thread(self.vector_store.list, filters=filters, top_k=10000)
```

## Tests

Added sync + async regression tests asserting `top_k=10000` is forwarded to the vector store.

```
$ pytest tests/test_memory.py -k delete_all -q
4 passed   # 2 new + 2 existing, no regression
```

Verified both new tests **fail** on the unfixed code and **pass** with the fix.