### PR TITLE
fix: persist filter scopes for direct memory adds

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -748,6 +748,13 @@ export class Memory {
     if (agentId) filters.agent_id = metadata.agent_id = agentId;
     if (runId) filters.run_id = metadata.run_id = runId;
 
+    // Persist scopes supplied through filters as well as top-level options.
+    // The non-inference path stores metadata directly, so omitting these
+    // fields would make the resulting memory impossible to retrieve by scope.
+    for (const scope of ["user_id", "agent_id", "run_id"] as const) {
+      if (filters[scope]) metadata[scope] = filters[scope];
+    }
+
     // Normalize expiration date into the stored metadata (round-trips via get()).
     if (config.expirationDate != null) {
       metadata.expiration_date = normalizeExpirationDate(config.expirationDate);

--- a/mem0-ts/src/oss/tests/memory.add.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add.test.ts
@@ -191,4 +191,20 @@ describe("Memory - add()", () => {
       expect.objectContaining({ event: "ADD" }),
     );
   });
+
+  test("with infer=false persists scopes supplied through filters", async () => {
+    const scopedUser = `filter_scope_${Date.now()}`;
+
+    await memory.add("Scoped direct storage content", {
+      filters: { user_id: scopedUser },
+      infer: false,
+    });
+
+    const stored = await memory.getAll({ filters: { user_id: scopedUser } });
+    expect(stored.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ memory: "Scoped direct storage content" }),
+      ]),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- persist `user_id`, `agent_id`, and `run_id` scopes supplied through `filters`
- keep direct (`infer: false`) memory writes retrievable by their scope
- add an end-to-end regression test through `add()` and `getAll()`

## Validation
- `jest --runInBand src/oss/tests/memory.add.test.ts` (12 passed)
- `prettier --check src/oss/src/memory/index.ts src/oss/tests/memory.add.test.ts`
- `git diff --check`

Closes #6170