### PR TITLE
fix(pinecone): treat '*' filter as field-exists

### DIFF
--- a/mem0/vector_stores/pinecone.py
+++ b/mem0/vector_stores/pinecone.py
@@ -207,7 +207,10 @@ class PineconeDB(VectorStoreBase):
         pinecone_filter = {}
 
         for key, value in filters.items():
-            if isinstance(value, dict):
+            if value == "*":
+                # Field-exists / match-any (mem0 metadata wildcard convention)
+                pinecone_filter[key] = {"$exists": True}
+            elif isinstance(value, dict):
                 condition = {}
                 for op, operand in value.items():
                     pc_op = self.OPERATOR_MAP.get(op)

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -263,3 +263,9 @@ def test_create_filter_in_operator(pinecone_db):
 def test_create_filter_ne_operator(pinecone_db):
     result = pinecone_db._create_filter({"status": {"ne": "deleted"}})
     assert result == {"status": {"$ne": "deleted"}}
+
+
+def test_create_filter_wildcard_star_is_exists(pinecone_db):
+    """'*' is field-exists, not a literal equality match on the star character."""
+    result = pinecone_db._create_filter({"user_id": "*"})
+    assert result == {"user_id": {"$exists": True}}


### PR DESCRIPTION
Closes #6652. Map metadata "*" to Pinecone $exists instead of $eq "*". pytest tests/vector_stores/test_pinecone.py -k create_filter.