### PR TITLE
fix: preserve JSON strings with code fences

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import re
 from typing import Any, Dict, List
@@ -135,6 +136,17 @@ def extract_json(text):
     If that also fails, returns the text as-is.
     """
     text = text.strip()
+
+    # A response that starts with JSON must be decoded before looking for
+    # markdown fences. Fences inside a JSON string are data, not wrappers.
+    if text.startswith(("{", "[")):
+        try:
+            _, end_idx = json.JSONDecoder().raw_decode(text)
+        except json.JSONDecodeError:
+            pass
+        else:
+            return text[:end_idx]
+
     match = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
     if match:
         json_str = match.group(1)

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -91,6 +91,13 @@ That's the result."""
         parsed = json.loads(result)
         assert parsed["memory"][0]["id"] == "0"
 
+    def test_json_string_with_embedded_code_fence(self):
+        payload = {"snippet": "```python\nx = 1\n```", "user_id": "u1"}
+
+        result = extract_json(json.dumps(payload))
+
+        assert json.loads(result) == payload
+
 
 # --- Test remove_code_blocks ---
 


### PR DESCRIPTION
## Summary
- decode responses that already begin with JSON before scanning for markdown fences
- preserve embedded code fences inside JSON string values
- add regression coverage for JSON snippets stored in string fields

## Validation
- `python -m pytest tests/test_chatty_llm_parsing.py -q` (22 passed)
- `python -m compileall -q mem0/memory/utils.py tests/test_chatty_llm_parsing.py`
- `git diff --check`

Closes #6427