### PR TITLE
fix: map assistant role for Gemini conversations

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -106,9 +106,10 @@ class GeminiLLM(LLMBase):
             if message["role"] == "system":
                 system_instruction = message["content"]
             else:
+                role = "model" if message["role"] == "assistant" else message["role"]
                 content = types.Content(
                     parts=[types.Part(text=message["content"])],
-                    role=message["role"],
+                    role=role,
                 )
                 contents.append(content)
 

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -51,6 +51,22 @@ def test_generate_response_without_tools(mock_gemini_client: Mock):
     assert response == "I'm doing well, thank you for asking!"
 
 
+def test_generate_response_maps_assistant_role_to_model(mock_gemini_client: Mock):
+    llm = GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash-latest"))
+    messages = [
+        {"role": "user", "content": "What is the weather?"},
+        {"role": "assistant", "content": "It is sunny."},
+        {"role": "user", "content": "Thanks!"},
+    ]
+    mock_response = Mock(candidates=[Mock(content=Mock(parts=[Mock(text="You're welcome!")]))])
+    mock_gemini_client.models.generate_content.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    contents = mock_gemini_client.models.generate_content.call_args.kwargs["contents"]
+    assert [content.role for content in contents] == ["user", "model", "user"]
+
+
 def test_generate_response_with_tools(mock_gemini_client: Mock):
     config = BaseLlmConfig(model="gemini-1.5-flash-latest", temperature=0.7, max_tokens=100, top_p=1.0)
     llm = GeminiLLM(config)


### PR DESCRIPTION
## Summary
- map OpenAI-style assistant messages to Gemini model role
- add a multi-turn regression test covering user/model/user content

## Validation
- `python -m pytest tests/llms/test_gemini.py -q` (18 passed)
- `python -m compileall -q mem0/llms/gemini.py`
- `git diff --check`

Closes #6393