### PR TITLE
fix: preserve batch update metadata

### DIFF
--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -542,6 +542,7 @@ export default class MemoryClient {
     const memoriesBody = memories.map((memory) => ({
       memory_id: memory.memoryId,
       text: memory.text,
+      ...(memory.metadata === undefined ? {} : { metadata: memory.metadata }),
     }));
     const response = await this._fetchWithErrorHandling(
       `${this.host}/v1/batch/`,

--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -144,6 +144,7 @@ export interface MemoryHistory {
 export interface MemoryUpdateBody {
   memoryId: string;
   text: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface User {

--- a/mem0-ts/src/client/tests/memoryClient.batch.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.batch.test.ts
@@ -57,6 +57,30 @@ describe("MemoryClient - batchUpdate()", () => {
     const call = findFetchCall(mock, "/v1/batch/", "PUT");
     expect(getFetchBody(call!).memories).toEqual([]);
   });
+
+  test("preserves metadata in request body", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v1/batch/", { status: 200, body: { message: "OK" } });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.batchUpdate([
+      {
+        memoryId: "mem_1",
+        text: "updated 1",
+        metadata: { source: "import", priority: 2 },
+      },
+    ]);
+
+    const call = findFetchCall(mock, "/v1/batch/", "PUT");
+    expect(getFetchBody(call!).memories).toEqual([
+      {
+        memory_id: "mem_1",
+        text: "updated 1",
+        metadata: { source: "import", priority: 2 },
+      },
+    ]);
+  });
 });
 
 // ─── batchDelete() ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- add optional metadata to the TypeScript batch-update item type
- preserve metadata when serializing `MemoryClient.batchUpdate()` request bodies
- keep the existing payload shape unchanged for items without metadata

## Validation
- `jest --runInBand src/client/tests/memoryClient.batch.test.ts` (7 passed)
- `prettier --check src/client/mem0.ts src/client/mem0.types.ts src/client/tests/memoryClient.batch.test.ts`
- `git diff --check`

Closes #6392