### PR TITLE
fix(storage): synchronize SQLiteManager close

### DIFF
--- a/mem0/memory/storage.py
+++ b/mem0/memory/storage.py
@@ -339,9 +339,10 @@ class SQLiteManager:
                 raise
 
     def close(self) -> None:
-        if self.connection:
-            self.connection.close()
-            self.connection = None
+        with self._lock:
+            if self.connection:
+                self.connection.close()
+                self.connection = None
 
     def __del__(self):
         self.close()

--- a/tests/memory/test_storage.py
+++ b/tests/memory/test_storage.py
@@ -3,6 +3,7 @@ import sqlite3
 import tempfile
 import uuid
 from datetime import datetime
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -66,6 +67,16 @@ class TestSQLiteManager:
         assert manager.connection is not None
         assert manager.db_path == db_path
         manager.close()
+
+    def test_close_acquires_connection_lock(self, memory_manager):
+        lock = MagicMock()
+        memory_manager._lock = lock
+
+        memory_manager.close()
+
+        lock.__enter__.assert_called_once_with()
+        lock.__exit__.assert_called_once()
+        assert memory_manager.connection is None
 
     def test_table_schema_creation(self, sqlite_manager):
         """Test that history table is created with correct schema."""


### PR DESCRIPTION
## Summary

- serialize `SQLiteManager.close()` with the existing transaction lock
- prevent concurrent close/transaction races from observing a half-closed connection
- add regression coverage proving the lock is acquired and the connection is cleared

Closes #6619

## Validation

- `python -m pytest tests/memory/test_storage.py -q` (16 passed)
- `python -m compileall -q mem0/memory/storage.py tests/memory/test_storage.py`
- `git diff --check`
