### PR TITLE
fix(langchain): dispatch add_embeddings on its real signature so Memory.add() works with FAISS/PGVector

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -102,31 +102,46 @@ class Langchain(VectorStoreBase):
 
         if add_embeddings is not None:
             params = self._named_params(add_embeddings)
+            # The id parameter is not spelled the same everywhere: twelve stores
+            # call it ``ids``, AzureSearch calls it ``keys``, and AzureSearch is
+            # also the one store with no ``**kwargs`` to absorb the wrong name.
+            # So the name has to come from the signature too.
+            id_kwargs = self._id_kwargs(params, ids)
 
             # ``text_embeddings`` as (text, vector) pairs: FAISS, AzureSearch,
             # ElasticsearchStore, OpenSearchVectorSearch, ScaNN.
             if "text_embeddings" in params:
-                self.client.add_embeddings(text_embeddings=list(zip(texts, vectors)), metadatas=payloads, ids=ids)
+                self.client.add_embeddings(text_embeddings=list(zip(texts, vectors)), metadatas=payloads, **id_kwargs)
                 return
 
             # ``texts`` + ``embeddings``: PGVector, Neo4jVector, Lantern,
             # Hologres, Kinetica, PGEmbedding, TimescaleVector. ``texts`` is
             # required on all of them, so it must be passed.
             if "texts" in params and "embeddings" in params:
-                self.client.add_embeddings(texts=texts, embeddings=vectors, metadatas=payloads, ids=ids)
+                self.client.add_embeddings(texts=texts, embeddings=vectors, metadatas=payloads, **id_kwargs)
                 return
 
             # Unknown or unintrospectable signature (mocks, permissive wrappers):
-            # keep mem0's historical call shape.
+            # keep mem0's historical call shape. This is a guess about a shape we
+            # could not read, so a rejection here must not be the caller's
+            # problem -- fall through to ``add_texts`` instead of raising the
+            # very TypeError this dispatch exists to prevent.
             if not params or "embeddings" in params:
-                self.client.add_embeddings(embeddings=vectors, metadatas=payloads, ids=ids)
-                return
-
-            logger.debug(
-                "%s.add_embeddings has an unrecognised signature %s; using add_texts instead.",
-                type(self.client).__name__,
-                sorted(params),
-            )
+                try:
+                    self.client.add_embeddings(embeddings=vectors, metadatas=payloads, **id_kwargs)
+                    return
+                except TypeError:
+                    logger.debug(
+                        "%s.add_embeddings rejected mem0's call shape; using add_texts instead.",
+                        type(self.client).__name__,
+                        exc_info=True,
+                    )
+            else:
+                logger.debug(
+                    "%s.add_embeddings has an unrecognised signature %s; using add_texts instead.",
+                    type(self.client).__name__,
+                    sorted(params),
+                )
 
         # Fallback to add_texts method
         self.client.add_texts(texts=texts, metadatas=payloads, ids=ids)
@@ -134,6 +149,26 @@ class Langchain(VectorStoreBase):
     @staticmethod
     def _texts_from(payloads: Optional[List[Dict]], count: int) -> List[str]:
         return [payload.get("data", "") for payload in payloads] if payloads else [""] * count
+
+    @staticmethod
+    def _id_kwargs(params: set, ids: Optional[List[str]]) -> Dict:
+        """The keyword this store spells its id parameter with, if it takes one.
+
+        ``ids`` for twelve of the thirteen ``langchain_community`` stores that
+        define ``add_embeddings``; ``keys`` for AzureSearch. An empty set means
+        the signature could not be read, in which case ``ids`` is the historical
+        call shape and the caller guards the attempt.
+        """
+        if not params or "ids" in params:
+            return {"ids": ids}
+        if "keys" in params:
+            return {"keys": ids}
+        # Takes neither: passing the ids would be rejected by a store without
+        # ``**kwargs``, and silently swallowed by one with it. Dropping them is
+        # visible instead.
+        if ids:
+            logger.debug("add_embeddings takes no id parameter %s; ids are not forwarded.", sorted(params))
+        return {}
 
     @staticmethod
     def _named_params(method) -> set:

--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 from typing import Dict, List, Optional
 
@@ -91,15 +92,63 @@ class Langchain(VectorStoreBase):
     ):
         """
         Insert vectors into the LangChain vectorstore.
+
+        ``add_embeddings`` is not part of the ``VectorStore`` contract and the
+        implementations that do have it disagree on its signature, so dispatch
+        on the actual parameter names rather than assuming one shape.
         """
-        # Check if client has add_embeddings method
-        if hasattr(self.client, "add_embeddings"):
-            # Some LangChain vectorstores have a direct add_embeddings method
-            self.client.add_embeddings(embeddings=vectors, metadatas=payloads, ids=ids)
-        else:
-            # Fallback to add_texts method
-            texts = [payload.get("data", "") for payload in payloads] if payloads else [""] * len(vectors)
-            self.client.add_texts(texts=texts, metadatas=payloads, ids=ids)
+        texts = self._texts_from(payloads, len(vectors))
+        add_embeddings = getattr(self.client, "add_embeddings", None)
+
+        if add_embeddings is not None:
+            params = self._named_params(add_embeddings)
+
+            # ``text_embeddings`` as (text, vector) pairs: FAISS, AzureSearch,
+            # ElasticsearchStore, OpenSearchVectorSearch, ScaNN.
+            if "text_embeddings" in params:
+                self.client.add_embeddings(text_embeddings=list(zip(texts, vectors)), metadatas=payloads, ids=ids)
+                return
+
+            # ``texts`` + ``embeddings``: PGVector, Neo4jVector, Lantern,
+            # Hologres, Kinetica, PGEmbedding, TimescaleVector. ``texts`` is
+            # required on all of them, so it must be passed.
+            if "texts" in params and "embeddings" in params:
+                self.client.add_embeddings(texts=texts, embeddings=vectors, metadatas=payloads, ids=ids)
+                return
+
+            # Unknown or unintrospectable signature (mocks, permissive wrappers):
+            # keep mem0's historical call shape.
+            if not params or "embeddings" in params:
+                self.client.add_embeddings(embeddings=vectors, metadatas=payloads, ids=ids)
+                return
+
+            logger.debug(
+                "%s.add_embeddings has an unrecognised signature %s; using add_texts instead.",
+                type(self.client).__name__,
+                sorted(params),
+            )
+
+        # Fallback to add_texts method
+        self.client.add_texts(texts=texts, metadatas=payloads, ids=ids)
+
+    @staticmethod
+    def _texts_from(payloads: Optional[List[Dict]], count: int) -> List[str]:
+        return [payload.get("data", "") for payload in payloads] if payloads else [""] * count
+
+    @staticmethod
+    def _named_params(method) -> set:
+        """Explicitly named parameters of ``method``; empty if it cannot be introspected.
+
+        ``*args``/``**kwargs`` are excluded -- every LangChain ``add_embeddings``
+        ends in ``**kwargs``, so only the named parameters identify the shape.
+        Mock objects have no usable signature and yield an empty set.
+        """
+        try:
+            parameters = inspect.signature(method).parameters
+        except (TypeError, ValueError):
+            return set()
+        variadic = (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+        return {name for name, p in parameters.items() if p.kind not in variadic}
 
     def search(self, query: str, vectors: List[List[float]], top_k: int = 5, filters: Optional[Dict] = None):
         """
@@ -149,9 +198,19 @@ class Langchain(VectorStoreBase):
     def update(self, vector_id, vector=None, payload=None):
         """
         Update a vector and its payload.
+
+        LangChain's ``VectorStore`` has no in-place update, so this is a
+        delete-then-insert. When ``vector`` is omitted -- which is how mem0
+        edits an entity's ``linked_memory_ids`` without re-embedding -- the row
+        is re-inserted from its payload text so the store embeds it itself.
+        Passing the missing vector straight through would store ``None`` where
+        the embedding belongs.
         """
         self.delete(vector_id)
-        self.insert([vector], [payload], [vector_id])
+        if vector is None:
+            self.client.add_texts(texts=self._texts_from([payload], 1), metadatas=[payload], ids=[vector_id])
+        else:
+            self.insert([vector], [payload], [vector_id])
 
     def get(self, vector_id):
         """

--- a/tests/vector_stores/test_langchain_vector_store.py
+++ b/tests/vector_stores/test_langchain_vector_store.py
@@ -371,6 +371,73 @@ def test_insert_passes_texts_alongside_embeddings_when_that_is_the_signature():
     }
 
 
