### PR TITLE
fix(ts-client): let createWebhook target a project; harden deleteWebhook

### DIFF
--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -622,6 +622,11 @@ export default class MemoryClient {
     if (this.telemetryId === "") await this.ping();
     this._captureEvent("get_webhooks", []);
     const project_id = data?.projectId || this.projectId;
+    if (!project_id) {
+      throw new Error(
+        "projectId is required to list webhooks; pass it in the argument or ensure the client resolved a project via ping().",
+      );
+    }
     const response = await this._fetchWithErrorHandling(
       `${this.host}/api/v1/webhooks/projects/${project_id}/`,
       {
@@ -634,13 +639,22 @@ export default class MemoryClient {
   async createWebhook(webhook: WebhookCreatePayload): Promise<Webhook> {
     if (this.telemetryId === "") await this.ping();
     this._captureEvent("create_webhook", []);
+    // Allow targeting a specific project (like getWebhooks and the Python
+    // client), falling back to the ping-resolved project. Guard against an
+    // unresolved project so the request can't post to `.../projects/undefined/`.
+    const project_id = webhook.projectId || this.projectId;
+    if (!project_id) {
+      throw new Error(
+        "projectId is required to create a webhook; pass it in the payload or ensure the client resolved a project via ping().",
+      );
+    }
     const body = {
       name: webhook.name,
       url: webhook.url,
       event_types: webhook.eventTypes,
     };
     const response = await this._fetchWithErrorHandling(
-      `${this.host}/api/v1/webhooks/projects/${this.projectId}/`,
+      `${this.host}/api/v1/webhooks/projects/${project_id}/`,
       {
         method: "POST",
         headers: this.headers,
@@ -670,12 +684,18 @@ export default class MemoryClient {
     return response;
   }
 
-  async deleteWebhook(data: {
-    webhookId: string;
-  }): Promise<{ message: string }> {
+  async deleteWebhook(
+    data: { webhookId: string } | string,
+  ): Promise<{ message: string }> {
     if (this.telemetryId === "") await this.ping();
     this._captureEvent("delete_webhook", []);
-    const webhook_id = data.webhookId || data;
+    // Accept both the typed object and a bare id string. The old
+    // `data.webhookId || data` fell back to the whole object when webhookId was
+    // missing, serializing "[object Object]" into the URL.
+    const webhook_id = typeof data === "string" ? data : data.webhookId;
+    if (!webhook_id) {
+      throw new Error("webhookId is required to delete a webhook.");
+    }
     const response = await this._fetchWithErrorHandling(
       `${this.host}/api/v1/webhooks/${webhook_id}/`,
       {

--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -205,6 +205,12 @@ export interface WebhookCreatePayload {
   name: string;
   url: string;
   eventTypes: WebhookEvent[];
+  /**
+   * Project to create the webhook under. Defaults to the client's resolved
+   * project (from `ping()`); set this to target a different project, matching
+   * the Python client's required `project_id`.
+   */
+  projectId?: string;
 }
 
 export interface WebhookUpdatePayload {

--- a/mem0-ts/src/client/tests/memoryClient.webhooks.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.webhooks.test.ts
@@ -5,7 +5,7 @@
  */
 import { MemoryClient } from "../mem0";
 import { WebhookEvent } from "../mem0.types";
-import { TEST_API_KEY } from "./helpers";
+import { TEST_API_KEY, TEST_PROJECT_ID } from "./helpers";
 import {
   setupMockFetch,
   findFetchCall,
@@ -105,6 +105,48 @@ describe("MemoryClient - createWebhook", () => {
     );
     expect(body.webhookId).toBeUndefined();
   });
+
+  test("defaults to the ping-resolved project", async () => {
+    const mock = await callCreate();
+    const call = findFetchCall(mock, "/api/v1/webhooks/", "POST")!;
+    expect(call[0]).toContain(`/api/v1/webhooks/projects/${TEST_PROJECT_ID}/`);
+  });
+
+  test("targets an explicit projectId when provided in the payload", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/api/v1/webhooks/projects/", {
+      status: 200,
+      body: { webhook_id: "wh_new" },
+    });
+    const mock = webhookMock(extra);
+    const client = createClient();
+    await client.createWebhook({
+      name: "new-hook",
+      url: "https://example.com",
+      eventTypes: [WebhookEvent.MEMORY_ADDED],
+      projectId: "proj_custom_789",
+    });
+
+    const call = findFetchCall(mock, "/api/v1/webhooks/", "POST")!;
+    expect(call[0]).toContain("/api/v1/webhooks/projects/proj_custom_789/");
+  });
+
+  test("throws when no project can be resolved (never posts to /projects/undefined/)", async () => {
+    // A ping response with no project_id leaves the client without a project.
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v1/ping/", { status: 200, body: { status: "ok" } });
+    extra.set("/api/v1/webhooks/projects/", { status: 200, body: {} });
+    webhookMock(extra);
+    const client = createClient();
+
+    await expect(
+      client.createWebhook({
+        name: "n",
+        url: "https://example.com",
+        eventTypes: [WebhookEvent.MEMORY_ADDED],
+      }),
+    ).rejects.toThrow(/projectId is required/);
+  });
 });
 
 // ─── updateWebhook ────────────────────────────────────────
@@ -187,5 +229,29 @@ describe("MemoryClient - deleteWebhook", () => {
     expect(
       findFetchCall(mock, "/api/v1/webhooks/wh_1/", "DELETE"),
     ).toBeDefined();
+  });
+
+  test("accepts a bare id string", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/api/v1/webhooks/wh_2/", {
+      status: 200,
+      body: { message: "Webhook deleted" },
+    });
+    const mock = webhookMock(extra);
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.deleteWebhook("wh_2" as any);
+
+    expect(
+      findFetchCall(mock, "/api/v1/webhooks/wh_2/", "DELETE"),
+    ).toBeDefined();
+  });
+
+  test("throws on an empty webhookId instead of serializing the object into the URL", async () => {
+    webhookMock();
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+
+    await expect(client.deleteWebhook({ webhookId: "" })).rejects.toThrow(
+      /webhookId is required/,
+    );
   });
 });


### PR DESCRIPTION
### Description

Two related webhook fixes in the TS platform client.

**1. `createWebhook` can now target a project.** It hardcoded `this.projectId`, so you couldn't create a webhook under a different project (the Python `create_webhook` takes an explicit `project_id`, and `getWebhooks` already accepts a `projectId` override). It now reads an optional `projectId` from the payload, defaulting to the client's resolved project. Both `getWebhooks` and `createWebhook` also now raise a clear error when no project can be resolved, instead of posting to `.../projects/undefined/`.

**2. `deleteWebhook` no longer serializes an object into the URL.** The old `data.webhookId || data` fell back to the whole object when `webhookId` was missing, producing `/api/v1/webhooks/[object Object]/`. It now accepts the typed object or a bare id string and throws on an empty id.

`updateWebhook`/`deleteWebhook` use `/api/v1/webhooks/{id}/` (project-independent, matching the Python client), so they need no `project_id`.

Closes #6699

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`jest src/client/tests/memoryClient.webhooks.test.ts` (from the `mem0-ts` root), 19 passed (14 existing + 5 new); full client unit suite green; `tsup` build (incl. DTS) compiles.

New tests:
- `createWebhook` defaults to the ping-resolved project, and **targets an explicit `projectId`** when provided.
- `createWebhook` **throws when no project can be resolved** (never posts to `/projects/undefined/`).
- `deleteWebhook` accepts a bare id string, and **throws on an empty `webhookId`** instead of serializing the object.

Reverting the source change fails the explicit-projectId, no-project-throw, and empty-webhookId tests.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes