### PR TITLE
fix: keep telemetry filter return shape consistent

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -227,7 +227,7 @@ def process_telemetry_filters(filters):
     Process the telemetry filters
     """
     if filters is None:
-        return {}
+        return [], {}
 
     encoded_ids = {}
     if "user_id" in filters:

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -6,7 +6,12 @@ from mem0.memory.utils import (
     parse_vision_messages,
     remove_spaces_from_entities,
     sanitize_relationship_for_cypher,
+    process_telemetry_filters,
 )
+
+
+def test_process_telemetry_filters_returns_empty_tuple_for_none():
+    assert process_telemetry_filters(None) == ([], {})
 
 
 class TestParseMessages:


### PR DESCRIPTION
## Summary
- return the same `(keys, encoded_ids)` tuple shape when telemetry filters are absent
- prevent callers that unpack the helper from failing on `None`
- add regression coverage for the `None` input path

## Validation
- `python -m pytest tests/memory/test_memory_utils.py -q` (20 passed)
- `python -m compileall -q mem0/memory/utils.py tests/memory/test_memory_utils.py`
- `git diff --check`

Closes #6171