### PR TITLE
fix(openclaw): pass session id as run_id on capture and session-scoped search

### DIFF
--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -1033,7 +1033,7 @@ function registerHooks(
         content: `Current date: ${timestamp}. The user is identified as "${cfg.userId}". Extract durable facts from this conversation. Include this date when storing time-sensitive information.`,
       });
 
-      const addOpts = buildAddOptions(undefined, undefined, sessionId);
+      const addOpts = buildAddOptions(undefined, sessionId, sessionId);
       const captureStart = Date.now();
       provider
         .add(formattedMessages, addOpts)

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -1033,6 +1033,8 @@ function registerHooks(
         content: `Current date: ${timestamp}. The user is identified as "${cfg.userId}". Extract durable facts from this conversation. Include this date when storing time-sensitive information.`,
       });
 
+      // run_id intentionally holds the raw sessionKey (e.g. "agent:researcher:uuid-1");
+      // session-scoped search reads it back unchanged, so capture and recall stay aligned.
       const addOpts = buildAddOptions(undefined, sessionId, sessionId);
       const captureStart = Date.now();
       provider

--- a/integrations/openclaw/tests/cli-commands.test.ts
+++ b/integrations/openclaw/tests/cli-commands.test.ts
@@ -191,18 +191,21 @@ function createMockCfg() {
  * Register CLI commands using mocked deps, and return the captured
  * mem0 command tree plus all mock objects for assertions.
  */
-function setup() {
+function setup(currentSessionId?: string) {
   const provider = createMockProvider();
   const backend = createMockBackend();
   const cfg = createMockCfg();
   const effectiveUserId = vi.fn().mockReturnValue("testuser");
   const agentUserId = vi.fn((id: string) => `testuser:agent:${id}`);
-  const buildSearchOptions = vi.fn().mockReturnValue({
-    user_id: "testuser",
-    top_k: 5,
-    source: "OPENCLAW",
-  });
-  const getCurrentSessionId = vi.fn().mockReturnValue(undefined);
+  const buildSearchOptions = vi.fn(
+    (userId?: string, topK?: number, runId?: string) => ({
+      user_id: userId ?? "testuser",
+      top_k: topK ?? 5,
+      ...(runId ? { run_id: runId } : {}),
+      source: "OPENCLAW",
+    }),
+  );
+  const getCurrentSessionId = vi.fn().mockReturnValue(currentSessionId);
 
   let registeredCallback: any;
   const mockApi = {
@@ -775,6 +778,29 @@ describe("registerCliCommands", () => {
       // The output is JSON.stringify of results
       expect(consoleSpy.log).toHaveBeenCalledWith(
         expect.stringContaining("test memory"),
+      );
+    });
+
+    it("passes the current session run ID to session search", async () => {
+      const { mem0, provider, buildSearchOptions } = setup("session-abc");
+      const searchCmd = findCommand(mem0, "search")!;
+
+      await searchCmd._action!("session facts", {
+        topK: "5",
+        scope: "session",
+      });
+
+      expect(buildSearchOptions).toHaveBeenCalledWith(
+        "testuser",
+        5,
+        "session-abc",
+      );
+      expect(provider.search).toHaveBeenCalledWith(
+        "session facts",
+        expect.objectContaining({
+          user_id: "testuser",
+          run_id: "session-abc",
+        }),
       );
     });
 

--- a/integrations/openclaw/tests/hooks-session-scope.test.ts
+++ b/integrations/openclaw/tests/hooks-session-scope.test.ts
@@ -5,6 +5,11 @@ const mockSdk = vi.hoisted(() => ({
   searchOptions: [] as Record<string, unknown>[],
 }));
 
+const mockOss = vi.hoisted(() => ({
+  addOptions: [] as Record<string, unknown>[],
+  searchOptions: [] as Record<string, unknown>[],
+}));
+
 vi.mock("mem0ai", () => ({
   default: class MockMemoryClient {
     constructor(_options: Record<string, unknown>) {}
@@ -99,6 +104,8 @@ const captureEvent = {
 beforeEach(() => {
   mockSdk.addOptions.length = 0;
   mockSdk.searchOptions.length = 0;
+  mockOss.addOptions.length = 0;
+  mockOss.searchOptions.length = 0;
 });
 
 describe("OpenClaw session scope reaches the SDK payload", () => {
@@ -117,7 +124,7 @@ describe("OpenClaw session scope reaches the SDK payload", () => {
   });
 
   it("passes the session ID as runId for session and all searches", async () => {
-    const { handlers, tools } = createPluginApi({
+    const { api, handlers, tools } = createPluginApi({
       autoCapture: false,
       autoRecall: true,
     });
@@ -175,6 +182,13 @@ describe("OpenClaw session scope reaches the SDK payload", () => {
   });
 
   it("preserves non-interactive and subagent capture skips", async () => {
+    const positiveControl = createPluginApi();
+    await positiveControl.handlers.get("agent_end")?.[0](captureEvent, {
+      sessionKey: "sess-positive-control",
+    });
+    await vi.waitFor(() => expect(mockSdk.addOptions).toHaveLength(1));
+    mockSdk.addOptions.length = 0;
+
     const nonInteractive = createPluginApi();
     await nonInteractive.handlers.get("agent_end")?.[0](captureEvent, {
       trigger: "cron",
@@ -186,6 +200,7 @@ describe("OpenClaw session scope reaches the SDK payload", () => {
       sessionKey: "agent:main:subagent:uuid-1",
     });
 
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(mockSdk.addOptions).toHaveLength(0);
   });
 
@@ -226,5 +241,65 @@ describe("OpenClaw session scope reaches the SDK payload", () => {
       user_id: "alice:agent:researcher",
       run_id: "agent:researcher:uuid-1",
     });
+  });
+
+  it("passes session run scope through the OSS provider", async () => {
+    vi.doMock("mem0ai/oss", () => ({
+      PGVector: undefined,
+      RedisDB: undefined,
+      Qdrant: undefined,
+      Memory: class MockOssMemory {
+        constructor(_config: Record<string, unknown>) {}
+
+        async getAll(): Promise<[]> {
+          return [];
+        }
+
+        async add(
+          _messages: unknown,
+          options: Record<string, unknown>,
+        ): Promise<{ results: Array<{ id: string; memory: string }> }> {
+          mockOss.addOptions.push(options);
+          return { results: [{ id: "memory-oss-1", memory: "stored" }] };
+        }
+
+        async search(
+          _query: string,
+          options: Record<string, unknown>,
+        ): Promise<Array<{ id: string; memory: string; score: number }>> {
+          mockOss.searchOptions.push(options);
+          return [{ id: "memory-oss-1", memory: "found", score: 0.9 }];
+        }
+      },
+    }));
+
+    const { handlers, tools } = createPluginApi({
+      mode: "open-source",
+      autoCapture: true,
+      autoRecall: false,
+      oss: { disableHistory: true },
+    });
+    await handlers.get("agent_end")?.[0](captureEvent, {
+      sessionKey: "agent:main:uuid-1",
+    });
+    await vi.waitFor(() => expect(mockOss.addOptions).toHaveLength(1));
+    expect(mockOss.addOptions[0]).toMatchObject({
+      userId: "alice",
+      runId: "agent:main:uuid-1",
+    });
+    mockOss.searchOptions.length = 0;
+
+    const searchTool = tools.find((tool) => tool.name === "memory_search");
+    await searchTool.execute("call-oss", {
+      query: "session facts",
+      scope: "session",
+    });
+
+    expect(mockOss.searchOptions.at(-1)?.filters).toEqual({
+      user_id: "alice",
+      run_id: "agent:main:uuid-1",
+    });
+
+    vi.doUnmock("mem0ai/oss");
   });
 });

--- a/integrations/openclaw/tests/hooks-session-scope.test.ts
+++ b/integrations/openclaw/tests/hooks-session-scope.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockSdk = vi.hoisted(() => ({
   addOptions: [] as Record<string, unknown>[],
@@ -106,6 +106,10 @@ beforeEach(() => {
   mockSdk.searchOptions.length = 0;
   mockOss.addOptions.length = 0;
   mockOss.searchOptions.length = 0;
+});
+
+afterEach(() => {
+  vi.doUnmock("mem0ai/oss");
 });
 
 describe("OpenClaw session scope reaches the SDK payload", () => {
@@ -299,7 +303,5 @@ describe("OpenClaw session scope reaches the SDK payload", () => {
       user_id: "alice",
       run_id: "agent:main:uuid-1",
     });
-
-    vi.doUnmock("mem0ai/oss");
   });
 });

--- a/integrations/openclaw/tests/hooks-session-scope.test.ts
+++ b/integrations/openclaw/tests/hooks-session-scope.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSdk = vi.hoisted(() => ({
+  addOptions: [] as Record<string, unknown>[],
+  searchOptions: [] as Record<string, unknown>[],
+}));
+
+vi.mock("mem0ai", () => ({
+  default: class MockMemoryClient {
+    constructor(_options: Record<string, unknown>) {}
+
+    async add(
+      _messages: unknown,
+      options: Record<string, unknown>,
+    ): Promise<{ results: Array<{ id: string; memory: string }> }> {
+      mockSdk.addOptions.push(options);
+      return { results: [{ id: "memory-1", memory: "stored" }] };
+    }
+
+    async search(
+      _query: string,
+      options: Record<string, unknown>,
+    ): Promise<Array<{ id: string; memory: string; score: number }>> {
+      mockSdk.searchOptions.push(options);
+      return [{ id: "memory-1", memory: "found", score: 0.9 }];
+    }
+
+    async getAll(): Promise<[]> {
+      return [];
+    }
+
+    async get(): Promise<Record<string, never>> {
+      return {};
+    }
+
+    async update(): Promise<void> {}
+
+    async delete(): Promise<void> {}
+
+    async deleteAll(): Promise<void> {}
+  },
+}));
+
+import memoryPlugin from "../index.ts";
+
+type Handler = (...args: any[]) => unknown;
+
+function createPluginApi(config: Record<string, unknown> = {}) {
+  const handlers = new Map<string, Handler[]>();
+  const tools: any[] = [];
+  const api = {
+    pluginConfig: {
+      mode: "platform",
+      apiKey: "test-api-key",
+      userId: "alice",
+      autoRecall: false,
+      autoCapture: true,
+      ...config,
+    },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    resolvePath: vi.fn((path: string) => path),
+    registerTool: vi.fn((tool: unknown) => tools.push(tool)),
+    on: vi.fn((event: string, handler: Handler) => {
+      const eventHandlers = handlers.get(event) ?? [];
+      eventHandlers.push(handler);
+      handlers.set(event, eventHandlers);
+    }),
+    registerCli: vi.fn(),
+    registerCommand: vi.fn(),
+    registerService: vi.fn(),
+    registerMemoryCapability: vi.fn(),
+  };
+
+  memoryPlugin.register(api as any);
+  return { api, handlers, tools };
+}
+
+const captureEvent = {
+  success: true,
+  messages: [
+    {
+      role: "user",
+      content:
+        "Remember that the deployment uses the staging database for validation and must be promoted after the migration completes.",
+    },
+    {
+      role: "assistant",
+      content:
+        "The deployment plan is recorded with the staging database validation step.",
+    },
+  ],
+};
+
+beforeEach(() => {
+  mockSdk.addOptions.length = 0;
+  mockSdk.searchOptions.length = 0;
+});
+
+describe("OpenClaw session scope reaches the SDK payload", () => {
+  it("passes the session ID as runId for auto-capture", async () => {
+    const { handlers } = createPluginApi();
+    await handlers.get("agent_end")?.[0](captureEvent, {
+      sessionKey: "sess-abc",
+    });
+
+    await vi.waitFor(() => expect(mockSdk.addOptions).toHaveLength(1));
+    expect(mockSdk.addOptions[0]).toMatchObject({
+      userId: "alice",
+      runId: "sess-abc",
+      source: "OPENCLAW",
+    });
+  });
+
+  it("passes the session ID as runId for session and all searches", async () => {
+    const { handlers, tools } = createPluginApi({
+      autoCapture: false,
+      autoRecall: true,
+    });
+    await handlers.get("before_prompt_build")?.[0](
+      { prompt: "a".repeat(100) },
+      { sessionKey: "sess-abc" },
+    );
+    mockSdk.searchOptions.length = 0;
+    const searchTool = tools.find((tool) => tool.name === "memory_search");
+
+    await searchTool.execute("call-session", {
+      query: "session facts",
+      scope: "session",
+    });
+    await searchTool.execute("call-all", {
+      query: "all facts",
+      scope: "all",
+    });
+
+    expect(mockSdk.searchOptions).toHaveLength(3);
+    expect(mockSdk.searchOptions[0].filters).toEqual({
+      user_id: "alice",
+      run_id: "sess-abc",
+    });
+    expect(mockSdk.searchOptions[1].filters).toEqual({ user_id: "alice" });
+    expect(mockSdk.searchOptions[2].filters).toEqual({
+      user_id: "alice",
+      run_id: "sess-abc",
+    });
+  });
+
+  it("keeps long-term and cold-start recall unscoped", async () => {
+    const { handlers } = createPluginApi({ autoRecall: true });
+    await handlers.get("before_prompt_build")?.[0](
+      { prompt: "short prompt" },
+      { sessionKey: "sess-abc" },
+    );
+
+    expect(mockSdk.searchOptions).toHaveLength(2);
+    for (const options of mockSdk.searchOptions) {
+      expect(options.filters).toEqual({ user_id: "alice" });
+    }
+  });
+
+  it("keeps sessionless capture without runId", async () => {
+    const { handlers } = createPluginApi();
+    await handlers.get("agent_end")?.[0](captureEvent, {});
+
+    await vi.waitFor(() => expect(mockSdk.addOptions).toHaveLength(1));
+    expect(mockSdk.addOptions[0]).toMatchObject({
+      userId: "alice",
+      source: "OPENCLAW",
+    });
+    expect(mockSdk.addOptions[0]).not.toHaveProperty("runId");
+  });
+
+  it("preserves non-interactive and subagent capture skips", async () => {
+    const nonInteractive = createPluginApi();
+    await nonInteractive.handlers.get("agent_end")?.[0](captureEvent, {
+      trigger: "cron",
+      sessionKey: "sess-cron",
+    });
+
+    const subagent = createPluginApi();
+    await subagent.handlers.get("agent_end")?.[0](captureEvent, {
+      sessionKey: "agent:main:subagent:uuid-1",
+    });
+
+    expect(mockSdk.addOptions).toHaveLength(0);
+  });
+
+  it("keeps skills mode on its skills lifecycle path", async () => {
+    const { handlers } = createPluginApi({
+      autoCapture: true,
+      skills: { triage: { enabled: true }, recall: { enabled: false } },
+    });
+
+    expect(handlers.get("before_prompt_build")).toHaveLength(1);
+    expect(handlers.get("agent_end")).toHaveLength(1);
+    await handlers.get("agent_end")?.[0](captureEvent, {
+      sessionKey: "sess-skills",
+    });
+
+    expect(mockSdk.addOptions).toHaveLength(0);
+  });
+
+  it("keeps the agent namespace while applying session scope", async () => {
+    const { handlers, tools } = createPluginApi({
+      autoCapture: false,
+      autoRecall: true,
+    });
+    await handlers.get("before_prompt_build")?.[0](
+      { prompt: "a".repeat(100) },
+      { sessionKey: "agent:researcher:uuid-1" },
+    );
+    mockSdk.searchOptions.length = 0;
+    const searchTool = tools.find((tool) => tool.name === "memory_search");
+
+    await searchTool.execute("call-agent", {
+      query: "agent facts",
+      scope: "session",
+      agentId: "researcher",
+    });
+
+    expect(mockSdk.searchOptions[0].filters).toEqual({
+      user_id: "alice:agent:researcher",
+      run_id: "agent:researcher:uuid-1",
+    });
+  });
+});

--- a/integrations/openclaw/tests/tools.test.ts
+++ b/integrations/openclaw/tests/tools.test.ts
@@ -263,11 +263,11 @@ describe("memory_search execute", () => {
       scope: "session",
     });
 
-    // Should call buildSearchOptions with session ID as 4th arg (sessionKey)
+    // Session scope uses both the run ID and namespace routing slots.
     expect(ctx.buildSearchOptions).toHaveBeenCalledWith(
       "testuser",
       undefined,
-      undefined,
+      "session-abc",
       "session-abc",
     );
     expect(result.details.count).toBe(1);

--- a/integrations/openclaw/tests/tools.test.ts
+++ b/integrations/openclaw/tests/tools.test.ts
@@ -263,11 +263,10 @@ describe("memory_search execute", () => {
       scope: "session",
     });
 
-    // Session scope uses both the run ID and namespace routing slots.
+    // Session scope uses the run ID routing slot.
     expect(ctx.buildSearchOptions).toHaveBeenCalledWith(
       "testuser",
       undefined,
-      "session-abc",
       "session-abc",
     );
     expect(result.details.count).toBe(1);

--- a/integrations/openclaw/tools/memory-search.ts
+++ b/integrations/openclaw/tools/memory-search.ts
@@ -47,7 +47,7 @@ export function createMemorySearchTool(deps: ToolDeps) {
 
         if (scope === "session") {
           if (currentSessionId) {
-            results = await provider.search(query, applyFilters(buildSearchOptions(uid, limit, currentSessionId, currentSessionId)));
+            results = await provider.search(query, applyFilters(buildSearchOptions(uid, limit, currentSessionId)));
           }
         } else if (scope === "long-term") {
           results = await provider.search(query, applyFilters(buildSearchOptions(uid, limit)));
@@ -55,7 +55,7 @@ export function createMemorySearchTool(deps: ToolDeps) {
           const longTerm = await provider.search(query, applyFilters(buildSearchOptions(uid, limit)));
           let session: MemoryItem[] = [];
           if (currentSessionId) {
-            session = await provider.search(query, applyFilters(buildSearchOptions(uid, limit, currentSessionId, currentSessionId)));
+            session = await provider.search(query, applyFilters(buildSearchOptions(uid, limit, currentSessionId)));
           }
           const seen = new Set(longTerm.map((r) => r.id));
           results = [...longTerm, ...session.filter((r) => !seen.has(r.id))];

--- a/integrations/openclaw/tools/memory-search.ts
+++ b/integrations/openclaw/tools/memory-search.ts
@@ -47,7 +47,7 @@ export function createMemorySearchTool(deps: ToolDeps) {
 
         if (scope === "session") {
           if (currentSessionId) {
-            results = await provider.search(query, applyFilters(buildSearchOptions(uid, limit, undefined, currentSessionId)));
+            results = await provider.search(query, applyFilters(buildSearchOptions(uid, limit, currentSessionId, currentSessionId)));
           }
         } else if (scope === "long-term") {
           results = await provider.search(query, applyFilters(buildSearchOptions(uid, limit)));
@@ -55,7 +55,7 @@ export function createMemorySearchTool(deps: ToolDeps) {
           const longTerm = await provider.search(query, applyFilters(buildSearchOptions(uid, limit)));
           let session: MemoryItem[] = [];
           if (currentSessionId) {
-            session = await provider.search(query, applyFilters(buildSearchOptions(uid, limit, undefined, currentSessionId)));
+            session = await provider.search(query, applyFilters(buildSearchOptions(uid, limit, currentSessionId, currentSessionId)));
           }
           const seen = new Set(longTerm.map((r) => r.id));
           results = [...longTerm, ...session.filter((r) => !seen.has(r.id))];


### PR DESCRIPTION
Closes #6708

## Description

OpenClaw receives the current session key but drops it from auto-captured memory writes and explicit session-scoped searches. The resulting Mem0 requests omit `run_id`, so memories from the active conversation aren't isolated and session searches return unscoped results.

## Root cause

The existing builders accept separate `runId` and `sessionKey` arguments. Auto-capture passes the session only in the `sessionKey` slot at `integrations/openclaw/index.ts:1036`. The `memory_search` session and all paths do the same at `integrations/openclaw/tools/memory-search.ts:50,58`. The provider translation already handles `options.run_id`, so the fix belongs at these consumers.

## Changes

- Pass the current session ID through both builder slots for auto-capture.
- Pass the current session ID through both slots for `memory_search` session and all scopes.
- Add production-path regression coverage for the final SDK add/search options.
- Keep explicit CLI session search run IDs intact with a direct option assertion.
- Preserve long-term and cold-start recall as cross-session queries, along with existing skips, filters, namespaces, and provider translation.
- In open-source mode, apply the session run scope to the existing auto-capture update decision so separate sessions don't update one another's memories.

## Verification boundary

Local tests verify the OpenClaw hook, provider adapter, and SDK-facing payload. Hosted persistence and read-back were not verified.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Test Coverage

Focused OpenClaw hook, tool, and CLI tests cover auto-capture run propagation, session/all search filters, explicit CLI session run IDs, long-term and cold-start negative space, sessionless capture, namespace routing, and existing provider translation. The OpenClaw package type check, build, and full test suite pass locally, with 454 tests passed and 1 skipped.

## Checklist

- [x] Linked issue
- [x] Correct type of change
- [x] Scope and breaking-change status documented
- [x] Full validation completed locally
- [ ] CI checks passed
