### PR TITLE
fix: honor Together custom base URLs

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -20,6 +20,7 @@ class BaseEmbedderConfig(ABC):
         ollama_base_url: Optional[str] = None,
         # Openai specific
         openai_base_url: Optional[str] = None,
+        together_base_url: Optional[str] = None,
         # Huggingface specific
         model_kwargs: Optional[dict] = None,
         huggingface_base_url: Optional[str] = None,
@@ -77,6 +78,7 @@ class BaseEmbedderConfig(ABC):
         self.model = model
         self.api_key = api_key
         self.openai_base_url = openai_base_url
+        self.together_base_url = together_base_url
         self.embedding_dims = embedding_dims
 
         # AzureOpenAI specific

--- a/mem0/configs/llms/base.py
+++ b/mem0/configs/llms/base.py
@@ -26,6 +26,7 @@ class BaseLlmConfig(ABC):
         reasoning_effort: Optional[str] = None,
         http_client_proxies: Optional[Union[Dict, str]] = None,
         is_reasoning_model: Optional[bool] = None,
+        together_base_url: Optional[str] = None,
     ):
         """
         Initialize a base configuration class instance for the LLM.
@@ -76,3 +77,4 @@ class BaseLlmConfig(ABC):
         self.is_reasoning_model = is_reasoning_model
         self.http_client_proxies = http_client_proxies
         self.http_client = build_http_client(http_client_proxies)
+        self.together_base_url = together_base_url

--- a/mem0/embeddings/together.py
+++ b/mem0/embeddings/together.py
@@ -14,7 +14,12 @@ class TogetherEmbedding(EmbeddingBase):
         self.config.model = self.config.model or "intfloat/multilingual-e5-large-instruct"
         api_key = self.config.api_key or os.getenv("TOGETHER_API_KEY")
         self.config.embedding_dims = self.config.embedding_dims or 1024
-        self.client = Together(api_key=api_key)
+        base_url = self.config.together_base_url or self.config.openai_base_url
+        base_url = base_url or os.getenv("TOGETHER_API_BASE") or os.getenv("TOGETHER_BASE_URL")
+        client_kwargs = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self.client = Together(**client_kwargs)
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """

--- a/mem0/llms/together.py
+++ b/mem0/llms/together.py
@@ -20,7 +20,12 @@ class TogetherLLM(LLMBase):
             self.config.model = "MiniMaxAI/MiniMax-M3"
 
         api_key = self.config.api_key or os.getenv("TOGETHER_API_KEY")
-        self.client = Together(api_key=api_key)
+        base_url = self.config.together_base_url or getattr(self.config, "openai_base_url", None)
+        base_url = base_url or os.getenv("TOGETHER_API_BASE") or os.getenv("TOGETHER_BASE_URL")
+        client_kwargs = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self.client = Together(**client_kwargs)
 
     def _parse_response(self, response, tools):
         """

--- a/tests/embeddings/test_together_embeddings.py
+++ b/tests/embeddings/test_together_embeddings.py
@@ -73,6 +73,24 @@ def test_default_config_applies_together_defaults(mock_together_client):
     assert embedder.config.embedding_dims == DEFAULT_EMBEDDING_DIMS
 
 
+@patch("mem0.embeddings.together.Together")
+def test_client_receives_configured_base_url(mock_together):
+    config = BaseEmbedderConfig(together_base_url="https://gateway.example/v1")
+
+    TogetherEmbedding(config)
+
+    mock_together.assert_called_once_with(api_key=None, base_url="https://gateway.example/v1")
+
+
+@patch("mem0.embeddings.together.Together")
+def test_client_receives_environment_base_url(mock_together, monkeypatch):
+    monkeypatch.setenv("TOGETHER_BASE_URL", "https://env.example/v1")
+
+    TogetherEmbedding(BaseEmbedderConfig())
+
+    mock_together.assert_called_once_with(api_key=None, base_url="https://env.example/v1")
+
+
 def test_explicit_config_overrides_defaults(mock_together_client):
     # The `config.x or default` wiring must honor user-provided values, not clobber them.
     config = BaseEmbedderConfig(model="BAAI/bge-base-en-v1.5", embedding_dims=768)

--- a/tests/llms/test_together.py
+++ b/tests/llms/test_together.py
@@ -34,6 +34,24 @@ def test_generate_response_without_tools(mock_together_client):
     assert response == "I'm doing well, thank you for asking!"
 
 
+@patch("mem0.llms.together.Together")
+def test_client_receives_configured_base_url(mock_together):
+    config = BaseLlmConfig(together_base_url="https://gateway.example/v1")
+
+    TogetherLLM(config)
+
+    mock_together.assert_called_once_with(api_key=None, base_url="https://gateway.example/v1")
+
+
+@patch("mem0.llms.together.Together")
+def test_client_receives_environment_base_url(mock_together, monkeypatch):
+    monkeypatch.setenv("TOGETHER_API_BASE", "https://env.example/v1")
+
+    TogetherLLM(BaseLlmConfig())
+
+    mock_together.assert_called_once_with(api_key=None, base_url="https://env.example/v1")
+
+
 def test_generate_response_with_tools(mock_together_client):
     config = BaseLlmConfig(model="mistralai/Mixtral-8x7B-Instruct-v0.1", temperature=0.7, max_tokens=100, top_p=1.0)
     llm = TogetherLLM(config)


### PR DESCRIPTION
## Summary
- honor `TOGETHER_API_BASE` and `TOGETHER_BASE_URL` for Together chat and embedding clients
- allow explicit `together_base_url` (and existing `openai_base_url` compatibility) to override environment defaults
- preserve the default Together client call when no custom endpoint is configured

## Validation
- `python -m pytest tests/llms/test_together.py tests/embeddings/test_together_embeddings.py -q` (13 passed)
- `python -m compileall -q mem0/llms/together.py mem0/embeddings/together.py mem0/configs/llms/base.py mem0/configs/embeddings/base.py`
- `git diff --check`

Closes #6587