### PR TITLE
fix(llms/gemini): default to gemini-2.5-flash after 2.0 retirement

### DIFF
--- a/docs/components/llms/models/google_AI.mdx
+++ b/docs/components/llms/models/google_AI.mdx
@@ -7,7 +7,7 @@ To use the Gemini model, set the `GOOGLE_API_KEY` environment variable. You can 
 
 > **Note:** As of the latest release, Mem0 uses the new `google.genai` SDK instead of the deprecated `google.generativeai`. All message formatting and model interaction now use the updated `types` module from `google.genai`.
 
-> **Note:** Some Gemini models are being deprecated and will retire soon. It is recommended to migrate to the latest stable models like `"gemini-2.0-flash-001"` or `"gemini-2.0-flash-lite-001"` to ensure ongoing support and improvements.
+> **Note:** Some Gemini models are being deprecated and will retire soon. It is recommended to migrate to the latest stable models like `"gemini-2.5-flash"` or `"gemini-2.5-flash-lite"` to ensure ongoing support and improvements.
 
 ## Usage
 
@@ -23,7 +23,7 @@ config = {
     "llm": {
         "provider": "gemini",
         "config": {
-            "model": "gemini-2.0-flash-001",
+            "model": "gemini-2.5-flash",
             "api_key": "your-gemini-api-key",
             "temperature": 0.2,
             "max_tokens": 2000,
@@ -52,7 +52,7 @@ const config = {
         // You can also use "google" as provider ( for backward compatibility )
         provider: "gemini",
         config: {
-            model: "gemini-2.0-flash-001",
+            model: "gemini-2.5-flash",
             apiKey: process.env.GOOGLE_API_KEY || '',
             temperature: 0.1
         }

--- a/docs/integrations/google-ai-adk.mdx
+++ b/docs/integrations/google-ai-adk.mdx
@@ -172,7 +172,7 @@ session_service = InMemorySessionService()
 
 agent = LlmAgent(
     name="personal_assistant",
-    model="gemini-2.0-flash",
+    model="gemini-2.5-flash",
     instruction="""You are a helpful personal assistant.
     Relevant memories from past conversations are provided to you automatically.
     Use them to personalize your responses.""",
@@ -234,7 +234,7 @@ session_service = InMemorySessionService()
 
 travel_agent = LlmAgent(
     name="travel_specialist",
-    model="gemini-2.0-flash",
+    model="gemini-2.5-flash",
     instruction="""You are a travel planning specialist.
     Relevant memories about the user's travel preferences are provided automatically.
     Use them to make personalized recommendations.""",
@@ -244,7 +244,7 @@ travel_agent = LlmAgent(
 
 health_agent = LlmAgent(
     name="health_advisor",
-    model="gemini-2.0-flash",
+    model="gemini-2.5-flash",
     instruction="""You are a health and wellness advisor.
     Relevant memories about the user's health goals are provided automatically.
     Use them to give personalized advice.""",
@@ -254,7 +254,7 @@ health_agent = LlmAgent(
 
 coordinator = LlmAgent(
     name="coordinator",
-    model="gemini-2.0-flash",
+    model="gemini-2.5-flash",
     instruction="""You are a coordinator that delegates requests to specialist agents.
     For travel-related questions, delegate to the travel specialist.
     For health-related questions, delegate to the health advisor.

--- a/mem0-ts/src/oss/src/llms/google.ts
+++ b/mem0-ts/src/oss/src/llms/google.ts
@@ -10,7 +10,7 @@ export class GoogleLLM implements LLM {
 
   constructor(config: LLMConfig) {
     this.apiKey = config.apiKey;
-    this.model = config.model || "gemini-2.0-flash";
+    this.model = config.model || "gemini-2.5-flash";
   }
 
   private async ensureClient(): Promise<void> {

--- a/mem0-ts/src/oss/tests/google-llm.test.ts
+++ b/mem0-ts/src/oss/tests/google-llm.test.ts
@@ -30,7 +30,6 @@ describe("GoogleLLM (unit)", () => {
     expect(callArgs.model).toBe("gemini-2.5-flash");
   });
 
-
   it("returns text response when no tools are provided", async () => {
     mockGenerateContent.mockResolvedValueOnce({
       text: '{"facts": ["fact1"]}',

--- a/mem0-ts/src/oss/tests/google-llm.test.ts
+++ b/mem0-ts/src/oss/tests/google-llm.test.ts
@@ -19,6 +19,18 @@ import { GoogleLLM } from "../src/llms/google";
 describe("GoogleLLM (unit)", () => {
   beforeEach(() => mockGenerateContent.mockClear());
 
+  it("defaults to gemini-2.5-flash when no model is configured", async () => {
+    mockGenerateContent.mockResolvedValueOnce({
+      text: "ok",
+      functionCalls: null,
+    });
+    const llm = new GoogleLLM({ apiKey: "test-key" });
+    await llm.generateResponse([{ role: "user", content: "hi" }]);
+    const callArgs = mockGenerateContent.mock.calls[0][0];
+    expect(callArgs.model).toBe("gemini-2.5-flash");
+  });
+
+
   it("returns text response when no tools are provided", async () => {
     mockGenerateContent.mockResolvedValueOnce({
       text: '{"facts": ["fact1"]}',

--- a/mem0/configs/llms/gemini.py
+++ b/mem0/configs/llms/gemini.py
@@ -32,7 +32,7 @@ class GeminiConfig(BaseLlmConfig):
         Initialize Gemini configuration.
 
         Args:
-            model: Gemini model to use (e.g., "gemini-2.0-flash"), defaults to None
+            model: Gemini model to use (e.g., "gemini-2.5-flash"), defaults to None
             temperature: Controls randomness, defaults to 0.1
             api_key: Google API key for the Gemini Developer API, defaults to None
             max_tokens: Maximum tokens to generate, defaults to 2000

--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -34,7 +34,7 @@ class GeminiLLM(LLMBase):
         super().__init__(config)
 
         if not self.config.model:
-            self.config.model = "gemini-2.0-flash"
+            self.config.model = "gemini-2.5-flash"
 
         if self.config.vertexai:
             self.client = genai.Client(vertexai=True, project=self.config.project, location=self.config.location)

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -17,15 +17,17 @@ def mock_gemini_client():
 
 
 
-def test_default_model_is_current_flash(mock_gemini_client: Mock):
+@pytest.mark.parametrize(
+    "config_factory",
+    [
+        pytest.param(lambda: GeminiConfig(), id="gemini_config"),
+        pytest.param(lambda: BaseLlmConfig(), id="base_llm_config"),
+        pytest.param(lambda: {}, id="empty_dict"),
+    ],
+)
+def test_default_model_is_current_flash(mock_gemini_client: Mock, config_factory):
     """When no model is configured, fall back to a non-retired Gemini Flash ID."""
-    llm = GeminiLLM(GeminiConfig())
-    assert llm.config.model == "gemini-2.5-flash"
-
-    llm = GeminiLLM(BaseLlmConfig())
-    assert llm.config.model == "gemini-2.5-flash"
-
-    llm = GeminiLLM({})
+    llm = GeminiLLM(config_factory())
     assert llm.config.model == "gemini-2.5-flash"
 
 

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -16,6 +16,19 @@ def mock_gemini_client():
         yield mock_client
 
 
+
+def test_default_model_is_current_flash(mock_gemini_client: Mock):
+    """When no model is configured, fall back to a non-retired Gemini Flash ID."""
+    llm = GeminiLLM(GeminiConfig())
+    assert llm.config.model == "gemini-2.5-flash"
+
+    llm = GeminiLLM(BaseLlmConfig())
+    assert llm.config.model == "gemini-2.5-flash"
+
+    llm = GeminiLLM({})
+    assert llm.config.model == "gemini-2.5-flash"
+
+
 def test_generate_response_without_tools(mock_gemini_client: Mock):
     config = BaseLlmConfig(model="gemini-2.0-flash-latest", temperature=0.7, max_tokens=100, top_p=1.0)
     llm = GeminiLLM(config)


### PR DESCRIPTION
## Summary
Default Gemini model falls back to `gemini-2.5-flash` (Python + TS) after `gemini-2.0-flash` retirement.

Closes #6681

## Motivation
Google retired Gemini 2.0 Flash from the API on 2026-06-01. Unset-model configs now fail.

## Verification
- `uv run --with google-genai --with pytest python -m pytest tests/llms/test_gemini.py` — 18 passed
- TS unit assert on default model id