### PR TITLE
feat(server): support independent LLM/embedder base URLs

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -24,6 +24,12 @@ APP_DB_NAME=mem0_app
 MEM0_DEFAULT_LLM_MODEL=gpt-5-mini
 MEM0_DEFAULT_EMBEDDER_MODEL=text-embedding-3-small
 
+# Point the LLM and/or embedder at a self-hosted OpenAI-compatible endpoint
+# instead of api.openai.com. Set independently — useful when your inference
+# server and embedding server aren't the same host.
+# MEM0_LLM_BASE_URL=http://localhost:11434/v1
+# MEM0_EMBEDDER_BASE_URL=http://localhost:11434/v1
+
 # Anonymous telemetry. Sends a single onboarding event per install
 # (install UUID, email domain, server version, source). No PII.
 # Set to false to opt out.

--- a/server/main.py
+++ b/server/main.py
@@ -116,6 +116,13 @@ OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 HISTORY_DB_PATH = os.environ.get("HISTORY_DB_PATH", "/app/history/history.db")
 DEFAULT_LLM_MODEL = os.environ.get("MEM0_DEFAULT_LLM_MODEL", "gpt-5-mini")
 DEFAULT_EMBEDDER_MODEL = os.environ.get("MEM0_DEFAULT_EMBEDDER_MODEL", "text-embedding-3-small")
+# The underlying OpenAI LLM/embedder classes already resolve openai_base_url from
+# config, falling back to the shared OPENAI_BASE_URL env var if unset. That's fine
+# when LLM and embedder are the same backend, but self-hosting an OpenAI-compatible
+# LLM and a separate OpenAI-compatible embedder (e.g. two different local servers)
+# needs them addressable independently — the server never wired that through.
+LLM_BASE_URL = os.environ.get("MEM0_LLM_BASE_URL")
+EMBEDDER_BASE_URL = os.environ.get("MEM0_EMBEDDER_BASE_URL")
 
 DEFAULT_CONFIG = {
     "version": "v1.1",
@@ -132,9 +139,21 @@ DEFAULT_CONFIG = {
     },
     "llm": {
         "provider": "openai",
-        "config": {"api_key": OPENAI_API_KEY, "temperature": 0.2, "model": DEFAULT_LLM_MODEL},
+        "config": {
+            "api_key": OPENAI_API_KEY,
+            "temperature": 0.2,
+            "model": DEFAULT_LLM_MODEL,
+            **({"openai_base_url": LLM_BASE_URL} if LLM_BASE_URL else {}),
+        },
     },
-    "embedder": {"provider": "openai", "config": {"api_key": OPENAI_API_KEY, "model": DEFAULT_EMBEDDER_MODEL}},
+    "embedder": {
+        "provider": "openai",
+        "config": {
+            "api_key": OPENAI_API_KEY,
+            "model": DEFAULT_EMBEDDER_MODEL,
+            **({"openai_base_url": EMBEDDER_BASE_URL} if EMBEDDER_BASE_URL else {}),
+        },
+    },
     "history_db_path": HISTORY_DB_PATH,
 }
 

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1,0 +1,69 @@
+"""Tests for server/main.py's DEFAULT_CONFIG construction from env vars."""
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+# server/ modules use bare imports (import telemetry, from auth import ...), so
+# the server directory itself must be importable, mirroring how it runs in
+# Docker. Mirrors tests/test_api_keys_router.py's guard.
+_SERVER_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "server")
+if _SERVER_DIR not in sys.path:
+    sys.path.insert(0, _SERVER_DIR)
+
+
+def _reload_server_main(env: dict):
+    """Reload server.main under a patched environment and return the module.
+
+    DEFAULT_CONFIG is built at import time from os.environ, so each case
+    needs a fresh reload rather than reading the already-imported module.
+    """
+    base_env = {"OPENAI_API_KEY": "fake-key", "ADMIN_API_KEY": "", "AUTH_DISABLED": "true"}
+    with patch.dict(os.environ, {**base_env, **env}, clear=False):
+        with patch("mem0.Memory.from_config", return_value=MagicMock()):
+            import server.main as server_main
+            importlib.reload(server_main)
+            return server_main
+
+
+class TestLLMBaseURL:
+    def test_unset_omits_openai_base_url(self):
+        mod = _reload_server_main({"MEM0_LLM_BASE_URL": ""})
+        assert "openai_base_url" not in mod.DEFAULT_CONFIG["llm"]["config"]
+
+    def test_set_forwarded_to_llm_config(self):
+        mod = _reload_server_main({"MEM0_LLM_BASE_URL": "http://llm.internal:11434/v1"})
+        assert mod.DEFAULT_CONFIG["llm"]["config"]["openai_base_url"] == "http://llm.internal:11434/v1"
+
+    def test_does_not_affect_embedder_config(self):
+        mod = _reload_server_main({"MEM0_LLM_BASE_URL": "http://llm.internal:11434/v1"})
+        assert "openai_base_url" not in mod.DEFAULT_CONFIG["embedder"]["config"]
+
+
+class TestEmbedderBaseURL:
+    def test_unset_omits_openai_base_url(self):
+        mod = _reload_server_main({"MEM0_EMBEDDER_BASE_URL": ""})
+        assert "openai_base_url" not in mod.DEFAULT_CONFIG["embedder"]["config"]
+
+    def test_set_forwarded_to_embedder_config(self):
+        mod = _reload_server_main({"MEM0_EMBEDDER_BASE_URL": "http://embed.internal:8080/v1"})
+        assert mod.DEFAULT_CONFIG["embedder"]["config"]["openai_base_url"] == "http://embed.internal:8080/v1"
+
+    def test_does_not_affect_llm_config(self):
+        mod = _reload_server_main({"MEM0_EMBEDDER_BASE_URL": "http://embed.internal:8080/v1"})
+        assert "openai_base_url" not in mod.DEFAULT_CONFIG["llm"]["config"]
+
+
+class TestBothIndependent:
+    def test_llm_and_embedder_can_point_at_different_hosts(self):
+        mod = _reload_server_main({
+            "MEM0_LLM_BASE_URL": "http://llm.internal:11434/v1",
+            "MEM0_EMBEDDER_BASE_URL": "http://embed.internal:8080/v1",
+        })
+        assert mod.DEFAULT_CONFIG["llm"]["config"]["openai_base_url"] == "http://llm.internal:11434/v1"
+        assert mod.DEFAULT_CONFIG["embedder"]["config"]["openai_base_url"] == "http://embed.internal:8080/v1"


