### PR TITLE
feat(memory): add Memory.cleanup(policy) for SDK-layer memory pruning

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -9,8 +9,8 @@ import time
 import uuid
 import warnings
 from copy import deepcopy
-from datetime import date, datetime, timezone
-from typing import Any, Dict, Optional
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Callable, Dict, Optional, Union
 
 from pydantic import ValidationError
 
@@ -296,6 +296,69 @@ def _normalize_iso_timestamp_to_utc(timestamp: Optional[str]) -> Optional[str]:
     if parsed.tzinfo is None:
         return timestamp
     return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _parse_iso_to_utc_datetime(timestamp: Optional[str]) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp into a timezone-aware UTC datetime.
+
+    Naive timestamps are assumed to be UTC. Returns None when the value is
+    missing or cannot be parsed, so callers can skip such records safely.
+    """
+    if not timestamp:
+        return None
+    try:
+        parsed = datetime.fromisoformat(timestamp)
+    except (ValueError, TypeError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _resolve_cleanup_policy(
+    policy: Union[str, Callable[[Dict[str, Any]], bool]],
+    older_than: Optional[Union[int, float, timedelta]],
+) -> tuple:
+    """Resolve a ``cleanup`` policy into a ``(predicate, policy_name)`` pair.
+
+    ``predicate(record)`` returns ``(should_remove, reason)`` for a single
+    memory record (in the shape returned by ``get_all``).
+    """
+    if callable(policy):
+
+        def _predicate(record: Dict[str, Any]):
+            return bool(policy(record)), "custom predicate"
+
+        return _predicate, "custom"
+
+    if policy == "ttl":
+        if older_than is None:
+            raise ValueError(
+                "The 'ttl' cleanup policy requires `older_than` (an int/float number of "
+                "seconds or a datetime.timedelta)."
+            )
+        max_age = older_than.total_seconds() if isinstance(older_than, timedelta) else float(older_than)
+        if max_age < 0:
+            raise ValueError("`older_than` must be non-negative.")
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=max_age)
+
+        def _predicate(record: Dict[str, Any]):
+            created = _parse_iso_to_utc_datetime(record.get("created_at"))
+            if created is None or created >= cutoff:
+                return False, ""
+            return True, f"created_at {created.isoformat()} is older than {max_age:g}s"
+
+        return _predicate, "ttl"
+
+    if policy == "lru":
+        raise ValueError(
+            "The 'lru' cleanup policy needs per-item access metadata (last_access / hit_count), "
+            "which is not yet tracked at the SDK layer "
+            "(see https://github.com/mem0ai/mem0/issues/5611). "
+            "Use the 'ttl' policy or pass a callable predicate for now."
+        )
+
+    raise ValueError(f"Unknown cleanup policy: {policy!r}. Use 'ttl' or a callable predicate.")
 
 
 def _build_filters_and_metadata(
@@ -1856,6 +1919,76 @@ class Memory(MemoryBase):
         else:
             display_first_run_notice(self, "sync", "delete")
         return {"message": "Memory deleted successfully!"}
+
+    def cleanup(
+        self,
+        policy: Union[str, Callable[[Dict[str, Any]], bool]] = "ttl",
+        *,
+        filters: Optional[Dict[str, Any]] = None,
+        older_than: Optional[Union[int, float, timedelta]] = None,
+        top_k: int = 100,
+        dry_run: bool = False,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """
+        Prune stored memories that match a retention policy.
+
+        ``cleanup`` is a thin SDK-layer helper: it composes the existing
+        ``get_all`` and ``delete`` calls, so it works across every vector
+        backend without any backend-specific changes.
+
+        Args:
+            policy: Either a builtin policy name or a predicate.
+                - ``"ttl"``: remove memories whose ``created_at`` is older than
+                  ``older_than`` (which is required for this policy).
+                - ``Callable[[dict], bool]``: a custom predicate that receives a
+                  memory record (in the shape returned by ``get_all``) and
+                  returns ``True`` for records that should be removed.
+            filters: Entity filters identifying the scope to clean up. Must
+                contain at least one of ``user_id``, ``agent_id``, ``run_id``
+                (same contract as ``get_all``) so cleanup never runs unscoped.
+            older_than: Age threshold for the ``"ttl"`` policy, given as a number
+                of seconds or a ``datetime.timedelta``. Ignored for callable
+                policies.
+            top_k: Maximum number of memories to scan for this scope. Defaults to 100.
+            dry_run: If ``True``, report what *would* be removed without deleting
+                anything.
+
+        Returns:
+            dict: A cleanup report of the form::
+
+                {
+                    "policy": "ttl",
+                    "dry_run": False,
+                    "scanned": 12,
+                    "removed": [{"id": "...", "reason": "..."}, ...],
+                    "removed_count": 3,
+                }
+
+        Raises:
+            ValueError: If ``policy`` is unknown, if ``"ttl"`` is used without
+                ``older_than``, or if ``filters`` lacks an entity id.
+        """
+        predicate, policy_name = _resolve_cleanup_policy(policy, older_than)
+        capture_event("mem0.cleanup", self, {"policy": policy_name, "dry_run": dry_run, "sync_type": "sync"})
+
+        records = self.get_all(filters=filters, top_k=top_k, **kwargs).get("results", [])
+        removed = []
+        for record in records:
+            should_remove, reason = predicate(record)
+            if not should_remove:
+                continue
+            removed.append({"id": record["id"], "reason": reason})
+            if not dry_run:
+                self.delete(record["id"])
+
+        return {
+            "policy": policy_name,
+            "dry_run": dry_run,
+            "scanned": len(records),
+            "removed": removed,
+            "removed_count": len(removed),
+        }
 
     def delete_all(self, user_id: Optional[str] = None, agent_id: Optional[str] = None, run_id: Optional[str] = None):
         """
@@ -3486,6 +3619,45 @@ class AsyncMemory(MemoryBase):
         else:
             await display_first_run_notice_async(self, "async", "delete")
         return {"message": "Memory deleted successfully!"}
+
+    async def cleanup(
+        self,
+        policy: Union[str, Callable[[Dict[str, Any]], bool]] = "ttl",
+        *,
+        filters: Optional[Dict[str, Any]] = None,
+        older_than: Optional[Union[int, float, timedelta]] = None,
+        top_k: int = 100,
+        dry_run: bool = False,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """
+        Prune stored memories that match a retention policy (async).
+
+        Async counterpart of :meth:`Memory.cleanup`. Composes the existing
+        ``get_all`` and ``delete`` calls, so it works across every vector
+        backend without any backend-specific changes. See :meth:`Memory.cleanup`
+        for full argument and return-value documentation.
+        """
+        predicate, policy_name = _resolve_cleanup_policy(policy, older_than)
+        capture_event("mem0.cleanup", self, {"policy": policy_name, "dry_run": dry_run, "sync_type": "async"})
+
+        records = (await self.get_all(filters=filters, top_k=top_k, **kwargs)).get("results", [])
+        removed = []
+        for record in records:
+            should_remove, reason = predicate(record)
+            if not should_remove:
+                continue
+            removed.append({"id": record["id"], "reason": reason})
+            if not dry_run:
+                await self.delete(record["id"])
+
+        return {
+            "policy": policy_name,
+            "dry_run": dry_run,
+            "scanned": len(records),
+            "removed": removed,
+            "removed_count": len(removed),
+        }
 
     async def delete_all(self, user_id=None, agent_id=None, run_id=None):
         """

--- a/tests/memory/test_cleanup.py
+++ b/tests/memory/test_cleanup.py
@@ -1,0 +1,155 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from mem0.memory.main import AsyncMemory, Memory
+
+
+def _setup_factory_mocks(mocker):
+    """Patch the provider factories so Memory/AsyncMemory can be constructed without real backends."""
+    mock_embedder = mocker.MagicMock()
+    mock_embedder.return_value.embed.return_value = [0.1, 0.2, 0.3]
+    mocker.patch("mem0.utils.factory.EmbedderFactory.create", mock_embedder)
+
+    mock_vector_store = mocker.MagicMock()
+    mock_vector_store.return_value.search.return_value = []
+    mocker.patch(
+        "mem0.utils.factory.VectorStoreFactory.create",
+        side_effect=[mock_vector_store.return_value, mocker.MagicMock()],
+    )
+
+    mocker.patch("mem0.utils.factory.LlmFactory.create", mocker.MagicMock())
+    mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+
+
+def _record(id_, created_at=None, memory="m", **extra):
+    record = {"id": id_, "memory": memory, "created_at": created_at}
+    record.update(extra)
+    return record
+
+
+@pytest.fixture
+def memory(mocker):
+    _setup_factory_mocks(mocker)
+    mocker.patch("mem0.memory.main.capture_event")
+    mem = Memory()
+    # cleanup is pure orchestration over get_all + delete, so stub those out.
+    mem.get_all = mocker.MagicMock()
+    mem.delete = mocker.MagicMock()
+    return mem
+
+
+class TestCleanupSync:
+    def test_ttl_removes_old_keeps_recent(self, memory):
+        now = datetime.now(timezone.utc)
+        memory.get_all.return_value = {
+            "results": [
+                _record("old", (now - timedelta(hours=2)).isoformat()),
+                _record("recent", (now - timedelta(minutes=1)).isoformat()),
+            ]
+        }
+
+        report = memory.cleanup(policy="ttl", filters={"user_id": "u"}, older_than=timedelta(hours=1))
+
+        assert report["policy"] == "ttl"
+        assert report["scanned"] == 2
+        assert report["removed_count"] == 1
+        assert report["removed"][0]["id"] == "old"
+        memory.delete.assert_called_once_with("old")
+        memory.get_all.assert_called_once_with(filters={"user_id": "u"}, top_k=100)
+
+    def test_ttl_accepts_seconds(self, memory):
+        now = datetime.now(timezone.utc)
+        memory.get_all.return_value = {"results": [_record("old", (now - timedelta(seconds=120)).isoformat())]}
+
+        report = memory.cleanup(policy="ttl", filters={"user_id": "u"}, older_than=60)
+
+        assert report["removed_count"] == 1
+        memory.delete.assert_called_once_with("old")
+
+    def test_dry_run_reports_without_deleting(self, memory):
+        now = datetime.now(timezone.utc)
+        memory.get_all.return_value = {"results": [_record("old", (now - timedelta(days=2)).isoformat())]}
+
+        report = memory.cleanup(
+            policy="ttl", filters={"user_id": "u"}, older_than=timedelta(days=1), dry_run=True
+        )
+
+        assert report["dry_run"] is True
+        assert report["removed_count"] == 1
+        memory.delete.assert_not_called()
+
+    def test_custom_predicate(self, memory):
+        memory.get_all.return_value = {
+            "results": [
+                _record("keep", memory="useful fact"),
+                _record("drop", memory="please drop me"),
+            ]
+        }
+
+        report = memory.cleanup(policy=lambda record: "drop" in record["memory"], filters={"user_id": "u"})
+
+        assert report["policy"] == "custom"
+        assert [r["id"] for r in report["removed"]] == ["drop"]
+        memory.delete.assert_called_once_with("drop")
+
+    def test_ttl_without_older_than_raises(self, memory):
+        with pytest.raises(ValueError, match="older_than"):
+            memory.cleanup(policy="ttl", filters={"user_id": "u"})
+        memory.get_all.assert_not_called()
+
+    def test_unknown_policy_raises(self, memory):
+        with pytest.raises(ValueError, match="Unknown cleanup policy"):
+            memory.cleanup(policy="nope", filters={"user_id": "u"})
+
+    def test_lru_not_yet_supported(self, memory):
+        with pytest.raises(ValueError, match="lru"):
+            memory.cleanup(policy="lru", filters={"user_id": "u"})
+
+    def test_record_without_created_at_is_skipped_by_ttl(self, memory):
+        memory.get_all.return_value = {"results": [_record("no_ts", None)]}
+
+        report = memory.cleanup(policy="ttl", filters={"user_id": "u"}, older_than=1)
+
+        assert report["removed_count"] == 0
+        memory.delete.assert_not_called()
+
+
+@pytest.fixture
+def async_memory(mocker):
+    _setup_factory_mocks(mocker)
+    mocker.patch("mem0.memory.main.capture_event")
+    mem = AsyncMemory()
+    mem.get_all = mocker.AsyncMock()
+    mem.delete = mocker.AsyncMock()
+    return mem
+
+
+class TestCleanupAsync:
+    @pytest.mark.asyncio
+    async def test_async_ttl_removes_old(self, async_memory):
+        now = datetime.now(timezone.utc)
+        async_memory.get_all.return_value = {
+            "results": [
+                _record("old", (now - timedelta(hours=2)).isoformat()),
+                _record("recent", (now - timedelta(minutes=1)).isoformat()),
+            ]
+        }
+
+        report = await async_memory.cleanup(policy="ttl", filters={"user_id": "u"}, older_than=timedelta(hours=1))
+
+        assert report["removed_count"] == 1
+        assert report["removed"][0]["id"] == "old"
+        async_memory.delete.assert_awaited_once_with("old")
+
+    @pytest.mark.asyncio
+    async def test_async_dry_run_reports_without_deleting(self, async_memory):
+        now = datetime.now(timezone.utc)
+        async_memory.get_all.return_value = {"results": [_record("old", (now - timedelta(days=2)).isoformat())]}
+
+        report = await async_memory.cleanup(
+            policy="ttl", filters={"user_id": "u"}, older_than=timedelta(days=1), dry_run=True
+        )
+
+        assert report["removed_count"] == 1
+        async_memory.delete.assert_not_awaited()


### PR DESCRIPTION
Adds `Memory.cleanup()` and `AsyncMemory.cleanup()` — a thin SDK-layer helper that prunes stored memories matching a retention policy by composing the existing `get_all` and `delete` calls, so it works across all 30+ vector backends with no backend-specific changes.

- policy="ttl": remove memories whose `created_at` is older than `older_than` (an int/float of seconds or a datetime.timedelta).
- policy=<callable>: a custom predicate (record) -> bool for arbitrary retention rules.
- dry_run=True returns what would be removed without deleting.
- Returns a report: {policy, dry_run, scanned, removed, removed_count}.
- Requires entity `filters` (same contract as get_all), so cleanup can never run unscoped.

The access-metadata / "lru" policy from the proposal is intentionally deferred — it raises a clear error pointing at the issue — pending the per-item access-metadata persistence decision still under discussion.

Adds sync + async unit tests covering ttl, custom predicates, dry-run, validation errors, and the deferred-lru path.

Addresses #5611

## Linked Issue

Closes #<!-- issue number -->

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
