### PR TITLE
feat(openai): support custom chat headers

### DIFF
--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -31,6 +31,7 @@ class OpenAIConfig(BaseLlmConfig):
         site_url: Optional[str] = None,
         app_name: Optional[str] = None,
         store: Optional[bool] = None,
+        extra_headers: Optional[dict] = None,
         # Response monitoring callback
         response_callback: Optional[Callable[[Any, dict, dict], None]] = None,
     ):
@@ -87,6 +88,7 @@ class OpenAIConfig(BaseLlmConfig):
         self.site_url = site_url
         self.app_name = app_name
         self.store = store
+        self.extra_headers = extra_headers
 
         # Response monitoring
         self.response_callback = response_callback

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -32,6 +32,7 @@ class OpenAILLM(LLMBase):
                 reasoning_effort=getattr(config, 'reasoning_effort', None),
                 http_client_proxies=config.http_client_proxies,
                 is_reasoning_model=getattr(config, 'is_reasoning_model', None),
+                extra_headers=getattr(config, "extra_headers", None),
             )
 
         super().__init__(config)
@@ -39,18 +40,27 @@ class OpenAILLM(LLMBase):
         if not self.config.model:
             self.config.model = "gpt-5-mini"
 
+        extra_headers = dict(self.config.extra_headers or {})
         if os.environ.get("OPENROUTER_API_KEY"):  # Use OpenRouter
-            self.client = OpenAI(
-                api_key=os.environ.get("OPENROUTER_API_KEY"),
-                base_url=self.config.openrouter_base_url
+            if self.config.site_url and self.config.app_name:
+                extra_headers.update({
+                    "HTTP-Referer": self.config.site_url,
+                    "X-Title": self.config.app_name,
+                })
+            client_kwargs = {
+                "api_key": os.environ.get("OPENROUTER_API_KEY"),
+                "base_url": self.config.openrouter_base_url
                 or os.getenv("OPENROUTER_API_BASE")
                 or "https://openrouter.ai/api/v1",
-            )
+            }
         else:
             api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
             base_url = self.config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
+            client_kwargs = {"api_key": api_key, "base_url": base_url}
 
-            self.client = OpenAI(api_key=api_key, base_url=base_url)
+        if extra_headers:
+            client_kwargs["default_headers"] = extra_headers
+        self.client = OpenAI(**client_kwargs)
 
     def _parse_response(self, response, tools):
         """

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -42,6 +42,38 @@ def test_openai_llm_base_url():
     assert str(llm.client.base_url) == config_base_url + "/"
 
 
+def test_openai_llm_passes_custom_headers_to_chat_client():
+    with patch("mem0.llms.openai.OpenAI") as mock_openai:
+        OpenAILLM(
+            OpenAIConfig(
+                model="gpt-4.1-nano-2025-04-14",
+                api_key="api_key",
+                extra_headers={"Helicone-Auth": "Bearer token"},
+            )
+        )
+
+        assert mock_openai.call_args.kwargs["default_headers"] == {"Helicone-Auth": "Bearer token"}
+
+
+def test_openrouter_headers_merge_with_custom_headers(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "router-key")
+    with patch("mem0.llms.openai.OpenAI") as mock_openai:
+        OpenAILLM(
+            OpenAIConfig(
+                model="openai/gpt-4o",
+                site_url="https://example.com",
+                app_name="Mem0 test",
+                extra_headers={"Helicone-Auth": "Bearer token"},
+            )
+        )
+
+        assert mock_openai.call_args.kwargs["default_headers"] == {
+            "Helicone-Auth": "Bearer token",
+            "HTTP-Referer": "https://example.com",
+            "X-Title": "Mem0 test",
+        }
+
+
 def test_generate_response_without_tools(mock_openai_client):
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0)
     llm = OpenAILLM(config)


### PR DESCRIPTION
## Summary

- add optional `extra_headers` to the OpenAI LLM configuration
- pass custom headers to OpenAI chat-completion clients
- merge OpenRouter `HTTP-Referer` and `X-Title` headers without dropping user headers
- add regression coverage for both standard OpenAI and OpenRouter clients

## Motivation

This addresses #3851. Applications using observability or proxy services such as Helicone need custom headers on chat-completion requests without monkey-patching the OpenAI client. The configuration remains optional and does not affect embedding clients.

## Validation

- `python -m pytest tests/llms/test_openai.py -q` (23 passed)
- `python -m compileall -q mem0/configs/llms/openai.py mem0/llms/openai.py`
- `git diff origin/main --check`

This is an agent-assisted contribution with a focused, auditable commit.