### PR TITLE
docs(rerankers): show rerank_score on the huggingface and llm_reranker pages

### DIFF
--- a/docs/components/rerankers/models/huggingface.mdx
+++ b/docs/components/rerankers/models/huggingface.mdx
@@ -194,7 +194,8 @@ results = m.search(
 
 for result in results["results"]:
     print(f"Memory: {result['memory']}")
-    print(f"Score: {result['score']:.3f}")
+    print(f"Vector Score: {result['score']:.3f}")
+    print(f"Rerank Score: {result['rerank_score']:.3f}")
 ```
 
 ### Batch Processing

--- a/docs/components/rerankers/models/llm_reranker.mdx
+++ b/docs/components/rerankers/models/llm_reranker.mdx
@@ -311,7 +311,8 @@ results = m.search(
 
 for result in results["results"]:
     print(f"Memory: {result['memory']}")
-    print(f"LLM Score: {result['score']:.2f}")
+    print(f"Vector Score: {result['score']:.2f}")
+    print(f"LLM Rerank Score: {result['rerank_score']:.2f}")
 ```
 
 ### Batch Processing with Error Handling


### PR DESCRIPTION
## Linked Issue

Closes #6705

## Description

Follow-up to #6492, which @kartik-mem0 flagged in review: the same `score` vs `rerank_score` mixup lives on two more pages. `huggingface.mdx:197` and `llm_reranker.mdx:314` both run a `rerank=True` search and then print the vector `score` while labelling it as the reranker's output ("Score", "LLM Score"). Rerankers copy the doc and add a separate `rerank_score` (huggingface_reranker.py:158, llm_reranker.py:154) while `score` stays the vector similarity from `_search_vector_store` (main.py:1645), so "LLM Score" was printing a number the LLM reranker never produced. Both pages now follow the pattern the other three reranker pages already use (`cohere.mdx:129-131`): vector score on one line, rerank score on the next. Docs-only, `python3 scripts/check-llms-txt-coverage.py` reports in sync.

One thing I deliberately left alone: those same snippets call `m.search(query, user_id="alice", rerank=True)`, and top-level entity kwargs are rejected by `_reject_top_level_entity_params`, so the call raises. That same `user_id=` pattern also shows up in `docs/migration/oss-v2-to-v3.mdx` and `platform-v2-to-v3.mdx`, so it felt like its own pass rather than a partial fix smuggled in here. Noted in #6705 so it does not get lost.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (docs-only; verified the field names against mem0/reranker/huggingface_reranker.py and llm_reranker.py and the search return path in mem0/memory/main.py, and ran the llms.txt coverage check)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (N/A, docs-only)
- [ ] New and existing tests pass locally (N/A, docs-only; ran the llms.txt coverage gate instead)
- [x] I have updated documentation if needed

---

*usual disclosure: freshman here, still learning this codebase. Claude Code helped me trace the reranker field names and the search return path, and I ran the docs gate locally. thanks for pointing at these two pages in the #6492 review, that made this one easy to pick up.*
