### PR TITLE
fix(zapier): raise the add_memory poll budget past the real API latency tail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ This is a **polyglot monorepo** containing Python and TypeScript packages, CLIs,
 | `integrations/openclaw/` | `@mem0/openclaw-mem0` — OpenClaw plugin for Claude Code / AI editors |
 | `integrations/pi-agent-plugin/` | `@mem0/pi-agent-plugin` — Pi Agent plugin |
 | `integrations/vercel-ai-sdk/` | `@mem0/vercel-ai-provider` — Vercel AI SDK memory provider |
-| `integrations/zapier-mem0/` | `zapier-mem0` — Zapier Platform CLI app (deploys to Zapier, not npm); add / search / get / delete memories |
+| `integrations/zapier-mem0/` | `@mem0/zapier` — Zapier Platform CLI app (deploys to Zapier, not npm); add / search / get / delete memories |
 | `server/` | FastAPI REST server for self-hosted Mem0 (Docker: FastAPI + PostgreSQL/pgvector + Neo4j) |
 | `skills/` | Claude Code skill definitions. Reference skills (SDK knowledge, always-on): `mem0/`, `mem0-cli/`, `mem0-vercel-ai-sdk/`. Pipeline skills (run on demand): `mem0-integrate/`, `mem0-test-integration/`, `mem0-oss-to-platform/` |
 | `docs/` | Documentation site (Mintlify) |

--- a/integrations/zapier-mem0/src/creates/add_memory.ts
+++ b/integrations/zapier-mem0/src/creates/add_memory.ts
@@ -2,8 +2,8 @@ import type { ZObject, Bundle, AddResponse, EventResponse } from '../types';
 import { captureEvent } from '../telemetry';
 
 const POLL_INTERVAL_MS = 1500;
-// Bounded so the poll budget stays under Zapier's per-step execution timeout.
-const MAX_POLL_ATTEMPTS = 12;
+// Bounded to a 60s poll budget, under Zapier's per-step execution timeout.
+const MAX_POLL_ATTEMPTS = 40;
 
 // Polls GET /v1/event/{id}/ until the async memory-addition event resolves.
 const pollEvent = async (z: ZObject, eventId: string): Promise<EventResponse> => {

--- a/integrations/zapier-mem0/test/unit.test.ts
+++ b/integrations/zapier-mem0/test/unit.test.ts
@@ -58,6 +58,25 @@ describe('add_memory (offline)', () => {
 		expect((res as any).status).toBe('SUCCEEDED');
 	});
 
+	it('keeps polling past the old 12-attempt budget when the API is slow', async () => {
+		jest.useFakeTimers();
+		const pendingPolls = Array.from({ length: 20 }, () => ({ data: { status: 'PENDING' } }));
+		const z = makeZ([
+			{ data: { event_id: 'e1', status: 'PENDING' } },
+			...pendingPolls,
+			{ data: { status: 'SUCCEEDED', results: [{ id: 'm1' }] } },
+		]);
+		const resultPromise = addMemory.operation.perform(z, {
+			inputData: { content: 'hi', user_id: 'u1', waitForCompletion: 'true' },
+		} as any);
+		for (let i = 0; i < pendingPolls.length; i++) {
+			await jest.advanceTimersByTimeAsync(1500);
+		}
+		const res = await resultPromise;
+		expect((res as any).status).toBe('SUCCEEDED');
+		jest.useRealTimers();
+	});
+
 	it('throws a clear error on invalid JSON metadata', async () => {
 		const z = makeZ();
 		await expect(


### PR DESCRIPTION
## Linked Issue

No linked issue. This is a follow-up to #6518, based on live testing against the production Mem0 API after that PR merged.

## Description

Live testing of the Zapier `add_memory` action with `waitForCompletion=true` against the real Mem0 API found:

1. **Bug**: `MAX_POLL_ATTEMPTS = 12` at `POLL_INTERVAL_MS = 1500` caps the poll budget at 18 seconds. Observed server latencies during live testing were 4.3s, 7.9s, and once over 18s. When the ceiling is crossed, `pollEvent` throws `Mem0Timeout` (HTTP 408) even though the memory was already written server-side (verified: the timed-out event's memory was present on a subsequent `get_memories` call). The Zapier step then reports failure, downstream Zap steps don't run, and a user retry double-writes the memory.

   Fix: raise `MAX_POLL_ATTEMPTS` from 12 to 40, giving a 60-second budget. Updated the adjacent comment (which claimed the budget "stays under Zapier's per-step execution timeout") to state the real 60s figure.

2. **Stale doc**: `AGENTS.md`'s directory table still listed the npm package name as `zapier-mem0`, which was renamed to `@mem0/zapier` during #6518's review. Corrected that one cell.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added a regression test in `integrations/zapier-mem0/test/unit.test.ts` (`keeps polling past the old 12-attempt budget when the API is slow`) that mocks the event endpoint to return `PENDING` for 20 consecutive polls before `SUCCEEDED`, using Jest fake timers to advance the poll's `setTimeout` sleeps without real wall-clock delay. Verified the test is a genuine regression check: temporarily reverted `MAX_POLL_ATTEMPTS` to 12 and reran — the new test failed with `Mem0Timeout` as expected (13/14 passed); restored to 40 and reran — all 14 passed.

Manual/live testing (done prior to this PR, informing the fix): ran the deployed `add_memory` action against the production Mem0 API with `waitForCompletion=true` five times, observing server completion latencies of 4.3s, 7.9s, and one run exceeding the old 18s budget. Confirmed via `get_memories` that the timed-out call's memory had in fact been written, i.e. the timeout was a false failure, not a real one.

Also verified after this change:
- `pnpm install --frozen-lockfile` — clean
- `pnpm build` — clean (`tsc`, no errors)
- `pnpm test:unit` — 14 passed (was 13 before this PR)
- `npx zapier-platform-cli@19 validate` — 0 structural errors, 23 checks passed, 0 checks failed (13 pre-existing general warnings, unrelated to this change, unchanged from before)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed