### PR TITLE
fix(telemetry): return consistent filter tuple

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -227,7 +227,7 @@ def process_telemetry_filters(filters):
     Process the telemetry filters
     """
     if filters is None:
-        return {}
+        return [], {}
 
     encoded_ids = {}
     if "user_id" in filters:

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 from mem0.memory.utils import (
     parse_messages,
     parse_vision_messages,
+    process_telemetry_filters,
     remove_spaces_from_entities,
     sanitize_relationship_for_cypher,
 )
@@ -32,6 +33,17 @@ class TestParseMessages:
             {"role": "assistant", "content": "a"},
         ]
         assert parse_messages(messages) == "system: sys\nuser: u\nassistant: a\n"
+
+
+class TestProcessTelemetryFilters:
+    def test_none_returns_empty_tuple_parts(self):
+        assert process_telemetry_filters(None) == ([], {})
+
+    def test_filters_returns_keys_and_hashed_entity_ids(self):
+        keys, encoded_ids = process_telemetry_filters({"user_id": "user-1", "topic": "notes"})
+
+        assert keys == ["user_id", "topic"]
+        assert encoded_ids == {"user_id": "d6d7705392bc7af633328bea8c4c6904"}
 
 
 class TestParseVisionMessages:


### PR DESCRIPTION
## Summary

- return `([], {})` when telemetry filters are absent
- add regression coverage for the empty-filter and hashed-ID paths

## Why

This fixes #6171. All callers unpack `process_telemetry_filters()` as `(keys, encoded_ids)`, but `None` previously returned a dictionary, causing a runtime unpacking error whenever a telemetry call had no filters.

## Validation

- `python -m pytest tests/memory/test_memory_utils.py -q` (21 passed)
- `python -m compileall -q mem0/memory/utils.py tests/memory/test_memory_utils.py`
- `git diff origin/main --check`

This is an agent-assisted contribution with a focused, auditable commit.