### PR TITLE
fix(memory): coerce bare-string LLM extractions so one bad doc can't abort ingestion (#6724)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -53,6 +53,7 @@ from mem0.memory.storage import SQLiteManager
 from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
 from mem0.memory.utils import (
     extract_json,
+    normalize_extracted_memories,
     parse_messages,
     parse_vision_messages,
     process_telemetry_filters,
@@ -938,6 +939,10 @@ class Memory(MemoryBase):
         except Exception as e:
             logger.error(f"Error parsing extraction response: {e}")
             extracted_memories = []
+
+        # Coerce bare-string / non-list extractions into {"text": ...} dicts so a
+        # single non-conforming element cannot abort the whole ingestion (#6724).
+        extracted_memories = normalize_extracted_memories(extracted_memories)
 
         if not extracted_memories:
             # Save messages even if nothing extracted
@@ -2575,6 +2580,10 @@ class AsyncMemory(MemoryBase):
         except Exception as e:
             logger.error(f"Error parsing extraction response (async): {e}")
             extracted_memories = []
+
+        # Coerce bare-string / non-list extractions into {"text": ...} dicts so a
+        # single non-conforming element cannot abort the whole ingestion (#6724).
+        extracted_memories = normalize_extracted_memories(extracted_memories)
 
         if not extracted_memories:
             await asyncio.to_thread(self.db.save_messages, messages, session_scope)

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -123,7 +123,10 @@ def normalize_extracted_memories(raw_memories):
     """
     if not raw_memories:
         return []
-    if isinstance(raw_memories, dict):
+    if isinstance(raw_memories, (dict, str)):
+        # A model can also return the whole payload as a single object or a
+        # bare string ("memory": "hello"); wrap it so it normalizes the same
+        # as the corresponding single-element list.
         raw_memories = [raw_memories]
     elif not isinstance(raw_memories, list):
         return []

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -112,6 +112,33 @@ def normalize_facts(raw_facts):
     return normalized
 
 
+def normalize_extracted_memories(raw_memories):
+    """Normalize LLM-extracted memories to a list of ``{"text": ...}`` dicts.
+
+    The additive-extraction prompt asks for ``{"memory": [{"text": ...}, ...]}``,
+    but a model can return bare strings (``{"memory": ["fact one", "fact two"]}``)
+    or a single object instead of a list. Coercing here keeps one malformed
+    element from aborting the whole ingestion with an ``AttributeError`` when the
+    downstream code calls ``m.get("text")``. Mirrors :func:`normalize_facts`.
+    """
+    if not raw_memories:
+        return []
+    if isinstance(raw_memories, dict):
+        raw_memories = [raw_memories]
+    elif not isinstance(raw_memories, list):
+        return []
+    normalized = []
+    for item in raw_memories:
+        if isinstance(item, dict):
+            normalized.append(item)
+        elif isinstance(item, str):
+            if item.strip():
+                normalized.append({"text": item})
+        else:
+            logger.warning("Unexpected memory shape from LLM, skipping: %s", item)
+    return normalized
+
+
 def remove_code_blocks(content: str) -> str:
     """
     Removes enclosing code block markers ```[language] and ``` from a given string.

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import Mock
 
 from mem0.memory.utils import (
+    normalize_extracted_memories,
     parse_messages,
     parse_vision_messages,
     remove_spaces_from_entities,
@@ -168,3 +169,38 @@ class TestRemoveSpacesFromEntities:
         f = remove_spaces_from_entities([dict(base)], sanitize_relationship=False)[0]["relationship"]
         assert t == sanitize_relationship_for_cypher("a/b")
         assert f == "a/b"
+
+
+class TestNormalizeExtractedMemories:
+    """Reproduces #6724: a bare-string extraction (`{"memory": ["a", "b"]}`)
+    used to reach `m.get("text")` and abort the whole ingestion with
+    `AttributeError: 'str' object has no attribute 'get'`.
+    """
+
+    def test_list_of_dicts_passes_through(self):
+        raw = [{"text": "a"}, {"text": "b", "attributed_to": "user"}]
+        assert normalize_extracted_memories(raw) == raw
+
+    def test_list_of_strings_is_wrapped(self):
+        assert normalize_extracted_memories(["fact one", "fact two"]) == [
+            {"text": "fact one"},
+            {"text": "fact two"},
+        ]
+
+    def test_mixed_shapes_are_coerced_or_dropped(self):
+        raw = [{"text": "a"}, "b", 5, None, "   "]
+        assert normalize_extracted_memories(raw) == [{"text": "a"}, {"text": "b"}]
+
+    def test_single_dict_is_listified(self):
+        assert normalize_extracted_memories({"text": "solo"}) == [{"text": "solo"}]
+
+    def test_empty_and_non_iterable_inputs(self):
+        assert normalize_extracted_memories([]) == []
+        assert normalize_extracted_memories(None) == []
+        assert normalize_extracted_memories("hello") == []
+
+    def test_downstream_comprehension_no_longer_raises(self):
+        # The exact expression from mem0/memory/main.py that used to crash.
+        extracted = normalize_extracted_memories(["fact one", "fact two"])
+        mem_texts = [m.get("text", "") for m in extracted if m.get("text")]
+        assert mem_texts == ["fact one", "fact two"]

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -194,10 +194,18 @@ class TestNormalizeExtractedMemories:
     def test_single_dict_is_listified(self):
         assert normalize_extracted_memories({"text": "solo"}) == [{"text": "solo"}]
 
+    def test_bare_string_is_wrapped_like_single_element_list(self):
+        # A top-level bare string normalizes the same as ["hello"], so a model
+        # returning "memory": "hello" is not silently dropped.
+        assert normalize_extracted_memories("hello") == [{"text": "hello"}]
+        assert normalize_extracted_memories("hello") == normalize_extracted_memories(["hello"])
+
     def test_empty_and_non_iterable_inputs(self):
         assert normalize_extracted_memories([]) == []
         assert normalize_extracted_memories(None) == []
-        assert normalize_extracted_memories("hello") == []
+        assert normalize_extracted_memories("") == []
+        assert normalize_extracted_memories("   ") == []
+        assert normalize_extracted_memories(5) == []
 
     def test_downstream_comprehension_no_longer_raises(self):
         # The exact expression from mem0/memory/main.py that used to crash.


### PR DESCRIPTION
## What & why

Fixes #6724.

`_add_to_vector_store` assumes every element of the LLM's extracted-memory list is a `dict` with a `text` key. When the model returns `{"memory": ["fact one", "fact two"]}` — a list of **plain strings** — the Phase 3 comprehension raises:

```
AttributeError: 'str' object has no attribute 'get'
```

```python
# mem0/memory/main.py (sync :963, async :2611)
mem_texts = [m.get("text", "") for m in extracted_memories if m.get("text")]
```

The downstream record loop (`mem.get("text")`, `mem.get("attributed_to")`) would crash the same way. Because `add()` is one LLM call per document, a single non-conforming extraction aborts the **whole** ingestion, and with the default ephemeral store everything already ingested is lost.

## Fix

Add `normalize_extracted_memories()` in `mem0/memory/utils.py`, mirroring the existing `normalize_facts()` helper the codebase already uses to absorb inconsistent LLM shapes on the fact-retrieval path. It coerces bare strings into `{"text": ...}`, lifts a lone dict into a list, and drops non-dict/non-str junk (with a warning) instead of crashing. It's called at both the sync and async parse sites, right after the response is parsed and before any `m.get(...)` access — so a malformed element degrades gracefully and the well-formed facts are still recovered.

## Behaviour

| `extracted_memories` (default instructions) | before | after |
|---|---|---|
| `[{"text": "a"}, {"text": "b"}]` | `["a", "b"]` | `["a", "b"]` (unchanged) |
| `["fact one", "fact two"]` | **AttributeError** (ingestion aborts) | `["fact one", "fact two"]` |
| `[{"text": "a"}, "b", 5, None]` | **AttributeError** | `["a", "b"]` |
| `{"text": "solo"}` | `["solo"]` | `["solo"]` |

## Tests

Added `TestNormalizeExtractedMemories` in `tests/memory/test_memory_utils.py` covering the pass-through, string-wrapping, mixed-junk, single-dict, and non-iterable cases, plus the exact `main.py` comprehension that used to raise. `pytest tests/memory/test_memory_utils.py` → all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
