### PR TITLE
fix(embeddings/lmstudio): honor LMSTUDIO_BASE_URL when config url unset

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -34,7 +34,7 @@ class BaseEmbedderConfig(ABC):
         # Gemini specific
         output_dimensionality: Optional[str] = None,
         # LM Studio specific
-        lmstudio_base_url: Optional[str] = "http://localhost:1234/v1",
+        lmstudio_base_url: Optional[str] = None,
         # AWS Bedrock specific
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
@@ -70,7 +70,7 @@ class BaseEmbedderConfig(ABC):
         :type memory_update_embedding_type: Optional[str], optional
         :param memory_search_embedding_type: The type of embedding to use for the search memory action, defaults to None
         :type memory_search_embedding_type: Optional[str], optional
-        :param lmstudio_base_url: LM Studio base URL to be use, defaults to "http://localhost:1234/v1"
+        :param lmstudio_base_url: LM Studio base URL to use. None falls through to LMSTUDIO_BASE_URL or http://localhost:1234/v1
         :type lmstudio_base_url: Optional[str], optional
         """
 

--- a/mem0/embeddings/lmstudio.py
+++ b/mem0/embeddings/lmstudio.py
@@ -1,3 +1,4 @@
+import os
 from typing import Literal, Optional
 
 from openai import OpenAI
@@ -13,8 +14,14 @@ class LMStudioEmbedding(EmbeddingBase):
         self.config.model = self.config.model or "nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.f16.gguf"
         self.config.embedding_dims = self.config.embedding_dims or 1536
         self.config.api_key = self.config.api_key or "lm-studio"
-
-        self.client = OpenAI(base_url=self.config.lmstudio_base_url, api_key=self.config.api_key)
+        # Prefer explicit config, then LMSTUDIO_BASE_URL, then local default (parity with LLM path intent).
+        base_url = (
+            self.config.lmstudio_base_url
+            or os.getenv("LMSTUDIO_BASE_URL")
+            or "http://localhost:1234/v1"
+        )
+        self.config.lmstudio_base_url = base_url
+        self.client = OpenAI(base_url=base_url, api_key=self.config.api_key)
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """

--- a/tests/embeddings/test_lmstudio.py
+++ b/tests/embeddings/test_lmstudio.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import patch
 
 from mem0.configs.embeddings.base import BaseEmbedderConfig

--- a/tests/embeddings/test_lmstudio.py
+++ b/tests/embeddings/test_lmstudio.py
@@ -1,0 +1,35 @@
+import os
+from unittest.mock import patch
+
+from mem0.configs.embeddings.base import BaseEmbedderConfig
+from mem0.embeddings.lmstudio import LMStudioEmbedding
+
+
+def test_lmstudio_embedder_honors_explicit_base_url():
+    with patch("mem0.embeddings.lmstudio.OpenAI") as mock_openai:
+        LMStudioEmbedding(BaseEmbedderConfig(lmstudio_base_url="http://custom:9999/v1"))
+        mock_openai.assert_called_once()
+        assert mock_openai.call_args.kwargs["base_url"] == "http://custom:9999/v1"
+
+
+def test_lmstudio_embedder_honors_env_when_config_unset(monkeypatch):
+    monkeypatch.setenv("LMSTUDIO_BASE_URL", "http://env-host:5555/v1")
+    with patch("mem0.embeddings.lmstudio.OpenAI") as mock_openai:
+        emb = LMStudioEmbedding(BaseEmbedderConfig())
+        mock_openai.assert_called_once()
+        assert mock_openai.call_args.kwargs["base_url"] == "http://env-host:5555/v1"
+        assert emb.config.lmstudio_base_url == "http://env-host:5555/v1"
+
+
+def test_lmstudio_embedder_default_localhost_when_no_env(monkeypatch):
+    monkeypatch.delenv("LMSTUDIO_BASE_URL", raising=False)
+    with patch("mem0.embeddings.lmstudio.OpenAI") as mock_openai:
+        LMStudioEmbedding(BaseEmbedderConfig())
+        assert mock_openai.call_args.kwargs["base_url"] == "http://localhost:1234/v1"
+
+
+def test_lmstudio_embedder_explicit_config_beats_env(monkeypatch):
+    monkeypatch.setenv("LMSTUDIO_BASE_URL", "http://env-host:5555/v1")
+    with patch("mem0.embeddings.lmstudio.OpenAI") as mock_openai:
+        LMStudioEmbedding(BaseEmbedderConfig(lmstudio_base_url="http://config-host:1/v1"))
+        assert mock_openai.call_args.kwargs["base_url"] == "http://config-host:1/v1"


### PR DESCRIPTION
## Summary
LM Studio embedder resolves base URL as config → `LMSTUDIO_BASE_URL` → localhost.

Closes #6692

## Motivation
Config default was a concrete localhost string, so the env var could never apply (LLM parity with #6526).

## Verification
`pytest tests/embeddings/test_lmstudio.py` — 4 passed