### PR TITLE
fix: honor LM Studio base URL environment

### DIFF
--- a/mem0-ts/src/oss/src/embeddings/lmstudio.ts
+++ b/mem0-ts/src/oss/src/embeddings/lmstudio.ts
@@ -12,7 +12,11 @@ export class LMStudioEmbedder implements Embedder {
   private model: string;
 
   constructor(config: EmbeddingConfig) {
-    const baseURL = config.baseURL ?? config.url ?? DEFAULT_BASE_URL;
+    const baseURL =
+      config.baseURL ??
+      config.url ??
+      process.env.LMSTUDIO_BASE_URL ??
+      DEFAULT_BASE_URL;
     const apiKey = config.apiKey || DEFAULT_LMSTUDIO_API_KEY;
     this.openai = new OpenAI({ apiKey, baseURL: String(baseURL) });
     this.model = config.model || DEFAULT_MODEL;

--- a/mem0-ts/src/oss/src/llms/lmstudio.ts
+++ b/mem0-ts/src/oss/src/llms/lmstudio.ts
@@ -12,7 +12,8 @@ export class LMStudioLLM extends OpenAILLM {
     super({
       ...config,
       apiKey: config.apiKey || DEFAULT_LMSTUDIO_API_KEY,
-      baseURL: config.baseURL ?? DEFAULT_BASE_URL,
+      baseURL:
+        config.baseURL ?? process.env.LMSTUDIO_BASE_URL ?? DEFAULT_BASE_URL,
       model: config.model || DEFAULT_MODEL,
     });
   }

--- a/mem0-ts/src/oss/tests/lmstudio-embedder.test.ts
+++ b/mem0-ts/src/oss/tests/lmstudio-embedder.test.ts
@@ -3,8 +3,6 @@
  * LM Studio Embedder — unit tests (mocked OpenAI).
  */
 
-import { LMStudioEmbedder } from "../src/embeddings/lmstudio";
-
 const mockEmbedding = [0.1, 0.2, 0.3, 0.4, 0.5];
 const mockCreate = jest.fn().mockResolvedValue({
   data: [{ embedding: mockEmbedding }],
@@ -16,8 +14,39 @@ jest.mock("openai", () => {
   }));
 });
 
+import OpenAI from "openai";
+import { LMStudioEmbedder } from "../src/embeddings/lmstudio";
+
+const mockOpenAI = OpenAI as unknown as jest.Mock;
+
 describe("LMStudioEmbedder (unit)", () => {
-  beforeEach(() => mockCreate.mockClear());
+  beforeEach(() => {
+    mockCreate.mockClear();
+    mockOpenAI.mockClear();
+    delete process.env.LMSTUDIO_BASE_URL;
+  });
+
+  it("uses LMSTUDIO_BASE_URL when no base URL is configured", () => {
+    process.env.LMSTUDIO_BASE_URL = "http://gateway.example/v1";
+
+    new LMStudioEmbedder({});
+
+    expect(mockOpenAI).toHaveBeenCalledWith({
+      apiKey: "lm-studio",
+      baseURL: "http://gateway.example/v1",
+    });
+  });
+
+  it("prefers an explicit base URL over LMSTUDIO_BASE_URL", () => {
+    process.env.LMSTUDIO_BASE_URL = "http://gateway.example/v1";
+
+    new LMStudioEmbedder({ baseURL: "http://configured.example/v1" });
+
+    expect(mockOpenAI).toHaveBeenCalledWith({
+      apiKey: "lm-studio",
+      baseURL: "http://configured.example/v1",
+    });
+  });
 
   it("embed() calls OpenAI with encoding_format float and returns vector", async () => {
     const embedder = new LMStudioEmbedder({

--- a/mem0-ts/src/oss/tests/lmstudio-llm.test.ts
+++ b/mem0-ts/src/oss/tests/lmstudio-llm.test.ts
@@ -3,8 +3,6 @@
  * LM Studio LLM — unit tests (mocked OpenAI).
  */
 
-import { LMStudioLLM } from "../src/llms/lmstudio";
-
 const mockCreate = jest.fn();
 
 jest.mock("openai", () => {
@@ -13,8 +11,39 @@ jest.mock("openai", () => {
   }));
 });
 
+import OpenAI from "openai";
+import { LMStudioLLM } from "../src/llms/lmstudio";
+
+const mockOpenAI = OpenAI as unknown as jest.Mock;
+
 describe("LMStudioLLM (unit)", () => {
-  beforeEach(() => mockCreate.mockClear());
+  beforeEach(() => {
+    mockCreate.mockClear();
+    mockOpenAI.mockClear();
+    delete process.env.LMSTUDIO_BASE_URL;
+  });
+
+  it("uses LMSTUDIO_BASE_URL when no base URL is configured", () => {
+    process.env.LMSTUDIO_BASE_URL = "http://gateway.example/v1";
+
+    new LMStudioLLM({});
+
+    expect(mockOpenAI).toHaveBeenCalledWith({
+      apiKey: "lm-studio",
+      baseURL: "http://gateway.example/v1",
+    });
+  });
+
+  it("prefers an explicit base URL over LMSTUDIO_BASE_URL", () => {
+    process.env.LMSTUDIO_BASE_URL = "http://gateway.example/v1";
+
+    new LMStudioLLM({ baseURL: "http://configured.example/v1" });
+
+    expect(mockOpenAI).toHaveBeenCalledWith({
+      apiKey: "lm-studio",
+      baseURL: "http://configured.example/v1",
+    });
+  });
 
   it("generateResponse() returns a text response", async () => {
     mockCreate.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- honor `LMSTUDIO_BASE_URL` for the TypeScript LM Studio LLM and embedder
- preserve explicit `baseURL`, then legacy `url` for embeddings, before the environment fallback
- add regression coverage for environment fallback and explicit configuration precedence

## Validation
- `jest --runInBand src/oss/tests/lmstudio-llm.test.ts src/oss/tests/lmstudio-embedder.test.ts` (13 passed)
- `prettier --check src/oss/src/llms/lmstudio.ts src/oss/src/embeddings/lmstudio.ts src/oss/tests/lmstudio-llm.test.ts src/oss/tests/lmstudio-embedder.test.ts`
- `git diff --check`

Closes #6542