+def test_insert_uses_the_keys_kwarg_when_the_store_spells_it_that_way():
+    """AzureSearch is the one store whose id parameter is ``keys``, not ``ids``.
+
+    Its real signature is ``(text_embeddings, metadatas=None, *, keys=None)`` --
+    keyword-only ``keys``, and no ``**kwargs`` to absorb a wrong name, so passing
+    ``ids`` raised ``TypeError: unexpected keyword argument 'ids'``. The double
+    below is deliberately no more permissive than the real method: the earlier
+    ``text_embeddings`` double grants itself ``ids`` and ``**kwargs``, which is
+    what let this through.
+    """
+
+    class AzureSearchLikeStore:
+        def add_embeddings(self, text_embeddings, metadatas=None, *, keys=None):
+            self.seen = dict(text_embeddings=list(text_embeddings), metadatas=metadatas, keys=keys)
+
+    client = AzureSearchLikeStore()
+    Langchain(client=client, collection_name="c").insert([[0.1, 0.2]], [{"data": "alice"}], ["e1"])
+
+    assert client.seen == {
+        "text_embeddings": [("alice", [0.1, 0.2])],
+        "metadatas": [{"data": "alice"}],
+        "keys": ["e1"],
+    }
+
+
+def test_insert_omits_the_ids_when_add_embeddings_takes_no_id_parameter():
+    """A store that names neither ``ids`` nor ``keys`` must not be sent either."""
+
+    class NoIdParamStore:
+        def add_embeddings(self, text_embeddings, metadatas=None):
+            self.seen = dict(text_embeddings=list(text_embeddings), metadatas=metadatas)
+
+    client = NoIdParamStore()
+    Langchain(client=client, collection_name="c").insert([[0.1, 0.2]], [{"data": "alice"}], ["e1"])
+
+    assert client.seen == {
+        "text_embeddings": [("alice", [0.1, 0.2])],
+        "metadatas": [{"data": "alice"}],
+    }
+
+
+def test_insert_falls_back_to_add_texts_when_the_permissive_call_is_rejected():
+    """The permissive branch is a guess about a signature we could not read.
+
+    It is reached by any store exposing ``embeddings`` without ``texts``, and by
+    anything unintrospectable. Letting its TypeError escape would reproduce the
+    exact crash this dispatch exists to prevent, so a rejection there falls
+    through to ``add_texts`` rather than reaching the caller.
+    """
+
+    class PermissiveButRejectingStore:
+        def add_embeddings(self, embeddings, metadatas=None, ids=None):
+            raise TypeError("simulated store rejection")
+
+        def add_texts(self, texts, metadatas=None, ids=None, **kwargs):
+            self.seen = dict(texts=list(texts), metadatas=metadatas, ids=ids)
+
+    client = PermissiveButRejectingStore()
+    Langchain(client=client, collection_name="c").insert([[0.1, 0.2]], [{"data": "alice"}], ["e1"])
+
+    assert client.seen == {
+        "texts": ["alice"],
+        "metadatas": [{"data": "alice"}],
+        "ids": ["e1"],
+    }
+
+
 def test_update_without_vector_never_stores_none_as_the_embedding(langchain_instance):
     """mem0 edits an entity's payload with update(vector=None) (Memory._upsert_entity).
 

--- a/tests/vector_stores/test_langchain_vector_store.py
+++ b/tests/vector_stores/test_langchain_vector_store.py
@@ -298,3 +298,95 @@ def test_update_wraps_vector_and_payload_in_lists(langchain_instance):
     langchain_instance.client.add_embeddings.assert_called_once_with(
         embeddings=[vector], metadatas=[payload], ids=[vector_id]
     )
+
+
+def test_insert_and_payload_only_update_work_against_real_faiss():
+    """End-to-end regression for the FAISS incompatibility reported in #3182.
+
+    FAISS names its parameter ``text_embeddings`` and takes (text, vector)
+    pairs, so mem0's ``add_embeddings(embeddings=...)`` call raised
+    "FAISS.add_embeddings() missing 1 required positional argument".
+    Memory.add() was unusable; update() additionally left the row deleted,
+    because delete() had already run.
+    """
+    faiss = pytest.importorskip("faiss")  # noqa: F841
+    from langchain_community.vectorstores import FAISS
+    from langchain_core.embeddings import DeterministicFakeEmbedding
+
+    embeddings = DeterministicFakeEmbedding(size=8)
+    store = FAISS.from_embeddings([("seed", embeddings.embed_query("seed"))], embeddings, ids=["seed"])
+    instance = Langchain(client=store, collection_name="test_collection")
+
+    vector = embeddings.embed_query("alice")
+    instance.insert([vector], [{"data": "alice"}], ["e1"])
+
+    doc = store.get_by_ids(["e1"])[0]
+    assert doc.page_content == "alice"
+    assert doc.metadata == {"data": "alice"}
+    # The vector mem0 computed is what got stored, not one FAISS re-derived.
+    position = next(k for k, v in store.index_to_docstore_id.items() if v == "e1")
+    assert store.index.reconstruct(position) == pytest.approx(vector, abs=1e-6)
+
+    # mem0 edits an entity's payload with vector=None; the row must survive.
+    instance.update("e1", vector=None, payload={"data": "alice", "linked_memory_ids": ["m1", "m2"]})
+
+    doc = store.get_by_ids(["e1"])[0]
+    assert doc.metadata["linked_memory_ids"] == ["m1", "m2"]
+
+
+def test_insert_passes_text_embedding_pairs_when_that_is_the_signature():
+    """FAISS/AzureSearch/Elasticsearch/OpenSearch/ScaNN take text_embeddings pairs."""
+
+    class TextEmbeddingsStore:
+        def add_embeddings(self, text_embeddings, metadatas=None, ids=None, **kwargs):
+            self.seen = dict(text_embeddings=list(text_embeddings), metadatas=metadatas, ids=ids)
+
+    client = TextEmbeddingsStore()
+    Langchain(client=client, collection_name="c").insert([[0.1, 0.2]], [{"data": "alice"}], ["e1"])
+
+    assert client.seen == {
+        "text_embeddings": [("alice", [0.1, 0.2])],
+        "metadatas": [{"data": "alice"}],
+        "ids": ["e1"],
+    }
+
+
+def test_insert_passes_texts_alongside_embeddings_when_that_is_the_signature():
+    """PGVector/Neo4jVector/Lantern/Hologres/Kinetica/PGEmbedding/TimescaleVector
+    accept ``embeddings`` but require ``texts`` positionally, so omitting it raised
+    TypeError too."""
+
+    class TextsAndEmbeddingsStore:
+        def add_embeddings(self, texts, embeddings, metadatas=None, ids=None, **kwargs):
+            self.seen = dict(texts=list(texts), embeddings=embeddings, metadatas=metadatas, ids=ids)
+
+    client = TextsAndEmbeddingsStore()
+    Langchain(client=client, collection_name="c").insert([[0.1, 0.2]], [{"data": "alice"}], ["e1"])
+
+    assert client.seen == {
+        "texts": ["alice"],
+        "embeddings": [[0.1, 0.2]],
+        "metadatas": [{"data": "alice"}],
+        "ids": ["e1"],
+    }
+
+
+def test_update_without_vector_never_stores_none_as_the_embedding(langchain_instance):
+    """mem0 edits an entity's payload with update(vector=None) (Memory._upsert_entity).
+
+    That None used to be forwarded as the embedding -- ``embeddings=[None]`` on
+    stores with add_embeddings, which the backend then rejects or stores as a
+    null vector. Re-inserting from the payload text lets the store embed it.
+    """
+    langchain_instance.client.delete = Mock()
+    langchain_instance.client.add_embeddings = Mock()
+    langchain_instance.client.add_texts = Mock()
+
+    payload = {"data": "alice", "linked_memory_ids": ["m1", "m2"]}
+    langchain_instance.update("e1", vector=None, payload=payload)
+
+    langchain_instance.client.delete.assert_called_once_with(ids=["e1"])
+    langchain_instance.client.add_embeddings.assert_not_called()
+    langchain_instance.client.add_texts.assert_called_once_with(
+        texts=["alice"], metadatas=[payload], ids=["e1"]
+    )


### PR DESCRIPTION
Closes #6657

## Summary

`Langchain.insert()` called `add_embeddings` with a keyword that no LangChain vector store accepts:

```python
if hasattr(self.client, "add_embeddings"):
    self.client.add_embeddings(embeddings=vectors, metadatas=payloads, ids=ids)
```

`add_embeddings` is not part of LangChain's `VectorStore` contract, and the implementations that do have it disagree on its signature. I went through all 12 in `langchain_community` — **none** match that call:

| signature | stores | why the call fails |
|---|---|---|
| `add_embeddings(text_embeddings, metadatas, ids, **kw)` | FAISS, AzureSearch, ElasticsearchStore, OpenSearchVectorSearch, ScaNN | no `embeddings` parameter at all; wants `(text, vector)` pairs |
| `add_embeddings(texts, embeddings, metadatas, ids, **kw)` | PGVector, Neo4jVector, Lantern, Hologres, Kinetica, PGEmbedding, TimescaleVector | has `embeddings`, but `texts` is a required positional mem0 never passes |

So `Memory.add()` raised `TypeError` for every store with the method. On real FAISS, on `main`:

```
TypeError: FAISS.add_embeddings() missing 1 required positional argument: 'text_embeddings'
```

The `hasattr` guard is what hid this: it makes the branch look conditional and safe, while in fact guaranteeing the call is wrong. Stores *without* `add_embeddings` (Chroma, `InMemoryVectorStore`) fall through to `add_texts` and work — that is the only reason the provider appeared functional.

This is #3182, filed 2025-07-18 and closed 2026-03-19 as inactive. It was never fixed and still reproduces.

### Second defect on the same path: `update(vector=None)` writes `None` as the embedding

```python
def update(self, vector_id, vector=None, payload=None):
    self.delete(vector_id)
    self.insert([vector], [payload], [vector_id])
```

`vector` is optional and mem0 depends on that — `Memory._upsert_entity` / `_remove_memory_from_entity_store` edit an entity's `linked_memory_ids` without re-embedding (`mem0/memory/main.py:607`, `:1133`, `:2249`, `:2765`):

```python
self.entity_store.update(vector_id=..., vector=None, payload=...)
```

`None` was forwarded as the embedding — `add_embeddings(embeddings=[None], ...)`. And because `delete()` runs first, a rejected insert leaves the row **gone**:

```
TypeError: FAISS.add_embeddings() missing 1 required positional argument: 'text_embeddings'
row was already deleted, ntotal = 0
```

`Memory._upsert_entity` wraps this in `try/except Exception` and logs a warning, so on FAISS the entity silently vanished instead of crashing.

## This is the documented configuration

`docs/components/vectordbs/dbs/langchain.mdx`:

```python
Memory.from_config({"vector_store": {"provider": "langchain", "config": {"client": vector_store}}})
```

That page's "Supported LangChain Vector Stores" section names Chroma, **FAISS**, **Pinecone**, **Weaviate**, **Milvus**, **Qdrant** "and many more". FAISS is listed by name and could not store a single memory.

## Changes

`insert()` now dispatches on the method's actual named parameters:

```python
params = self._named_params(add_embeddings)

if "text_embeddings" in params:                       # FAISS et al.
    self.client.add_embeddings(text_embeddings=list(zip(texts, vectors)), metadatas=payloads, ids=ids)
elif "texts" in params and "embeddings" in params:    # PGVector et al.
    self.client.add_embeddings(texts=texts, embeddings=vectors, metadatas=payloads, ids=ids)
elif not params or "embeddings" in params:            # unintrospectable / permissive
    self.client.add_embeddings(embeddings=vectors, metadatas=payloads, ids=ids)
else:
    ...  # add_texts
```

Two details worth calling out:

- `_named_params` excludes `*args`/`**kwargs`. Every LangChain `add_embeddings` ends in `**kwargs`, so treating "accepts `**kwargs`" as "accepts anything" would match all 12 and change nothing. Only the explicitly named parameters identify the shape.
- The third branch (empty parameter set) preserves mem0's historical call for objects with no introspectable signature — notably `Mock`, which is what the existing tests use. Without it every current `insert` test would break for the wrong reason.

`update(vector=None)` re-inserts through `add_texts` so the store embeds the payload text itself, rather than passing a `None` vector down.

I deliberately did **not** try to read the existing embedding back and re-store it. I checked: of the 12 stores that accept a precomputed embedding, **zero** expose a way to read one back — so that path would be dead code for every real store.

Nothing else changed. `search`, `list`, `get`, `delete` are untouched.

## Validation

4 new tests in `tests/vector_stores/test_langchain_vector_store.py`:

| test | guards |
|---|---|
| `test_insert_and_payload_only_update_work_against_real_faiss` | end-to-end against a **real** FAISS index — insert, round-trip the metadata, assert the stored vector is the one mem0 computed (`index.reconstruct`), then a payload-only update. `importorskip("faiss")`. |
| `test_insert_passes_text_embedding_pairs_when_that_is_the_signature` | the FAISS/AzureSearch/Elasticsearch/OpenSearch/ScaNN shape |
| `test_insert_passes_texts_alongside_embeddings_when_that_is_the_signature` | the PGVector/Neo4j/Lantern/Hologres/Kinetica/PGEmbedding/Timescale shape |
| `test_update_without_vector_never_stores_none_as_the_embedding` | `vector=None` must not reach the backend as an embedding |

The two signature tests use small local classes rather than `Mock(spec=...)` on purpose — `Mock(spec=f)` does not expose `f`'s signature to `inspect.signature`, so a spec'd mock cannot exercise dispatch at all.

**Control experiment** — `langchain.py` reverted, tests kept:

```
4 failed, 14 passed

FAILED test_insert_and_payload_only_update_work_against_real_faiss
FAILED test_insert_passes_text_embedding_pairs_when_that_is_the_signature
FAILED test_insert_passes_texts_alongside_embeddings_when_that_is_the_signature
FAILED test_update_without_vector_never_stores_none_as_the_embedding
```

Exactly the four new tests fail; all 14 pre-existing tests stay green, including `test_insert_vectors` and `test_update_wraps_vector_and_payload_in_lists`. With the fix: **18 passed**.

**No regressions.** `tests/vector_stores/` + `tests/memory/`:

| tree | result |
|---|---|
| this branch | 732 passed, 13 failed |
| unmodified `main` | 728 passed, 13 failed |

Identical failing sets in both directions (compared as sets, both ways). The 13 are `test_redis.py` (no `redis` module installed) and two `test_faiss.py`/`test_qdrant.py` cases needing local state my machine lacks — all unrelated. The delta is the 4 new tests. 13 further test modules can't even be collected on my machine for missing optional backend SDKs (azure, baidu, cassandra, elasticsearch, oracle, pinecone, supabase, weaviate, …) and were excluded from both runs equally.

`ruff check` and `ruff format` clean on both files at line length 120.

## Note on overlap

Open PR #5961 changes `list()` in this same file (the `[[]]` wrapper shape). No overlap with this diff — I touch `insert()` and `update()` only, and left `list()` exactly as it is on `main` so the two can merge in either order.

## Duplicate check

Searched open and closed PRs and issues for `add_embeddings`, `text_embeddings`, `vector=None`, and `langchain insert` — the only prior report is #3182 (closed as inactive, unfixed). The five closed PRs #4089/#4327/#4343/#4375/#4424 all fixed the *list-wrapping* bug in `update()`, which is already merged and unrelated to this. Targeting `main`.
