### PR TITLE
fix(client): honor host environment overrides

### DIFF
--- a/mem0/client/main.py
+++ b/mem0/client/main.py
@@ -38,6 +38,12 @@ setup_config()
 
 # Entity parameters that must be passed via filters, not top-level
 ENTITY_PARAMS = frozenset({"user_id", "agent_id", "app_id", "run_id"})
+DEFAULT_HOST = "https://api.mem0.ai"
+
+
+def _resolve_host(host: Optional[str]) -> str:
+    """Resolve an explicit host, environment override, or public default."""
+    return host or os.getenv("MEM0_HOST") or os.getenv("MEM0_API_URL") or DEFAULT_HOST
 
 
 def _validate_and_trim_search_query(query: str) -> str:
@@ -104,8 +110,8 @@ class MemoryClient:
             api_key: The API key for authenticating with the Mem0 API. If not
                      provided, it will attempt to use the MEM0_API_KEY
                      environment variable.
-            host: The base URL for the Mem0 API. Defaults to
-                  "https://api.mem0.ai".
+            host: The base URL for the Mem0 API. When omitted, ``MEM0_HOST``
+                  then ``MEM0_API_URL`` are checked before the public default.
             client: A custom httpx.Client instance. If provided, it will be
                     used instead of creating a new one. Note that base_url and
                     headers will be set/overridden as needed.
@@ -114,7 +120,7 @@ class MemoryClient:
             ValueError: If no API key is provided or found in the environment.
         """
         self.api_key = api_key or os.getenv("MEM0_API_KEY")
-        self.host = host or "https://api.mem0.ai"
+        self.host = _resolve_host(host)
         self.org_id = None
         self.project_id = None
         self.user_id = get_user_id()
@@ -993,8 +999,8 @@ class AsyncMemoryClient:
             api_key: The API key for authenticating with the Mem0 API. If not
                      provided, it will attempt to use the MEM0_API_KEY
                      environment variable.
-            host: The base URL for the Mem0 API. Defaults to
-                  "https://api.mem0.ai".
+            host: The base URL for the Mem0 API. When omitted, ``MEM0_HOST``
+                  then ``MEM0_API_URL`` are checked before the public default.
             client: A custom httpx.AsyncClient instance. If provided, it will
                     be used instead of creating a new one. Note that base_url
                     and headers will be set/overridden as needed.
@@ -1003,7 +1009,7 @@ class AsyncMemoryClient:
             ValueError: If no API key is provided or found in the environment.
         """
         self.api_key = api_key or os.getenv("MEM0_API_KEY")
-        self.host = host or "https://api.mem0.ai"
+        self.host = _resolve_host(host)
         self.org_id = None
         self.project_id = None
         self.user_id = get_user_id()

--- a/tests/test_client_host_env.py
+++ b/tests/test_client_host_env.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _ping_response():
+    response = MagicMock()
+    response.json.return_value = {
+        "org_id": "org-test",
+        "project_id": "project-test",
+        "user_email": "test@example.com",
+    }
+    response.raise_for_status.return_value = None
+    return response
+
+
+@pytest.fixture(autouse=True)
+def isolate_host_environment(monkeypatch):
+    monkeypatch.delenv("MEM0_HOST", raising=False)
+    monkeypatch.delenv("MEM0_API_URL", raising=False)
+    monkeypatch.setenv("MEM0_API_KEY", "test-api-key")
+
+
+def test_memory_client_prefers_explicit_host_over_environment(monkeypatch):
+    monkeypatch.setenv("MEM0_HOST", "https://host.example.com")
+    monkeypatch.setenv("MEM0_API_URL", "https://api-url.example.com")
+
+    with (
+        patch("mem0.client.main.httpx.Client") as client_factory,
+        patch("mem0.client.main.capture_client_event"),
+    ):
+        client_factory.return_value.get.return_value = _ping_response()
+        from mem0.client.main import MemoryClient
+
+        client = MemoryClient(host="https://explicit.example.com")
+
+    assert client.host == "https://explicit.example.com"
+    assert client_factory.call_args.kwargs["base_url"] == "https://explicit.example.com"
+
+
+@pytest.mark.parametrize(
+    ("host_env", "api_url_env", "expected"),
+    [
+        ("https://host.example.com", "https://api-url.example.com", "https://host.example.com"),
+        (None, "https://api-url.example.com", "https://api-url.example.com"),
+        (None, None, "https://api.mem0.ai"),
+    ],
+)
+def test_memory_client_resolves_host_from_environment(
+    monkeypatch, host_env, api_url_env, expected
+):
+    if host_env is not None:
+        monkeypatch.setenv("MEM0_HOST", host_env)
+    if api_url_env is not None:
+        monkeypatch.setenv("MEM0_API_URL", api_url_env)
+
+    with (
+        patch("mem0.client.main.httpx.Client") as client_factory,
+        patch("mem0.client.main.capture_client_event"),
+    ):
+        client_factory.return_value.get.return_value = _ping_response()
+        from mem0.client.main import MemoryClient
+
+        client = MemoryClient()
+
+    assert client.host == expected
+    assert client_factory.call_args.kwargs["base_url"] == expected
+
+
+def test_async_memory_client_uses_the_same_environment_precedence(monkeypatch):
+    monkeypatch.setenv("MEM0_HOST", "https://host.example.com")
+    monkeypatch.setenv("MEM0_API_URL", "https://api-url.example.com")
+
+    with (
+        patch("mem0.client.main.httpx.AsyncClient") as client_factory,
+        patch("mem0.client.main.requests.get", return_value=_ping_response()),
+        patch("mem0.client.main.capture_client_event"),
+    ):
+        from mem0.client.main import AsyncMemoryClient
+
+        client = AsyncMemoryClient()
+
+    assert client.host == "https://host.example.com"
+    assert client_factory.call_args.kwargs["base_url"] == "https://host.example.com"


### PR DESCRIPTION
## Summary

- resolve `MemoryClient` and `AsyncMemoryClient` hosts from `MEM0_HOST` or `MEM0_API_URL` when no explicit host is provided
- preserve explicit `host` precedence and the existing public API default
- add focused tests covering precedence, fallback, and sync/async parity

Closes #6622

## Validation

- `python -m pytest tests/test_client_host_env.py -q` (5 passed)
- `python -m compileall -q mem0/client/main.py tests/test_client_host_env.py`
- `git diff --check`
