### PR TITLE
fix: support non-English spaCy pipelines in NLP utilities

### DIFF
--- a/mem0/utils/entity_extraction.py
+++ b/mem0/utils/entity_extraction.py
@@ -588,7 +588,14 @@ def _add_quoted_candidates(text: str, candidates: list[_EntityCandidate]) -> Non
 
 
 def _add_topic_phrase_candidates(doc, candidates: list[_EntityCandidate]) -> None:
-    for chunk in doc.noun_chunks:
+    try:
+        # Materialize eagerly: noun_chunks is a lazy iterator and raises
+        # NotImplementedError on iteration for languages without a noun-chunk
+        # iterator (e.g. zh, ja) — skip this pass for those languages.
+        noun_chunks = list(doc.noun_chunks)
+    except NotImplementedError:
+        return
+    for chunk in noun_chunks:
         chunk_tokens = list(chunk)
         split_indices: list[int] = []
         poss_splits: list[int] = []

--- a/mem0/utils/lemmatization.py
+++ b/mem0/utils/lemmatization.py
@@ -38,7 +38,9 @@ def lemmatize_for_bm25(text: str) -> str:
         if token.is_punct or token.is_stop:
             continue
 
-        lemma = token.lemma_
+        # Fall back to the surface form when the pipeline produces no lemma
+        # (e.g. zh_core_web_sm returns empty lemmas) so tokens aren't dropped.
+        lemma = token.lemma_ or token.text
         if lemma.isalnum():
             tokens.append(lemma)
 

--- a/mem0/utils/spacy_models.py
+++ b/mem0/utils/spacy_models.py
@@ -4,12 +4,20 @@ Shared spaCy model loader.
 Consolidates spaCy model loading into a single module so that
 entity_extraction and lemmatization share one instance instead of
 each loading their own copy from disk.
