### PR TITLE
fix: preserve caller LLM factory config

### DIFF
--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -86,8 +86,7 @@ class LlmFactory:
             config = config_class(**kwargs)
         elif isinstance(config, dict):
             # Merge dict config with kwargs
-            config.update(kwargs)
-            config = config_class(**config)
+            config = config_class(**{**config, **kwargs})
         elif isinstance(config, BaseLlmConfig):
             # Convert base config to provider-specific config if needed
             if config_class != BaseLlmConfig:

--- a/tests/utils/test_factory.py
+++ b/tests/utils/test_factory.py
@@ -51,3 +51,18 @@ def test_base_to_provider_without_reasoning_fields_still_builds():
 
     assert isinstance(built, AnthropicConfig)
     assert built.model == "claude-3-5-sonnet-20240620"
+
+
+def test_dict_config_is_not_mutated_by_keyword_overrides():
+    config = {"model": "gpt-4o-mini"}
+    captured = {}
+
+    def fake_llm_class(built_config):
+        captured["config"] = built_config
+        return Mock()
+
+    with patch("mem0.utils.factory.load_class", return_value=fake_llm_class):
+        LlmFactory.create("openai", config, api_key="temporary-key")
+
+    assert config == {"model": "gpt-4o-mini"}
+    assert captured["config"].api_key == "temporary-key"


### PR DESCRIPTION
## Summary
- merge LLM factory keyword overrides into a new dictionary
- preserve caller-owned configuration dictionaries across factory construction
- add a regression test covering the mutation and resulting API-key override

## Validation
- `python -m pytest tests/utils/test_factory.py -q` (4 passed)
- `python -m compileall -q mem0/utils/factory.py tests/utils/test_factory.py`
- `git diff --check`

Closes #6428