### PR TITLE
fix(vector-stores): Supabase 1000-row cap, RLS init probe, and col_info crash

### DIFF
--- a/docs/components/vectordbs/dbs/supabase.mdx
+++ b/docs/components/vectordbs/dbs/supabase.mdx
@@ -115,6 +115,27 @@ $$;
 
 Go to [Supabase](https://supabase.com/dashboard/projects) and run the above SQL migrations in the SQL Editor.
 
+### Row Level Security
+
+Tables created through the Supabase dashboard have Row Level Security (RLS) enabled by default with no policies attached. With RLS on and no policies, the TypeScript SDK's queries return zero rows with an HTTP 200 (no error is raised), which looks like an empty memory store rather than a permissions problem. If you use the SQL migrations above (via the SQL Editor), RLS is left in its default off state and this does not apply.
+
+If your table has RLS enabled, add policies for the key your app uses (the example below grants full access to the `service_role` key; scope it down for anon/authenticated keys as needed):
+
+```sql
+alter table memories enable row level security;
+
+create policy "Allow service role full access to memories"
+on memories
+for all
+to service_role
+using (true)
+with check (true);
+```
+
+### PostgREST Row Limits
+
+Supabase's PostgREST layer caps the number of rows returned by a single request at `db-max-rows` (1000 by default), for both `.select()` queries and RPC function calls like `match_vectors`. Requesting a `topK` above this limit for `search()` or `list()` will not raise an error, results are capped at `db-max-rows` instead. The TypeScript `list()` method paginates internally to work around this, but `search()` cannot since `match_vectors` has no offset parameter; it logs a warning when it detects a truncated result. Raise `db-max-rows` in your Supabase project settings if you need more than 1000 results per search.
+
 ### Config
 
 Here are the parameters available for configuring Supabase:

--- a/mem0-ts/src/oss/src/vector_stores/supabase.ts
+++ b/mem0-ts/src/oss/src/vector_stores/supabase.ts
@@ -360,7 +360,8 @@ See the SQL migration instructions in the code comments.`,
 
         let query = this.client
           .from(this.tableName)
-          .select("*", { count: "exact" });
+          .select("*", { count: "exact" })
+          .order("id", { ascending: true });
 
         if (filters) {
           Object.entries(filters).forEach(([key, value]) => {

--- a/mem0-ts/src/oss/src/vector_stores/supabase.ts
+++ b/mem0-ts/src/oss/src/vector_stores/supabase.ts
@@ -31,6 +31,8 @@ interface SupabaseConfig extends VectorStoreConfig {
   metadataColumnName?: string;
 }
 
+const POSTGREST_MAX_ROWS = 1000;
+
 /*
 SQL Migration to run in Supabase SQL Editor:
 
@@ -123,34 +125,19 @@ export class SupabaseDB implements VectorStore {
   private async _doInitialize(): Promise<void> {
     await this.ensureClient();
     try {
-      // Verify table exists and vector operations work by attempting a test insert
-      const testVector = Array(1536).fill(0);
-
-      // First try to delete any existing test vector
-      try {
-        await this.client.from(this.tableName).delete().eq("id", "test_vector");
-      } catch {
-        // Ignore delete errors - table might not exist yet
-      }
-
-      // Try to insert the test vector
-      const { error: insertError } = await this.client
+      const { error: probeError } = await this.client
         .from(this.tableName)
-        .insert({
-          id: "test_vector",
-          [this.embeddingColumnName]: testVector,
-          [this.metadataColumnName]: {},
-        })
-        .select();
+        .select(this.embeddingColumnName)
+        .limit(1);
 
-      // If we get a duplicate key error, that's actually fine - it means the table exists
-      if (insertError && insertError.code !== "23505") {
-        console.error("Test insert error:", insertError);
+      if (probeError) {
+        console.error("Table probe error:", probeError);
         throw new Error(
           `Vector operations failed. Please ensure:
 1. The vector extension is enabled
 2. The table "${this.tableName}" exists with correct schema
 3. The match_vectors function is created
+4. Row Level Security policies allow the configured Supabase key to read the table
 
 RUN THE FOLLOWING SQL IN YOUR SUPABASE SQL EDITOR:
 
@@ -203,13 +190,6 @@ $$;
 
 See the SQL migration instructions in the code comments.`,
         );
-      }
-
-      // Clean up test vector - ignore errors here too
-      try {
-        await this.client.from(this.tableName).delete().eq("id", "test_vector");
-      } catch {
-        // Ignore delete errors
       }
 
       console.log("Connected to Supabase successfully");
@@ -270,6 +250,13 @@ See the SQL migration instructions in the code comments.`,
       if (!data) return [];
 
       const results = data as VectorSearchResult[];
+
+      if (topK > POSTGREST_MAX_ROWS && results.length === POSTGREST_MAX_ROWS) {
+        console.warn(
+          `Supabase search requested topK=${topK} but match_vectors returned exactly the PostgREST row cap of ${POSTGREST_MAX_ROWS}; results were likely truncated.`,
+        );
+      }
+
       return results.map((result) => ({
         id: result.id,
         payload: result.metadata,
@@ -364,27 +351,44 @@ See the SQL migration instructions in the code comments.`,
   ): Promise<[VectorStoreResult[], number]> {
     await this.initialize();
     try {
-      let query = this.client
-        .from(this.tableName)
-        .select("*", { count: "exact" })
-        .limit(topK);
+      const results: VectorStoreResult[] = [];
+      let totalCount = 0;
+      let offset = 0;
 
-      if (filters) {
-        Object.entries(filters).forEach(([key, value]) => {
-          query = query.eq(`${this.metadataColumnName}->>${key}`, value);
-        });
+      while (results.length < topK) {
+        const to = Math.min(offset + POSTGREST_MAX_ROWS, topK) - 1;
+
+        let query = this.client
+          .from(this.tableName)
+          .select("*", { count: "exact" });
+
+        if (filters) {
+          Object.entries(filters).forEach(([key, value]) => {
+            query = query.eq(`${this.metadataColumnName}->>${key}`, value);
+          });
+        }
+
+        const { data, error, count } = await query.range(offset, to);
+
+        if (error) throw error;
+
+        totalCount = count ?? totalCount;
+
+        const page = (data ?? []).map((item: VectorData) => ({
+          id: item.id,
+          payload: item[this.metadataColumnName],
+        }));
+        results.push(...page);
+
+        const requestedPageSize = to - offset + 1;
+        if (page.length < requestedPageSize) break;
+
+        offset += page.length;
+
+        if (results.length >= totalCount) break;
       }
 
-      const { data, error, count } = await query;
-
-      if (error) throw error;
-
-      const results = data.map((item: VectorData) => ({
-        id: item.id,
-        payload: item[this.metadataColumnName],
-      }));
-
-      return [results, count || 0];
+      return [results, totalCount];
     } catch (error) {
       console.error("Error listing vectors:", error);
       throw error;

--- a/mem0-ts/src/oss/tests/vector-stores-compat.test.ts
+++ b/mem0-ts/src/oss/tests/vector-stores-compat.test.ts
@@ -544,6 +544,7 @@ describe("Supabase – backward compat with mocked client", () => {
       maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
     };
     mockSelectBuilder.eq = jest.fn().mockReturnValue(mockSelectBuilder);
+    mockSelectBuilder.order = jest.fn().mockReturnValue(mockSelectBuilder);
 
     mockTableApi = {
       select: jest.fn().mockReturnValue(mockSelectBuilder),
@@ -643,6 +644,7 @@ describe("Supabase – backward compat with mocked client", () => {
       range: rangeMock,
     };
     listBuilder.eq = jest.fn().mockReturnValue(listBuilder);
+    listBuilder.order = jest.fn().mockReturnValue(listBuilder);
     mockTableApi.select.mockReturnValue(listBuilder);
 
     const store = new SupabaseDB({
@@ -657,6 +659,8 @@ describe("Supabase – backward compat with mocked client", () => {
     expect(count).toBe(totalRows);
     expect(results).toHaveLength(totalRows);
     expect(rangeMock.mock.calls.length).toBeGreaterThan(1);
+    expect(listBuilder.order).toHaveBeenCalledWith("id", { ascending: true });
+    expect(new Set(results.map((r) => r.id)).size).toBe(totalRows);
   });
 
   it("search() warns when results are truncated at the PostgREST row cap", async () => {

--- a/mem0-ts/src/oss/tests/vector-stores-compat.test.ts
+++ b/mem0-ts/src/oss/tests/vector-stores-compat.test.ts
@@ -531,34 +531,42 @@ describe("Redis – backward compat with mocked client", () => {
 // ───────────────────────────────────────────────────────────────────────────
 describe("Supabase – backward compat with mocked client", () => {
   let SupabaseDB: any;
+  let mockClient: any;
+  let mockTableApi: any;
+  let mockSelectBuilder: any;
 
   beforeEach(() => {
     jest.resetModules();
 
-    jest.doMock("@supabase/supabase-js", () => {
-      const mockClient = {
-        from: jest.fn().mockReturnValue({
-          insert: jest.fn().mockReturnValue({
-            select: jest.fn().mockReturnValue({ error: null }),
-          }),
-          select: jest.fn().mockReturnValue({
-            eq: jest.fn().mockReturnValue({ data: [], error: null }),
-          }),
-          delete: jest.fn().mockReturnValue({
-            eq: jest.fn().mockReturnValue({ error: null }),
-          }),
-          update: jest.fn().mockReturnValue({
-            eq: jest.fn().mockReturnValue({ error: null }),
-          }),
-          upsert: jest.fn().mockReturnValue({ error: null }),
-        }),
-        rpc: jest.fn().mockResolvedValue({ data: [], error: null }),
-      };
-      return {
-        createClient: jest.fn().mockReturnValue(mockClient),
-        __mockClient: mockClient,
-      };
-    });
+    mockSelectBuilder = {
+      limit: jest.fn().mockResolvedValue({ data: [{}], error: null }),
+      range: jest.fn().mockResolvedValue({ data: [], error: null, count: 0 }),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    mockSelectBuilder.eq = jest.fn().mockReturnValue(mockSelectBuilder);
+
+    mockTableApi = {
+      select: jest.fn().mockReturnValue(mockSelectBuilder),
+      insert: jest.fn().mockReturnValue({ error: null }),
+      delete: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({ error: null }),
+        neq: jest.fn().mockReturnValue({ error: null }),
+      }),
+      update: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({ error: null }),
+      }),
+      upsert: jest.fn().mockReturnValue({ error: null }),
+    };
+
+    mockClient = {
+      from: jest.fn().mockReturnValue(mockTableApi),
+      rpc: jest.fn().mockResolvedValue({ data: [], error: null }),
+    };
+
+    jest.doMock("@supabase/supabase-js", () => ({
+      createClient: jest.fn().mockReturnValue(mockClient),
+      __mockClient: mockClient,
+    }));
 
     SupabaseDB = require("../src/vector_stores/supabase").SupabaseDB;
   });
@@ -598,7 +606,83 @@ describe("Supabase – backward compat with mocked client", () => {
     const p1 = store.initialize();
     const p2 = store.initialize();
     await Promise.all([p1, p2]);
-    // No crash = idempotent (Supabase init runs test insert only once)
+    // No crash = idempotent (Supabase init runs a read-only probe query only once)
+  });
+
+  it("_doInitialize probes with a non-destructive select, not an insert", async () => {
+    const store = new SupabaseDB({
+      supabaseUrl: "https://example.supabase.co",
+      supabaseKey: "fake-key",
+      tableName: "memories",
+      collectionName: "test",
+    });
+
+    await store.initialize();
+
+    expect(mockTableApi.insert).not.toHaveBeenCalled();
+    expect(mockTableApi.select).toHaveBeenCalledWith("embedding");
+    expect(mockSelectBuilder.limit).toHaveBeenCalledWith(1);
+  });
+
+  it("list() paginates via .range() across multiple pages when count exceeds page size", async () => {
+    const totalRows = 1500;
+    const rangeMock = jest
+      .fn()
+      .mockImplementation((from: number, to: number) => {
+        const remaining = totalRows - from;
+        const rowCount = Math.max(0, Math.min(to - from + 1, remaining));
+        const data = Array.from({ length: rowCount }, (_, i) => ({
+          id: `id-${from + i}`,
+          metadata: { index: from + i },
+        }));
+        return Promise.resolve({ data, error: null, count: totalRows });
+      });
+
+    const listBuilder: any = {
+      limit: jest.fn().mockResolvedValue({ data: [{}], error: null }),
+      range: rangeMock,
+    };
+    listBuilder.eq = jest.fn().mockReturnValue(listBuilder);
+    mockTableApi.select.mockReturnValue(listBuilder);
+
+    const store = new SupabaseDB({
+      supabaseUrl: "https://example.supabase.co",
+      supabaseKey: "fake-key",
+      tableName: "memories",
+      collectionName: "test",
+    });
+
+    const [results, count] = await store.list(undefined, totalRows);
+
+    expect(count).toBe(totalRows);
+    expect(results).toHaveLength(totalRows);
+    expect(rangeMock.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("search() warns when results are truncated at the PostgREST row cap", async () => {
+    const cappedResults = Array.from({ length: 1000 }, (_, i) => ({
+      id: `id-${i}`,
+      similarity: 0.9,
+      metadata: {},
+    }));
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const store = new SupabaseDB({
+      supabaseUrl: "https://example.supabase.co",
+      supabaseKey: "fake-key",
+      tableName: "memories",
+      collectionName: "test",
+    });
+    mockClient.rpc.mockResolvedValue({ data: cappedResults, error: null });
+
+    const results = await store.search([0.1, 0.2, 0.3], 5000);
+
+    expect(results).toHaveLength(1000);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("5000"));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("1000"));
+
+    warnSpy.mockRestore();
   });
 
   it("constructor does not emit an unhandled rejection when init fails", async () => {
@@ -606,13 +690,14 @@ describe("Supabase – backward compat with mocked client", () => {
     jest.doMock("@supabase/supabase-js", () => {
       const failing = {
         from: jest.fn().mockReturnValue({
-          insert: jest.fn().mockReturnValue({
-            select: jest.fn().mockResolvedValue({
-              error: { code: "42P01", message: "no table" },
+          select: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue({
+              data: null,
+              error: {
+                code: "42501",
+                message: "permission denied for table memories",
+              },
             }),
-          }),
-          delete: jest.fn().mockReturnValue({
-            eq: jest.fn().mockResolvedValue({ error: null }),
           }),
         }),
       };

--- a/mem0/vector_stores/supabase.py
+++ b/mem0/vector_stores/supabase.py
@@ -14,6 +14,8 @@ from mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 
+VECS_MAX_QUERY_LIMIT = 1000
+
 
 class OutputData(BaseModel):
     id: Optional[str]
@@ -131,11 +133,21 @@ class Supabase(VectorStoreBase):
             List[OutputData]: Search results
         """
         filters = self._preprocess_filters(filters)
+        limit = top_k
+        if limit > VECS_MAX_QUERY_LIMIT:
+            logger.warning(
+                f"Requested top_k={top_k} exceeds the vecs query limit of {VECS_MAX_QUERY_LIMIT}; "
+                f"capping to {VECS_MAX_QUERY_LIMIT}."
+            )
+            limit = VECS_MAX_QUERY_LIMIT
         results = self.collection.query(
-            data=vectors, limit=top_k, filters=filters, include_metadata=True, include_value=True
+            data=vectors, limit=limit, filters=filters, include_metadata=True, include_value=True
         )
 
-        return [OutputData(id=str(result[0]), score=max(0.0, 1.0 - float(result[1])), payload=result[2]) for result in results]
+        return [
+            OutputData(id=str(result[0]), score=max(0.0, 1.0 - float(result[1])), payload=result[2])
+            for result in results
+        ]
 
     def delete(self, vector_id: str):
         """
@@ -201,12 +213,15 @@ class Supabase(VectorStoreBase):
         Returns:
             Dict: Collection information including name and configuration
         """
-        info = self.collection.describe()
         return {
-            "name": info.name,
-            "count": info.vectors,
-            "dimension": info.dimension,
-            "index": {"method": info.index_method, "metric": info.distance_metric},
+            "name": self.collection.name,
+            "count": len(self.collection),
+            "dimension": self.collection.dimension,
+            "index": {
+                "name": self.collection.index,
+                "measure": self.index_measure.value,
+                "is_indexed": self.collection.is_indexed_for_measure(self.index_measure),
+            },
         }
 
     def list(self, filters: Optional[dict] = None, top_k: int = 100) -> List[OutputData]:
@@ -222,8 +237,15 @@ class Supabase(VectorStoreBase):
         """
         filters = self._preprocess_filters(filters)
         query = [0] * self.embedding_model_dims
+        limit = top_k
+        if limit > VECS_MAX_QUERY_LIMIT:
+            logger.warning(
+                f"Requested top_k={top_k} exceeds the vecs query limit of {VECS_MAX_QUERY_LIMIT}; "
+                f"capping to {VECS_MAX_QUERY_LIMIT}."
+            )
+            limit = VECS_MAX_QUERY_LIMIT
         ids = self.collection.query(
-            data=query, limit=top_k, filters=filters, include_metadata=True, include_value=False
+            data=query, limit=limit, filters=filters, include_metadata=True, include_value=False
         )
         ids = [id[0] for id in ids]
         records = self.collection.fetch(ids=ids)

--- a/tests/vector_stores/test_supabase.py
+++ b/tests/vector_stores/test_supabase.py
@@ -1,9 +1,10 @@
-from unittest.mock import Mock, patch
+import logging
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from mem0.configs.vector_stores.supabase import IndexMeasure, IndexMethod
-from mem0.vector_stores.supabase import Supabase
+from mem0.vector_stores.supabase import VECS_MAX_QUERY_LIMIT, Supabase
 
 
 @pytest.fixture
@@ -14,13 +15,12 @@ def mock_vecs_client():
 
 @pytest.fixture
 def mock_collection():
-    collection = Mock()
+    collection = MagicMock()
     collection.name = "test_collection"
-    collection.vectors = 100
     collection.dimension = 1536
-    collection.index_method = "hnsw"
-    collection.distance_metric = "cosine_distance"
-    collection.describe.return_value = collection
+    collection.index = "ix_vector_cosine_ops_hnsw_m16_efc64_abc1234"
+    collection.is_indexed_for_measure.return_value = True
+    collection.__len__.return_value = 100
     return collection
 
 
@@ -141,8 +141,55 @@ def test_col_info(supabase_instance, mock_collection):
         "name": "test_collection",
         "count": 100,
         "dimension": 1536,
-        "index": {"method": "hnsw", "metric": "cosine_distance"},
+        "index": {
+            "name": "ix_vector_cosine_ops_hnsw_m16_efc64_abc1234",
+            "measure": "cosine_distance",
+            "is_indexed": True,
+        },
     }
+
+
+def test_search_clamps_top_k_to_vecs_limit(supabase_instance, mock_collection, caplog):
+    mock_collection.query.return_value = []
+
+    with caplog.at_level(logging.WARNING, logger="mem0.vector_stores.supabase"):
+        supabase_instance.search(query="", vectors=[[0.1, 0.2, 0.3]], top_k=5000)
+
+    mock_collection.query.assert_called_once_with(
+        data=[[0.1, 0.2, 0.3]], limit=VECS_MAX_QUERY_LIMIT, filters=None, include_metadata=True, include_value=True
+    )
+    assert "5000" in caplog.text
+    assert str(VECS_MAX_QUERY_LIMIT) in caplog.text
+
+
+def test_search_does_not_clamp_top_k_within_limit(supabase_instance, mock_collection):
+    mock_collection.query.return_value = []
+
+    supabase_instance.search(query="", vectors=[[0.1, 0.2, 0.3]], top_k=5)
+
+    mock_collection.query.assert_called_once_with(
+        data=[[0.1, 0.2, 0.3]], limit=5, filters=None, include_metadata=True, include_value=True
+    )
+
+
+def test_list_clamps_top_k_to_vecs_limit(supabase_instance, mock_collection, caplog):
+    mock_collection.query.return_value = []
+    mock_collection.fetch.return_value = []
+
+    with caplog.at_level(logging.WARNING, logger="mem0.vector_stores.supabase"):
+        supabase_instance.list(top_k=5000)
+
+    _, kwargs = mock_collection.query.call_args
+    assert kwargs["limit"] == VECS_MAX_QUERY_LIMIT
+    assert "5000" in caplog.text
+    assert str(VECS_MAX_QUERY_LIMIT) in caplog.text
+
+
+def test_col_info_does_not_raise(supabase_instance):
+    info = supabase_instance.col_info()
+
+    assert isinstance(info, dict)
+    assert info["name"] == "test_collection"
 
 
 def test_preprocess_filters(supabase_instance):


### PR DESCRIPTION
## Linked Issue

Closes #6694

## Description

Fixes the Supabase vector store's 1000-row ceiling in both SDKs, plus two adjacent defects found while verifying the behavior against a live hosted Supabase project (PostgreSQL 17.6, table seeded with 1200 rows).

**Python (`mem0/vector_stores/supabase.py`)**

`vecs` connects directly to Postgres and hard-raises `ArgError: limit must be <= 1000` for any larger query limit. `search()` and `list()` passed `top_k` through unmodified, so the error propagated to the caller. Because `Memory.get_all()` / `search()` over-fetch with `max(limit * 4, 60)`, the user-visible break point was `limit=251`, not 1000.

Both methods now clamp to `VECS_MAX_QUERY_LIMIT = 1000` and log a warning naming the requested value.

`col_info()` called `self.collection.describe()`, which does not exist on `vecs.Collection`, so every call raised `AttributeError`. It now returns real metadata (`count`, `dimension`, index name/measure/`is_indexed_for_measure`) using methods that exist.

**TypeScript (`mem0-ts/src/oss/src/vector_stores/supabase.ts`)**

PostgREST caps rows at `db-max-rows` (Supabase default 1000) for tables, views, *and* RPC results. Measured on the live project:

```
rpc(match_count=1200) -> http 200, 1000 rows   <-- TRUNCATED, no error
rpc(match_count=5000) -> http 200, 1000 rows   <-- TRUNCATED, no error
select(limit=1200)    -> http 206, 1000 rows, content-range 0-999/1200
```

- `list()` now paginates with `.range()` until it has `topK` rows or the table is exhausted, ordered by `id` so pages are stable (unordered paged `.range()` can duplicate or skip rows).
- `search()` cannot paginate, since `match_vectors` takes no offset. It warns when a request above the cap comes back at exactly the cap.
- `_doInitialize()` probed the table with a throwaway INSERT. Tables created via the Supabase dashboard have RLS enabled with no policies by default, so that INSERT failed with `42501` and the store threw a misleading "create this table" error for a table that existed and was correctly shaped. The probe is now a non-destructive `select(...).limit(1)`, and the error message lists RLS policies as a possible cause.

**Docs (`docs/components/vectordbs/dbs/supabase.mdx`)**

Adds a Row Level Security section (RLS-on-with-no-policies returns HTTP 200 and zero rows, which looks like an empty store) and a PostgREST Row Limits section documenting `db-max-rows`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A. Requests above 1000 previously crashed (Python) or silently truncated (TypeScript); they now return capped results with a warning, or paginate to the full set where possible.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Unit tests** — `tests/vector_stores/test_supabase.py`: clamp on `search()`, clamp on `list()`, no clamp within limit, `col_info()` does not raise. `mem0-ts/src/oss/tests/vector-stores-compat.test.ts`: `list()` paginates past the cap without duplicates and orders by `id`, `search()` warns on truncation, `initialize()` probes without writing.

**Manual verification** — reproduced every defect against a live hosted Supabase project seeded with 1200 rows before fixing: the Python `ArgError` at `top_k=1001`, the `col_info()` `AttributeError`, RPC truncation at 1000 across `match_count` 1200/1500/5000, `content-range: 0-999/1200` on table select, and `42501` from the INSERT probe on an RLS table. Test data and the temporary read policy were removed afterward and the removal verified.

**Suites** — `mem0-ts` OSS jest: 1229/1229 passing. Prettier clean. `tsc --noEmit` reports no Supabase errors (26 pre-existing errors in `src/client/tests/*` and `src/community/.../langchain/mem0.ts` are identical on unmodified `main` and untouched here). Python: ruff clean, `tests/vector_stores/test_supabase.py` passing.

## Out of scope

`delete_all()` / `deleteAll()` paginating at 100 (#6627) is a separate defect with several open PRs and is deliberately not touched here. Relevant to whichever of those lands: on Supabase, `top_k=1000` is the maximum safe page size, so a fix that pages with a larger sentinel will crash Supabase specifically. This PR's clamp is a precondition for that work.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
