### PR TITLE
fix: preserve Gemini message roles

### DIFF
--- a/mem0-ts/src/oss/src/llms/google.ts
+++ b/mem0-ts/src/oss/src/llms/google.ts
@@ -23,18 +23,34 @@ export class GoogleLLM implements LLM {
     this.google = new sdk.GoogleGenAI({ apiKey: this.apiKey });
   }
 
-  private formatContents(messages: Message[]) {
-    return messages.map((msg) => ({
-      parts: [
-        {
-          text:
-            typeof msg.content === "string"
-              ? msg.content
-              : JSON.stringify(msg.content),
-        },
-      ],
-      role: msg.role === "system" ? "model" : "user",
-    }));
+  private formatMessages(messages: Message[]) {
+    const systemParts = messages
+      .filter((msg) => msg.role === "system")
+      .map((msg) => ({
+        text:
+          typeof msg.content === "string"
+            ? msg.content
+            : JSON.stringify(msg.content),
+      }));
+    const contents = messages
+      .filter((msg) => msg.role !== "system")
+      .map((msg) => ({
+        parts: [
+          {
+            text:
+              typeof msg.content === "string"
+                ? msg.content
+                : JSON.stringify(msg.content),
+          },
+        ],
+        role: msg.role === "assistant" ? "model" : "user",
+      }));
+
+    return {
+      contents,
+      systemInstruction:
+        systemParts.length > 0 ? { parts: systemParts } : undefined,
+    };
   }
 
   async generateResponse(
@@ -43,10 +59,13 @@ export class GoogleLLM implements LLM {
     tools?: any[],
   ): Promise<string | LLMResponse> {
     await this.ensureClient();
-    const contents = this.formatContents(messages);
+    const { contents, systemInstruction } = this.formatMessages(messages);
 
     // Build config with tools if provided
     const config: Record<string, any> = {};
+    if (systemInstruction) {
+      config.systemInstruction = systemInstruction;
+    }
     if (tools && tools.length > 0) {
       config.tools = [
         {
@@ -95,9 +114,12 @@ export class GoogleLLM implements LLM {
 
   async generateChat(messages: Message[]): Promise<LLMResponse> {
     await this.ensureClient();
+    const { contents, systemInstruction } = this.formatMessages(messages);
+    const config = systemInstruction ? { systemInstruction } : undefined;
     const completion = await this.google.models.generateContent({
-      contents: this.formatContents(messages),
+      contents,
       model: this.model,
+      ...(config ? { config } : {}),
     });
     const response = completion.candidates?.[0]?.content;
     const content =

--- a/mem0-ts/src/oss/tests/google-llm.test.ts
+++ b/mem0-ts/src/oss/tests/google-llm.test.ts
@@ -236,13 +236,39 @@ describe("GoogleLLM (unit)", () => {
 
     expect(mockGenerateContent).toHaveBeenCalledWith(
       expect.objectContaining({
-        contents: [
-          { role: "model", parts: [{ text: "Be concise" }] },
-          { role: "user", parts: [{ text: "Say hello" }] },
-        ],
+        contents: [{ role: "user", parts: [{ text: "Say hello" }] }],
+        config: {
+          systemInstruction: { parts: [{ text: "Be concise" }] },
+        },
       }),
     );
     expect(result).toEqual({ content: "Hello, world", role: "model" });
+  });
+
+  it("maps assistant turns to model role and system prompts to systemInstruction", async () => {
+    mockGenerateContent.mockResolvedValueOnce({
+      text: "ok",
+      functionCalls: null,
+    });
+
+    const llm = new GoogleLLM({ apiKey: "test-key" });
+    await llm.generateResponse([
+      { role: "system", content: "Follow the policy" },
+      { role: "user", content: "Question" },
+      { role: "assistant", content: "Earlier answer" },
+    ]);
+
+    expect(mockGenerateContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contents: [
+          { role: "user", parts: [{ text: "Question" }] },
+          { role: "model", parts: [{ text: "Earlier answer" }] },
+        ],
+        config: {
+          systemInstruction: { parts: [{ text: "Follow the policy" }] },
+        },
+      }),
+    );
   });
 
   it("returns an empty assistant response when generateChat has no candidates", async () => {


### PR DESCRIPTION
## Summary
- route Gemini system messages through `config.systemInstruction` instead of a fake model turn
- map assistant messages to Gemini's `model` role while preserving user turns
- apply the same message formatting to `generateResponse` and `generateChat`

## Validation
- `jest --runInBand src/oss/tests/google-llm.test.ts` (10 passed)
- `prettier --check src/oss/src/llms/google.ts src/oss/tests/google-llm.test.ts`
- `git diff --check`

Closes #6569