### PR TITLE
docs: redirect /integrations/keywords to /integrations/respan

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1235,6 +1235,10 @@
     {
       "source": "/platform/features/criteria-retrieval",
       "destination": "/platform/features/advanced-retrieval"
+    },
+    {
+      "source": "/integrations/keywords",
+      "destination": "/integrations/respan"
     }
   ]
 }


### PR DESCRIPTION
## Problem
`https://docs.mem0.ai/integrations/keywords` returns 404. The Keywords AI card on https://mem0.ai/integrations links to it, so the card is a dead link.

## Cause
e615cc66 ("docs: rebrand Keywords AI integration to Respan") renamed `docs/integrations/keywords.mdx` -> `docs/integrations/respan.mdx` and updated `integrations.mdx` / `llms.txt`, but no redirect was added for the old URL.

## Fix
One redirect entry in `docs/docs.json`: `/integrations/keywords` -> `/integrations/respan`. This fixes the mem0.ai card plus any other stale referrers (search results, cached llms.txt, external blog posts) rather than only patching the one card.

## Verification
- `python3 -m json.tool docs/docs.json` passes
- `/integrations/respan` currently returns 200; `/integrations/keywords` returns 404