### PR TITLE
fix(memory): stop add() metadata from setting a memory's identity scope

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -134,18 +134,30 @@ _SENSITIVE_SUFFIXES = (
 # Entity parameters that must be passed via filters, not top-level kwargs
 ENTITY_PARAMS = frozenset({"user_id", "agent_id", "run_id"})
 
-# Tenant-scoping fields that update() must never let caller-supplied metadata overwrite (issues #4490, #6277).
+# Tenant-scoping fields that caller-supplied metadata must never set, on either the
+# creation or the update path (issues #4490, #6277, #6655).
 _IDENTITY_KEYS = ENTITY_PARAMS | {"actor_id"}
 
 
-def _strip_identity_keys(metadata: Dict[str, Any], existing_payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Drop identity keys from caller metadata; they are immutable after creation (issues #4490, #6277)."""
+def _strip_identity_keys(
+    metadata: Dict[str, Any],
+    existing_payload: Dict[str, Any],
+    *,
+    context: str = "update()",
+) -> Dict[str, Any]:
+    """Drop identity keys from caller metadata; scope is set by the entity params, not metadata.
+
+    On the update path `existing_payload` carries the memory's current scope, so
+    re-sending an identical value is silently accepted; only a changed value warns.
+    On the creation path there is no prior payload, so pass an empty dict and every
+    identity key present in `metadata` is dropped with a warning.
+    """
     clean = {}
     for key, value in metadata.items():
         if key not in _IDENTITY_KEYS:
             clean[key] = value
         elif value != existing_payload.get(key):
-            logger.warning(f"update(): ignoring metadata['{key}'] - identity fields are immutable after creation")
+            logger.warning(f"{context}: ignoring metadata['{key}'] - identity fields cannot be set through metadata")
     return clean
 
 
@@ -314,7 +326,9 @@ def _build_filters_and_metadata(
     for flexible session scoping and optionally narrows queries to a specific `actor_id`. It returns two dicts:
 
     1. `base_metadata_template`: Used as a template for metadata when storing new memories.
-       It includes all provided session identifier(s) and any `input_metadata`.
+       It includes all provided session identifier(s) and any `input_metadata`. Identity
+       scope is set from the entity params only; identity keys in `input_metadata` are
+       dropped, so freeform metadata cannot place a memory into an unrequested scope.
     2. `effective_query_filters`: Used for querying existing memories. It includes all
        provided session identifier(s), any `input_filters`, and a resolved actor
        identifier for targeted filtering if specified by any actor-related inputs.
@@ -342,7 +356,12 @@ def _build_filters_and_metadata(
               scoped to the provided session(s) and potentially a resolved actor.
     """
 
-    base_metadata_template = deepcopy(input_metadata) if input_metadata else {}
+    # Identity scope is set below from the entity params only. Stripping the keys here
+    # stops caller metadata from placing a memory into a scope the caller did not pass,
+    # which the re-pins below cannot prevent for a param that was left unset (issue #6655).
+    base_metadata_template = (
+        _strip_identity_keys(deepcopy(input_metadata), {}, context="add()") if input_metadata else {}
+    )
     effective_query_filters = deepcopy(input_filters) if input_filters else {}
 
     # ---------- validate and add all provided session ids ----------

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -453,6 +453,95 @@ def test_update_memory_metadata_cannot_change_identity_fields(mocker, caplog):
     assert "ignoring metadata['user_id']" in caplog.text
 
 
+_ATTACKER_ADD_METADATA = {
+    "agent_id": "victim-agent",
+    "run_id": "victim-run",
+    "actor_id": "victim-actor",
+    "category": "sports",
+}
+
+
+def _captured_add_metadata(memory, mocker, **add_kwargs):
+    """Run add() with the pipeline stubbed and return the metadata template it produced."""
+    captured = {}
+
+    def _capture(messages, metadata, filters, infer, **kwargs):
+        captured.update(metadata)
+        return []
+
+    mocker.patch.object(memory, "_add_to_vector_store", side_effect=_capture)
+    memory.add("I like coffee", infer=False, **add_kwargs)
+    return captured
+
+
+def test_add_metadata_cannot_set_identity_fields(mocker, caplog):
+    """Regression (issue #6655): add() metadata must not inject identity scope.
+
+    The caller scopes by user_id only, so the agent_id/run_id re-pins in
+    _build_filters_and_metadata never fire and cannot defend the payload.
+    """
+    memory = _build_memory_instance(mocker, Memory)
+
+    with caplog.at_level(logging.WARNING, logger="mem0.memory.main"):
+        metadata = _captured_add_metadata(
+            memory, mocker, user_id="attacker", metadata=dict(_ATTACKER_ADD_METADATA)
+        )
+
+    assert metadata["user_id"] == "attacker"
+    for key in ("agent_id", "run_id", "actor_id"):
+        assert key not in metadata, f"{key} was injected through add() metadata"
+    # Non-identity metadata is untouched.
+    assert metadata["category"] == "sports"
+    assert "ignoring metadata['agent_id']" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_add_metadata_cannot_set_identity_fields(mocker):
+    """Async counterpart of test_add_metadata_cannot_set_identity_fields."""
+    memory = _build_memory_instance(mocker, AsyncMemory)
+    captured = {}
+
+    async def _capture(messages, metadata, filters, infer, **kwargs):
+        captured.update(metadata)
+        return []
+
+    mocker.patch.object(memory, "_add_to_vector_store", side_effect=_capture)
+    await memory.add(
+        "I like coffee",
+        user_id="attacker",
+        metadata=dict(_ATTACKER_ADD_METADATA),
+        infer=False,
+    )
+
+    assert captured["user_id"] == "attacker"
+    for key in ("agent_id", "run_id", "actor_id"):
+        assert key not in captured, f"{key} was injected through async add() metadata"
+    assert captured["category"] == "sports"
+
+
+def test_add_entity_params_still_set_scope(mocker):
+    """The documented top-level params remain the only way to set scope."""
+    memory = _build_memory_instance(mocker, Memory)
+
+    metadata = _captured_add_metadata(
+        memory, mocker, user_id="u1", agent_id="a1", run_id="r1", metadata={"category": "sports"}
+    )
+
+    assert metadata["user_id"] == "u1"
+    assert metadata["agent_id"] == "a1"
+    assert metadata["run_id"] == "r1"
+    assert metadata["category"] == "sports"
+
+
+def test_add_without_metadata_is_unaffected(mocker):
+    """No metadata argument means no stripping and no behaviour change."""
+    memory = _build_memory_instance(mocker, Memory)
+
+    metadata = _captured_add_metadata(memory, mocker, user_id="u1")
+
+    assert metadata == {"user_id": "u1"}
+
+
 @pytest.mark.asyncio
 async def test_async_update_memory_metadata_cannot_change_identity_fields(mocker):
     """Async counterpart of test_update_memory_metadata_cannot_change_identity_fields."""


### PR DESCRIPTION
## Linked Issue

Closes #6655

## Description

`add()` let caller-supplied `metadata` set a memory's identity scope. In `_build_filters_and_metadata()` the caller's metadata was deep-copied straight into the payload template, and the identity keys were re-pinned only when the matching entity param was truthy:

```python
base_metadata_template = deepcopy(input_metadata) if input_metadata else {}
...
if user_id:
    base_metadata_template["user_id"] = user_id
if agent_id:
    base_metadata_template["agent_id"] = agent_id
```

For any identity key the caller did not pass as a top-level argument, that re-pin never fired, so whatever sat in `metadata` survived into the created memory. `actor_id` was never re-pinned there at all.

A caller scoped by `user_id` alone could therefore write into scopes it never held:

```python
m.add("I like coffee", user_id="attacker",
      metadata={"agent_id": "victim-agent", "run_id": "victim-run"})
# stored payload: {'agent_id': 'victim-agent', 'run_id': 'victim-run', 'user_id': 'attacker'}
```

That memory is then reachable from `get_all(filters={"agent_id": "victim-agent"})` and `search(..., filters={"run_id": "victim-run"})`.

`update()` already refuses exactly this through `_strip_identity_keys()` (#6277 / #6278), so the creation and update paths disagreed about whether identity fields can be set through metadata. This PR applies the same helper on the creation path.

Why `_build_filters_and_metadata()` is the right place: it is the only chokepoint that both creation paths share. Only two call sites pass `input_metadata`, sync `add()` and async `add()`, so one change covers both, and it covers `infer=True` and `infer=False` alike because they share the same template. The helper gains a `context` argument so the warning names the calling method, and its message now states the rule that holds on both paths rather than only the update-path phrasing.

Passing an entity param is unchanged and remains the only way to set scope. An explicitly passed argument already won over metadata for the same key, so the gap was exactly the keys a caller left unset.

This is the Python twin of #6371 / #6377 (TypeScript `add()`). `update()` is already handled on both sides.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

Not a breaking change for the documented API. Identity scope was always meant to come from the `user_id` / `agent_id` / `run_id` params, and those behave identically.

Code that relied on setting scope through `metadata` will now find those keys dropped, with a warning naming each one. That path was writing into scopes the caller did not request, which is the bug being fixed. Non-identity metadata is untouched.

One shared-helper detail worth calling out for review: `_strip_identity_keys()` had its warning text changed from "identity fields are immutable after creation" to "identity fields cannot be set through metadata", so a single message is accurate on both the add and update paths. The existing assertion in `tests/memory/test_main.py` checks the `ignoring metadata['user_id']` substring, which still holds.

## Test Coverage

- [x] I added/updated unit tests

Four tests in `tests/memory/test_main.py`, placed next to the existing `update()` identity-field pair:

- `test_add_metadata_cannot_set_identity_fields` - caller scopes by `user_id` only; `agent_id`/`run_id`/`actor_id` in metadata must not reach the payload, non-identity metadata must survive, warning emitted
- `test_async_add_metadata_cannot_set_identity_fields` - the async twin, written rather than assumed
- `test_add_entity_params_still_set_scope` - the documented params remain the only way to set scope
- `test_add_without_metadata_is_unaffected` - no metadata means no stripping and no behaviour change

**Proof, red on `upstream/main` and green with the fix** (source file reverted to `upstream/main` with the new tests kept, then restored):

```
# BEFORE (upstream/main source, new tests):
$ pytest tests/memory/test_main.py -k "identity or add_without_metadata or entity_params_still" -q
  2 failed, 4 passed
  AssertionError: agent_id was injected through add() metadata
  AssertionError: agent_id was injected through async add() metadata

# AFTER (this branch):
  6 passed

# Full suite on this branch:
$ pytest tests/memory/ -q
  356 passed
$ ruff check mem0/memory/main.py tests/memory/test_main.py
  All checks passed!
```

To be precise about what each test proves: the two that go red are the load-bearing ones. `test_add_entity_params_still_set_scope` and `test_add_without_metadata_is_unaffected` pass on unpatched `main` by design; they are compatibility guards against a future over-broad strip, not evidence of the bug.

The two pre-existing `update()` identity tests pass unchanged, which is what covers the shared-helper edit.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A for public docs; the `_build_filters_and_metadata` docstring now states that identity scope comes from the entity params only)
