### PR TITLE
fix(ts-sdk): add Elasticsearch hybrid keyword search

### DIFF
--- a/mem0-ts/src/oss/src/tests/elasticsearch.test.ts
+++ b/mem0-ts/src/oss/src/tests/elasticsearch.test.ts
@@ -1,0 +1,83 @@
+import { ElasticsearchDB } from "../vector_stores/elasticsearch";
+
+describe("Elasticsearch Vector Store", () => {
+  const search = jest.fn();
+  const client = {
+    indices: {
+      exists: jest.fn().mockResolvedValue(true),
+    },
+    search,
+  };
+
+  let store: ElasticsearchDB;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    store = new ElasticsearchDB({
+      client,
+      collectionName: "memories",
+      embeddingModelDims: 3,
+      autoCreateIndex: false,
+    });
+    await store.initialize();
+  });
+
+  it("sets the top-level size to the KNN candidate count", async () => {
+    search.mockResolvedValueOnce({
+      hits: {
+        hits: [{ _id: "memory-1", _score: 0.9, _source: { metadata: {} } }],
+      },
+    });
+
+    await store.search([0.1, 0.2, 0.3], 80);
+
+    expect(search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        index: "memories",
+        size: 80,
+        knn: expect.objectContaining({ k: 80 }),
+      }),
+    );
+  });
+
+  it("runs keyword search over the stored text fields and applies filters", async () => {
+    search.mockResolvedValueOnce({
+      hits: {
+        hits: [
+          {
+            _id: "memory-1",
+            _score: 1.2,
+            _source: { metadata: { data: "Berlin engineer" } },
+          },
+        ],
+      },
+    });
+
+    const results = await store.keywordSearch("Berlin engineer", 7, {
+      user_id: "user-1",
+    });
+
+    expect(results).toEqual([
+      {
+        id: "memory-1",
+        score: 1.2,
+        payload: { data: "Berlin engineer" },
+      },
+    ]);
+    expect(search).toHaveBeenCalledWith({
+      index: "memories",
+      size: 7,
+      query: {
+        bool: {
+          should: [
+            { match: { "metadata.data": "Berlin engineer" } },
+            { match: { "metadata.text_lemmatized": "Berlin engineer" } },
+            { match: { "metadata.textLemmatized": "Berlin engineer" } },
+          ],
+          minimum_should_match: 1,
+          filter: [{ term: { "metadata.user_id": "user-1" } }],
+        },
+      },
+    });
+  });
+});

--- a/mem0-ts/src/oss/src/vector_stores/elasticsearch.ts
+++ b/mem0-ts/src/oss/src/vector_stores/elasticsearch.ts
@@ -187,6 +187,7 @@ export class ElasticsearchDB implements VectorStore {
   ): Promise<VectorStoreResult[]> {
     await this.initialize();
     const searchBody: Record<string, any> = {
+      size: topK,
       knn: {
         field: "vector",
         query_vector: query,
@@ -206,6 +207,41 @@ export class ElasticsearchDB implements VectorStore {
     const response = await this.client.search({
       index: this.collectionName,
       ...searchBody,
+    });
+
+    return response.hits.hits.map((hit: any) => ({
+      id: hit._id,
+      score: hit._score,
+      payload: hit._source?.metadata || {},
+    }));
+  }
+
+  async keywordSearch(
+    query: string,
+    topK: number = 5,
+    filters?: SearchFilters,
+  ): Promise<VectorStoreResult[]> {
+    await this.initialize();
+    const boolQuery: Record<string, any> = {
+      should: [
+        { match: { "metadata.data": query } },
+        { match: { "metadata.text_lemmatized": query } },
+        { match: { "metadata.textLemmatized": query } },
+      ],
+      minimum_should_match: 1,
+    };
+
+    if (filters && Object.keys(filters).length > 0) {
+      boolQuery.filter = Object.entries(filters).map(([key, value]) => {
+        validateFilter(key, value);
+        return { term: { [`metadata.${key}`]: value } };
+      });
+    }
+
+    const response = await this.client.search({
+      index: this.collectionName,
+      size: topK,
+      query: { bool: boolQuery },
     });
 
     return response.hits.hits.map((hit: any) => ({


### PR DESCRIPTION
## Summary

- add Elasticsearch `keywordSearch()` over stored data and lemmatized text fields so TS hybrid retrieval can use BM25
- apply metadata filters to keyword queries using the adapter's existing validation
- set top-level KNN `size` to the requested candidate count so Elasticsearch does not fall back to its default 10 hits
- add focused Jest coverage for KNN sizing and keyword query construction/results

Closes #6611

## Validation

- `npm test -- --runInBand src/oss/src/tests/elasticsearch.test.ts` (2 passed)
- Prettier check and `git diff --check` pass
- Full TypeScript compilation remains blocked by pre-existing missing optional peer dependencies and test type packages in this minimal environment.
