### PR TITLE
fix(ts-oss): preserve system messages and use the configured LLM in parse_vision_messages

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -763,7 +763,10 @@ export class Memory {
       ? (messages as Message[])
       : [{ role: "user", content: messages }];
 
-    const final_parsedMessages = await parse_vision_messages(parsedMessages);
+    const final_parsedMessages = await parse_vision_messages(
+      parsedMessages,
+      this.llm,
+    );
 
     // Add to vector store
     const vectorStoreResult = await this.addToVectorStore(

--- a/mem0-ts/src/oss/src/utils/memory.ts
+++ b/mem0-ts/src/oss/src/utils/memory.ts
@@ -1,11 +1,15 @@
+import { LLM } from "../llms/base";
 import { OpenAILLM } from "../llms/openai";
 import { Message } from "../types";
 
-const get_image_description = async (image_url: string) => {
-  const llm = new OpenAILLM({
-    apiKey: process.env.OPENAI_API_KEY,
-  });
-  const response = await llm.generateResponse([
+const get_image_description = async (image_url: string, llm?: LLM) => {
+  // Use the configured LLM (which carries the caller's provider + apiKey), like
+  // the Python parse_vision_messages does. Falling back to a bare OpenAI client
+  // read only from the env, as before, ignored a provider/apiKey set via config
+  // and forced OpenAI even for non-OpenAI setups.
+  const visionLlm =
+    llm ?? new OpenAILLM({ apiKey: process.env.OPENAI_API_KEY });
+  const response = await visionLlm.generateResponse([
     {
       role: "user",
       content:
@@ -19,29 +23,35 @@ const get_image_description = async (image_url: string) => {
   return response;
 };
 
-const parse_vision_messages = async (messages: Message[]) => {
-  const parsed_messages = [];
+const parse_vision_messages = async (messages: Message[], llm?: LLM) => {
+  const parsed_messages: Message[] = [];
   for (const message of messages) {
-    let new_message = {
-      role: message.role,
-      content: "",
-    };
-    if (message.role !== "system") {
-      if (
-        typeof message.content === "object" &&
-        message.content.type === "image_url"
-      ) {
-        const imageUrl = message.content.image_url?.url;
-        if (!imageUrl) {
-          throw new Error("image_url content part is missing image_url.url");
-        }
-        const description = await get_image_description(imageUrl);
-        new_message.content =
+    // Preserve system messages (they carry extraction context/instructions),
+    // matching the Python parse_vision_messages. Dropping them silently stripped
+    // caller-provided system context before the extraction pipeline.
+    if (message.role === "system") {
+      parsed_messages.push(message);
+      continue;
+    }
+
+    if (
+      typeof message.content === "object" &&
+      message.content.type === "image_url"
+    ) {
+      const imageUrl = message.content.image_url?.url;
+      if (!imageUrl) {
+        throw new Error("image_url content part is missing image_url.url");
+      }
+      const description = await get_image_description(imageUrl, llm);
+      parsed_messages.push({
+        role: message.role,
+        content:
           typeof description === "string"
             ? description
-            : JSON.stringify(description);
-        parsed_messages.push(new_message);
-      } else parsed_messages.push(message);
+            : JSON.stringify(description),
+      });
+    } else {
+      parsed_messages.push(message);
     }
   }
   return parsed_messages;

--- a/mem0-ts/src/oss/tests/parse-vision-messages.unit.test.ts
+++ b/mem0-ts/src/oss/tests/parse-vision-messages.unit.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="jest" />
+/**
+ * Unit tests for parse_vision_messages (utils/memory.ts).
+ *
+ * Covers two parity fixes vs the Python parse_vision_messages:
+ *  - system messages are preserved (not silently dropped);
+ *  - image description uses the configured LLM, not a hardcoded OpenAI client.
+ */
+import { parse_vision_messages } from "../src/utils/memory";
+import type { LLM } from "../src/llms/base";
+import type { Message } from "../src/types";
+
+function fakeLlm(description = "a photo of a cat"): LLM & {
+  generateResponse: jest.Mock;
+} {
+  return {
+    generateResponse: jest.fn().mockResolvedValue(description),
+    generateChat: jest.fn(),
+  } as any;
+}
+
+describe("parse_vision_messages", () => {
+  it("preserves system messages instead of dropping them", async () => {
+    const messages: Message[] = [
+      { role: "system", content: "You summarize concisely." },
+      { role: "user", content: "I love hiking." },
+    ];
+
+    const result = await parse_vision_messages(messages);
+
+    expect(result).toEqual(messages);
+  });
+
+  it("passes plain user/assistant messages through unchanged", async () => {
+    const messages: Message[] = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ];
+
+    const result = await parse_vision_messages(messages);
+
+    expect(result).toEqual(messages);
+  });
+
+  it("describes an image with the configured LLM (not a hardcoded OpenAI client)", async () => {
+    const llm = fakeLlm("a golden retriever on a beach");
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: {
+          type: "image_url",
+          image_url: { url: "https://example.com/dog.jpg" },
+        },
+      },
+    ];
+
+    const result = await parse_vision_messages(messages, llm);
+
+    expect(llm.generateResponse).toHaveBeenCalledTimes(1);
+    // The image_url is forwarded to the configured LLM for description.
+    const sent = llm.generateResponse.mock.calls[0][0];
+    expect(sent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: {
+            type: "image_url",
+            image_url: { url: "https://example.com/dog.jpg" },
+          },
+        }),
+      ]),
+    );
+    expect(result).toEqual([
+      { role: "user", content: "a golden retriever on a beach" },
+    ]);
+  });
+
+  it("keeps a system message alongside an image message", async () => {
+    const llm = fakeLlm("a sunset");
+    const messages: Message[] = [
+      { role: "system", content: "Describe vividly." },
+      {
+        role: "user",
+        content: {
+          type: "image_url",
+          image_url: { url: "https://example.com/sunset.jpg" },
+        },
+      },
+    ];
+
+    const result = await parse_vision_messages(messages, llm);
+
+    expect(result).toEqual([
+      { role: "system", content: "Describe vividly." },
+      { role: "user", content: "a sunset" },
+    ]);
+  });
+
+  it("throws when an image_url content part is missing its url", async () => {
+    const llm = fakeLlm();
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: { type: "image_url", image_url: { url: "" } },
+      },
+    ];
+
+    await expect(parse_vision_messages(messages, llm)).rejects.toThrow(
+      /missing image_url\.url/,
+    );
+  });
+});


### PR DESCRIPTION
### Description

Two bugs in `parse_vision_messages` (`mem0-ts/src/oss/src/utils/memory.ts`), both divergences from the Python implementation:

**1. System messages were silently dropped.** The `if (message.role !== "system")` guard meant `system` messages were never pushed, so caller-provided system context/instructions were stripped before the extraction pipeline. Python explicitly preserves them (`if role == "system": returned_messages.append(msg)`). Now TS does too.

**2. Image description hardcoded an env-only OpenAI client.** `get_image_description` built `new OpenAILLM({ apiKey: process.env.OPENAI_API_KEY })`, so multimodal `add()` always used OpenAI read from the env var — ignoring a non-OpenAI provider, and even ignoring an OpenAI `apiKey` supplied via config rather than the env. It now threads the configured LLM through from `Memory.add()` (matching Python's `parse_vision_messages(messages, llm=...)`), falling back to the env OpenAI client only when no LLM is provided.

Closes #6701

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

`jest src/oss/tests/parse-vision-messages.unit.test.ts` (from the `mem0-ts` root), 5 passed; `memory.add.test.ts` still green; `tsup` build (incl. DTS) compiles.

New tests:
- system messages preserved (alone and alongside an image message);
- plain user/assistant messages pass through unchanged;
- an image is described with the **configured LLM** (asserts the injected LLM receives the `image_url` and its output becomes the message content);
- missing `image_url.url` still throws.

Reverting the source change fails the system-preservation and configured-LLM tests.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes