### PR TITLE
fix: paginate delete_all so it deletes more than the first list() page

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1885,14 +1885,30 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # delete all vector memories and reset the collections
-        memories = self.vector_store.list(filters=filters)[0]
-        for memory in memories:
-            self._delete_memory(memory.id)
+        # Delete all matching vector memories. `vector_store.list` is paginated (most
+        # stores default to a 100-item page), so keep listing and deleting until no
+        # matching memories remain instead of trusting a single page.
+        deleted_count = 0
+        previous_page_ids: set = set()
+        while True:
+            memories = self.vector_store.list(filters=filters)[0]
+            if not memories:
+                break
+            page_ids = {memory.id for memory in memories}
+            if page_ids == previous_page_ids:
+                logger.warning(
+                    "delete_all made no progress on %d remaining memories; stopping to avoid an infinite loop",
+                    len(page_ids),
+                )
+                break
+            previous_page_ids = page_ids
+            for memory in memories:
+                self._delete_memory(memory.id)
+            deleted_count += len(memories)
 
-        logger.info(f"Deleted {len(memories)} memories")
+        logger.info(f"Deleted {deleted_count} memories")
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories))
+        decay_usage_notice = detect_decay_usage_from_delete_all(deleted_count)
         if decay_usage_notice:
             display_decay_usage_notice(self, "sync", "delete_all", *decay_usage_notice)
         else:
@@ -3515,26 +3531,40 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        memories = await asyncio.to_thread(self.vector_store.list, filters=filters)
-
-        delete_tasks = []
-        for memory in memories[0]:
-            delete_tasks.append(self._delete_memory(memory.id, skip_entity_cleanup=True))
-
-        results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+        # Delete all matching vector memories. `vector_store.list` is paginated (most
+        # stores default to a 100-item page), so keep listing and deleting until no
+        # matching memories remain instead of trusting a single page.
+        attempted_count = 0
+        errors = []
+        previous_page_ids = set()
+        while True:
+            memories = (await asyncio.to_thread(self.vector_store.list, filters=filters))[0]
+            if not memories:
+                break
+            page_ids = {memory.id for memory in memories}
+            if page_ids == previous_page_ids:
+                logger.warning(
+                    "delete_all made no progress on %d remaining memories; stopping to avoid an infinite loop",
+                    len(page_ids),
+                )
+                break
+            previous_page_ids = page_ids
+            delete_tasks = [self._delete_memory(memory.id, skip_entity_cleanup=True) for memory in memories]
+            results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+            attempted_count += len(results)
+            errors.extend(r for r in results if isinstance(r, BaseException))
 
         if self._entity_store is not None:
             await self._bulk_clear_entity_store(filters)
 
-        errors = [r for r in results if isinstance(r, BaseException)]
         if errors:
-            logger.warning("Failed to delete %d out of %d memories", len(errors), len(results))
+            logger.warning("Failed to delete %d out of %d memories", len(errors), attempted_count)
             for err in errors:
                 logger.warning("Delete error: %s", err)
 
-        logger.info(f"Deleted {len(results) - len(errors)} memories")
+        logger.info(f"Deleted {attempted_count - len(errors)} memories")
 
-        decay_usage_notice = detect_decay_usage_from_delete_all(len(memories[0]))
+        decay_usage_notice = detect_decay_usage_from_delete_all(attempted_count)
         if decay_usage_notice:
             await display_decay_usage_notice_async(self, "async", "delete_all", *decay_usage_notice)
         else:

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -431,6 +431,7 @@ logger = logging.getLogger(__name__)
 
 _UNSET = object()
 _PROJECT_UPDATE_UNSUPPORTED_ERROR = "Project updates are not supported by the OSS Memory SDK."
+DELETE_ALL_BATCH_SIZE = 1000
 
 
 class _OSSProject:
@@ -1885,13 +1886,13 @@ class Memory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"})
-        # Delete all matching vector memories. `vector_store.list` is paginated (most
-        # stores default to a 100-item page), so keep listing and deleting until no
-        # matching memories remain instead of trusting a single page.
+        # Delete all matching vector memories. `vector_store.list` is paginated (we
+        # request DELETE_ALL_BATCH_SIZE items per page), so keep listing and deleting
+        # until no matching memories remain instead of trusting a single page.
         deleted_count = 0
         previous_page_ids: set = set()
         while True:
-            memories = self.vector_store.list(filters=filters)[0]
+            memories = self.vector_store.list(filters=filters, top_k=DELETE_ALL_BATCH_SIZE)[0]
             if not memories:
                 break
             page_ids = {memory.id for memory in memories}
@@ -3531,14 +3532,16 @@ class AsyncMemory(MemoryBase):
 
         keys, encoded_ids = process_telemetry_filters(filters)
         capture_event("mem0.delete_all", self, {"keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"})
