### PR TITLE
fix: normalize Turbopuffer euclidean scores

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/turbopuffer.ts
+++ b/mem0-ts/src/oss/src/vector_stores/turbopuffer.ts
@@ -274,7 +274,12 @@ export class TurbopufferDB implements VectorStore {
   private parseRows(rows: any[]): VectorStoreResult[] {
     return rows.map((row) => {
       const { id, $dist, vector, ...rest } = row;
-      const score = $dist != null ? 1 - $dist : undefined;
+      const score =
+        $dist == null
+          ? undefined
+          : this.distanceMetric === "euclidean_squared"
+            ? 1 / (1 + $dist)
+            : 1 - $dist;
       return { id: String(id), payload: rest, score };
     });
   }

--- a/mem0-ts/src/oss/tests/turbopuffer.test.ts
+++ b/mem0-ts/src/oss/tests/turbopuffer.test.ts
@@ -1,0 +1,61 @@
+/// <reference types="jest" />
+
+import { TurbopufferDB } from "../src/vector_stores/turbopuffer";
+
+describe("TurbopufferDB score normalization", () => {
+  it("normalizes euclidean_squared distances to a positive similarity", () => {
+    const store = new TurbopufferDB({
+      apiKey: "test-key",
+      collectionName: "memories",
+      distanceMetric: "euclidean_squared",
+    });
+
+    const results = (store as any).parseRows([
+      { id: "near", $dist: 0.5, user_id: "u1" },
+      { id: "far", $dist: 3, user_id: "u1" },
+    ]);
+
+    expect(results).toEqual([
+      { id: "near", payload: { user_id: "u1" }, score: 2 / 3 },
+      { id: "far", payload: { user_id: "u1" }, score: 1 / 4 },
+    ]);
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+    expect(results[1].score).toBeGreaterThan(0);
+  });
+
+  it("preserves cosine distance scoring", () => {
+    const store = new TurbopufferDB({
+      apiKey: "test-key",
+      collectionName: "memories",
+      distanceMetric: "cosine_distance",
+    });
+
+    const [result] = (store as any).parseRows([
+      { id: "doc-1", $dist: 0.25, topic: "alpha" },
+    ]);
+
+    expect(result).toEqual({
+      id: "doc-1",
+      payload: { topic: "alpha" },
+      score: 0.75,
+    });
+  });
+
+  it("leaves missing distances undefined", () => {
+    const store = new TurbopufferDB({
+      apiKey: "test-key",
+      collectionName: "memories",
+      distanceMetric: "euclidean_squared",
+    });
+
+    const [result] = (store as any).parseRows([
+      { id: "doc-1", topic: "alpha" },
+    ]);
+
+    expect(result).toEqual({
+      id: "doc-1",
+      payload: { topic: "alpha" },
+      score: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- normalize Turbopuffer `euclidean_squared` distances with `1 / (1 + distance)` so scores stay positive and higher-is-better
- preserve existing cosine-distance scoring
- add regression coverage for metric-specific and missing-distance behavior

## Validation
- `jest --runInBand src/oss/tests/turbopuffer.test.ts` (3 passed)
- `prettier --check src/oss/src/vector_stores/turbopuffer.ts src/oss/tests/turbopuffer.test.ts`
- `git diff --check`

Closes #6579