### PR TITLE
fix(memory): prevent identity metadata injection

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -342,7 +342,14 @@ def _build_filters_and_metadata(
               scoped to the provided session(s) and potentially a resolved actor.
     """
 
-    base_metadata_template = deepcopy(input_metadata) if input_metadata else {}
+    # Identity scope is controlled by the explicit arguments below. Do not
+    # allow free-form metadata to inject a scope that was not supplied by the
+    # caller (the update path applies the same invariant after creation).
+    base_metadata_template = {
+        key: value
+        for key, value in (input_metadata or {}).items()
+        if key not in _IDENTITY_KEYS
+    }
     effective_query_filters = deepcopy(input_filters) if input_filters else {}
 
     # ---------- validate and add all provided session ids ----------

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, Mock
 import pytest
 
 from mem0.exceptions import LLMError
-from mem0.memory.main import AsyncMemory, Memory
+from mem0.memory.main import AsyncMemory, Memory, _build_filters_and_metadata
 
 
 def _setup_mocks(mocker):
@@ -451,6 +451,21 @@ def test_update_memory_metadata_cannot_change_identity_fields(mocker, caplog):
     assert payload["category"] == "sports"
     assert payload["data"] == "new memory"
     assert "ignoring metadata['user_id']" in caplog.text
+
+
+def test_add_metadata_cannot_inject_identity_fields():
+    metadata, filters = _build_filters_and_metadata(
+        user_id="tenant_a",
+        input_metadata={
+            "agent_id": "attacker_agent",
+            "run_id": "attacker_run",
+            "actor_id": "attacker_actor",
+            "category": "sports",
+        },
+    )
+
+    assert metadata == {"user_id": "tenant_a", "category": "sports"}
+    assert filters == {"user_id": "tenant_a"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- prevent free-form metadata from injecting `user_id`, `agent_id`, `run_id`, or `actor_id` during memory creation
- retain explicit top-level identity arguments as the only source of scope
- add regression coverage for the creation helper

Closes #6655

## Validation

- `python -m pytest tests/memory/test_main.py -q -k add_metadata_cannot_inject_identity_fields` (1 passed)
- `git diff --check`

The full `test_main.py` module could not run because this environment lacks the repository's `pytest-mock` fixture plugin; 48 existing tests report the missing `mocker` fixture before executing.