### PR TITLE
fix: preserve Gemini proxy configuration

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -29,6 +29,7 @@ class GeminiLLM(LLMBase):
                 top_k=config.top_k,
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
+                http_client_proxies=config.http_client_proxies,
             )
 
         super().__init__(config)

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -253,6 +253,19 @@ def test_init_backward_compat_with_base_config(monkeypatch):
     mock_client_class.assert_called_once_with(api_key="legacy-key")
 
 
+def test_init_base_config_preserves_http_client_proxies(monkeypatch):
+    monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+    with patch("mem0.llms.gemini.genai.Client"):
+        llm = GeminiLLM(
+            BaseLlmConfig(
+                model="gemini-2.0-flash",
+                http_client_proxies="http://proxy.local:8080",
+            )
+        )
+
+    assert llm.config.http_client_proxies == "http://proxy.local:8080"
+
+
 def test_init_vertexai_via_explicit_config(monkeypatch):
     """vertexai=True in GeminiConfig routes to the Vertex AI client with project/location, no api_key."""
     monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)


### PR DESCRIPTION
## Summary
- preserve `http_client_proxies` when converting a `BaseLlmConfig` to `GeminiConfig`
- keep Gemini proxy behavior consistent with other configured LLM providers
- add regression coverage for the legacy base-config construction path

## Validation
- `python -m pytest tests/llms/test_gemini.py -q` (18 passed)
- `python -m compileall -q mem0/llms/gemini.py tests/llms/test_gemini.py`
- `git diff --check`

Closes #6385