### PR TITLE
fix(ts-client): send page/page_size independently in getAll()

### DIFF
--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -349,9 +349,17 @@ export default class MemoryClient {
       ...(filters && { filters }),
     };
 
+    // Pagination is read from the query string by the server, so send page and
+    // page_size independently. Requiring both (the old `page && pageSize`) meant
+    // getAll({ pageSize: 50 }) — a caller relying on page defaulting to 1 —
+    // silently dropped page_size and returned the server's default page size.
     let url = `${this.host}/v3/memories/`;
-    if (page && pageSize) {
-      url += `?page=${page}&page_size=${pageSize}`;
+    const queryParams = new URLSearchParams();
+    if (page !== undefined) queryParams.set("page", String(page));
+    if (pageSize !== undefined) queryParams.set("page_size", String(pageSize));
+    const queryString = queryParams.toString();
+    if (queryString) {
+      url += `?${queryString}`;
     }
 
     const response = await this._fetchWithErrorHandling(url, {

--- a/mem0-ts/src/client/tests/memoryClient.crud.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.crud.test.ts
@@ -134,6 +134,54 @@ describe("MemoryClient - get()", () => {
   });
 });
 
+// ─── getAll() pagination ─────────────────────────────────
+
+describe("MemoryClient - getAll() pagination", () => {
+  const mockV3 = () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v3/memories/", { status: 200, body: { results: [] } });
+    return setupMockFetch(extra);
+  };
+
+  test("sends page_size when only pageSize is provided", async () => {
+    const mock = mockV3();
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.getAll({ pageSize: 50 });
+
+    const call = findFetchCall(mock, "/v3/memories/", "POST");
+    expect(call).toBeDefined();
+    expect(call![0]).toContain("page_size=50");
+  });
+
+  test("sends page when only page is provided", async () => {
+    const mock = mockV3();
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.getAll({ page: 2 });
+
+    const call = findFetchCall(mock, "/v3/memories/", "POST");
+    expect(call![0]).toContain("page=2");
+  });
+
+  test("sends both page and page_size when both are provided", async () => {
+    const mock = mockV3();
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.getAll({ page: 2, pageSize: 50 });
+
+    const call = findFetchCall(mock, "/v3/memories/", "POST");
+    expect(call![0]).toContain("page=2");
+    expect(call![0]).toContain("page_size=50");
+  });
+
+  test("sends no pagination query string when neither is provided", async () => {
+    const mock = mockV3();
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.getAll({ filters: { user_id: "u1" } });
+
+    const call = findFetchCall(mock, "/v3/memories/", "POST");
+    expect(call![0]).not.toContain("?");
+  });
+});
+
 // ─── update() ────────────────────────────────────────────
 
 describe("MemoryClient - update()", () => {


### PR DESCRIPTION
### Description

`MemoryClient.getAll()` only appended pagination to the URL when **both** `page` and `pageSize` were provided:

```ts
if (page && pageSize) {
  url += `?page=${page}&page_size=${pageSize}`;
}
```

So `getAll({ pageSize: 50 })` — a caller who sets a page size and relies on `page` defaulting to 1 — sent no query string, and the server returned its default page size; `getAll({ page: 2 })` dropped the page the same way. The fix builds the query string from whichever of `page`/`page_size` is present, so either takes effect on its own.

This is the TS counterpart of the Python client bug #6227 (fix #6229); the Python `get_all()` has the same gate on main.

Closes #6697

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`jest src/client/tests/memoryClient.crud.test.ts` (from the `mem0-ts` root), 27 passed. Added a `getAll() pagination` suite (fetch-mocked):

- `sends page_size when only pageSize is provided` — URL now contains `page_size=50`.
- `sends page when only page is provided` — URL contains `page=2`.
- `sends both page and page_size when both are provided`.
- `sends no pagination query string when neither is provided`.

Reverting the source change fails the two "only one provided" tests (the URL comes back as bare `/v3/memories/`).

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes