### PR TITLE
fix(reranker): align llm_reranker default model with SDK default

### DIFF
--- a/docs/components/rerankers/config.mdx
+++ b/docs/components/rerankers/config.mdx
@@ -52,7 +52,7 @@ All rerankers share these common configuration parameters:
 
 | Parameter        | Description                                | Type    | Default                |
 | ---------------- | ------------------------------------------ | ------- | ---------------------- |
-| `model`          | LLM model to use for scoring               | `str`   | `"gpt-4o-mini"`        |
+| `model`          | LLM model to use for scoring               | `str`   | `"gpt-5-mini"`        |
 | `provider`       | LLM provider (`openai`, `anthropic`, etc.) | `str`   | `"openai"`             |
 | `api_key`        | API key for LLM provider                   | `str`   | `None`                 |
 | `temperature`    | Temperature for LLM generation             | `float` | `0.0`                  |
@@ -114,7 +114,7 @@ The self-hosted [TypeScript SDK](/open-source/features/reranker-search#typescrip
 | `zero_entropy` | `pnpm add zeroentropy` | `zerank-1` | `apiKey`, `model`, `topK` |
 | `sentence_transformer` | `pnpm add @huggingface/transformers` | `Xenova/ms-marco-MiniLM-L-6-v2` | `model`, `device`, `maxLength`, `normalize`, `topK` |
 | `huggingface` | `pnpm add @huggingface/transformers` | `Xenova/bge-reranker-base` | `model`, `device`, `maxLength`, `normalize`, `topK` |
-| `llm_reranker` | None (uses your LLM provider's own SDK) | `openai` / `gpt-4o-mini` | `provider`, `model`, `apiKey`, `llm` (nested override), `topK` |
+| `llm_reranker` | None (uses your LLM provider's own SDK) | `openai` / `gpt-5-mini` | `provider`, `model`, `apiKey`, `llm` (nested override), `topK` |
 
 ```typescript
 import { Memory } from "mem0ai/oss";

--- a/docs/components/rerankers/custom-prompts.mdx
+++ b/docs/components/rerankers/custom-prompts.mdx
@@ -48,7 +48,7 @@ config = {
         "provider": "llm_reranker",
         "config": {
             "provider": "openai",
-            "model": "gpt-4o-mini",
+            "model": "gpt-5-mini",
             "api_key": "your-openai-key",
             "scoring_prompt": custom_prompt,
             "top_k": 5

--- a/docs/components/rerankers/models/cohere.mdx
+++ b/docs/components/rerankers/models/cohere.mdx
@@ -101,7 +101,7 @@ os.environ["COHERE_API_KEY"] = "your-api-key"
 # Initialize memory with Cohere reranker
 config = {
     "vector_store": {"provider": "chroma"},
-    "llm": {"provider": "openai", "config": {"model": "gpt-4o-mini"}},
+    "llm": {"provider": "openai", "config": {"model": "gpt-5-mini"}},
     "rerank": {
         "provider": "cohere",
         "config": {

--- a/docs/components/rerankers/models/llm_reranker.mdx
+++ b/docs/components/rerankers/models/llm_reranker.mdx
@@ -19,7 +19,7 @@ config = {
         "provider": "llm_reranker",
         "config": {
             "provider": "openai",
-            "model": "gpt-4o-mini",
+            "model": "gpt-5-mini",
             "api_key": "your-openai-api-key"
         }
     }
@@ -33,7 +33,7 @@ m = Memory.from_config(config)
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `provider` | str | `"openai"` | LLM provider (openai, anthropic, etc.) |
-| `model` | str | `"gpt-4o-mini"` | LLM model to use for reranking |
+| `model` | str | `"gpt-5-mini"` | LLM model to use for reranking |
 | `api_key` | str | None | API key for the LLM provider |
 | `top_k` | int | None | Number of top documents to return after reranking |
 | `temperature` | float | 0.0 | LLM temperature for consistency |
@@ -69,7 +69,7 @@ config = {
 
 ## TypeScript (self-hosted)
 
-The [TypeScript OSS SDK](/open-source/features/reranker-search#typescript-sdk) (`mem0ai/oss`) ships the LLM reranker under the provider name `llm_reranker`. It does **not** reuse the Memory's main `llm` instance; it builds its own LLM from the reranker's own config, defaulting to `openai` / `gpt-4o-mini`. Set `provider`/`model`/`apiKey` directly on `config`, or nest a fully separate `config.llm: { provider, config }` (its `provider`/`config` take priority over the top-level fields, which only backfill values missing from the nested config).
+The [TypeScript OSS SDK](/open-source/features/reranker-search#typescript-sdk) (`mem0ai/oss`) ships the LLM reranker under the provider name `llm_reranker`. It does **not** reuse the Memory's main `llm` instance; it builds its own LLM from the reranker's own config, defaulting to `openai` / `gpt-5-mini`. Set `provider`/`model`/`apiKey` directly on `config`, or nest a fully separate `config.llm: { provider, config }` (its `provider`/`config` take priority over the top-level fields, which only backfill values missing from the nested config).
 
 ```typescript
 import { Memory } from "mem0ai/oss";
@@ -114,7 +114,7 @@ config = {
         "provider": "llm_reranker",
         "config": {
             "provider": "openai",
-            "model": "gpt-4o-mini",
+            "model": "gpt-5-mini",
             "api_key": "your-openai-api-key",
             "temperature": 0.0
         }
@@ -170,15 +170,15 @@ config = {
         "provider": "llm_reranker",
         "config": {
             "provider": "azure_openai",
-            "model": "gpt-4o-mini",
+            "model": "gpt-5-mini",
             "api_key": "your-azure-api-key",
             "llm": {
                 "provider": "azure_openai",
                 "config": {
-                    "model": "gpt-4o-mini",
+                    "model": "gpt-5-mini",
                     "api_key": "your-azure-api-key",
                     "azure_endpoint": "https://your-resource.openai.azure.com/",
-                    "azure_deployment": "gpt-4o-mini-deployment"
+                    "azure_deployment": "gpt-5-mini-deployment"
                 }
             }
         }
@@ -232,7 +232,7 @@ config = {
         "provider": "llm_reranker",
         "config": {
             "provider": "openai",
-            "model": "gpt-4o-mini",
+            "model": "gpt-5-mini",
             "api_key": "your-api-key",
             "scoring_prompt": custom_prompt
         }
@@ -351,7 +351,7 @@ fast_config = {
         "provider": "llm_reranker",
         "config": {
             "provider": "openai",
-            "model": "gpt-4o-mini",
+            "model": "gpt-5-mini",
             "api_key": "your-api-key",
             "top_k": 5,
             "temperature": 0.0
@@ -444,7 +444,7 @@ fallback_config = {
         "provider": "llm_reranker",
         "config": {
             "provider": "openai",
-            "model": "gpt-4o-mini",
+            "model": "gpt-5-mini",
             "api_key": "your-api-key"
         }
     }

--- a/docs/components/rerankers/models/sentence_transformer.mdx
+++ b/docs/components/rerankers/models/sentence_transformer.mdx
@@ -36,7 +36,7 @@ config = {
     "llm": {
         "provider": "openai",
         "config": {
-            "model": "gpt-4o-mini"
+            "model": "gpt-5-mini"
         }
     },
     "rerank": {
@@ -113,7 +113,7 @@ from mem0 import Memory
 # Initialize memory with local reranker
 config = {
     "vector_store": {"provider": "chroma"},
-    "llm": {"provider": "openai", "config": {"model": "gpt-4o-mini"}},
+    "llm": {"provider": "openai", "config": {"model": "gpt-5-mini"}},
     "rerank": {
         "provider": "sentence_transformer",
         "config": {

--- a/docs/components/rerankers/models/zero_entropy.mdx
+++ b/docs/components/rerankers/models/zero_entropy.mdx
@@ -34,7 +34,7 @@ config = {
     "llm": {
         "provider": "openai",
         "config": {
-            "model": "gpt-4o-mini"
+            "model": "gpt-5-mini"
         }
     },
     "rerank": {
@@ -98,7 +98,7 @@ os.environ["ZERO_ENTROPY_API_KEY"] = "your-api-key"
 # Initialize memory with Zero Entropy reranker
 config = {
     "vector_store": {"provider": "chroma"},
-    "llm": {"provider": "openai", "config": {"model": "gpt-4o-mini"}},
+    "llm": {"provider": "openai", "config": {"model": "gpt-5-mini"}},
     "rerank": {"provider": "zero_entropy", "config": {"model": "zerank-1"}}
 }
 

--- a/docs/open-source/features/reranker-search.mdx
+++ b/docs/open-source/features/reranker-search.mdx
@@ -97,7 +97,7 @@ const results = await memory.search("What movies do I like?", {
 
 ### LLM reranker
 
-To score with an LLM instead of a dedicated reranker, use the `llm_reranker` provider. It builds its own LLM from the reranker's config (defaulting to `openai` / `gpt-4o-mini`) rather than reusing the Memory's main `llm`:
+To score with an LLM instead of a dedicated reranker, use the `llm_reranker` provider. It builds its own LLM from the reranker's config (defaulting to `openai` / `gpt-5-mini`) rather than reusing the Memory's main `llm`:
 
 ```typescript
 const memory = new Memory({
@@ -137,7 +137,7 @@ const memory = new Memory({
 | `zero_entropy` | `zerank-1` | `apiKey`, `model`, `topK` |
 | `sentence_transformer` | `Xenova/ms-marco-MiniLM-L-6-v2` | `model`, `device`, `maxLength`, `normalize`, `topK` |
 | `huggingface` | `Xenova/bge-reranker-base` | `model`, `device`, `maxLength`, `normalize`, `topK` |
-| `llm_reranker` | `openai` / `gpt-4o-mini` | `provider`, `model`, `apiKey`, `llm` (nested override), `topK` |
+| `llm_reranker` | `openai` / `gpt-5-mini` | `provider`, `model`, `apiKey`, `llm` (nested override), `topK` |
 
 <Note>
   `rerank` is opt-in per search and a no-op when no `reranker` is configured. If the reranker call fails, Mem0 logs a warning and returns the original vector-ranked results.

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -247,7 +247,7 @@ export class RerankerFactory {
       llmProvider = nested.provider || config.provider || "openai";
       llmConfig = { ...(nested.config || {}) };
       if (llmConfig.model === undefined) {
-        llmConfig.model = config.model ?? "gpt-4o-mini";
+        llmConfig.model = config.model ?? "gpt-5-mini";
       }
       if (llmConfig.temperature === undefined) {
         llmConfig.temperature = config.temperature ?? 0.0;
@@ -261,7 +261,7 @@ export class RerankerFactory {
     } else {
       llmProvider = config.provider || "openai";
       llmConfig = {
-        model: config.model ?? "gpt-4o-mini",
+        model: config.model ?? "gpt-5-mini",
         temperature: config.temperature ?? 0.0,
         maxTokens: config.maxTokens ?? 100,
       };

--- a/mem0/configs/rerankers/llm.py
+++ b/mem0/configs/rerankers/llm.py
@@ -10,7 +10,7 @@ class LLMRerankerConfig(BaseRerankerConfig):
     Configuration for LLM-based reranker.
     
     Attributes:
-        model (str): LLM model to use for reranking. Defaults to "gpt-4o-mini".
+        model (str): LLM model to use for reranking. Defaults to "gpt-5-mini".
         api_key (str): API key for the LLM provider.
         provider (str): LLM provider. Defaults to "openai".
         top_k (int): Number of top documents to return after reranking.
@@ -20,7 +20,7 @@ class LLMRerankerConfig(BaseRerankerConfig):
     """
     
     model: str = Field(
-        default="gpt-4o-mini",
+        default="gpt-5-mini",
         description="LLM model to use for reranking"
     )
     api_key: Optional[str] = Field(

--- a/mem0/reranker/llm_reranker.py
+++ b/mem0/reranker/llm_reranker.py
@@ -27,7 +27,7 @@ class LLMReranker(BaseReranker):
             # Convert BaseRerankerConfig to LLMRerankerConfig with defaults
             config = LLMRerankerConfig(
                 provider=getattr(config, 'provider', 'openai'),
-                model=getattr(config, 'model', 'gpt-4o-mini'),
+                model=getattr(config, 'model', 'gpt-5-mini'),
                 api_key=getattr(config, 'api_key', None),
                 top_k=getattr(config, 'top_k', None),
                 temperature=0.0,  # Default for reranking

--- a/tests/rerankers/test_llm_reranker_config.py
+++ b/tests/rerankers/test_llm_reranker_config.py
@@ -6,7 +6,7 @@ from mem0.reranker.llm_reranker import LLMReranker
 class TestLLMRerankerConfig:
     def test_default_config(self):
         config = LLMRerankerConfig()
-        assert config.model == "gpt-4o-mini"
+        assert config.model == "gpt-5-mini"
         assert config.provider == "openai"
         assert config.temperature == 0.0
         assert config.max_tokens == 100


### PR DESCRIPTION
## Linked Issue

No existing issue — found while auditing `docs/open-source/features/reranker-search.mdx` against the reranker implementation.

## Description

The LLM reranker defaulted to `gpt-4o-mini` while the OpenAI LLM provider defaults to `gpt-5-mini`:

```python
# mem0/llms/openai.py:40
self.config.model = "gpt-5-mini"

# mem0/configs/rerankers/llm.py (before)
model: str = Field(default="gpt-4o-mini", ...)
```

So turning on the reranker silently scored against a different model than the rest of the SDK, with no way to notice short of reading the config class. This aligns the default in three places:

- `mem0/configs/rerankers/llm.py` — the `Field` default and its docstring
- `mem0/reranker/llm_reranker.py` — the `getattr` fallback used when converting a `BaseRerankerConfig`
- `mem0-ts/src/oss/src/utils/factory.ts` — both `?? "gpt-4o-mini"` fallbacks in `buildLLMRerankerLLM`

Docs that state or demonstrate the default are updated to match. Explicit `model` overrides are unaffected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

None for anyone who sets `model` explicitly. Users relying on the implicit default move from `gpt-4o-mini` to `gpt-5-mini`, which is the model the rest of the SDK already defaults to.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

`tests/rerankers/test_llm_reranker_config.py::test_default_config` updated to assert the new default. The other `gpt-4o-mini` references in that suite pass the model explicitly as an override and are intentionally left alone.

```
$ pytest tests/rerankers/ -q
53 passed, 1 warning in 0.66s

$ ruff check mem0/configs/rerankers/llm.py mem0/reranker/llm_reranker.py tests/rerankers/
All checks passed!

$ python scripts/check-llms-txt-coverage.py
docs/llms.txt is in sync with docs/**/*.mdx.
```

Also exercised end to end against a live `LLMReranker` (local embedder + OpenAI-compatible endpoint), confirming the reranker builds its LLM from the reranker config and reorders results by `rerank_score`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed