### PR TITLE
fix(openai): forward http_client into OpenAI SDK clients

### DIFF
--- a/mem0/embeddings/openai.py
+++ b/mem0/embeddings/openai.py
@@ -32,7 +32,10 @@ class OpenAIEmbedding(EmbeddingBase):
                 DeprecationWarning,
             )
 
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        client_kwargs = {}
+        if getattr(self.config, "http_client", None) is not None:
+            client_kwargs["http_client"] = self.config.http_client
+        self.client = OpenAI(api_key=api_key, base_url=base_url, **client_kwargs)
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -39,18 +39,23 @@ class OpenAILLM(LLMBase):
         if not self.config.model:
             self.config.model = "gpt-5-mini"
 
+        client_kwargs = {}
+        if getattr(self.config, "http_client", None) is not None:
+            client_kwargs["http_client"] = self.config.http_client
+
         if os.environ.get("OPENROUTER_API_KEY"):  # Use OpenRouter
             self.client = OpenAI(
                 api_key=os.environ.get("OPENROUTER_API_KEY"),
                 base_url=self.config.openrouter_base_url
                 or os.getenv("OPENROUTER_API_BASE")
                 or "https://openrouter.ai/api/v1",
+                **client_kwargs,
             )
         else:
             api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
             base_url = self.config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 
-            self.client = OpenAI(api_key=api_key, base_url=base_url)
+            self.client = OpenAI(api_key=api_key, base_url=base_url, **client_kwargs)
 
     def _parse_response(self, response, tools):
         """

--- a/tests/test_http_client_proxies.py
+++ b/tests/test_http_client_proxies.py
@@ -37,3 +37,36 @@ def test_llm_factory_preserves_http_client_proxies():
     llm = LlmFactory.create("openai", base)
     assert llm.config.http_client_proxies == "http://proxy.local:8080"
     assert isinstance(llm.config.http_client, httpx.Client)
+
+
+def test_openai_llm_forwards_http_client_to_sdk():
+    from unittest.mock import patch, MagicMock
+
+    base = BaseLlmConfig(
+        model="gpt-4o-mini",
+        api_key="sk-test",
+        http_client_proxies="http://proxy.local:8080",
+    )
+    with patch("mem0.llms.openai.OpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        llm = LlmFactory.create("openai", base)
+        assert mock_openai.called
+        kwargs = mock_openai.call_args.kwargs
+        assert kwargs.get("http_client") is llm.config.http_client
+
+
+def test_openai_embedding_forwards_http_client_to_sdk():
+    from unittest.mock import patch, MagicMock
+
+    from mem0.embeddings.openai import OpenAIEmbedding
+
+    cfg = BaseEmbedderConfig(
+        model="text-embedding-3-small",
+        api_key="sk-test",
+        http_client_proxies="http://proxy.local:8080",
+    )
+    with patch("mem0.embeddings.openai.OpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        emb = OpenAIEmbedding(cfg)
+        kwargs = mock_openai.call_args.kwargs
+        assert kwargs.get("http_client") is emb.config.http_client


### PR DESCRIPTION
Closes #6651. Pass config.http_client into openai.OpenAI() for LLM + embedder so proxies apply. pytest tests/test_http_client_proxies.py (9 passed).