### PR TITLE
fix(memory): reject NaN search threshold (#6713)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -4,6 +4,7 @@ import gc
 import hashlib
 import json
 import logging
+import math
 import os
 import time
 import uuid
@@ -196,7 +197,7 @@ def _validate_search_params(threshold: Optional[float] = None, top_k: Optional[i
     if threshold is not None:
         if not isinstance(threshold, (int, float)):
             raise ValueError("threshold must be a valid number")
-        if threshold < 0 or threshold > 1:
+        if math.isnan(threshold) or threshold < 0 or threshold > 1:
             raise ValueError(
                 f"Invalid threshold: {threshold}. Must be between 0 and 1 (inclusive)."
             )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -540,3 +540,14 @@ class TestSearchParamValidation:
             result = memory_instance.search("test", filters={"user_id": "test"}, top_k=0)
 
         assert "results" in result
+
+    def test_search_rejects_nan_threshold(self, memory_instance):
+        """Search should reject a NaN threshold before doing any retrieval work."""
+        memory_instance.embedding_model.embed = Mock()
+        memory_instance.vector_store.search = Mock()
+
+        with pytest.raises(ValueError, match="Invalid threshold.*Must be between 0 and 1"):
+            memory_instance.search("test query", filters={"user_id": "test"}, threshold=float("nan"))
+
+        memory_instance.embedding_model.embed.assert_not_called()
+        memory_instance.vector_store.search.assert_not_called()


### PR DESCRIPTION
### What

`Memory.search(..., threshold=float("nan"))` is accepted even though `threshold` is documented and validated as a value in `[0, 1]`.

`_validate_search_params()` guards the range with:

```python
if threshold < 0 or threshold > 1:
```

For `NaN` both comparisons are `False`, so validation passes. Downstream, the semantic gate `semantic_score < threshold` is also always `False` for `NaN`, so the threshold filter silently keeps every candidate instead of filtering.

### Fix

Reject `NaN` in the same range check, so it raises the existing `Invalid threshold: ...` `ValueError` before any embedding or vector-store work happens. The shared validator covers both `Memory.search()` and `AsyncMemory.search()`.

`inf`/`-inf` were already rejected by the existing comparisons; `0` and `1` keep being accepted.

### Verification

Ran `tests/test_main.py` against the released `mem0ai` package (byte-identical to `mem0/memory/main.py` on `main`) with the new test appended:

- **before the fix**: `1 failed, 44 passed` — NaN slipped past validation and reached the search path
- **after the fix**: `45 passed`

```
>>> from mem0.memory.main import _validate_search_params
>>> _validate_search_params(float("nan"))
ValueError: Invalid threshold: nan. Must be between 0 and 1 (inclusive).
>>> _validate_search_params(0); _validate_search_params(1)   # still fine
```

Lint: `ruff==0.16.0` (the pinned version) `check` passes on both changed files, and the added block is `ruff format` clean.

Fixes #6713

🤖 Generated with [Claude Code](https://claude.com/claude-code)
