### PR TITLE
fix: isolate entity store database paths

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -301,7 +301,12 @@ export class Memory {
       // For file-based stores (memory/SQLite), always use a separate DB for entities
       if (entityProvider === "memory") {
         const basePath = entityConfig.dbPath || getDefaultVectorStoreDbPath();
-        entityConfig.dbPath = basePath.replace(/\.db$/, "_entities.db");
+        if (basePath !== ":memory:") {
+          const extension = basePath.match(/(\.[^./\\]+)$/)?.[1];
+          entityConfig.dbPath = extension
+            ? `${basePath.slice(0, -extension.length)}_entities${extension}`
+            : `${basePath}_entities`;
+        }
       }
       if (entityProvider === "databricks") {
         entityConfig.tableName = entityConfig.tableName

--- a/mem0-ts/src/oss/tests/vector-stores-compat.test.ts
+++ b/mem0-ts/src/oss/tests/vector-stores-compat.test.ts
@@ -5257,6 +5257,47 @@ describe("Memory class – backward compat with all providers", () => {
     expect(entityStore.initialize).toHaveBeenCalled();
   });
 
+  it("separates entity DB paths for every file extension", async () => {
+    const cases = [
+      ["/tmp/mem0-path.db", "/tmp/mem0-path_entities.db"],
+      ["/tmp/mem0-path.sqlite", "/tmp/mem0-path_entities.sqlite"],
+      ["/tmp/mem0-path.sqlite3", "/tmp/mem0-path_entities.sqlite3"],
+      ["/tmp/mem0-path", "/tmp/mem0-path_entities"],
+      [":memory:", ":memory:"],
+    ];
+
+    for (const [dbPath, expectedEntityPath] of cases) {
+      const primaryStore = createMockVectorStore();
+      const entityStore = createMockVectorStore();
+      mockVectorStoreFactory.create
+        .mockReset()
+        .mockReturnValueOnce(primaryStore)
+        .mockReturnValueOnce(entityStore);
+
+      const mem = new MemoryClass({
+        embedder: { provider: "openai", config: { apiKey: "k" } },
+        vectorStore: {
+          provider: "memory",
+          config: { collectionName: "memories", dbPath, dimension: 1536 },
+        },
+        llm: { provider: "openai", config: { apiKey: "k" } },
+        disableHistory: true,
+      });
+
+      await mem.getAll({ filters: { user_id: "u1" } });
+      await (mem as any).getEntityStore();
+
+      expect(mockVectorStoreFactory.create).toHaveBeenNthCalledWith(
+        2,
+        "memory",
+        expect.objectContaining({
+          collectionName: "memories_entities",
+          dbPath: expectedEntityPath,
+        }),
+      );
+    }
+  });
+
   it("propagates init error to public methods", async () => {
     const failingEmbedder = {
       embed: jest.fn().mockRejectedValue(new Error("Embedder unreachable")),


### PR DESCRIPTION
## Summary
- derive a separate entity SQLite path for `.db`, `.sqlite`, `.sqlite3`, and extensionless paths
- preserve the special `:memory:` behavior
- add regression coverage across all supported path shapes

## Validation
- focused `vector-stores-compat` entity-path regression passed (1 test)
- `prettier --check src/oss/src/memory/index.ts src/oss/tests/vector-stores-compat.test.ts`
- `git diff --check`

Closes #6606