### PR TITLE
fix: honor Together embedder base URL

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/together.ts
+++ b/mem0-ts/src/oss/src/embeddings/together.ts
@@ -17,7 +17,11 @@ export class TogetherEmbedder extends OpenAIEmbedder {
     super({
       ...openAICompatibleConfig,
       apiKey,
-      baseURL: config.baseURL || config.url || DEFAULT_BASE_URL,
+      baseURL:
+        config.baseURL ||
+        config.url ||
+        process.env.TOGETHER_API_BASE ||
+        DEFAULT_BASE_URL,
       model: config.model || DEFAULT_MODEL,
     });
   }

--- a/mem0-ts/src/oss/tests/together-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/together-embedder.test.ts
@@ -60,6 +60,35 @@ describe("TogetherEmbedder (unit)", () => {
     });
   });
 
+  it("uses TOGETHER_API_BASE when no base URL is configured", async () => {
+    process.env.TOGETHER_API_BASE = "https://env.together.test/v1";
+
+    const embedder = new TogetherEmbedder({ apiKey: "test-key" });
+
+    await embedder.embed("hello");
+
+    expect(mockOpenAI).toHaveBeenCalledWith({
+      apiKey: "test-key",
+      baseURL: "https://env.together.test/v1",
+    });
+  });
+
+  it("prefers an explicit base URL over TOGETHER_API_BASE", async () => {
+    process.env.TOGETHER_API_BASE = "https://env.together.test/v1";
+
+    const embedder = new TogetherEmbedder({
+      apiKey: "test-key",
+      baseURL: "https://config.together.test/v1",
+    });
+
+    await embedder.embed("hello");
+
+    expect(mockOpenAI).toHaveBeenCalledWith({
+      apiKey: "test-key",
+      baseURL: "https://config.together.test/v1",
+    });
+  });
+
   it("supports custom model and baseURL without forwarding embeddingDims", async () => {
     const embedder = new TogetherEmbedder({
       apiKey: "test-key",


### PR DESCRIPTION
## Summary
- honor `TOGETHER_API_BASE` in the TypeScript Together embedder
- preserve precedence of explicit `baseURL`, then legacy `url`, then environment, then the Together default
- add regression coverage for environment fallback and explicit-config precedence

## Validation
- `jest --runInBand src/oss/tests/together-embedder.test.ts` (8 passed)
- `prettier --check src/oss/src/embeddings/together.ts src/oss/tests/together-embedder.test.ts`
- `git diff --check`

Closes #6571