### PR TITLE
fix: respect Vertex embedding model batch limits

### DIFF
--- a/mem0/embeddings/vertexai.py
+++ b/mem0/embeddings/vertexai.py
@@ -72,8 +72,9 @@ class VertexAIEmbedding(EmbeddingBase):
                 raise ValueError(f"Invalid memory action: {memory_action}")
             embedding_type = self.embedding_types[memory_action]
         all_embeddings = []
-        for i in range(0, len(texts), 250):
-            chunk = texts[i : i + 250]
+        max_instances = 1 if self.config.model.startswith("gemini-embedding") else 250
+        for i in range(0, len(texts), max_instances):
+            chunk = texts[i : i + max_instances]
             inputs = [TextEmbeddingInput(text=t, task_type=embedding_type) for t in chunk]
             results = self.model.get_embeddings(texts=inputs, output_dimensionality=self.config.embedding_dims)
             all_embeddings.extend(r.values for r in results)

--- a/tests/embeddings/test_vertexai_embeddings.py
+++ b/tests/embeddings/test_vertexai_embeddings.py
@@ -163,7 +163,7 @@ def test_invalid_memory_action(mock_text_embedding_model, mock_config):
 
 @patch("mem0.embeddings.vertexai.TextEmbeddingModel")
 def test_embed_batch_single_call(mock_text_embedding_model, mock_os_environ, mock_config):
-    mock_config.return_value.model = "gemini-embedding-001"
+    mock_config.return_value.model = "text-embedding-005"
     mock_config.return_value.embedding_dims = 256
 
     config = mock_config()
@@ -198,7 +198,7 @@ def test_embed_batch_empty_list(mock_text_embedding_model, mock_os_environ, mock
 
 @patch("mem0.embeddings.vertexai.TextEmbeddingModel")
 def test_embed_batch_count_mismatch_raises(mock_text_embedding_model, mock_os_environ, mock_config):
-    mock_config.return_value.model = "gemini-embedding-001"
+    mock_config.return_value.model = "text-embedding-005"
     mock_config.return_value.embedding_dims = 256
 
     config = mock_config()
@@ -262,7 +262,7 @@ def test_embed_batch_invalid_memory_action_raises(mock_text_embedding_model, moc
 @patch("mem0.embeddings.vertexai.TextEmbeddingModel")
 def test_embed_batch_chunking_triggers_two_api_calls(mock_text_embedding_model, mock_os_environ, mock_config):
     """300 texts must produce exactly 2 get_embeddings calls (chunks of 250 and 50)."""
-    mock_config.return_value.model = "gemini-embedding-001"
+    mock_config.return_value.model = "text-embedding-005"
     mock_config.return_value.embedding_dims = 256
 
     config = mock_config()
@@ -278,3 +278,24 @@ def test_embed_batch_chunking_triggers_two_api_calls(mock_text_embedding_model, 
 
     assert mock_text_embedding_model.from_pretrained.return_value.get_embeddings.call_count == 2
     assert len(result) == 300
+
+
+@patch("mem0.embeddings.vertexai.TextEmbeddingModel")
+def test_embed_batch_gemini_embedding_uses_one_input_per_request(
+    mock_text_embedding_model, mock_os_environ, mock_config
+):
+    mock_config.return_value.model = "gemini-embedding-001"
+    mock_config.return_value.embedding_dims = 256
+    embedder = VertexAIEmbedding(mock_config())
+
+    def make_response(texts, output_dimensionality):
+        return [Mock(values=[0.1, 0.2]) for _ in texts]
+
+    client = mock_text_embedding_model.from_pretrained.return_value
+    client.get_embeddings.side_effect = make_response
+
+    result = embedder.embed_batch(["first", "second", "third"])
+
+    assert client.get_embeddings.call_count == 3
+    assert all(len(call.kwargs["texts"]) == 1 for call in client.get_embeddings.call_args_list)
+    assert len(result) == 3


### PR DESCRIPTION
## Summary
- use one input per Vertex request for `gemini-embedding-*` models
- retain 250-input batching for models that support it
- update the existing generic batching test and add regression coverage for Gemini

## Validation
- `python -m pytest tests/embeddings/test_vertexai_embeddings.py -q` (15 passed)
- `python -m compileall -q mem0/embeddings/vertexai.py tests/embeddings/test_vertexai_embeddings.py`
- `git diff --check`

Closes #6189