### PR TITLE
fix(vector_stores/faiss): derive expected module name in SafeUnpickler test

### DIFF
--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -387,7 +387,9 @@ class TestSafeUnpickler:
             SafeUnpickler(io.BytesIO(malicious_payload)).load()
 
         assert "Unsafe pickle" in str(exc_info.value)
-        assert "posix.system" in str(exc_info.value)
+        # os.system lives in `posix` on Unix and `nt` on Windows, so derive the
+        # expected name from the same callable the payload was built from.
+        assert f"{os.system.__module__}.system" in str(exc_info.value)
 
     def test_safe_unpickler_blocks_subprocess(self):
         """SafeUnpickler should block subprocess execution attempts."""


### PR DESCRIPTION
## Linked Issue

Closes #6719

## Description

`tests/vector_stores/test_faiss.py::TestSafeUnpickler::test_safe_unpickler_blocks_os_system` fails on Windows. `SafeUnpickler` itself is fine and blocks the payload exactly as intended; the test just pins the POSIX name of the module `os.system` belongs to:

```
assert "posix.system" in str(exc_info.value)
E   assert 'posix.system' in "Unsafe pickle: attempted to load 'nt.system'. ..."
```

`os.system` lives in `posix` on Unix and in `nt` on Windows. The assertion added in #4833 hardcodes the Unix name, and CI only runs ubuntu-latest, so this has never shown up there.

This derives the expected name from the same callable the payload is built from:

```python
assert f"{os.system.__module__}.system" in str(exc_info.value)
```

That keeps the assertion exactly as strict as it is today — it still requires the real module name, not just `.system` — while working on both platforms. I offered the alternative in the issue (drop the module-name half and match the neighbouring `test_safe_unpickler_blocks_subprocess`); happy to switch to that if you prefer it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests (the change is itself the test)
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

On Windows 11 x64 / Python 3.13.9:

- Before: `tests/vector_stores/test_faiss.py::TestSafeUnpickler::test_safe_unpickler_blocks_os_system` fails as above.
- After: `pytest tests/vector_stores/test_faiss.py` → **33 passed**.

**On Linux this change is a no-op.** The new expression evaluates to the same string literal the test asserts today — checked on Ubuntu 22.04:

```
$ python3 -c "import os; print(repr(f'{os.system.__module__}.system'))"
'posix.system'
```

I did not run the full suite on Linux, so that is an equivalence check on the changed expression, not a full Linux CI reproduction. CI will cover the rest.

One deviation to flag: `AGENTS.md` says to use hatch rather than pip, but the hatch envs only cover Python 3.10–3.12 and this bug is only observable on Windows, so I ran it in a plain venv on 3.13 with `pip install -e ".[test,vector-stores,llms,extras]"`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (the fixed assertion is red before this change on Windows, green after)
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

`ruff check tests/vector_stores/test_faiss.py` passes. `ruff format --check` reports the file as needing reformatting, but that is pre-existing on a clean `main` (an unrelated `search(...)` call above), so I left it alone rather than mixing an unrelated reformat into this diff.
