### PR TITLE
fix(pinecone): treat wildcard filters as field existence

### DIFF
--- a/mem0/vector_stores/pinecone.py
+++ b/mem0/vector_stores/pinecone.py
@@ -216,6 +216,8 @@ class PineconeDB(VectorStoreBase):
                     else:
                         condition[f"${op}"] = operand
                 pinecone_filter[key] = condition
+            elif value == "*":
+                pinecone_filter[key] = {"$exists": True}
             else:
                 pinecone_filter[key] = {"$eq": value}
 

--- a/tests/vector_stores/test_pinecone.py
+++ b/tests/vector_stores/test_pinecone.py
@@ -245,6 +245,11 @@ def test_create_filter_plain_value(pinecone_db):
     assert result == {"user_id": {"$eq": "alice"}}
 
 
+def test_create_filter_wildcard_matches_existing_field(pinecone_db):
+    result = pinecone_db._create_filter({"user_id": "*"})
+    assert result == {"user_id": {"$exists": True}}
+
+
 def test_create_filter_range(pinecone_db):
     result = pinecone_db._create_filter({"age": {"gte": 18, "lte": 65}})
     assert result == {"age": {"$gte": 18, "$lte": 65}}


### PR DESCRIPTION
## Summary

- translate the documented `*` metadata filter into Pinecone's `$exists` operator
- preserve literal equality behavior for all other scalar filter values
- add regression coverage for the wildcard case

Closes #6652

## Validation

- `python -m pytest tests/vector_stores/test_pinecone.py -q` (28 passed)
- `git diff --check`