### PR TITLE
fix: bind Azure MySQL filter scalars natively

### DIFF
--- a/mem0/vector_stores/azure_mysql.py
+++ b/mem0/vector_stores/azure_mysql.py
@@ -298,7 +298,7 @@ class AzureMySQL(VectorStoreBase):
                     logger.warning("Skipping invalid filter key: %r", k)
                     continue
                 filter_conditions.append("JSON_EXTRACT(payload, %s) = %s")
-                filter_params.extend([f"$.{k}", json.dumps(v)])
+                filter_params.extend([f"$.{k}", v])
 
         filter_clause = "WHERE " + " AND ".join(filter_conditions) if filter_conditions else ""
 
@@ -357,7 +357,7 @@ class AzureMySQL(VectorStoreBase):
                         logger.warning("Skipping invalid filter key: %r", k)
                         continue
                     filter_conditions.append("JSON_EXTRACT(payload, %s) = %s")
-                    filter_params.extend([f"$.{k}", json.dumps(v)])
+                    filter_params.extend([f"$.{k}", v])
 
             filter_clause = ""
             if filter_conditions:
@@ -516,7 +516,7 @@ class AzureMySQL(VectorStoreBase):
                     logger.warning("Skipping invalid filter key: %r", k)
                     continue
                 filter_conditions.append("JSON_EXTRACT(payload, %s) = %s")
-                filter_params.extend([f"$.{k}", json.dumps(v)])
+                filter_params.extend([f"$.{k}", v])
 
         filter_clause = "WHERE " + " AND ".join(filter_conditions) if filter_conditions else ""
 

--- a/tests/vector_stores/test_azure_mysql.py
+++ b/tests/vector_stores/test_azure_mysql.py
@@ -330,3 +330,24 @@ class TestAzureMySQLFilterKeySanitization:
         azure_mysql_instance.list(filters=self._FILTERS)
         blob = self._executed_blob(azure_mysql_instance)
         assert "$.user_id" in blob and "OR '1'='1" not in blob
+
+
+@pytest.mark.parametrize(
+    "method,kwargs",
+    [
+        ("search", {"query": "q", "vectors": [0.1, 0.2, 0.3]}),
+        ("keyword_search", {"query": "q"}),
+        ("list", {}),
+    ],
+)
+def test_string_filters_bind_native_scalars(azure_mysql_instance, method, kwargs):
+    getattr(azure_mysql_instance, method)(filters={"user_id": "u1"}, **kwargs)
+
+    cursor = azure_mysql_instance.connection_pool.connection().cursor()
+    filter_call = next(
+        call
+        for call in cursor.execute.call_args_list
+        if len(call.args) > 1 and "$.user_id" in call.args[1]
+    )
+    assert "u1" in filter_call.args[1]
+    assert '"u1"' not in filter_call.args[1]


### PR DESCRIPTION
## Summary
- bind Azure MySQL JSON filter values as native DB parameters instead of JSON-encoded strings
- apply the correction consistently to `search`, `keyword_search`, and `list`
- add regression coverage for string scope filters across all three methods

## Validation
- `python -m pytest tests/vector_stores/test_azure_mysql.py -q` (27 passed, 1 skipped)
- `python -m compileall -q mem0/vector_stores/azure_mysql.py tests/vector_stores/test_azure_mysql.py`
- `git diff --check`

Closes #6178