### PR DESCRIPTION
## Description

`mem0/embeddings/openai.py` and `mem0/llms/openai.py` already accept a per-component `openai_base_url` override (falling back to the shared `OPENAI_BASE_URL` env var if unset). `server/main.py`'s `DEFAULT_CONFIG`, however, never wires an env var through to it — so a self-hosted OpenAI-compatible LLM and a separate self-hosted OpenAI-compatible embedder (two different backends, e.g. an inference server and a dedicated embedding server) can't be pointed at independently via the self-hosted server. Only a single shared base URL is expressible today.

Adds `MEM0_LLM_BASE_URL` and `MEM0_EMBEDDER_BASE_URL`, each optional and independent. Omitted, behavior is unchanged (falls through to `OPENAI_BASE_URL`/`api.openai.com` exactly as before).

## Linked Issue

N/A — found while self-hosting with LLM and embedder on separate hosts.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Changes

None — purely additive, default behavior unchanged when the new env vars are unset.

## Test Coverage

- [x] I added/updated unit tests (`tests/test_server_config.py`, 7 cases: unset omits the key, set forwards it, and the two are independent of each other)
- [x] I tested manually — verified `DEFAULT_CONFIG` construction against both a local llama.cpp endpoint and unset/default state

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (`pytest tests/test_server_config.py` — 7/7 passing in isolation; note there's a pre-existing test-isolation issue in this environment where `auth.py`'s module-level constants get cached across `importlib.reload()` calls when multiple server test files run in the same process, reproducible on unmodified `main` too and unrelated to this change)
- [x] I have updated documentation if needed (`server/.env.example`)