+
+The model defaults to ``en_core_web_sm`` and can be overridden with the
+``MEM0_SPACY_MODEL`` environment variable so non-English users can pick a
+language-specific pipeline (e.g. ``zh_core_web_sm``, ``ja_core_news_sm``,
+``de_core_news_sm``).
 """
 
 import logging
+import os
 import threading
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL = "en_core_web_sm"
 
 _nlp_full = None
 _nlp_lemma = None
@@ -18,26 +26,30 @@ _load_failed_lemma = False
 _lock = threading.Lock()
 
 
+def _spacy_model_name() -> str:
+    """Return the configured spaCy model name (env override, default English)."""
+    return os.environ.get("MEM0_SPACY_MODEL", "").strip() or _DEFAULT_MODEL
+
+
 def _ensure_model_available():
-    """Download en_core_web_sm if spaCy is installed but model is missing."""
+    """Download the configured spaCy model if spaCy is installed but it is missing."""
+    model = _spacy_model_name()
     try:
         import spacy
     except ImportError:
-        raise ImportError(
-            "spaCy is not installed. Install it with: pip install mem0ai[nlp]"
-        )
+        raise ImportError("spaCy is not installed. Install it with: pip install mem0ai[nlp]")
 
-    if not spacy.util.is_package("en_core_web_sm"):
-        logger.info("Downloading spaCy model en_core_web_sm...")
+    if not spacy.util.is_package(model):
+        logger.info(f"Downloading spaCy model {model}...")
         try:
             from spacy.cli import download
 
-            download("en_core_web_sm")
-            logger.info("spaCy model en_core_web_sm downloaded successfully")
+            download(model)
+            logger.info(f"spaCy model {model} downloaded successfully")
         except Exception as e:
             raise RuntimeError(
-                f"Failed to download spaCy model en_core_web_sm: {e}. "
-                "Please install manually: python -m spacy download en_core_web_sm"
+                f"Failed to download spaCy model {model}: {e}. "
+                f"Please install manually: python -m spacy download {model}"
             ) from e
 
 
@@ -57,7 +69,7 @@ def get_nlp_full():
             _ensure_model_available()
             import spacy
 
-            _nlp_full = spacy.load("en_core_web_sm")
+            _nlp_full = spacy.load(_spacy_model_name())
             logger.info("spaCy full model loaded")
         except Exception as e:
             logger.warning(f"Failed to load spaCy full model: {e}")
@@ -82,7 +94,7 @@ def get_nlp_lemma():
             _ensure_model_available()
             import spacy
 
-            _nlp_lemma = spacy.load("en_core_web_sm", disable=["ner", "parser"])
+            _nlp_lemma = spacy.load(_spacy_model_name(), disable=["ner", "parser"])
             logger.info("spaCy lemma model loaded")
         except Exception as e:
             logger.warning(f"Failed to load spaCy lemma model: {e}")

--- a/tests/utils/test_entity_extraction.py
+++ b/tests/utils/test_entity_extraction.py
@@ -139,3 +139,33 @@ class TestExtractEntitiesBatch:
         assert len(batch) == 1
         # Both should extract the same entities
         assert set(t for _, t in single) == set(t for _, t in batch[0])
+
+
+@pytest.fixture()
+def _use_zh_model(monkeypatch):
+    """Point mem0 at the Chinese pipeline and reset its cached spaCy state."""
+    import spacy
+
+    if not spacy.util.is_package("zh_core_web_sm"):
+        pytest.skip("spaCy zh_core_web_sm model not available")
+    import mem0.utils.spacy_models as sm
+
+    monkeypatch.setenv("MEM0_SPACY_MODEL", "zh_core_web_sm")
+    monkeypatch.setattr(sm, "_nlp_full", None)
+    monkeypatch.setattr(sm, "_load_failed_full", False)
+
+
+class TestExtractEntitiesChinese:
+    def test_no_noun_chunks_crash(self, _use_zh_model):
+        """zh has no noun_chunks iterator; extraction must not raise."""
+        from mem0.utils.entity_extraction import extract_entities
+
+        entities = extract_entities("张三是阿里巴巴的工程师，他在杭州负责大模型训练。")
+        assert isinstance(entities, list)
+
+    def test_chinese_proper_noun(self, _use_zh_model):
+        from mem0.utils.entity_extraction import extract_entities
+
+        entities = extract_entities("张三是阿里巴巴的工程师，用的框架是 PyTorch。")
+        entity_texts = [e[1] for e in entities]
+        assert any("PyTorch" in t for t in entity_texts), f"Expected PyTorch, got {entities}"

--- a/tests/utils/test_lemmatization.py
+++ b/tests/utils/test_lemmatization.py
@@ -6,6 +6,7 @@ def _ensure_spacy():
     """Skip tests if spaCy model is not available."""
     try:
         import spacy
+
         spacy.load("en_core_web_sm")
     except Exception:
         pytest.skip("spaCy en_core_web_sm model not available")
@@ -65,3 +66,30 @@ class TestLemmatizeForBm25:
         tokens = result.split()
         for stop in ["this", "is", "a", "very", "of", "the"]:
             assert stop not in tokens
+
+
+@pytest.fixture()
+def _use_zh_model(monkeypatch):
+    """Point mem0 at the Chinese pipeline and reset its cached spaCy state."""
+    import spacy
+
+    if not spacy.util.is_package("zh_core_web_sm"):
+        pytest.skip("spaCy zh_core_web_sm model not available")
+    import mem0.utils.spacy_models as sm
+
+    monkeypatch.setenv("MEM0_SPACY_MODEL", "zh_core_web_sm")
+    monkeypatch.setattr(sm, "_nlp_lemma", None)
+    monkeypatch.setattr(sm, "_load_failed_lemma", False)
+
+
+class TestLemmatizeForBm25Chinese:
+    def test_chinese_tokens_kept(self, _use_zh_model):
+        """zh pipelines return empty lemmas; surface forms must be kept."""
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        result = lemmatize_for_bm25("张三是阿里巴巴的工程师")
+        assert result != ""
+        assert "阿里巴巴" in result.split()
+        # Chinese stop words should be removed
+        assert "是" not in result.split()
+        assert "的" not in result.split()

--- a/tests/utils/test_spacy_models.py
+++ b/tests/utils/test_spacy_models.py
@@ -1,0 +1,18 @@
+class TestSpacyModelName:
+    def test_default_is_en(self, monkeypatch):
+        monkeypatch.delenv("MEM0_SPACY_MODEL", raising=False)
+        from mem0.utils.spacy_models import _spacy_model_name
+
+        assert _spacy_model_name() == "en_core_web_sm"
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("MEM0_SPACY_MODEL", "zh_core_web_sm")
+        from mem0.utils.spacy_models import _spacy_model_name
+
+        assert _spacy_model_name() == "zh_core_web_sm"
+
+    def test_blank_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("MEM0_SPACY_MODEL", "  ")
+        from mem0.utils.spacy_models import _spacy_model_name
+
+        assert _spacy_model_name() == "en_core_web_sm"


### PR DESCRIPTION
Closes #6717

## Problem

The optional spaCy-based NLP utilities (`mem0ai[nlp]`) only work with English text. Three issues affect non-English users (Chinese, Japanese, etc.):

1. **Hardcoded model**: `mem0/utils/spacy_models.py` hardcodes `en_core_web_sm` (`is_package` check, auto-download, `get_nlp_full`, `get_nlp_lemma`). Users cannot select spaCy's language-specific pipelines (`zh_core_web_sm`, `ja_core_news_sm`, `de_core_news_sm`, ...) which provide proper tokenization/NER for their language.

2. **Crash on `doc.noun_chunks`**: `entity_extraction._add_topic_phrase_candidates` iterates `doc.noun_chunks`, which raises `NotImplementedError [E894]` for languages without a noun-chunk iterator (zh, ja, ...), making `extract_entities()` throw instead of returning results.

3. **Empty BM25 text**: `lemmatization.lemmatize_for_bm25` uses `token.lemma_` only. Pipelines like `zh_core_web_sm` return empty lemmas, so `lemma.isalnum()` drops *every* token and the lemmatized text stored in memory metadata becomes `""`, defeating BM25 keyword matching entirely.

## Changes

- `spacy_models.py`: new `MEM0_SPACY_MODEL` env var (default `en_core_web_sm`, fully backward-compatible) used by the auto-download check and both loaders.
- `entity_extraction.py`: materialize `doc.noun_chunks` under `try/except NotImplementedError` and skip the topic-phrase pass for languages without the iterator.
- `lemmatization.py`: `token.lemma_ or token.text` — keep the surface form when the pipeline produces no lemma.

## Tests

- `tests/utils/test_spacy_models.py` (new): default, env override, and blank-env fallback.
- `tests/utils/test_lemmatization.py`: Chinese case — tokens kept, stop words removed.
- `tests/utils/test_entity_extraction.py`: Chinese cases — no `noun_chunks` crash, proper-noun extraction still works.

All 25 tests in `tests/utils/` pass with both `en_core_web_sm` and `zh_core_web_sm` installed; `ruff check` and `ruff format --check` are clean.

Verified end-to-end with `MEM0_SPACY_MODEL=zh_core_web_sm`:

```python
lemmatize_for_bm25('张三是阿里巴巴的工程师')
# '张三 阿里巴巴 工程师'  (was: '')
extract_entities('张三是阿里巴巴的工程师，用的框架是 PyTorch。')
# [('PROPER', '阿里巴巴'), ('PROPER', 'PyTorch')]  (was: NotImplementedError)
```
