### PR TITLE
fix(embeddings): normalize fastembed vectors to lists

### DIFF
--- a/mem0/embeddings/fastembed.py
+++ b/mem0/embeddings/fastembed.py
@@ -29,4 +29,7 @@ class FastEmbedEmbedding(EmbeddingBase):
         """
         text = text.replace("\n", " ")
         embeddings = list(self.dense_model.embed(text))
-        return embeddings[0]
+        vector = embeddings[0]
+        # FastEmbed commonly returns a numpy array, but callers expect the
+        # JSON-serializable list contract shared by every other embedder.
+        return vector.tolist() if hasattr(vector, "tolist") else list(vector)

--- a/tests/embeddings/test_fastembed_embeddings.py
+++ b/tests/embeddings/test_fastembed_embeddings.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import Mock, patch
 
 import pytest
@@ -29,7 +30,9 @@ def test_embed_with_jina_model(mock_fastembed_client):
     embedding = embedder.embed(text)
     
     mock_fastembed_client.embed.assert_called_once_with(text)
-    assert list(embedding) == [0.1, 0.2, 0.3, 0.4, 0.5]
+    assert embedding == [0.1, 0.2, 0.3, 0.4, 0.5]
+    assert isinstance(embedding, list)
+    json.dumps(embedding)
 
 
 def test_embed_removes_newlines(mock_fastembed_client):
@@ -43,4 +46,15 @@ def test_embed_removes_newlines(mock_fastembed_client):
     embedding = embedder.embed(text_with_newlines)
     
     mock_fastembed_client.embed.assert_called_once_with("Hello world")
-    assert list(embedding) == [0.7, 0.8, 0.9]
+    assert embedding == [0.7, 0.8, 0.9]
+
+
+def test_embed_normalizes_iterable_without_tolist(mock_fastembed_client):
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=3)
+    embedder = FastEmbedEmbedding(config)
+    mock_fastembed_client.embed.return_value = iter([(0.1, 0.2, 0.3)])
+
+    embedding = embedder.embed("Sample text")
+
+    assert embedding == [0.1, 0.2, 0.3]
+    assert isinstance(embedding, list)


### PR DESCRIPTION
## Summary

- normalize FastEmbed vectors to plain Python lists before returning them from `embed()`
- support both numpy-like vectors with `tolist()` and generic iterables
- strengthen regression tests with list-type and JSON-serialization assertions

Closes #6621

## Validation

- `python -m pytest tests/embeddings/test_fastembed_embeddings.py -q` (skipped because optional `fastembed` is not installed here)
- mocked FastEmbed normalization smoke test passed, including `json.dumps`
- `python -m compileall -q mem0/embeddings/fastembed.py tests/embeddings/test_fastembed_embeddings.py`
- `git diff --check`
