### PR TITLE
chore: bump versions and update changelog for Python 2.0.15, TypeScript 3.1.3, and plugin releases

### DIFF
--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -7,6 +7,18 @@ mode: "wide"
 <Tabs>
 <Tab title="Python">
 
+<Update label="2026-08-01" description="v2.0.15">
+
+**Bug Fixes:**
+- **Core:** `delete_all()` now paginates through the vector store in batches of 1000 instead of listing once, so accounts with more memories than a single page (most vector stores default to ~100) had the remainder silently left behind ([#6636](https://github.com/mem0ai/mem0/pull/6636))
+- **Vector Stores:** Cap Supabase `search()`/`list()` `top_k` at the `vecs` query limit of 1000 instead of erroring, and fix a `col_info()` crash by reading collection attributes directly instead of calling the removed `describe()` method ([#6695](https://github.com/mem0ai/mem0/pull/6695))
+- **Vector Stores:** Set `size` on Elasticsearch KNN search queries, so results respect `top_k` instead of being capped at Elasticsearch's default of 10 hits ([#5910](https://github.com/mem0ai/mem0/pull/5910))
+
+**Changes:**
+- **Rerankers:** `LLMReranker`'s default model is now `gpt-5-mini` (was `gpt-4o-mini`) ([#6703](https://github.com/mem0ai/mem0/pull/6703))
+
+</Update>
+
 <Update label="2026-07-25" description="v2.0.14">
 
 **New Features:**
@@ -1157,6 +1169,24 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 
 <Tab title="TypeScript">
 
+<Update label="2026-08-01" description="v3.1.3">
+
+**New Features:**
+- **Vector Stores:** Add Qdrant server-side BM25 `keywordSearch()` (requires Qdrant >= 1.15.2) plus payload filter indexes, so keyword search runs without a client-side BM25 dependency ([#5851](https://github.com/mem0ai/mem0/pull/5851))
+
+**Bug Fixes:**
+- **Core:** `deleteAll()` now paginates through the vector store in batches of 1000 instead of listing once, so accounts with more memories than a single page had the remainder silently left behind ([#4872](https://github.com/mem0ai/mem0/pull/4872))
+- **Vector Stores:** Supabase `list()` now paginates past PostgREST's 1000-row cap instead of stopping at the first page, `search()` warns when results may have been truncated by that same cap, and the initialization probe reads a row instead of writing a test vector, so Row Level Security policies that only grant read access no longer fail table verification ([#6695](https://github.com/mem0ai/mem0/pull/6695))
+- **Embeddings:** Honor `TOGETHER_API_BASE` in the Together embedder, matching the Together LLM provider, so a custom gateway URL is no longer silently ignored for embeddings ([#6572](https://github.com/mem0ai/mem0/pull/6572))
+
+**Changes:**
+- **Rerankers:** `RerankerFactory`'s default LLM reranker model is now `gpt-5-mini` (was `gpt-4o-mini`) ([#6703](https://github.com/mem0ai/mem0/pull/6703))
+
+**Security:**
+- **Dependencies:** Patched 32 high and 57 medium severity dependency vulnerabilities across the pnpm workspace via `pnpm.overrides` (`axios`, `brace-expansion`, `js-yaml`, `postcss`, `protobufjs`, `mongoose`, `tar`, `fast-xml-parser`, `thrift`) ([#6639](https://github.com/mem0ai/mem0/pull/6639))
+
+</Update>
+
 <Update label="2026-07-25" description="v3.1.2">
 
 **Bug Fixes:**
@@ -2278,6 +2308,16 @@ Existing memories written by the previous versions are not rewritten. If your me
 
 <Tab title="OpenClaw">
 
+<Update label="2026-08-01" description="openclaw-mem0 v1.0.15">
+
+**Improvements:**
+- **Onboarding suggestions:** The example commands shown by `openclaw mem0 config show` now suggest `gpt-5-mini` instead of `gpt-4o` ([#6704](https://github.com/mem0ai/mem0/pull/6704))
+
+**Security:**
+- **Dependencies:** Patched high and medium severity dependency vulnerabilities via `pnpm.overrides` (`protobufjs`, `axios`, `postcss`, `mongoose`) ([#6639](https://github.com/mem0ai/mem0/pull/6639))
+
+</Update>
+
 <Update label="2026-06-30" description="openclaw-mem0 v1.0.14">
 
 **Improvements:**
@@ -2531,6 +2571,13 @@ Existing memories written by the previous versions are not rewritten. If your me
 
 <Tab title="Pi Agent">
 
+<Update label="2026-08-01" description="Pi Agent plugin v0.1.4">
+
+**Security:**
+- **Dependencies:** Patched high and medium severity dependency vulnerabilities via `pnpm.overrides` (`axios`, `brace-expansion`, `postcss`, `mongoose`, `protobufjs`) ([#6639](https://github.com/mem0ai/mem0/pull/6639))
+
+</Update>
+
 <Update label="2026-06-30" description="Pi Agent plugin v0.1.3">
 
 **New Features:**
@@ -2582,6 +2629,13 @@ Existing memories written by the previous versions are not rewritten. If your me
 </Tab>
 
 <Tab title="Vercel AI SDK">
+
+<Update label="2026-08-01" description="Vercel AI SDK v3.0.1">
+
+**Security:**
+- **Dependencies:** Patched high and medium severity dependency vulnerabilities via `pnpm.overrides` (`brace-expansion`, `js-yaml`) ([#6639](https://github.com/mem0ai/mem0/pull/6639))
+
+</Update>
 
 <Update label="2026-06-10" description="Vercel AI SDK v3.0.0">
 

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "openclaw-mem0",
   "name": "Memory (Mem0)",
   "description": "Mem0 memory backend for OpenClaw — platform (mem0.ai cloud) or self-hosted open-source. Auto-recall and auto-capture are opt-in (disabled by default). Supports OpenAI, Anthropic, Ollama (fully local), Qdrant, and PGVector providers.",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "kind": "memory",
   "skills": ["skills"],
   "commandAliases": [

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem0/openclaw-mem0",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "type": "module",
   "description": "Mem0 memory backend for OpenClaw — platform or self-hosted open-source",
   "license": "Apache-2.0",

--- a/integrations/pi-agent-plugin/package.json
+++ b/integrations/pi-agent-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem0/pi-agent-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "Mem0 memory extension for Pi Agent persistent, scoped, semantic memory across sessions and projects",
   "license": "Apache-2.0",

--- a/integrations/vercel-ai-sdk/package.json
+++ b/integrations/vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem0/vercel-ai-provider",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Vercel AI Provider for providing memory to LLMs",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0ai",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "The Memory Layer For Your AI Apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mem0ai"
-version = "2.0.14"
+version = "2.0.15"
 description = "Long-term memory for AI Agents"
 authors = [
     { name = "Mem0", email = "support@mem0.ai" }


### PR DESCRIPTION
## Linked Issue

N/A, routine release version bump.

## Description

Bumps package versions and adds matching changelog entries for the Python SDK, TypeScript SDK, and three editor/agent plugins.

| Package | Old version | New version |
|---------|-------------|-------------|
| Python SDK (`mem0ai` on PyPI) | 2.0.14 | 2.0.15 |
| TypeScript SDK (`mem0ai` on npm) | 3.1.2 | 3.1.3 |
| OpenClaw plugin (`@mem0/openclaw-mem0`) | 1.0.14 | 1.0.15 |
| Pi Agent plugin (`@mem0/pi-agent-plugin`) | 0.1.3 | 0.1.4 |
| Vercel AI SDK provider (`@mem0/vercel-ai-provider`) | 3.0.0 | 3.0.1 |

The TypeScript SDK bump is a patch release (3.1.2 to 3.1.3) per maintainer decision, even though it includes a new Qdrant BM25 keyword search feature.

Changelog entries in `docs/changelog/sdk.mdx` summarize the changes shipped since the last release for each package, including the `delete_all()`/`deleteAll()` pagination fix, Supabase and Elasticsearch vector store fixes, the `LLMReranker` default model change, the new Qdrant server-side BM25 `keywordSearch()`, the Together embedder base URL fix, and a dependency security patch across the affected pnpm workspaces.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

Version metadata and changelog documentation only, no code behavior changes in this PR.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed