### PR TITLE
fix(azure-mysql): compare JSON filter scalars

### DIFF
--- a/mem0/vector_stores/azure_mysql.py
+++ b/mem0/vector_stores/azure_mysql.py
@@ -297,8 +297,8 @@ class AzureMySQL(VectorStoreBase):
                 if not _VALID_FILTER_KEY.match(k):
                     logger.warning("Skipping invalid filter key: %r", k)
                     continue
-                filter_conditions.append("JSON_EXTRACT(payload, %s) = %s")
-                filter_params.extend([f"$.{k}", json.dumps(v)])
+                filter_conditions.append("JSON_UNQUOTE(JSON_EXTRACT(payload, %s)) = %s")
+                filter_params.extend([f"$.{k}", v])
 
         filter_clause = "WHERE " + " AND ".join(filter_conditions) if filter_conditions else ""
 
@@ -356,8 +356,8 @@ class AzureMySQL(VectorStoreBase):
                     if not _VALID_FILTER_KEY.match(k):
                         logger.warning("Skipping invalid filter key: %r", k)
                         continue
-                    filter_conditions.append("JSON_EXTRACT(payload, %s) = %s")
-                    filter_params.extend([f"$.{k}", json.dumps(v)])
+                    filter_conditions.append("JSON_UNQUOTE(JSON_EXTRACT(payload, %s)) = %s")
+                    filter_params.extend([f"$.{k}", v])
 
             filter_clause = ""
             if filter_conditions:
@@ -515,8 +515,8 @@ class AzureMySQL(VectorStoreBase):
                 if not _VALID_FILTER_KEY.match(k):
                     logger.warning("Skipping invalid filter key: %r", k)
                     continue
-                filter_conditions.append("JSON_EXTRACT(payload, %s) = %s")
-                filter_params.extend([f"$.{k}", json.dumps(v)])
+                filter_conditions.append("JSON_UNQUOTE(JSON_EXTRACT(payload, %s)) = %s")
+                filter_params.extend([f"$.{k}", v])
 
         filter_clause = "WHERE " + " AND ".join(filter_conditions) if filter_conditions else ""
 

--- a/tests/vector_stores/test_azure_mysql.py
+++ b/tests/vector_stores/test_azure_mysql.py
@@ -321,6 +321,15 @@ class TestAzureMySQLFilterKeySanitization:
         blob = self._executed_blob(azure_mysql_instance)
         assert "$.user_id" in blob and "OR '1'='1" not in blob
 
+    def test_search_unquotes_json_scalars_before_comparing(self, azure_mysql_instance):
+        azure_mysql_instance.search(query="q", vectors=[0.1, 0.2, 0.3], filters={"user_id": "u1"})
+        cursor = azure_mysql_instance.connection_pool.connection().cursor()
+        sql, params = cursor.execute.call_args.args
+
+        assert "JSON_UNQUOTE(JSON_EXTRACT(payload, %s))" in sql
+        assert list(params[:2]) == ["$.user_id", "u1"]
+        assert '"u1"' not in params
+
     def test_keyword_search_drops_invalid_key(self, azure_mysql_instance):
         azure_mysql_instance.keyword_search(query="q", filters=self._FILTERS)
         blob = self._executed_blob(azure_mysql_instance)


### PR DESCRIPTION
## Summary

- compare Azure MySQL JSON payload scalars using `JSON_UNQUOTE`
- bind native filter values instead of `json.dumps()` strings
- apply the fix consistently to vector search, keyword search, and list
- add regression coverage for string filter parameters

## Why

This addresses #6178. The previous implementation bound a string filter such as `user_id=u1` as the JSON text `u1`, so scoped filters did not match stored JSON string values and returned empty results.

## Validation

- `python -m pytest tests/vector_stores/test_azure_mysql.py -q` (25 passed, 1 skipped)
- `python -m compileall -q mem0/vector_stores/azure_mysql.py tests/vector_stores/test_azure_mysql.py`
- `git diff origin/main --check`

This is an agent-assisted contribution with a focused, auditable commit.