-        # Delete all matching vector memories. `vector_store.list` is paginated (most
-        # stores default to a 100-item page), so keep listing and deleting until no
-        # matching memories remain instead of trusting a single page.
+        # Delete all matching vector memories. `vector_store.list` is paginated (we
+        # request DELETE_ALL_BATCH_SIZE items per page), so keep listing and deleting
+        # until no matching memories remain instead of trusting a single page.
         attempted_count = 0
         errors = []
         previous_page_ids = set()
         while True:
-            memories = (await asyncio.to_thread(self.vector_store.list, filters=filters))[0]
+            memories = (
+                await asyncio.to_thread(self.vector_store.list, filters=filters, top_k=DELETE_ALL_BATCH_SIZE)
+            )[0]
             if not memories:
                 break
             page_ids = {memory.id for memory in memories}

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -418,6 +418,57 @@ async def test_async_update_memory_uses_utc_timestamps(mocker):
     assert payload["updated_at"] is not None
 
 
+@pytest.mark.asyncio
+async def test_async_delete_all_paginates_beyond_single_list_page(mocker):
+    """Regression test for #6627 (async): delete_all must keep listing pages
+    until every matching memory is deleted, not just the first 100."""
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory._entity_store = None
+
+    all_ids = [str(i) for i in range(150)]
+    remaining = list(all_ids)
+
+    def fake_list(filters=None, **kwargs):
+        # Simulate a store that returns at most 100 results per list() call.
+        return ([SimpleNamespace(id=memory_id) for memory_id in remaining[:100]], None)
+
+    async def fake_delete(memory_id, *args, **kwargs):
+        remaining.remove(memory_id)
+
+    memory.vector_store.list = Mock(side_effect=fake_list)
+    delete_mock = mocker.patch.object(memory, "_delete_memory", side_effect=fake_delete)
+
+    result = await memory.delete_all(user_id="test_user")
+
+    assert delete_mock.call_count == 150
+    deleted_ids = {call.args[0] for call in delete_mock.call_args_list}
+    assert deleted_ids == set(all_ids)
+    assert remaining == []
+    assert result["message"] == "Memories deleted successfully!"
+
+
+@pytest.mark.asyncio
+async def test_async_delete_all_stops_if_store_makes_no_progress(mocker):
+    """If the store keeps returning the same page (deletes not taking effect),
+    async delete_all should stop instead of looping forever."""
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    memory._entity_store = None
+
+    stuck_page = [SimpleNamespace(id=str(i)) for i in range(3)]
+    memory.vector_store.list = Mock(return_value=(stuck_page, None))
+
+    async def fake_delete(memory_id, *args, **kwargs):
+        return None
+
+    delete_mock = mocker.patch.object(memory, "_delete_memory", side_effect=fake_delete)
+
+    result = await memory.delete_all(user_id="test_user")
+
+    # Each memory in the stuck page is deleted exactly once before bailing out.
+    assert delete_mock.call_count == 3
+    assert result["message"] == "Memories deleted successfully!"
+
+
 _ATTACKER_UPDATE_METADATA = {
     "user_id": "attacker_tenant",
     "agent_id": "attacker_agent",

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, Mock
 import pytest
 
 from mem0.exceptions import LLMError
-from mem0.memory.main import AsyncMemory, Memory
+from mem0.memory.main import DELETE_ALL_BATCH_SIZE, AsyncMemory, Memory
 
 
 def _setup_mocks(mocker):
@@ -445,6 +445,8 @@ async def test_async_delete_all_paginates_beyond_single_list_page(mocker):
     assert deleted_ids == set(all_ids)
     assert remaining == []
     assert result["message"] == "Memories deleted successfully!"
+    for call in memory.vector_store.list.call_args_list:
+        assert call.kwargs["top_k"] == DELETE_ALL_BATCH_SIZE
 
 
 @pytest.mark.asyncio
@@ -467,6 +469,7 @@ async def test_async_delete_all_stops_if_store_makes_no_progress(mocker):
     # Each memory in the stuck page is deleted exactly once before bailing out.
     assert delete_mock.call_count == 3
     assert result["message"] == "Memories deleted successfully!"
+    memory.vector_store.list.assert_called_with(filters={"user_id": "test_user"}, top_k=DELETE_ALL_BATCH_SIZE)
 
 
 _ATTACKER_UPDATE_METADATA = {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -293,6 +293,45 @@ def test_delete_all(memory_instance):
     assert result["message"] == "Memories deleted successfully!"
 
 
+def test_delete_all_paginates_beyond_single_list_page(memory_instance):
+    """Regression test for #6627: delete_all must not stop at the vector store's
+    default list() page size (100) and must delete every matching memory."""
+    all_memories = [Mock(id=str(i)) for i in range(150)]
+    remaining = list(all_memories)
+
+    def fake_list(filters=None, **kwargs):
+        # Simulate a store that returns at most 100 results per list() call.
+        return (remaining[:100], None)
+
+    def fake_delete(memory_id, *args, **kwargs):
+        remaining[:] = [memory for memory in remaining if memory.id != memory_id]
+
+    memory_instance.vector_store.list = Mock(side_effect=fake_list)
+    memory_instance._delete_memory = Mock(side_effect=fake_delete)
+
+    result = memory_instance.delete_all(user_id="test_user")
+
+    assert memory_instance._delete_memory.call_count == 150
+    deleted_ids = {call.args[0] for call in memory_instance._delete_memory.call_args_list}
+    assert deleted_ids == {memory.id for memory in all_memories}
+    assert remaining == []
+    assert result["message"] == "Memories deleted successfully!"
+
+
+def test_delete_all_stops_if_store_makes_no_progress(memory_instance):
+    """If the store keeps returning the same page (deletes not taking effect),
+    delete_all should stop instead of looping forever."""
+    stuck_page = [Mock(id=str(i)) for i in range(3)]
+    memory_instance.vector_store.list = Mock(return_value=(stuck_page, None))
+    memory_instance._delete_memory = Mock()
+
+    result = memory_instance.delete_all(user_id="test_user")
+
+    # Each memory in the stuck page is deleted exactly once before bailing out.
+    assert memory_instance._delete_memory.call_count == 3
+    assert result["message"] == "Memories deleted successfully!"
+
+
 def test_get_all(memory_instance):
     mock_memories = [Mock(id="1", payload={"data": "Memory 1", "user_id": "test_user"})]
     memory_instance.vector_store.list = Mock(return_value=(mock_memories, None))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from mem0.configs.base import MemoryConfig
-from mem0.memory.main import Memory, _validate_and_trim_entity_id
+from mem0.memory.main import DELETE_ALL_BATCH_SIZE, Memory, _validate_and_trim_entity_id
 
 
 @pytest.fixture(autouse=True)
@@ -316,6 +316,8 @@ def test_delete_all_paginates_beyond_single_list_page(memory_instance):
     assert deleted_ids == {memory.id for memory in all_memories}
     assert remaining == []
     assert result["message"] == "Memories deleted successfully!"
+    for call in memory_instance.vector_store.list.call_args_list:
+        assert call.kwargs["top_k"] == DELETE_ALL_BATCH_SIZE
 
 
 def test_delete_all_stops_if_store_makes_no_progress(memory_instance):
@@ -330,6 +332,7 @@ def test_delete_all_stops_if_store_makes_no_progress(memory_instance):
     # Each memory in the stuck page is deleted exactly once before bailing out.
     assert memory_instance._delete_memory.call_count == 3
     assert result["message"] == "Memories deleted successfully!"
+    memory_instance.vector_store.list.assert_called_with(filters={"user_id": "test_user"}, top_k=DELETE_ALL_BATCH_SIZE)
 
 
 def test_get_all(memory_instance):
@@ -470,7 +473,9 @@ class TestEntityIdValidation:
 
         memory_instance.delete_all(user_id="  alice  ")
 
-        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "alice"})
+        memory_instance.vector_store.list.assert_called_once_with(
+            filters={"user_id": "alice"}, top_k=DELETE_ALL_BATCH_SIZE
+        )
 
     def test_validate_coerces_non_string_entity_id(self):
         """Integer (and other non-string) ids are coerced to str, not crashed on."""
@@ -483,7 +488,9 @@ class TestEntityIdValidation:
 
         memory_instance.delete_all(user_id=42)
 
-        memory_instance.vector_store.list.assert_called_once_with(filters={"user_id": "42"})
+        memory_instance.vector_store.list.assert_called_once_with(
+            filters={"user_id": "42"}, top_k=DELETE_ALL_BATCH_SIZE
+        )
 
     def test_get_all_coerces_integer_user_id(self, memory_instance):
         """get_all should accept an integer user_id in filters and scope by its str form."""


### PR DESCRIPTION
Fixes #6627

## What

`delete_all()` fetched one `list()` page (default 100) and deleted those, so stores with more than 100 memories were only partially cleared while the call reported success.

The fix paginates until the store is exhausted, following the same pagination pattern already used elsewhere in the client, and deletes every page.

## Tests

Regression tests mock a store with >100 memories across multiple pages and assert every memory is deleted. They fail on main (only the first page is deleted) and pass with the fix. No new failures in the surrounding suites.

Credit to @soullst for the report in #6627.
