### PR TITLE
fix(openai): pass configured proxy clients

### DIFF
--- a/mem0/embeddings/openai.py
+++ b/mem0/embeddings/openai.py
@@ -32,7 +32,11 @@ class OpenAIEmbedding(EmbeddingBase):
                 DeprecationWarning,
             )
 
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            http_client=self.config.http_client,
+        )
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -45,12 +45,17 @@ class OpenAILLM(LLMBase):
                 base_url=self.config.openrouter_base_url
                 or os.getenv("OPENROUTER_API_BASE")
                 or "https://openrouter.ai/api/v1",
+                http_client=self.config.http_client,
             )
         else:
             api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
             base_url = self.config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 
-            self.client = OpenAI(api_key=api_key, base_url=base_url)
+            self.client = OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                http_client=self.config.http_client,
+            )
 
     def _parse_response(self, response, tools):
         """

--- a/tests/embeddings/test_openai_embeddings.py
+++ b/tests/embeddings/test_openai_embeddings.py
@@ -109,6 +109,14 @@ def test_embed_passes_encoding_format_float(mock_openai_client):
     assert call_kwargs.kwargs.get("encoding_format") == "float" or call_kwargs[1].get("encoding_format") == "float"
 
 
+def test_openai_embedding_passes_proxy_client_to_openai():
+    config = BaseEmbedderConfig(http_client_proxies="http://proxy.local:8080")
+    with patch("mem0.embeddings.openai.OpenAI") as openai:
+        OpenAIEmbedding(config)
+
+    assert openai.call_args.kwargs["http_client"] is config.http_client
+
+
 def test_embed_passes_dimensions_only_when_explicit(mock_openai_client):
     """Matryoshka / truncated embeddings: dimensions sent only if user sets embedding_dims (#4153)."""
     config = BaseEmbedderConfig(embedding_dims=256)

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -464,3 +464,15 @@ def test_openai_llm_preserves_proxies_from_base_config(mock_openai_client):
     llm = OpenAILLM(config)
     assert llm.config.http_client_proxies == "http://proxy.local:8080"
     assert isinstance(llm.config.http_client, httpx.Client)
+
+
+def test_openai_llm_passes_proxy_client_to_openai():
+    config = OpenAIConfig(
+        model="gpt-4.1-nano-2025-04-14",
+        api_key="api_key",
+        http_client_proxies="http://proxy.local:8080",
+    )
+    with patch("mem0.llms.openai.OpenAI") as openai:
+        OpenAILLM(config)
+
+    assert openai.call_args.kwargs["http_client"] is config.http_client


### PR DESCRIPTION
## Summary

- pass the configured proxy-aware `httpx.Client` into OpenAI LLM clients
- pass the same client into OpenAI embedding clients
- add constructor-level regression tests for both paths

Closes #6651

## Validation

- `python -m pytest tests/llms/test_openai.py tests/embeddings/test_openai_embeddings.py -q` (32 passed)
- `git diff --check`