### PR TITLE
fix: add Keywords AI redirect and unconditioned favicon fallback

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -17,551 +17,551 @@
   "navigation": {
     "anchors": [
       {
-            "anchor": "Documentation",
-            "icon": "book-open",
-            "tabs": [
+        "anchor": "Documentation",
+        "icon": "book-open",
+        "tabs": [
+          {
+            "tab": "Get Started",
+            "groups": [
               {
-                "tab": "Get Started",
-                "groups": [
-                  {
-                    "group": "Start Here",
-                    "icon": "home",
-                    "pages": [
-                      "introduction"
-                    ]
-                  }
+                "group": "Start Here",
+                "icon": "home",
+                "pages": [
+                  "introduction"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Mem0 Platform",
+            "groups": [
+              {
+                "group": "Getting Started",
+                "icon": "rocket",
+                "pages": [
+                  "platform/quickstart",
+                  "platform/overview",
+                  "platform/agent-signup",
+                  "vibecoding",
+                  "platform/cli",
+                  "platform/mem0-mcp",
+                  "platform/platform-vs-oss"
                 ]
               },
               {
-                "tab": "Mem0 Platform",
-                "groups": [
-                  {
-                    "group": "Getting Started",
-                    "icon": "rocket",
-                    "pages": [
-                      "platform/quickstart",
-                      "platform/overview",
-                      "platform/agent-signup",
-                      "vibecoding",
-                      "platform/cli",
-                      "platform/mem0-mcp",
-                      "platform/platform-vs-oss"
-                    ]
-                  },
-                  {
-                    "group": "Core Concepts",
-                    "icon": "brain",
-                    "pages": [
-                      "core-concepts/how-it-works",
-                      "core-concepts/memory-types",
-                      "core-concepts/memory-operations/add",
-                      "core-concepts/memory-operations/search",
-                      "core-concepts/memory-operations/update",
-                      "core-concepts/memory-operations/delete",
-                      "core-concepts/memory-evaluation"
-                    ]
-                  },
-                  {
-                    "group": "Features",
-                    "icon": "star",
-                    "pages": [
-                      {
-                        "group": "Essentials",
-                        "icon": "circle-check",
-                        "pages": [
-                          "platform/features/v2-memory-filters",
-                          "platform/features/entity-scoped-memory",
-                          "platform/features/graph-memory",
-                          "platform/features/async-client",
-                          "platform/features/multimodal-support",
-                          "platform/features/custom-categories",
-                          "platform/features/temporal-reasoning"
-                        ]
-                      },
-                      {
-                        "group": "Advanced",
-                        "icon": "bolt",
-                        "pages": [
-                          "platform/features/advanced-retrieval",
-                          "platform/advanced-memory-operations",
-                          "platform/features/custom-instructions",
-                          "platform/features/memory-decay"
-                        ]
-                      },
-                      {
-                        "group": "Data Management",
-                        "icon": "database",
-                        "pages": [
-                          "platform/features/direct-import",
-                          "platform/features/memory-export",
-                          "platform/features/timestamp",
-                          "platform/features/memory-expiration"
-                        ]
-                      },
-                      {
-                        "group": "Integrations",
-                        "icon": "plug",
-                        "pages": [
-                          "platform/features/webhooks",
-                          "platform/features/feedback-mechanism",
-                          "platform/features/group-chat"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Support",
-                    "icon": "life-buoy",
-                    "pages": [
-                      "platform/faqs"
-                    ]
-                  },
-                  {
-                    "group": "Migration",
-                    "icon": "arrow-right",
-                    "pages": [
-                      "migration/platform-v2-to-v3",
-                      "migration/oss-to-platform"
-                    ]
-                  }
+                "group": "Core Concepts",
+                "icon": "brain",
+                "pages": [
+                  "core-concepts/how-it-works",
+                  "core-concepts/memory-types",
+                  "core-concepts/memory-operations/add",
+                  "core-concepts/memory-operations/search",
+                  "core-concepts/memory-operations/update",
+                  "core-concepts/memory-operations/delete",
+                  "core-concepts/memory-evaluation"
                 ]
               },
               {
-                "tab": "Open Source",
-                "groups": [
+                "group": "Features",
+                "icon": "star",
+                "pages": [
                   {
-                    "group": "Getting Started",
-                    "icon": "rocket",
+                    "group": "Essentials",
+                    "icon": "circle-check",
                     "pages": [
-                      "open-source/overview",
-                      "open-source/python-quickstart",
-                      "open-source/node-quickstart",
-                      "open-source/setup",
-                      "vibecoding"
+                      "platform/features/v2-memory-filters",
+                      "platform/features/entity-scoped-memory",
+                      "platform/features/graph-memory",
+                      "platform/features/async-client",
+                      "platform/features/multimodal-support",
+                      "platform/features/custom-categories",
+                      "platform/features/temporal-reasoning"
                     ]
                   },
                   {
-                    "group": "Features",
-                    "icon": "server",
+                    "group": "Advanced",
+                    "icon": "bolt",
                     "pages": [
-                      "open-source/features/overview",
-                      "open-source/features/metadata-filtering",
-                      "open-source/features/reranker-search",
-                      "open-source/features/async-memory",
-                      "open-source/features/multimodal-support",
-                      "open-source/features/custom-instructions",
-                      "open-source/features/rest-api",
-                      "open-source/features/openai_compatibility",
+                      "platform/features/advanced-retrieval",
+                      "platform/advanced-memory-operations",
+                      "platform/features/custom-instructions",
+                      "platform/features/memory-decay"
+                    ]
+                  },
+                  {
+                    "group": "Data Management",
+                    "icon": "database",
+                    "pages": [
+                      "platform/features/direct-import",
+                      "platform/features/memory-export",
+                      "platform/features/timestamp",
                       "platform/features/memory-expiration"
                     ]
                   },
                   {
-                    "group": "Configuration",
-                    "icon": "sliders",
+                    "group": "Integrations",
+                    "icon": "plug",
                     "pages": [
-                      "open-source/configuration",
+                      "platform/features/webhooks",
+                      "platform/features/feedback-mechanism",
+                      "platform/features/group-chat"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Support",
+                "icon": "life-buoy",
+                "pages": [
+                  "platform/faqs"
+                ]
+              },
+              {
+                "group": "Migration",
+                "icon": "arrow-right",
+                "pages": [
+                  "migration/platform-v2-to-v3",
+                  "migration/oss-to-platform"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Open Source",
+            "groups": [
+              {
+                "group": "Getting Started",
+                "icon": "rocket",
+                "pages": [
+                  "open-source/overview",
+                  "open-source/python-quickstart",
+                  "open-source/node-quickstart",
+                  "open-source/setup",
+                  "vibecoding"
+                ]
+              },
+              {
+                "group": "Features",
+                "icon": "server",
+                "pages": [
+                  "open-source/features/overview",
+                  "open-source/features/metadata-filtering",
+                  "open-source/features/reranker-search",
+                  "open-source/features/async-memory",
+                  "open-source/features/multimodal-support",
+                  "open-source/features/custom-instructions",
+                  "open-source/features/rest-api",
+                  "open-source/features/openai_compatibility",
+                  "platform/features/memory-expiration"
+                ]
+              },
+              {
+                "group": "Configuration",
+                "icon": "sliders",
+                "pages": [
+                  "open-source/configuration",
+                  {
+                    "group": "LLMs",
+                    "icon": "message-bot",
+                    "pages": [
+                      "components/llms/overview",
+                      "components/llms/config",
                       {
-                        "group": "LLMs",
-                        "icon": "message-bot",
+                        "group": "Supported LLMs",
+                        "icon": "list",
                         "pages": [
-                          "components/llms/overview",
-                          "components/llms/config",
-                          {
-                            "group": "Supported LLMs",
-                            "icon": "list",
-                            "pages": [
-                              "components/llms/models/openai",
-                              "components/llms/models/anthropic",
-                              "components/llms/models/azure_openai",
-                              "components/llms/models/ollama",
-                              "components/llms/models/together",
-                              "components/llms/models/groq",
-                              "components/llms/models/litellm",
-                              "components/llms/models/mistral_AI",
-                              "components/llms/models/google_AI",
-                              "components/llms/models/aws_bedrock",
-                              "components/llms/models/deepseek",
-                              "components/llms/models/minimax",
-                              "components/llms/models/xAI",
-                              "components/llms/models/sarvam",
-                              "components/llms/models/lmstudio",
-                              "components/llms/models/langchain",
-                              "components/llms/models/vllm"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Vector Databases",
-                        "icon": "hard-drive",
-                        "pages": [
-                          "components/vectordbs/overview",
-                          "components/vectordbs/config",
-                          {
-                            "group": "Supported Vector Databases",
-                            "icon": "list",
-                            "pages": [
-                              "components/vectordbs/dbs/qdrant",
-                              "components/vectordbs/dbs/chroma",
-                              "components/vectordbs/dbs/pgvector",
-                              "components/vectordbs/dbs/milvus",
-                              "components/vectordbs/dbs/pinecone",
-                              "components/vectordbs/dbs/mongodb",
-                              "components/vectordbs/dbs/oracledb",
-                              "components/vectordbs/dbs/azure",
-                              "components/vectordbs/dbs/azure_mysql",
-                              "components/vectordbs/dbs/redis",
-                              "components/vectordbs/dbs/valkey",
-                              "components/vectordbs/dbs/elasticsearch",
-                              "components/vectordbs/dbs/opensearch",
-                              "components/vectordbs/dbs/supabase",
-                              "components/vectordbs/dbs/upstash-vector",
-                              "components/vectordbs/dbs/vectorize",
-                              "components/vectordbs/dbs/vertex_ai",
-                              "components/vectordbs/dbs/weaviate",
-                              "components/vectordbs/dbs/faiss",
-                              "components/vectordbs/dbs/langchain",
-                              "components/vectordbs/dbs/baidu",
-                              "components/vectordbs/dbs/cassandra",
-                              "components/vectordbs/dbs/s3_vectors",
-                              "components/vectordbs/dbs/databricks",
-                              "components/vectordbs/dbs/neon",
-                              "components/vectordbs/dbs/neptune_analytics",
-                              "components/vectordbs/dbs/turbopuffer"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Embedding Models",
-                        "icon": "cube",
-                        "pages": [
-                          "components/embedders/overview",
-                          "components/embedders/config",
-                          {
-                            "group": "Supported Embedding Models",
-                            "icon": "list",
-                            "pages": [
-                              "components/embedders/models/openai",
-                              "components/embedders/models/azure_openai",
-                              "components/embedders/models/ollama",
-                              "components/embedders/models/huggingface",
-                              "components/embedders/models/vertexai",
-                              "components/embedders/models/google_AI",
-                              "components/embedders/models/lmstudio",
-                              "components/embedders/models/together",
-                              "components/embedders/models/langchain",
-                              "components/embedders/models/aws_bedrock",
-                              "components/embedders/models/fastembed"
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "Rerankers",
-                        "icon": "ranking-star",
-                        "pages": [
-                          "components/rerankers/overview",
-                          "components/rerankers/config",
-                          "components/rerankers/optimization",
-                          "components/rerankers/custom-prompts",
-                          {
-                            "group": "Supported Rerankers",
-                            "icon": "list",
-                            "pages": [
-                              "components/rerankers/models/cohere",
-                              "components/rerankers/models/sentence_transformer",
-                              "components/rerankers/models/huggingface",
-                              "components/rerankers/models/llm_reranker",
-                              "components/rerankers/models/zero_entropy"
-                            ]
-                          }
+                          "components/llms/models/openai",
+                          "components/llms/models/anthropic",
+                          "components/llms/models/azure_openai",
+                          "components/llms/models/ollama",
+                          "components/llms/models/together",
+                          "components/llms/models/groq",
+                          "components/llms/models/litellm",
+                          "components/llms/models/mistral_AI",
+                          "components/llms/models/google_AI",
+                          "components/llms/models/aws_bedrock",
+                          "components/llms/models/deepseek",
+                          "components/llms/models/minimax",
+                          "components/llms/models/xAI",
+                          "components/llms/models/sarvam",
+                          "components/llms/models/lmstudio",
+                          "components/llms/models/langchain",
+                          "components/llms/models/vllm"
                         ]
                       }
                     ]
                   },
                   {
-                    "group": "Migration",
-                    "icon": "arrow-right",
+                    "group": "Vector Databases",
+                    "icon": "hard-drive",
                     "pages": [
-                      "migration/oss-v2-to-v3",
-                      "migration/server-pgvector-upgrade"
+                      "components/vectordbs/overview",
+                      "components/vectordbs/config",
+                      {
+                        "group": "Supported Vector Databases",
+                        "icon": "list",
+                        "pages": [
+                          "components/vectordbs/dbs/qdrant",
+                          "components/vectordbs/dbs/chroma",
+                          "components/vectordbs/dbs/pgvector",
+                          "components/vectordbs/dbs/milvus",
+                          "components/vectordbs/dbs/pinecone",
+                          "components/vectordbs/dbs/mongodb",
+                          "components/vectordbs/dbs/oracledb",
+                          "components/vectordbs/dbs/azure",
+                          "components/vectordbs/dbs/azure_mysql",
+                          "components/vectordbs/dbs/redis",
+                          "components/vectordbs/dbs/valkey",
+                          "components/vectordbs/dbs/elasticsearch",
+                          "components/vectordbs/dbs/opensearch",
+                          "components/vectordbs/dbs/supabase",
+                          "components/vectordbs/dbs/upstash-vector",
+                          "components/vectordbs/dbs/vectorize",
+                          "components/vectordbs/dbs/vertex_ai",
+                          "components/vectordbs/dbs/weaviate",
+                          "components/vectordbs/dbs/faiss",
+                          "components/vectordbs/dbs/langchain",
+                          "components/vectordbs/dbs/baidu",
+                          "components/vectordbs/dbs/cassandra",
+                          "components/vectordbs/dbs/s3_vectors",
+                          "components/vectordbs/dbs/databricks",
+                          "components/vectordbs/dbs/neon",
+                          "components/vectordbs/dbs/neptune_analytics",
+                          "components/vectordbs/dbs/turbopuffer"
+                        ]
+                      }
                     ]
                   },
                   {
-                    "group": "Community & Support",
-                    "icon": "users",
+                    "group": "Embedding Models",
+                    "icon": "cube",
                     "pages": [
-                      "contributing/development",
-                      "contributing/documentation",
-                      "platform/contribute"
+                      "components/embedders/overview",
+                      "components/embedders/config",
+                      {
+                        "group": "Supported Embedding Models",
+                        "icon": "list",
+                        "pages": [
+                          "components/embedders/models/openai",
+                          "components/embedders/models/azure_openai",
+                          "components/embedders/models/ollama",
+                          "components/embedders/models/huggingface",
+                          "components/embedders/models/vertexai",
+                          "components/embedders/models/google_AI",
+                          "components/embedders/models/lmstudio",
+                          "components/embedders/models/together",
+                          "components/embedders/models/langchain",
+                          "components/embedders/models/aws_bedrock",
+                          "components/embedders/models/fastembed"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Rerankers",
+                    "icon": "ranking-star",
+                    "pages": [
+                      "components/rerankers/overview",
+                      "components/rerankers/config",
+                      "components/rerankers/optimization",
+                      "components/rerankers/custom-prompts",
+                      {
+                        "group": "Supported Rerankers",
+                        "icon": "list",
+                        "pages": [
+                          "components/rerankers/models/cohere",
+                          "components/rerankers/models/sentence_transformer",
+                          "components/rerankers/models/huggingface",
+                          "components/rerankers/models/llm_reranker",
+                          "components/rerankers/models/zero_entropy"
+                        ]
+                      }
                     ]
                   }
                 ]
               },
               {
-                "tab": "Integrations",
-                "groups": [
-                  {
-                    "group": "Overview",
-                    "icon": "plug",
-                    "pages": [
-                      "integrations"
-                    ]
-                  },
-                  {
-                    "group": "Agent Frameworks",
-                    "icon": "robot",
-                    "pages": [
-                      "integrations/langchain",
-                      "integrations/langgraph",
-                      "integrations/llama-index",
-                      "integrations/crewai",
-                      "integrations/autogen",
-                      "integrations/agno",
-                      "integrations/camel-ai",
-                      "integrations/openai-agents-sdk",
-                      "integrations/google-ai-adk",
-                      "integrations/mastra",
-                      "integrations/vercel-ai-sdk",
-                      "integrations/chatdev"
-                    ]
-                  },
-                  {
-                    "group": "Voice & Real-time",
-                    "icon": "microphone",
-                    "pages": [
-                      "integrations/livekit",
-                      "integrations/pipecat",
-                      "integrations/elevenlabs"
-                    ]
-                  },
-                  {
-                    "group": "Cloud & Infrastructure",
-                    "icon": "cloud",
-                    "pages": [
-                      "integrations/aws-bedrock"
-                    ]
-                  },
-                  {
-                    "group": "Developer Tools",
-                    "icon": "wrench",
-                    "pages": [
-                      "integrations/dify",
-                      "integrations/flowise",
-                      "integrations/langchain-tools",
-                      "integrations/agentops",
-                      "integrations/respan",
-                      "integrations/raycast"
-                    ]
-                  }
+                "group": "Migration",
+                "icon": "arrow-right",
+                "pages": [
+                  "migration/oss-v2-to-v3",
+                  "migration/server-pgvector-upgrade"
                 ]
               },
               {
-                "tab": "Agent Plugins",
-                "groups": [
-                  {
-                    "group": "Coding Agents",
-                    "icon": "terminal",
-                    "pages": [
-                      "integrations/claude-code",
-                      "integrations/cursor",
-                      "integrations/codex",
-                      "integrations/opencode",
-                      "integrations/antigravity"
-                    ]
-                  },
-                  {
-                    "group": "Agent Harness",
-                    "icon": "robot",
-                    "pages": [
-                      "integrations/openclaw",
-                      "integrations/hermes",
-                      "integrations/pi-agent"
-                    ]
-                  }
+                "group": "Community & Support",
+                "icon": "users",
+                "pages": [
+                  "contributing/development",
+                  "contributing/documentation",
+                  "platform/contribute"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Integrations",
+            "groups": [
+              {
+                "group": "Overview",
+                "icon": "plug",
+                "pages": [
+                  "integrations"
                 ]
               },
               {
-                "tab": "Cookbooks",
-                "groups": [
-                  {
-                    "group": "Getting Started",
-                    "icon": "lightbulb",
-                    "pages": [
-                      "cookbooks/overview"
-                    ]
-                  },
-                  {
-                    "group": "Essentials",
-                    "icon": "flag",
-                    "pages": [
-                      "cookbooks/essentials/building-ai-companion",
-                      "cookbooks/essentials/entity-partitioning-playbook",
-                      "cookbooks/essentials/controlling-memory-ingestion",
-                      "cookbooks/essentials/tagging-and-organizing-memories",
-                      "cookbooks/essentials/exporting-memories"
-                    ]
-                  },
-                  {
-                    "group": "Companion Playbooks",
-                    "icon": "users",
-                    "pages": [
-                      "cookbooks/companions/quickstart-demo",
-                      "cookbooks/companions/nodejs-companion",
-                      "cookbooks/companions/ai-tutor",
-                      "cookbooks/companions/travel-assistant",
-                      "cookbooks/companions/youtube-research",
-                      "cookbooks/companions/voice-companion-openai",
-                      "cookbooks/companions/local-companion-ollama"
-                    ]
-                  },
-                  {
-                    "group": "Ops & Automations",
-                    "icon": "briefcase",
-                    "pages": [
-                      "cookbooks/operations/support-inbox",
-                      "cookbooks/operations/email-automation",
-                      "cookbooks/operations/content-writing",
-                      "cookbooks/operations/deep-research",
-                      "cookbooks/operations/team-task-agent"
-                    ]
-                  },
-                  {
-                    "group": "Integrations & Platforms",
-                    "icon": "plug",
-                    "pages": [
-                      "cookbooks/integrations/agents-sdk-tool",
-                      "cookbooks/integrations/openai-tool-calls",
-                      "cookbooks/integrations/mastra-agent",
-                      "cookbooks/integrations/healthcare-google-adk",
-                      "cookbooks/integrations/aws-bedrock",
-                      "cookbooks/integrations/tavily-search"
-                    ]
-                  },
-                  {
-                    "group": "Frameworks & Multimodal",
-                    "icon": "layers",
-                    "pages": [
-                      "cookbooks/frameworks/llamaindex-react",
-                      "cookbooks/frameworks/llamaindex-multiagent",
-                      "cookbooks/frameworks/multimodal-retrieval",
-                      "cookbooks/frameworks/eliza-os-character",
-                      "cookbooks/frameworks/gemini-3-with-mem0-mcp"
-                    ]
-                  }
+                "group": "Agent Frameworks",
+                "icon": "robot",
+                "pages": [
+                  "integrations/langchain",
+                  "integrations/langgraph",
+                  "integrations/llama-index",
+                  "integrations/crewai",
+                  "integrations/autogen",
+                  "integrations/agno",
+                  "integrations/camel-ai",
+                  "integrations/openai-agents-sdk",
+                  "integrations/google-ai-adk",
+                  "integrations/mastra",
+                  "integrations/vercel-ai-sdk",
+                  "integrations/chatdev"
                 ]
               },
               {
-                "tab": "API Reference",
-                "groups": [
-                  {
-                    "group": "Getting Started",
-                    "icon": "rocket",
-                    "pages": [
-                      "api-reference",
-                      "api-reference/organizations-projects"
-                    ]
-                  },
-                  {
-                    "group": "Core Memory Operations",
-                    "icon": "microchip",
-                    "pages": [
-                      "api-reference/memory/add-memories",
-                      "api-reference/memory/get-memories",
-                      "api-reference/memory/search-memories",
-                      "api-reference/memory/update-memory",
-                      "api-reference/memory/delete-memory"
-                    ]
-                  },
-                  {
-                    "group": "Memory Management",
-                    "icon": "sparkles",
-                    "pages": [
-                      "api-reference/memory/create-memory-export",
-                      "api-reference/memory/feedback",
-                      "api-reference/memory/get-memory",
-                      "api-reference/memory/history-memory",
-                      "api-reference/memory/get-memory-export",
-                      "api-reference/memory/batch-update",
-                      "api-reference/memory/batch-delete",
-                      "api-reference/memory/delete-memories"
-                    ]
-                  },
-                  {
-                    "group": "Events",
-                    "icon": "clock",
-                    "pages": [
-                      "api-reference/events/get-events",
-                      "api-reference/events/get-event"
-                    ]
-                  },
-                  {
-                    "group": "Entities",
-                    "icon": "users",
-                    "pages": [
-                      "api-reference/entities/get-users",
-                      "api-reference/entities/delete-user"
-                    ]
-                  },
-                  {
-                    "group": "Organizations",
-                    "icon": "building",
-                    "pages": [
-                      "api-reference/organization/create-org",
-                      "api-reference/organization/get-orgs",
-                      "api-reference/organization/get-org",
-                      "api-reference/organization/get-org-members",
-                      "api-reference/organization/add-org-member",
-                      "api-reference/organization/update-org-member",
-                      "api-reference/organization/remove-org-member",
-                      "api-reference/organization/delete-org"
-                    ]
-                  },
-                  {
-                    "group": "Projects",
-                    "icon": "folder",
-                    "pages": [
-                      "api-reference/project/create-project",
-                      "api-reference/project/get-projects",
-                      "api-reference/project/get-project",
-                      "api-reference/project/get-project-members",
-                      "api-reference/project/add-project-member",
-                      "api-reference/project/update-project",
-                      "api-reference/project/update-project-member",
-                      "api-reference/project/remove-project-member",
-                      "api-reference/project/delete-project"
-                    ]
-                  },
-                  {
-                    "group": "Webhooks",
-                    "icon": "webhook",
-                    "pages": [
-                      "api-reference/webhook/create-webhook",
-                      "api-reference/webhook/get-webhook",
-                      "api-reference/webhook/update-webhook",
-                      "api-reference/webhook/delete-webhook"
-                    ]
-                  }
+                "group": "Voice & Real-time",
+                "icon": "microphone",
+                "pages": [
+                  "integrations/livekit",
+                  "integrations/pipecat",
+                  "integrations/elevenlabs"
                 ]
               },
               {
-                "tab": "Release Notes",
-                "groups": [
-                  {
-                    "group": "Release Notes",
-                    "icon": "rocket",
-                    "pages": [
-                      "changelog/highlights",
-                      "changelog/sdk",
-                      "changelog/platform"
-                    ]
-                  }
+                "group": "Cloud & Infrastructure",
+                "icon": "cloud",
+                "pages": [
+                  "integrations/aws-bedrock"
+                ]
+              },
+              {
+                "group": "Developer Tools",
+                "icon": "wrench",
+                "pages": [
+                  "integrations/dify",
+                  "integrations/flowise",
+                  "integrations/langchain-tools",
+                  "integrations/agentops",
+                  "integrations/respan",
+                  "integrations/raycast"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Agent Plugins",
+            "groups": [
+              {
+                "group": "Coding Agents",
+                "icon": "terminal",
+                "pages": [
+                  "integrations/claude-code",
+                  "integrations/cursor",
+                  "integrations/codex",
+                  "integrations/opencode",
+                  "integrations/antigravity"
+                ]
+              },
+              {
+                "group": "Agent Harness",
+                "icon": "robot",
+                "pages": [
+                  "integrations/openclaw",
+                  "integrations/hermes",
+                  "integrations/pi-agent"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Cookbooks",
+            "groups": [
+              {
+                "group": "Getting Started",
+                "icon": "lightbulb",
+                "pages": [
+                  "cookbooks/overview"
+                ]
+              },
+              {
+                "group": "Essentials",
+                "icon": "flag",
+                "pages": [
+                  "cookbooks/essentials/building-ai-companion",
+                  "cookbooks/essentials/entity-partitioning-playbook",
+                  "cookbooks/essentials/controlling-memory-ingestion",
+                  "cookbooks/essentials/tagging-and-organizing-memories",
+                  "cookbooks/essentials/exporting-memories"
+                ]
+              },
+              {
+                "group": "Companion Playbooks",
+                "icon": "users",
+                "pages": [
+                  "cookbooks/companions/quickstart-demo",
+                  "cookbooks/companions/nodejs-companion",
+                  "cookbooks/companions/ai-tutor",
+                  "cookbooks/companions/travel-assistant",
+                  "cookbooks/companions/youtube-research",
+                  "cookbooks/companions/voice-companion-openai",
+                  "cookbooks/companions/local-companion-ollama"
+                ]
+              },
+              {
+                "group": "Ops & Automations",
+                "icon": "briefcase",
+                "pages": [
+                  "cookbooks/operations/support-inbox",
+                  "cookbooks/operations/email-automation",
+                  "cookbooks/operations/content-writing",
+                  "cookbooks/operations/deep-research",
+                  "cookbooks/operations/team-task-agent"
+                ]
+              },
+              {
+                "group": "Integrations & Platforms",
+                "icon": "plug",
+                "pages": [
+                  "cookbooks/integrations/agents-sdk-tool",
+                  "cookbooks/integrations/openai-tool-calls",
+                  "cookbooks/integrations/mastra-agent",
+                  "cookbooks/integrations/healthcare-google-adk",
+                  "cookbooks/integrations/aws-bedrock",
+                  "cookbooks/integrations/tavily-search"
+                ]
+              },
+              {
+                "group": "Frameworks & Multimodal",
+                "icon": "layers",
+                "pages": [
+                  "cookbooks/frameworks/llamaindex-react",
+                  "cookbooks/frameworks/llamaindex-multiagent",
+                  "cookbooks/frameworks/multimodal-retrieval",
+                  "cookbooks/frameworks/eliza-os-character",
+                  "cookbooks/frameworks/gemini-3-with-mem0-mcp"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "API Reference",
+            "groups": [
+              {
+                "group": "Getting Started",
+                "icon": "rocket",
+                "pages": [
+                  "api-reference",
+                  "api-reference/organizations-projects"
+                ]
+              },
+              {
+                "group": "Core Memory Operations",
+                "icon": "microchip",
+                "pages": [
+                  "api-reference/memory/add-memories",
+                  "api-reference/memory/get-memories",
+                  "api-reference/memory/search-memories",
+                  "api-reference/memory/update-memory",
+                  "api-reference/memory/delete-memory"
+                ]
+              },
+              {
+                "group": "Memory Management",
+                "icon": "sparkles",
+                "pages": [
+                  "api-reference/memory/create-memory-export",
+                  "api-reference/memory/feedback",
+                  "api-reference/memory/get-memory",
+                  "api-reference/memory/history-memory",
+                  "api-reference/memory/get-memory-export",
+                  "api-reference/memory/batch-update",
+                  "api-reference/memory/batch-delete",
+                  "api-reference/memory/delete-memories"
+                ]
+              },
+              {
+                "group": "Events",
+                "icon": "clock",
+                "pages": [
+                  "api-reference/events/get-events",
+                  "api-reference/events/get-event"
+                ]
+              },
+              {
+                "group": "Entities",
+                "icon": "users",
+                "pages": [
+                  "api-reference/entities/get-users",
+                  "api-reference/entities/delete-user"
+                ]
+              },
+              {
+                "group": "Organizations",
+                "icon": "building",
+                "pages": [
+                  "api-reference/organization/create-org",
+                  "api-reference/organization/get-orgs",
+                  "api-reference/organization/get-org",
+                  "api-reference/organization/get-org-members",
+                  "api-reference/organization/add-org-member",
+                  "api-reference/organization/update-org-member",
+                  "api-reference/organization/remove-org-member",
+                  "api-reference/organization/delete-org"
+                ]
+              },
+              {
+                "group": "Projects",
+                "icon": "folder",
+                "pages": [
+                  "api-reference/project/create-project",
+                  "api-reference/project/get-projects",
+                  "api-reference/project/get-project",
+                  "api-reference/project/get-project-members",
+                  "api-reference/project/add-project-member",
+                  "api-reference/project/update-project",
+                  "api-reference/project/update-project-member",
+                  "api-reference/project/remove-project-member",
+                  "api-reference/project/delete-project"
+                ]
+              },
+              {
+                "group": "Webhooks",
+                "icon": "webhook",
+                "pages": [
+                  "api-reference/webhook/create-webhook",
+                  "api-reference/webhook/get-webhook",
+                  "api-reference/webhook/update-webhook",
+                  "api-reference/webhook/delete-webhook"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Release Notes",
+            "groups": [
+              {
+                "group": "Release Notes",
+                "icon": "rocket",
+                "pages": [
+                  "changelog/highlights",
+                  "changelog/sdk",
+                  "changelog/platform"
                 ]
               }
             ]
           }
         ]
+      }
+    ]
   },
   "background": {
     "color": {
@@ -1235,6 +1235,13 @@
     {
       "source": "/platform/features/criteria-retrieval",
       "destination": "/platform/features/advanced-retrieval"
+    },
+    {
+      "source": "/integrations/keywords",
+      "destination": "/integrations"
     }
+  ],
+  "head": [
+    "<link rel=\"icon\" href=\"/logo/favicon.svg\" type=\"image/svg+xml\" />"
   ]
 }


### PR DESCRIPTION
## Summary

### 1. Keywords AI broken link on `mem0.ai/integrations`

The Keywords AI integration card on `mem0.ai/integrations` links to `docs.mem0.ai/integrations/keywords`, which 404s since the page was removed.

**Fix**: Added a redirect in `docs.json` so `/integrations/keywords` → `/integrations` (same pattern used for other removed integrations like `multion` and `composio`).

> **Note**: The card itself lives on the Framer-hosted `mem0.ai/integrations` page and should also be removed there. This redirect prevents the 404 in the meantime.

### 2. Missing unconditioned favicon on `docs.mem0.ai`

Mintlify generates all favicon `<link>` tags with `media="(prefers-color-scheme: light|dark)"` conditions, which means browsers/tools that don't support `prefers-color-scheme` see no favicon.

**Fix**: Added an unconditioned `<link rel="icon">` tag via Mintlify's `head` config that serves as a fallback for all contexts.