### PR TITLE
fix: preserve Turbopuffer filter operators

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/turbopuffer.ts
+++ b/mem0-ts/src/oss/src/vector_stores/turbopuffer.ts
@@ -250,18 +250,33 @@ export class TurbopufferDB implements VectorStore {
   private convertFilters(filters?: SearchFilters): any {
     if (!filters || Object.keys(filters).length === 0) return null;
 
+    const operatorMap: Record<string, string> = {
+      eq: "Eq",
+      ne: "NotEq",
+      gt: "Gt",
+      gte: "Gte",
+      lt: "Lt",
+      lte: "Lte",
+      in: "In",
+      nin: "NotIn",
+    };
     const conditions: any[] = [];
     for (const [key, value] of Object.entries(filters)) {
-      if (
-        typeof value === "object" &&
-        value !== null &&
-        !Array.isArray(value)
-      ) {
-        if ("gte" in value) conditions.push([key, "Gte", value.gte]);
-        if ("lte" in value) conditions.push([key, "Lte", value.lte]);
-        if ("gt" in value) conditions.push([key, "Gt", value.gt]);
-        if ("lt" in value) conditions.push([key, "Lt", value.lt]);
+      if (Array.isArray(value)) {
+        conditions.push([key, "In", value]);
+      } else if (typeof value === "object" && value !== null) {
+        for (const [operator, operand] of Object.entries(value)) {
+          const token = operatorMap[operator];
+          if (!token) {
+            throw new Error(
+              `Unsupported Turbopuffer filter operator "${operator}" for "${key}"`,
+            );
+          }
+          if (operator === "eq" && operand === "*") continue;
+          conditions.push([key, token, operand]);
+        }
       } else {
+        if (value === "*") continue;
         conditions.push([key, "Eq", value]);
       }
     }

--- a/mem0-ts/src/oss/tests/turbopuffer-filters.test.ts
+++ b/mem0-ts/src/oss/tests/turbopuffer-filters.test.ts
@@ -1,0 +1,60 @@
+/// <reference types="jest" />
+
+import { TurbopufferDB } from "../src/vector_stores/turbopuffer";
+
+describe("TurbopufferDB filter conversion", () => {
+  const store = () =>
+    new TurbopufferDB({ apiKey: "test-key", collectionName: "memories" });
+  const convert = (filters: Record<string, any>) =>
+    (store() as any).convertFilters(filters);
+
+  it("maps all supported operators", () => {
+    expect(
+      convert({
+        eq_field: { eq: "x" },
+        ne_field: { ne: "x" },
+        gt_field: { gt: 1 },
+        gte_field: { gte: 1 },
+        lt_field: { lt: 9 },
+        lte_field: { lte: 9 },
+        in_field: { in: ["a", "b"] },
+        nin_field: { nin: ["c"] },
+      }),
+    ).toEqual([
+      "And",
+      [
+        ["eq_field", "Eq", "x"],
+        ["ne_field", "NotEq", "x"],
+        ["gt_field", "Gt", 1],
+        ["gte_field", "Gte", 1],
+        ["lt_field", "Lt", 9],
+        ["lte_field", "Lte", 9],
+        ["in_field", "In", ["a", "b"]],
+        ["nin_field", "NotIn", ["c"]],
+      ],
+    ]);
+  });
+
+  it("treats bare arrays as membership filters", () => {
+    expect(convert({ tier: ["free", "pro"] })).toEqual([
+      "tier",
+      "In",
+      ["free", "pro"],
+    ]);
+  });
+
+  it("skips wildcard filters instead of querying literal asterisk", () => {
+    expect(convert({ user_id: "*", tier: { eq: "*" } })).toBeNull();
+    expect(convert({ user_id: "*", tier: "pro" })).toEqual([
+      "tier",
+      "Eq",
+      "pro",
+    ]);
+  });
+
+  it("rejects unknown operators instead of dropping the filter", () => {
+    expect(() => convert({ tier: { contains: "pro" } })).toThrow(
+      'Unsupported Turbopuffer filter operator "contains" for "tier"',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- map all supported Turbopuffer filter operators, including `eq`, `ne`, `in`, and `nin`
- treat bare arrays as membership filters and skip `*` wildcards
- raise on unknown operators instead of silently dropping filters

## Validation
- `jest --runInBand src/oss/tests/turbopuffer-filters.test.ts` (4 passed)
- `prettier --check src/oss/src/vector_stores/turbopuffer.ts src/oss/tests/turbopuffer-filters.test.ts`
- `git diff --check`

Closes #6577