### PR TITLE
feat: add AWS Bedrock reranker implementation

### DIFF
--- a/docs/components/rerankers/config.mdx
+++ b/docs/components/rerankers/config.mdx
@@ -67,6 +67,19 @@ All rerankers share these common configuration parameters:
 | `llm.config`   | LLM configuration object    | `dict` | Required |
 | `top_n`        | Number of results to return | `int`  | `None`   |
 
+### AWS Bedrock
+
+| Parameter | Description | Type | Default |
+|-----------|-------------|------|---------|
+| `model` | Bedrock rerank model ID, or a full model ARN | `str` | `"cohere.rerank-v3-5:0"` |
+| `aws_region` | AWS region for the Bedrock reranking service | `str` | `AWS_REGION` env var, else `"us-west-2"` |
+| `aws_access_key_id` | AWS access key ID | `str` | `None` |
+| `aws_secret_access_key` | AWS secret access key | `str` | `None` |
+| `aws_session_token` | AWS session token for temporary credentials (STS / assume-role) | `str` | `None` |
+| `top_k` | Maximum documents to return after reranking | `int` | `None` |
+
+Authenticates via IAM, not an `api_key` — see the [AWS Bedrock reranker page](/components/rerankers/models/aws_bedrock) for details.
+
 ## Environment Variables
 
 You can set API keys using environment variables:
@@ -76,6 +89,7 @@ You can set API keys using environment variables:
 - `HUGGINGFACE_API_KEY` - HuggingFace API token
 - `OPENAI_API_KEY` - OpenAI API key (for LLM-based reranker)
 - `ANTHROPIC_API_KEY` - Anthropic API key (for LLM-based reranker)
+- `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` - AWS credentials (for the Bedrock reranker)
 
 ## Basic Configuration Example
 
@@ -106,7 +120,7 @@ config = {
 
 ## TypeScript SDK
 
-The self-hosted [TypeScript SDK](/open-source/features/reranker-search#typescript-sdk) (`mem0ai/oss`) supports the same five providers. Config keys are camelCase (`apiKey`, `topK`, `maxLength`) and each provider's SDK is a peer dependency you install per reranker.
+The self-hosted [TypeScript SDK](/open-source/features/reranker-search#typescript-sdk) (`mem0ai/oss`) supports the same six providers. Config keys are camelCase (`apiKey`, `topK`, `maxLength`) and each provider's SDK is a peer dependency you install per reranker.
 
 | Provider | Install | Default model | Key config fields |
 | --- | --- | --- | --- |
@@ -115,6 +129,7 @@ The self-hosted [TypeScript SDK](/open-source/features/reranker-search#typescrip
 | `sentence_transformer` | `pnpm add @huggingface/transformers` | `Xenova/ms-marco-MiniLM-L-6-v2` | `model`, `device`, `maxLength`, `normalize`, `topK` |
 | `huggingface` | `pnpm add @huggingface/transformers` | `Xenova/bge-reranker-base` | `model`, `device`, `maxLength`, `normalize`, `topK` |
 | `llm_reranker` | None (uses your LLM provider's own SDK) | `openai` / `gpt-5-mini` | `provider`, `model`, `apiKey`, `llm` (nested override), `topK` |
+| `aws_bedrock` | `pnpm add @aws-sdk/client-bedrock-agent-runtime` | `cohere.rerank-v3-5:0` | `model`, `awsRegion`, `awsAccessKeyId`, `awsSecretAccessKey`, `awsSessionToken`, `topK` |
 
 ```typescript
 import { Memory } from "mem0ai/oss";

--- a/docs/components/rerankers/models/aws_bedrock.mdx
+++ b/docs/components/rerankers/models/aws_bedrock.mdx
@@ -1,0 +1,152 @@
+---
+title: AWS Bedrock
+description: "Configure AWS Bedrock as a reranker in Mem0 using the Bedrock Rerank API, with IAM-based authentication via boto3."
+---
+
+AWS Bedrock exposes managed reranking through the Bedrock Agent Runtime **Rerank API**, giving you Cohere Rerank and Amazon's own rerank model behind a single interface, authenticated with your existing AWS credentials instead of a separate provider API key.
+
+<Note>
+The Rerank API is a different Bedrock service (`bedrock-agent-runtime`) from the `bedrock-runtime` service used by the [AWS Bedrock LLM](/components/llms/models/aws_bedrock) and [AWS Bedrock embedder](/components/embedders/models/aws_bedrock). Model access, quotas, and IAM permissions for it are managed separately in the [Bedrock model catalog](https://console.aws.amazon.com/bedrock/).
+</Note>
+
+## Models
+
+- **`cohere.rerank-v3-5:0`** (default): Cohere's latest reranker, multilingual
+- **`amazon.rerank-v1:0`**: Amazon's own rerank model
+
+You can also pass a full foundation-model ARN directly as `model` (e.g. if you need to pin a specific region other than the client's).
+
+## Installation
+
+```bash
+pip install boto3
+```
+
+## Configuration
+
+```python Python
+from mem0 import Memory
+
+config = {
+    "vector_store": {
+        "provider": "chroma",
+        "config": {
+            "collection_name": "my_memories",
+            "path": "./chroma_db"
+        }
+    },
+    "llm": {
+        "provider": "openai",
+        "config": {
+            "model": "gpt-5-mini"
+        }
+    },
+    "reranker": {
+        "provider": "aws_bedrock",
+        "config": {
+            "model": "cohere.rerank-v3-5:0",
+            "aws_region": "us-east-1",
+            "top_k": 5
+        }
+    }
+}
+
+memory = Memory.from_config(config)
+```
+
+## TypeScript (self-hosted)
+
+The [TypeScript OSS SDK](/open-source/features/reranker-search#typescript-sdk) (`mem0ai/oss`) ships the AWS Bedrock reranker too. Config keys are camelCase, it defaults to the `cohere.rerank-v3-5:0` model, and you opt in per search with `rerank: true`.
+
+```bash
+pnpm add @aws-sdk/client-bedrock-agent-runtime
+```
+
+```typescript
+import { Memory } from "mem0ai/oss";
+
+const memory = new Memory({
+  reranker: {
+    provider: "aws_bedrock",
+    config: {
+      // model: "cohere.rerank-v3-5:0",  // default; or "amazon.rerank-v1:0"
+      awsRegion: "us-east-1",
+      topK: 5,
+    },
+  },
+});
+
+const results = await memory.search("What is the user's profession?", {
+  filters: { userId: "bob" },
+  rerank: true,
+});
+```
+
+Omit the three credential fields to use the AWS default credential chain. `@aws-sdk/client-bedrock-agent-runtime` is loaded on first use via dynamic `import()`, so it stays an optional peer dependency for consumers who don't use this reranker.
+
+## Environment Variables
+
+Bedrock authenticates with standard AWS credentials — no separate reranker API key is needed. Omit the credential fields in config to use the default AWS credential chain (environment variables, shared config, SSO, or an instance role):
+
+```bash
+export AWS_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=your-access-key
+export AWS_SECRET_ACCESS_KEY=your-secret-key
+```
+
+## Usage Example
+
+```python Python
+import os
+from mem0 import Memory
+
+os.environ["AWS_REGION"] = "us-east-1"
+os.environ["AWS_ACCESS_KEY_ID"] = "your-access-key"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "your-secret-key"
+
+config = {
+    "vector_store": {"provider": "chroma"},
+    "llm": {"provider": "openai", "config": {"model": "gpt-5-mini"}},
+    "reranker": {
+        "provider": "aws_bedrock",
+        "config": {
+            "model": "cohere.rerank-v3-5:0",
+            "top_k": 3
+        }
+    }
+}
+
+memory = Memory.from_config(config)
+
+messages = [
+    {"role": "user", "content": "I work as a data scientist at Microsoft"},
+    {"role": "user", "content": "I specialize in machine learning and NLP"},
+    {"role": "user", "content": "I enjoy playing tennis on weekends"}
+]
+memory.add(messages, user_id="bob")
+
+results = memory.search("What is the user's profession?", user_id="bob", rerank=True)
+
+for result in results["results"]:
+    print(f"Memory: {result['memory']}")
+    print(f"Vector Score: {result['score']:.3f}")
+    print(f"Rerank Score: {result['rerank_score']:.3f}")
+    print()
+```
+
+## Configuration Parameters
+
+| Parameter | Description | Type | Default |
+|-----------|-------------|------|---------|
+| `model` | Bedrock rerank model ID, or a full model ARN | `str` | `"cohere.rerank-v3-5:0"` |
+| `aws_region` | AWS region for the Bedrock reranking service | `str` | `AWS_REGION` env var, else `"us-west-2"` |
+| `aws_access_key_id` | AWS access key ID | `str` | `None` |
+| `aws_secret_access_key` | AWS secret access key | `str` | `None` |
+| `aws_session_token` | AWS session token for temporary credentials (STS / assume-role) | `str` | `None` |
+| `top_k` | Maximum documents to return after reranking | `int` | `None` |
+
+TypeScript config keys are the same, camelCased: `model`, `awsRegion`, `awsAccessKeyId`, `awsSecretAccessKey`, `awsSessionToken`, `topK`.
+
+## Notes
+
+- **IAM permissions.** The calling identity needs `bedrock:Rerank` on the target model, distinct from the `bedrock:InvokeModel`/`bedrock:Converse` permissions used by the LLM and embedder providers.

--- a/docs/components/rerankers/overview.mdx
+++ b/docs/components/rerankers/overview.mdx
@@ -17,10 +17,11 @@ Reranking trades extra latency for better precision. Start once you have baselin
   <Card title="Hugging Face" icon="/images/provider-icons/huggingface.svg" href="/components/rerankers/models/huggingface" />
   <Card title="LLM Reranker" icon="wand-magic-sparkles" href="/components/rerankers/models/llm_reranker" />
   <Card title="Zero Entropy" icon="/images/provider-icons/zeroentropy.svg" href="/components/rerankers/models/zero_entropy" />
+  <Card title="AWS Bedrock" icon="/images/provider-icons/aws-color.svg" href="/components/rerankers/models/aws_bedrock" />
 </CardGroup>
 
 <Note>
-All five rerankers are available in both the Python and the [TypeScript](/open-source/features/reranker-search#typescript-sdk) self-hosted SDKs. Each provider page has a **TypeScript (self-hosted)** section with the camelCase config.
+All six rerankers are available in both the Python and the [TypeScript](/open-source/features/reranker-search#typescript-sdk) self-hosted SDKs. Each provider page has a **TypeScript (self-hosted)** section with the camelCase config.
 </Note>
 
 ## Reranking Workflow

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -273,7 +273,8 @@
                               "components/rerankers/models/sentence_transformer",
                               "components/rerankers/models/huggingface",
                               "components/rerankers/models/llm_reranker",
-                              "components/rerankers/models/zero_entropy"
+                              "components/rerankers/models/zero_entropy",
+                              "components/rerankers/models/aws_bedrock"
                             ]
                           }
                         ]

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -505,3 +505,4 @@ Everything below is OSS-only provider configuration. Skip this entire section wh
 - [Hugging Face Reranker](https://docs.mem0.ai/components/rerankers/models/huggingface) [OSS]: Use for HF-hosted reranker models.
 - [LLM Reranker](https://docs.mem0.ai/components/rerankers/models/llm_reranker) [OSS]: Use when the reranker is a prompted LLM (implementation reference).
 - [Zero Entropy Reranker](https://docs.mem0.ai/components/rerankers/models/zero_entropy) [OSS]: Use for the Zero Entropy reranker.
+- [AWS Bedrock Reranker](https://docs.mem0.ai/components/rerankers/models/aws_bedrock) [OSS]: Use for the Bedrock Rerank API (Cohere Rerank / Amazon Rerank via IAM auth).

--- a/docs/open-source/features/reranker-search.mdx
+++ b/docs/open-source/features/reranker-search.mdx
@@ -18,14 +18,14 @@ Reranker-enhanced search adds a second scoring pass after vector retrieval so Me
 </Warning>
 
 <Note>
-  The `Configure it` and `See it in action` snippets below use the Python SDK. The self-hosted **TypeScript SDK** supports the Cohere, Zero Entropy, Sentence Transformer, Hugging Face, and LLM rerankers; see [TypeScript SDK](#typescript-sdk).
+  The `Configure it` and `See it in action` snippets below use the Python SDK. The self-hosted **TypeScript SDK** supports the Cohere, Zero Entropy, Sentence Transformer, Hugging Face, LLM, and AWS Bedrock rerankers; see [TypeScript SDK](#typescript-sdk).
 </Note>
 
 ---
 
 ## TypeScript SDK
 
-The self-hosted TypeScript SDK (`mem0ai/oss`) ships five rerankers: **Cohere**, **Zero Entropy**, **Sentence Transformer**, **Hugging Face**, and the **LLM reranker**. Configure one under `reranker`, then opt in per search with `rerank: true`. Keys are camelCase (`apiKey`, not `api_key`).
+The self-hosted TypeScript SDK (`mem0ai/oss`) ships six rerankers: **Cohere**, **Zero Entropy**, **Sentence Transformer**, **Hugging Face**, the **LLM reranker**, and **AWS Bedrock**. Configure one under `reranker`, then opt in per search with `rerank: true`. Keys are camelCase (`apiKey`, not `api_key`).
 
 Provider SDKs are peer dependencies. Install the one your reranker needs:
 
@@ -33,6 +33,7 @@ Provider SDKs are peer dependencies. Install the one your reranker needs:
 pnpm add cohere-ai          # cohere
 pnpm add zeroentropy        # zero_entropy
 pnpm add @huggingface/transformers   # sentence_transformer, huggingface
+pnpm add @aws-sdk/client-bedrock-agent-runtime   # aws_bedrock
 # llm_reranker defaults to openai (already a core dependency); install another
 # provider's SDK only if you nest a different one under config.llm
 ```
@@ -67,6 +68,35 @@ const memory = new Memory({
   },
 });
 ```
+
+### AWS Bedrock
+
+Calls the Bedrock Agent Runtime **Rerank API** (`RerankCommand`), giving you Cohere Rerank and Amazon's own rerank model behind one interface. Authentication is plain AWS credentials — no separate reranker API key — resolved via the standard AWS credential chain unless provided explicitly in config.
+
+```typescript
+import { Memory } from "mem0ai/oss";
+
+const memory = new Memory({
+  reranker: {
+    provider: "aws_bedrock",
+    config: {
+      model: "cohere.rerank-v3-5:0", // default; or "amazon.rerank-v1:0"
+      awsRegion: "us-east-1",
+      // awsAccessKeyId / awsSecretAccessKey / awsSessionToken: omit to use
+      // the default AWS credential chain (env vars, shared config, SSO, instance role)
+    },
+  },
+});
+
+const results = await memory.search("What is the user's profession?", {
+  filters: { userId: "bob" },
+  rerank: true,
+});
+```
+
+<Note>
+  The Rerank API is a different Bedrock service (`bedrock-agent-runtime`) from `@aws-sdk/client-bedrock-runtime`, used by the [AWS Bedrock LLM](/components/llms/models/aws_bedrock) and [embedder](/components/embedders/models/aws_bedrock) providers. The calling identity needs `bedrock:Rerank` on the target model.
+</Note>
 
 ### Local cross-encoders (Sentence Transformer, Hugging Face)
 
@@ -138,6 +168,7 @@ const memory = new Memory({
 | `sentence_transformer` | `Xenova/ms-marco-MiniLM-L-6-v2` | `model`, `device`, `maxLength`, `normalize`, `topK` |
 | `huggingface` | `Xenova/bge-reranker-base` | `model`, `device`, `maxLength`, `normalize`, `topK` |
 | `llm_reranker` | `openai` / `gpt-5-mini` | `provider`, `model`, `apiKey`, `llm` (nested override), `topK` |
+| `aws_bedrock` | `cohere.rerank-v3-5:0` | `model`, `awsRegion`, `awsAccessKeyId`, `awsSecretAccessKey`, `awsSessionToken`, `topK` |
 
 <Note>
   `rerank` is opt-in per search and a no-op when no `reranker` is configured. If the reranker call fails, Mem0 logs a warning and returns the original vector-ranked results.
@@ -159,6 +190,7 @@ const memory = new Memory({
     - **[Hugging Face](/components/rerankers/models/huggingface)**: Bring any hosted or on-prem reranker model ID.  
     - **[LLM Reranker](/components/rerankers/models/llm_reranker)**: Use your preferred LLM (OpenAI, etc.) for prompt-driven scoring.  
     - **[Zero Entropy](/components/rerankers/models/zero_entropy)**: High-quality neural reranking tuned for retrieval tasks.
+    - **[AWS Bedrock](/components/rerankers/models/aws_bedrock)**: Cohere Rerank and Amazon Rerank via IAM auth, no separate API key.
   </Accordion>
   <Accordion title="Provider comparison">
     | Provider | Latency | Quality | Cost | Local deploy |
@@ -167,6 +199,7 @@ const memory = new Memory({
     | Sentence Transformer | Low | Good | Free | ✅ |
     | Hugging Face | Low–Medium | Variable | Free | ✅ |
     | LLM Reranker | High | Very high | API cost | Depends |
+    | AWS Bedrock | Medium | High | AWS usage cost | ❌ |
   </Accordion>
 </AccordionGroup>
 

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -148,7 +148,8 @@
     "zeroentropy": "^0.1.0-alpha.10",
     "mysql2": "^3.0.0",
     "@zilliz/milvus2-sdk-node": "^2.4.0 || ^3.0.0",
-    "@aws-sdk/client-bedrock-runtime": ">=3.0.0 <3.968.0"
+    "@aws-sdk/client-bedrock-runtime": ">=3.0.0 <3.968.0",
+    "@aws-sdk/client-bedrock-agent-runtime": ">=3.0.0 <3.968.0"
   },
   "peerDependenciesMeta": {
     "@qdrant/js-client-rest": {
@@ -197,6 +198,9 @@
       "optional": true
     },
     "@aws-sdk/client-bedrock-runtime": {
+      "optional": true
+    },
+    "@aws-sdk/client-bedrock-agent-runtime": {
       "optional": true
     },
     "@databricks/sql": {

--- a/mem0-ts/pnpm-lock.yaml
+++ b/mem0-ts/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.40.1
         version: 0.40.1
+      '@aws-sdk/client-bedrock-agent-runtime':
+        specifier: '>=3.0.0 <3.968.0'
+        version: 3.967.0
       '@aws-sdk/client-bedrock-runtime':
         specifier: 3.967.0
         version: 3.967.0
@@ -273,6 +276,10 @@ packages:
   '@aws-sdk/checksums@3.1000.16':
     resolution: {integrity: sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==}
     engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-bedrock-agent-runtime@3.967.0':
+    resolution: {integrity: sha512-MH080FS9wwuK1j6qvxezOVxgGBmhTREKYignqrV9WVf1NNYjktxKh4ET+dVsev6HR3mzIJuMgR2JE9dhvq2ZLA==}
+    engines: {node: '>=18.0.0'}
 
   '@aws-sdk/client-bedrock-runtime@3.967.0':
     resolution: {integrity: sha512-pFID1Lb/54u413HTpnqQYLJjX+voEKLZyqlpdVHDbxcw8MfalmmSg5PR/uJWGO3kku0LkB+H/Ca5ftL11PTL9w==}
@@ -1710,10 +1717,6 @@ packages:
 
   '@smithy/shared-ini-file-loader@4.6.2':
     resolution: {integrity: sha512-9Xti1yhj7Em9t4ZQ1E8YRA6wbhAqx1nfLu0XSAqv82HED43TMUvn3nOO2xBISxZc0hcOg7wvuHEypUy4L4XF2w==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/signature-v4@5.5.2':
-    resolution: {integrity: sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.6.2':
@@ -4887,6 +4890,53 @@ snapshots:
       '@smithy/types': 4.16.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-bedrock-agent-runtime@3.967.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.967.0
+      '@aws-sdk/credential-provider-node': 3.967.0
+      '@aws-sdk/middleware-host-header': 3.965.0
+      '@aws-sdk/middleware-logger': 3.965.0
+      '@aws-sdk/middleware-recursion-detection': 3.965.0
+      '@aws-sdk/middleware-user-agent': 3.967.0
+      '@aws-sdk/region-config-resolver': 3.965.0
+      '@aws-sdk/types': 3.965.0
+      '@aws-sdk/util-endpoints': 3.965.0
+      '@aws-sdk/util-user-agent-browser': 3.965.0
+      '@aws-sdk/util-user-agent-node': 3.967.0
+      '@smithy/config-resolver': 4.6.2
+      '@smithy/core': 3.29.2
+      '@smithy/eventstream-serde-browser': 4.4.6
+      '@smithy/eventstream-serde-config-resolver': 4.5.6
+      '@smithy/eventstream-serde-node': 4.4.6
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/hash-node': 4.4.2
+      '@smithy/invalid-dependency': 4.4.2
+      '@smithy/middleware-content-length': 4.4.2
+      '@smithy/middleware-endpoint': 4.6.2
+      '@smithy/middleware-retry': 4.7.2
+      '@smithy/middleware-serde': 4.4.2
+      '@smithy/middleware-stack': 4.4.2
+      '@smithy/node-config-provider': 4.5.2
+      '@smithy/node-http-handler': 4.9.4
+      '@smithy/protocol-http': 5.5.2
+      '@smithy/smithy-client': 4.14.2
+      '@smithy/types': 4.16.0
+      '@smithy/url-parser': 4.4.2
+      '@smithy/util-base64': 4.5.2
+      '@smithy/util-body-length-browser': 4.4.2
+      '@smithy/util-body-length-node': 4.4.2
+      '@smithy/util-defaults-mode-browser': 4.5.2
+      '@smithy/util-defaults-mode-node': 4.4.2
+      '@smithy/util-endpoints': 3.6.2
+      '@smithy/util-middleware': 4.4.2
+      '@smithy/util-retry': 4.5.2
+      '@smithy/util-utf8': 4.4.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-bedrock-runtime@3.967.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -5149,13 +5199,13 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.965.0
       '@aws-sdk/xml-builder': 3.965.0
-      '@smithy/core': 3.26.0
+      '@smithy/core': 3.29.2
       '@smithy/node-config-provider': 4.5.2
       '@smithy/property-provider': 4.4.2
       '@smithy/protocol-http': 5.5.2
-      '@smithy/signature-v4': 5.5.2
+      '@smithy/signature-v4': 5.6.3
       '@smithy/smithy-client': 4.14.2
-      '@smithy/types': 4.15.0
+      '@smithy/types': 4.16.0
       '@smithy/util-base64': 4.5.2
       '@smithy/util-middleware': 4.4.2
       '@smithy/util-utf8': 4.4.2
@@ -7005,12 +7055,6 @@ snapshots:
   '@smithy/shared-ini-file-loader@4.6.2':
     dependencies:
       '@smithy/core': 3.29.1
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@5.5.2':
-    dependencies:
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.6.2':

--- a/mem0-ts/src/oss/src/rerankers/aws_bedrock.test.ts
+++ b/mem0-ts/src/oss/src/rerankers/aws_bedrock.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Fake BedrockAgentRuntimeClient capturing the RerankCommand input and
+ * returning a scripted response — exercises request shaping + response
+ * parsing without the AWS SDK or live credentials.
+ */
+class FakeBedrockAgentRuntimeClient {
+  public lastInput: any = null;
+  public response: any;
+  constructor(response: any) {
+    this.response = response;
+  }
+  async send(command: any) {
+    this.lastInput = command?.input ?? command;
+    return this.response;
+  }
+}
+
+// The provider loads the AWS SDK on first use via dynamic import(). Mock the
+// module so it resolves and RerankCommand simply wraps its input.
+jest.mock(
+  "@aws-sdk/client-bedrock-agent-runtime",
+  () => ({
+    BedrockAgentRuntimeClient: class {
+      constructor(public config: any) {}
+    },
+    RerankCommand: class {
+      input: any;
+      constructor(input: any) {
+        this.input = input;
+      }
+    },
+  }),
+  { virtual: true },
+);
+
+import { AWSBedrockReranker } from "./aws_bedrock";
+
+function makeReranker(
+  client: FakeBedrockAgentRuntimeClient,
+  overrides: any = {},
+) {
+  return new AWSBedrockReranker({ client, ...overrides });
+}
+
+describe("AWSBedrockReranker", () => {
+  it("defaults to the cohere.rerank-v3-5:0 model and us-west-2 region", async () => {
+    const client = new FakeBedrockAgentRuntimeClient({ results: [] });
+    const reranker = makeReranker(client);
+
+    await reranker.rerank("q", ["a"]);
+
+    expect(
+      client.lastInput.rerankingConfiguration.bedrockRerankingConfiguration
+        .modelConfiguration.modelArn,
+    ).toBe("arn:aws:bedrock:us-west-2::foundation-model/cohere.rerank-v3-5:0");
+  });
+
+  it("expands a short model id to a region-scoped foundation-model ARN", async () => {
+    const client = new FakeBedrockAgentRuntimeClient({ results: [] });
+    const reranker = makeReranker(client, {
+      model: "amazon.rerank-v1:0",
+      awsRegion: "eu-central-1",
+    });
+
+    await reranker.rerank("q", ["a"]);
+
+    expect(
+      client.lastInput.rerankingConfiguration.bedrockRerankingConfiguration
+        .modelConfiguration.modelArn,
+    ).toBe("arn:aws:bedrock:eu-central-1::foundation-model/amazon.rerank-v1:0");
+  });
+
+  it("passes a full ARN through unchanged", async () => {
+    const arn =
+      "arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0";
+    const client = new FakeBedrockAgentRuntimeClient({ results: [] });
+    const reranker = makeReranker(client, {
+      model: arn,
+      awsRegion: "us-west-2",
+    });
+
+    await reranker.rerank("q", ["a"]);
+
+    expect(
+      client.lastInput.rerankingConfiguration.bedrockRerankingConfiguration
+        .modelConfiguration.modelArn,
+    ).toBe(arn);
+  });
+
+  it("sends the query and documents in the Bedrock Rerank request shape", async () => {
+    const client = new FakeBedrockAgentRuntimeClient({ results: [] });
+    const reranker = makeReranker(client, { topK: 3 });
+
+    await reranker.rerank("what does the user do", ["alpha", "beta"]);
+
+    expect(client.lastInput.queries).toEqual([
+      { textQuery: { text: "what does the user do" }, type: "TEXT" },
+    ]);
+    expect(client.lastInput.sources).toEqual([
+      {
+        inlineDocumentSource: { textDocument: { text: "alpha" }, type: "TEXT" },
+        type: "INLINE",
+      },
+      {
+        inlineDocumentSource: { textDocument: { text: "beta" }, type: "TEXT" },
+        type: "INLINE",
+      },
+    ]);
+    expect(
+      client.lastInput.rerankingConfiguration.bedrockRerankingConfiguration
+        .numberOfResults,
+    ).toBe(3);
+  });
+
+  it("defaults numberOfResults to documents.length when neither the call nor config sets topK", async () => {
+    const client = new FakeBedrockAgentRuntimeClient({ results: [] });
+    const reranker = makeReranker(client);
+
+    await reranker.rerank("q", ["a", "b", "c"]);
+
+    expect(
+      client.lastInput.rerankingConfiguration.bedrockRerankingConfiguration
+        .numberOfResults,
+    ).toBe(3);
+  });
+
+  it("returns Bedrock's ranked results as {index, rerankScore}", async () => {
+    const client = new FakeBedrockAgentRuntimeClient({
+      results: [
+        { index: 2, relevanceScore: 0.9 },
+        { index: 0, relevanceScore: 0.31 },
+      ],
+    });
+    const reranker = makeReranker(client);
+
+    const results = await reranker.rerank("q", ["x", "y", "z"]);
+
+    expect(results).toEqual([
+      { index: 2, rerankScore: 0.9 },
+      { index: 0, rerankScore: 0.31 },
+    ]);
+  });
+
+  it("returns an empty array without calling Bedrock when there are no documents", async () => {
+    const client = new FakeBedrockAgentRuntimeClient({ results: [] });
+    const reranker = makeReranker(client);
+
+    const results = await reranker.rerank("q", []);
+
+    expect(results).toEqual([]);
+    expect(client.lastInput).toBeNull();
+  });
+
+  it("falls back to the original order with rerankScore 0.0 when the Bedrock call fails", async () => {
+    const client = new FakeBedrockAgentRuntimeClient(null);
+    client.send = async () => {
+      throw new Error("bedrock is down");
+    };
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const reranker = makeReranker(client);
+
+    const results = await reranker.rerank("q", ["a", "b", "c"]);
+
+    expect(results).toEqual([
+      { index: 0, rerankScore: 0.0 },
+      { index: 1, rerankScore: 0.0 },
+      { index: 2, rerankScore: 0.0 },
+    ]);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it("slices the fallback results by topK when the Bedrock call fails", async () => {
+    const client = new FakeBedrockAgentRuntimeClient(null);
+    client.send = async () => {
+      throw new Error("bedrock is down");
+    };
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    const reranker = makeReranker(client, { topK: 2 });
+
+    const results = await reranker.rerank("q", ["a", "b", "c"]);
+
+    expect(results).toEqual([
+      { index: 0, rerankScore: 0.0 },
+      { index: 1, rerankScore: 0.0 },
+    ]);
+
+    (console.warn as jest.Mock).mockRestore();
+  });
+
+  it("passes explicit AWS credentials through to the client config", async () => {
+    let capturedConfig: any = null;
+
+    jest.resetModules();
+    jest.doMock(
+      "@aws-sdk/client-bedrock-agent-runtime",
+      () => ({
+        BedrockAgentRuntimeClient: class {
+          constructor(config: any) {
+            capturedConfig = config;
+          }
+        },
+        RerankCommand: class {
+          input: any;
+          constructor(input: any) {
+            this.input = input;
+          }
+        },
+      }),
+      { virtual: true },
+    );
+
+    const { AWSBedrockReranker: FreshReranker } = await import("./aws_bedrock");
+    const reranker = new FreshReranker({
+      awsRegion: "ap-southeast-1",
+      awsAccessKeyId: "AKIA_TEST",
+      awsSecretAccessKey: "SECRET_TEST",
+      awsSessionToken: "SESSION_TOKEN_TEST",
+    });
+
+    await reranker.rerank("q", []);
+    // rerank() with no documents short-circuits before constructing the
+    // client, so force construction directly to inspect the config.
+    // @ts-expect-error accessing a private method for the test
+    await reranker.getClient();
+
+    expect(capturedConfig).toEqual({
+      region: "ap-southeast-1",
+      credentials: {
+        accessKeyId: "AKIA_TEST",
+        secretAccessKey: "SECRET_TEST",
+        sessionToken: "SESSION_TOKEN_TEST",
+      },
+    });
+  });
+});

--- a/mem0-ts/src/oss/src/rerankers/aws_bedrock.ts
+++ b/mem0-ts/src/oss/src/rerankers/aws_bedrock.ts
@@ -1,0 +1,149 @@
+import { RerankerConfig } from "../types";
+import { Reranker, RerankResult } from "./base";
+
+const DEFAULT_MODEL = "cohere.rerank-v3-5:0";
+
+/**
+ * AWS Bedrock reranker provider for the TypeScript OSS SDK.
+ *
+ * Calls the Bedrock Agent Runtime `Rerank` API (`RerankCommand`), a distinct
+ * service from `@aws-sdk/client-bedrock-runtime` (used by the AWS Bedrock LLM
+ * and embedding providers) that exposes both the Cohere Rerank and Amazon
+ * Rerank foundation models through one interface, authenticated via the
+ * standard AWS credential chain rather than a separate provider API key.
+ *
+ * The `@aws-sdk/client-bedrock-agent-runtime` dependency is loaded on first
+ * use via dynamic `import()` so the package stays optional.
+ */
+interface BedrockAgentRuntimeSDK {
+  BedrockAgentRuntimeClient: new (config: Record<string, any>) => any;
+  RerankCommand: new (input: Record<string, any>) => any;
+}
+
+export class AWSBedrockReranker implements Reranker {
+  private model: string;
+  private topK?: number;
+  private clientConfig: Record<string, any>;
+  private clientOverride?: any;
+  private sdkPromise?: Promise<BedrockAgentRuntimeSDK>;
+  private clientPromise?: Promise<any>;
+  private awsRegion: string;
+
+  constructor(config: RerankerConfig) {
+    this.model = config.model || DEFAULT_MODEL;
+    this.topK = config.topK;
+
+    this.awsRegion = config.awsRegion || process.env.AWS_REGION || "us-west-2";
+    const clientConfig: Record<string, any> = { region: this.awsRegion };
+    if (config.awsAccessKeyId && config.awsSecretAccessKey) {
+      clientConfig.credentials = {
+        accessKeyId: config.awsAccessKeyId,
+        secretAccessKey: config.awsSecretAccessKey,
+        ...(config.awsSessionToken && {
+          sessionToken: config.awsSessionToken,
+        }),
+      };
+    }
+    this.clientConfig = clientConfig;
+    this.clientOverride = config.client;
+  }
+
+  /**
+   * Bedrock's Rerank API addresses models by a region-scoped foundation-model
+   * ARN, not the bare model id the LLM/embedding providers use. A
+   * caller-supplied ARN is passed through unchanged.
+   */
+  private resolveModelArn(): string {
+    if (this.model.startsWith("arn:aws")) return this.model;
+    return `arn:aws:bedrock:${this.awsRegion}::foundation-model/${this.model}`;
+  }
+
+  /**
+   * Load the optional AWS SDK on first use.
+   *
+   * This MUST be a dynamic `import()`, never `require()`: tsup/esbuild rewrite
+   * `require()` in the published ESM bundle into a `__require` shim that
+   * throws `Dynamic require of "..." is not supported`, so every ESM consumer
+   * would hit a dead provider even with the SDK installed.
+   */
+  private async getSDK(): Promise<BedrockAgentRuntimeSDK> {
+    if (!this.sdkPromise) {
+      this.sdkPromise = import("@aws-sdk/client-bedrock-agent-runtime").then(
+        (sdk) => sdk as unknown as BedrockAgentRuntimeSDK,
+        (err) => {
+          this.sdkPromise = undefined;
+          const detail = err instanceof Error ? err.message : String(err);
+          throw new Error(
+            "The '@aws-sdk/client-bedrock-agent-runtime' package is required to use the AWS Bedrock reranker. " +
+              `Install it with: npm install @aws-sdk/client-bedrock-agent-runtime (original error: ${detail})`,
+          );
+        },
+      );
+    }
+    return this.sdkPromise;
+  }
+
+  /** Memoized Bedrock Agent Runtime client; an injected `config.client` short-circuits the SDK. */
+  private async getClient(): Promise<any> {
+    if (this.clientOverride) return this.clientOverride;
+    if (!this.clientPromise) {
+      this.clientPromise = this.getSDK().then(
+        ({ BedrockAgentRuntimeClient }) =>
+          new BedrockAgentRuntimeClient(this.clientConfig),
+      );
+    }
+    return this.clientPromise;
+  }
+
+  async rerank(
+    query: string,
+    documents: string[],
+    topK?: number,
+  ): Promise<RerankResult[]> {
+    if (documents.length === 0) return [];
+
+    const numberOfResults = topK || this.topK || documents.length;
+
+    try {
+      const [{ RerankCommand }, client] = await Promise.all([
+        this.getSDK(),
+        this.getClient(),
+      ]);
+
+      const response = await client.send(
+        new RerankCommand({
+          queries: [{ textQuery: { text: query }, type: "TEXT" }],
+          sources: documents.map((text) => ({
+            inlineDocumentSource: {
+              textDocument: { text },
+              type: "TEXT",
+            },
+            type: "INLINE",
+          })),
+          rerankingConfiguration: {
+            type: "BEDROCK_RERANKING_MODEL",
+            bedrockRerankingConfiguration: {
+              modelConfiguration: { modelArn: this.resolveModelArn() },
+              numberOfResults,
+            },
+          },
+        }),
+      );
+
+      return response.results.map((result: any) => ({
+        index: result.index,
+        rerankScore: result.relevanceScore,
+      }));
+    } catch (e) {
+      console.warn(
+        `AWS Bedrock reranking failed, falling back to original order: ${e}`,
+      );
+      const scored = documents.map((_, index) => ({
+        index,
+        rerankScore: 0.0,
+      }));
+      const finalTopK = topK || this.topK;
+      return finalTopK ? scored.slice(0, finalTopK) : scored;
+    }
+  }
+}

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -126,6 +126,14 @@ export interface RerankerConfig {
     provider: string;
     config: LLMConfig;
   };
+  // AWS Bedrock provider config (used when provider === "aws_bedrock").
+  // Credentials otherwise resolve via the standard AWS credential chain.
+  awsRegion?: string;
+  awsAccessKeyId?: string;
+  awsSecretAccessKey?: string;
+  awsSessionToken?: string;
+  // Optional pre-constructed client (e.g. BedrockAgentRuntimeClient) for DI/testing.
+  client?: any;
   [key: string]: any;
 }
 

--- a/mem0-ts/src/oss/src/utils/factory.test.ts
+++ b/mem0-ts/src/oss/src/utils/factory.test.ts
@@ -9,6 +9,7 @@ import { CohereReranker } from "../rerankers/cohere";
 import { LLMReranker } from "../rerankers/llm";
 import { ZeroEntropyReranker } from "../rerankers/zeroentropy";
 import { CrossEncoderReranker } from "../rerankers/cross_encoder";
+import { AWSBedrockReranker } from "../rerankers/aws_bedrock";
 
 describe("RerankerFactory", () => {
   const originalOpenAiKey = process.env.OPENAI_API_KEY;
@@ -76,6 +77,11 @@ describe("RerankerFactory", () => {
     delete process.env.OPENAI_API_KEY;
 
     expect(() => RerankerFactory.create("llm_reranker", {})).toThrow();
+  });
+
+  it("creates an AWSBedrockReranker for provider 'aws_bedrock'", () => {
+    const reranker = RerankerFactory.create("aws_bedrock", {});
+    expect(reranker).toBeInstanceOf(AWSBedrockReranker);
   });
 
   it("throws for an unsupported provider", () => {

--- a/mem0-ts/src/oss/src/utils/factory.ts
+++ b/mem0-ts/src/oss/src/utils/factory.ts
@@ -21,6 +21,7 @@ import { CohereReranker } from "../rerankers/cohere";
 import { LLMReranker } from "../rerankers/llm";
 import { ZeroEntropyReranker } from "../rerankers/zeroentropy";
 import { CrossEncoderReranker } from "../rerankers/cross_encoder";
+import { AWSBedrockReranker } from "../rerankers/aws_bedrock";
 import { Embedder } from "../embeddings/base";
 import { LLM } from "../llms/base";
 import { VectorStore } from "../vector_stores/base";
@@ -233,6 +234,8 @@ export class RerankerFactory {
         const llm = RerankerFactory.buildLLMRerankerLLM(config);
         return new LLMReranker(config, llm);
       }
+      case "aws_bedrock":
+        return new AWSBedrockReranker(config);
       default:
         throw new Error(`Unsupported reranker provider: ${provider}`);
     }

--- a/mem0/configs/rerankers/aws_bedrock.py
+++ b/mem0/configs/rerankers/aws_bedrock.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+from pydantic import Field
+
+from mem0.configs.rerankers.base import BaseRerankerConfig
+
+
+class AWSBedrockRerankerConfig(BaseRerankerConfig):
+    """
+    Configuration for the AWS Bedrock reranker.
+
+    Uses the Bedrock Agent Runtime Rerank API rather than the bedrock-runtime
+    invoke_model/converse calls used by the LLM and embedding providers, so
+    authentication is plain IAM (no api_key) and the model is addressed by a
+    foundation-model ARN.
+    """
+
+    model: str = Field(
+        default="cohere.rerank-v3-5:0",
+        description="Bedrock rerank model ID (e.g. 'cohere.rerank-v3-5:0', 'amazon.rerank-v1:0') or a full model ARN",
+    )
+    aws_region: Optional[str] = Field(
+        default=None, description="AWS region for the Bedrock reranking service. Falls back to the AWS_REGION env var"
+    )
+    aws_access_key_id: Optional[str] = Field(default=None, description="AWS access key ID for authentication")
+    aws_secret_access_key: Optional[str] = Field(default=None, description="AWS secret access key for authentication")
+    aws_session_token: Optional[str] = Field(
+        default=None, description="AWS session token for temporary credentials (STS / assume-role)"
+    )
+    top_k: Optional[int] = Field(default=None, description="Number of top documents to return after reranking")

--- a/mem0/reranker/__init__.py
+++ b/mem0/reranker/__init__.py
@@ -2,6 +2,7 @@
 Reranker implementations for mem0 search functionality.
 """
 
+from .aws_bedrock_reranker import AWSBedrockReranker
 from .base import BaseReranker
 from .cohere_reranker import CohereReranker
 from .huggingface_reranker import HuggingFaceReranker
@@ -10,6 +11,7 @@ from .sentence_transformer_reranker import SentenceTransformerReranker
 from .zero_entropy_reranker import ZeroEntropyReranker
 
 __all__ = [
+    "AWSBedrockReranker",
     "BaseReranker",
     "CohereReranker",
     "HuggingFaceReranker",

--- a/mem0/reranker/aws_bedrock_reranker.py
+++ b/mem0/reranker/aws_bedrock_reranker.py
@@ -1,0 +1,126 @@
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from mem0.reranker.base import BaseReranker
+
+try:
+    import boto3
+
+    BOTO3_AVAILABLE = True
+except ImportError:
+    BOTO3_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+
+class AWSBedrockReranker(BaseReranker):
+    """AWS Bedrock-based reranker implementation.
+
+    Calls the Bedrock Agent Runtime `Rerank` API, a distinct service from
+    `bedrock-runtime` (used by the AWS Bedrock LLM/embedding providers) that
+    exposes both the Cohere Rerank and Amazon Rerank foundation models
+    through one interface.
+    """
+
+    def __init__(self, config):
+        """
+        Initialize AWS Bedrock reranker.
+
+        Args:
+            config: AWSBedrockRerankerConfig object with configuration parameters
+        """
+        if not BOTO3_AVAILABLE:
+            raise ImportError("boto3 is required for AWSBedrockReranker. Install with: pip install boto3")
+
+        self.config = config
+
+        aws_region = config.aws_region or os.getenv("AWS_REGION", "us-west-2")
+        aws_access_key = config.aws_access_key_id or os.getenv("AWS_ACCESS_KEY_ID")
+        aws_secret_key = config.aws_secret_access_key or os.getenv("AWS_SECRET_ACCESS_KEY")
+        aws_session_token = config.aws_session_token or os.getenv("AWS_SESSION_TOKEN")
+
+        self.client = boto3.client(
+            "bedrock-agent-runtime",
+            region_name=aws_region,
+            aws_access_key_id=aws_access_key or None,
+            aws_secret_access_key=aws_secret_key or None,
+            aws_session_token=aws_session_token or None,
+        )
+
+        self.model_arn = self._resolve_model_arn(config.model, aws_region)
+
+    @staticmethod
+    def _resolve_model_arn(model: str, aws_region: str) -> str:
+        """Bedrock's Rerank API addresses models by ARN, not the bare 'provider.model' id
+        the LLM/embedding providers use, so a short id is expanded to the region-scoped
+        foundation-model ARN. A caller-supplied ARN is passed through unchanged.
+        """
+        if model.startswith("arn:aws"):
+            return model
+        return f"arn:aws:bedrock:{aws_region}::foundation-model/{model}"
+
+    @staticmethod
+    def _extract_text(doc: Dict[str, Any]) -> str:
+        if "memory" in doc:
+            return doc["memory"]
+        if "text" in doc:
+            return doc["text"]
+        if "content" in doc:
+            return doc["content"]
+        return str(doc)
+
+    def rerank(self, query: str, documents: List[Dict[str, Any]], top_k: Optional[int] = None) -> List[Dict[str, Any]]:
+        """
+        Rerank documents using the AWS Bedrock Rerank API.
+
+        Args:
+            query: The search query
+            documents: List of documents to rerank
+            top_k: Number of top documents to return
+
+        Returns:
+            List of reranked documents with rerank_score
+        """
+        if not documents:
+            return documents
+
+        sources = [
+            {
+                "inlineDocumentSource": {
+                    "textDocument": {"text": self._extract_text(doc)},
+                    "type": "TEXT",
+                },
+                "type": "INLINE",
+            }
+            for doc in documents
+        ]
+
+        try:
+            response = self.client.rerank(
+                queries=[{"textQuery": {"text": query}, "type": "TEXT"}],
+                sources=sources,
+                rerankingConfiguration={
+                    "type": "BEDROCK_RERANKING_MODEL",
+                    "bedrockRerankingConfiguration": {
+                        "modelConfiguration": {"modelArn": self.model_arn},
+                        "numberOfResults": top_k or self.config.top_k or len(documents),
+                    },
+                },
+            )
+
+            reranked_docs = []
+            for result in response["results"]:
+                original_doc = documents[result["index"]].copy()
+                original_doc["rerank_score"] = result["relevanceScore"]
+                reranked_docs.append(original_doc)
+
+            return reranked_docs
+
+        except Exception as e:
+            # Fallback to original order if reranking fails
+            logger.warning("AWS Bedrock reranking failed, falling back to original order: %s", e)
+            for doc in documents:
+                doc["rerank_score"] = 0.0
+            final_top_k = top_k or self.config.top_k
+            return documents[:final_top_k] if final_top_k else documents

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -15,11 +15,14 @@ from mem0.configs.llms.ollama import OllamaConfig
 from mem0.configs.llms.openai import OpenAIConfig
 from mem0.configs.llms.vllm import VllmConfig
 from mem0.configs.llms.xai import XAIConfig
+from mem0.configs.rerankers.aws_bedrock import AWSBedrockRerankerConfig
 from mem0.configs.rerankers.base import BaseRerankerConfig
 from mem0.configs.rerankers.cohere import CohereRerankerConfig
 from mem0.configs.rerankers.huggingface import HuggingFaceRerankerConfig
 from mem0.configs.rerankers.llm import LLMRerankerConfig
-from mem0.configs.rerankers.sentence_transformer import SentenceTransformerRerankerConfig
+from mem0.configs.rerankers.sentence_transformer import (
+    SentenceTransformerRerankerConfig,
+)
 from mem0.configs.rerankers.zero_entropy import ZeroEntropyRerankerConfig
 from mem0.embeddings.mock import MockEmbeddings
 
@@ -237,6 +240,7 @@ class RerankerFactory:
         "zero_entropy": ("mem0.reranker.zero_entropy_reranker.ZeroEntropyReranker", ZeroEntropyRerankerConfig),
         "llm_reranker": ("mem0.reranker.llm_reranker.LLMReranker", LLMRerankerConfig),
         "huggingface": ("mem0.reranker.huggingface_reranker.HuggingFaceReranker", HuggingFaceRerankerConfig),
+        "aws_bedrock": ("mem0.reranker.aws_bedrock_reranker.AWSBedrockReranker", AWSBedrockRerankerConfig),
     }
 
     @classmethod

--- a/tests/rerankers/test_aws_bedrock_reranker.py
+++ b/tests/rerankers/test_aws_bedrock_reranker.py
@@ -1,0 +1,168 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mem0.configs.rerankers.aws_bedrock import AWSBedrockRerankerConfig
+from mem0.reranker.aws_bedrock_reranker import AWSBedrockReranker
+
+
+@pytest.fixture
+def mock_boto3_client():
+    with patch("mem0.reranker.aws_bedrock_reranker.boto3.client") as mock_client:
+        mock_client.return_value = Mock()
+        yield mock_client
+
+
+def _docs(n):
+    return [{"memory": f"doc{i}"} for i in range(n)]
+
+
+def _rerank_response(*index_score_pairs):
+    return {"results": [{"index": i, "relevanceScore": s} for i, s in index_score_pairs]}
+
+
+class TestAWSBedrockRerankerInit:
+    def test_default_model_and_region(self, mock_boto3_client):
+        with patch("mem0.reranker.aws_bedrock_reranker.os.environ", {}):
+            reranker = AWSBedrockReranker(AWSBedrockRerankerConfig())
+
+        _, kwargs = mock_boto3_client.call_args
+        assert mock_boto3_client.call_args[0][0] == "bedrock-agent-runtime"
+        assert kwargs["region_name"] == "us-west-2"
+        assert reranker.model_arn == "arn:aws:bedrock:us-west-2::foundation-model/cohere.rerank-v3-5:0"
+
+    def test_short_model_id_is_expanded_to_region_scoped_arn(self, mock_boto3_client):
+        config = AWSBedrockRerankerConfig(model="amazon.rerank-v1:0", aws_region="eu-central-1")
+        reranker = AWSBedrockReranker(config)
+
+        assert reranker.model_arn == "arn:aws:bedrock:eu-central-1::foundation-model/amazon.rerank-v1:0"
+
+    def test_full_arn_is_passed_through_unchanged(self, mock_boto3_client):
+        arn = "arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0"
+        config = AWSBedrockRerankerConfig(model=arn, aws_region="us-west-2")
+        reranker = AWSBedrockReranker(config)
+
+        assert reranker.model_arn == arn
+
+    def test_credentials_from_config_reach_client(self, mock_boto3_client):
+        config = AWSBedrockRerankerConfig(
+            aws_access_key_id="AKIA_TEST",
+            aws_secret_access_key="SECRET_TEST",
+            aws_session_token="SESSION_TOKEN_TEST",
+            aws_region="ap-southeast-1",
+        )
+        AWSBedrockReranker(config)
+
+        _, kwargs = mock_boto3_client.call_args
+        assert kwargs["aws_access_key_id"] == "AKIA_TEST"
+        assert kwargs["aws_secret_access_key"] == "SECRET_TEST"
+        assert kwargs["aws_session_token"] == "SESSION_TOKEN_TEST"
+        assert kwargs["region_name"] == "ap-southeast-1"
+
+    def test_credentials_fall_back_to_env(self, mock_boto3_client):
+        env = {
+            "AWS_REGION": "eu-west-1",
+            "AWS_ACCESS_KEY_ID": "ENV_KEY",
+            "AWS_SECRET_ACCESS_KEY": "ENV_SECRET",
+            "AWS_SESSION_TOKEN": "ENV_TOKEN",
+        }
+        with patch("mem0.reranker.aws_bedrock_reranker.os.environ", env):
+            AWSBedrockReranker(AWSBedrockRerankerConfig())
+
+        _, kwargs = mock_boto3_client.call_args
+        assert kwargs["region_name"] == "eu-west-1"
+        assert kwargs["aws_access_key_id"] == "ENV_KEY"
+        assert kwargs["aws_secret_access_key"] == "ENV_SECRET"
+        assert kwargs["aws_session_token"] == "ENV_TOKEN"
+
+
+class TestAWSBedrockRerankerRerank:
+    def test_rerank_maps_index_and_relevance_score(self, mock_boto3_client):
+        reranker = AWSBedrockReranker(AWSBedrockRerankerConfig())
+        reranker.client.rerank.return_value = _rerank_response((1, 0.9), (0, 0.4))
+
+        docs = _docs(2)
+        result = reranker.rerank("query", docs)
+
+        assert [d["memory"] for d in result] == ["doc1", "doc0"]
+        assert result[0]["rerank_score"] == 0.9
+        assert result[1]["rerank_score"] == 0.4
+
+    def test_rerank_sends_expected_request_shape(self, mock_boto3_client):
+        config = AWSBedrockRerankerConfig(model="amazon.rerank-v1:0", aws_region="us-east-1", top_k=3)
+        reranker = AWSBedrockReranker(config)
+        reranker.client.rerank.return_value = _rerank_response((0, 0.5))
+
+        reranker.rerank("what does the user do", [{"memory": "alpha"}])
+
+        _, call_kwargs = reranker.client.rerank.call_args
+        assert call_kwargs["queries"] == [{"textQuery": {"text": "what does the user do"}, "type": "TEXT"}]
+        assert call_kwargs["sources"] == [
+            {
+                "inlineDocumentSource": {"textDocument": {"text": "alpha"}, "type": "TEXT"},
+                "type": "INLINE",
+            }
+        ]
+        reranking_config = call_kwargs["rerankingConfiguration"]
+        assert reranking_config["type"] == "BEDROCK_RERANKING_MODEL"
+        bedrock_config = reranking_config["bedrockRerankingConfiguration"]
+        assert bedrock_config["modelConfiguration"]["modelArn"] == (
+            "arn:aws:bedrock:us-east-1::foundation-model/amazon.rerank-v1:0"
+        )
+        assert bedrock_config["numberOfResults"] == 3
+
+    def test_number_of_results_defaults_to_document_count(self, mock_boto3_client):
+        reranker = AWSBedrockReranker(AWSBedrockRerankerConfig())
+        reranker.client.rerank.return_value = _rerank_response((0, 0.1), (1, 0.2), (2, 0.3))
+
+        reranker.rerank("query", _docs(3))
+
+        _, call_kwargs = reranker.client.rerank.call_args
+        number_of_results = call_kwargs["rerankingConfiguration"]["bedrockRerankingConfiguration"]["numberOfResults"]
+        assert number_of_results == 3
+
+    def test_empty_documents_returns_empty_without_calling_client(self, mock_boto3_client):
+        reranker = AWSBedrockReranker(AWSBedrockRerankerConfig())
+
+        result = reranker.rerank("query", [])
+
+        assert result == []
+        reranker.client.rerank.assert_not_called()
+
+    def test_text_extraction_prefers_memory_then_text_then_content(self, mock_boto3_client):
+        reranker = AWSBedrockReranker(AWSBedrockRerankerConfig())
+        reranker.client.rerank.return_value = _rerank_response((0, 1.0), (1, 1.0), (2, 1.0))
+
+        docs = [{"memory": "m", "text": "t"}, {"text": "t2", "content": "c2"}, {"content": "c3"}]
+        reranker.rerank("query", docs)
+
+        _, call_kwargs = reranker.client.rerank.call_args
+        texts = [s["inlineDocumentSource"]["textDocument"]["text"] for s in call_kwargs["sources"]]
+        assert texts == ["m", "t2", "c3"]
+
+
+class TestAWSBedrockRerankerFallback:
+    def test_fallback_respects_config_top_k(self, mock_boto3_client):
+        reranker = AWSBedrockReranker(AWSBedrockRerankerConfig(top_k=2))
+        reranker.client.rerank.side_effect = RuntimeError("throttled")
+
+        result = reranker.rerank("query", _docs(5))
+
+        assert len(result) == 2
+        assert all(d["rerank_score"] == 0.0 for d in result)
+
+    def test_fallback_per_call_top_k_overrides_config(self, mock_boto3_client):
+        reranker = AWSBedrockReranker(AWSBedrockRerankerConfig(top_k=4))
+        reranker.client.rerank.side_effect = RuntimeError("throttled")
+
+        result = reranker.rerank("query", _docs(5), top_k=1)
+
+        assert len(result) == 1
+
+    def test_fallback_returns_all_when_no_top_k(self, mock_boto3_client):
+        reranker = AWSBedrockReranker(AWSBedrockRerankerConfig())
+        reranker.client.rerank.side_effect = RuntimeError("throttled")
+
+        result = reranker.rerank("query", _docs(5))
+
+        assert len(result) == 5

--- a/tests/rerankers/test_reranker_public_exports.py
+++ b/tests/rerankers/test_reranker_public_exports.py
@@ -1,6 +1,6 @@
 """Regression test pinning the public exports of ``mem0.reranker``.
 
-All five rerankers are first-class providers in ``RerankerFactory``, so all five
+All six rerankers are first-class providers in ``RerankerFactory``, so all six
 classes must be importable from the package root. A regression once dropped the
 LLM, HuggingFace, and ZeroEntropy rerankers from ``__init__`` while keeping them
 in the factory, so ``from mem0.reranker import LLMReranker`` raised ImportError.
@@ -11,6 +11,7 @@ import mem0.reranker as reranker_pkg
 
 def test_all_rerankers_are_importable_from_package_root():
     from mem0.reranker import (
+        AWSBedrockReranker,
         BaseReranker,
         CohereReranker,
         HuggingFaceReranker,
@@ -20,6 +21,7 @@ def test_all_rerankers_are_importable_from_package_root():
     )
 
     assert {
+        AWSBedrockReranker,
         BaseReranker,
         CohereReranker,
         HuggingFaceReranker,
@@ -31,6 +33,7 @@ def test_all_rerankers_are_importable_from_package_root():
 
 def test_all_exported_names_are_present_in_dunder_all():
     expected = {
+        "AWSBedrockReranker",
         "BaseReranker",
         "CohereReranker",
         "HuggingFaceReranker",


### PR DESCRIPTION
## Linked Issue

Closes #6728 

## Description

Adds `aws_bedrock` as a new reranker provider for both the Python and TypeScript SDKs, calling AWS Bedrock's Agent Runtime **Rerank API** — a single interface exposing both Cohere Rerank (`cohere.rerank-v3-5:0`, default) and Amazon's own rerank model (`amazon.rerank-v1:0`).

mem0 already ships a full AWS Bedrock stack (LLM, embedder, S3 Vectors, OpenSearch) but had no Bedrock-native reranker, so anyone running fully on Bedrock had to fall back to a third-party API key (Cohere directly) or a local cross-encoder. This closes that gap with IAM-based auth via the standard AWS credential chain — no separate reranker API key needed.

**Python** (`mem0/reranker/aws_bedrock_reranker.py`, `mem0/configs/rerankers/aws_bedrock.py`): follows the existing `CohereReranker`/`ZeroEntropyReranker` pattern exactly — same `rerank(query, documents, top_k)` contract, same fail-open fallback (log + return original order) on API failure, registered in `RerankerFactory`.

**TypeScript** (`mem0-ts/src/oss/src/rerankers/aws_bedrock.ts`): mirrors the existing `CohereReranker`/`AWSBedrockLLM` patterns — `@aws-sdk/client-bedrock-agent-runtime` is an optional peer dependency loaded via dynamic `import()` on first use, so it stays out of the bundle for consumers who don't use this reranker. Registered in `RerankerFactory`, `RerankerConfig` type extended with the standard `awsRegion`/`awsAccessKeyId`/`awsSecretAccessKey`/`awsSessionToken`/`client` fields already used by the LLM/embedder AWS providers.

Both implementations resolve a short model id (e.g. `cohere.rerank-v3-5:0`) to a region-scoped foundation-model ARN automatically, or accept a full ARN directly.

Docs added/updated for both SDKs: new provider page (`docs/components/rerankers/models/aws_bedrock.mdx`), overview card, config reference tables, and the TypeScript feature guide section.

**Known caveat (not introduced by this PR, not blocking):** combining this reranker with the existing `s3_vectors` vector store in the same TypeScript project may hit a `@smithy/core` dependency version conflict, since `@aws-sdk/client-s3vectors`'s pinned version depends on older `@smithy/*` internals than the rest of the AWS SDK family used here. Confirmed via a clean isolated install that this reranker alone has no such conflict. A proper fix means coordinating a version bump across all of `mem0-ts`'s pinned AWS SDK v3 clients together — out of scope for this PR, worth its own follow-up.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Unit tests:** `tests/rerankers/test_aws_bedrock_reranker.py` (Python, mocked `boto3`) and `mem0-ts/src/oss/src/rerankers/aws_bedrock.test.ts` (TypeScript, mocked AWS SDK) cover ARN resolution (short id vs. full ARN), credential pass-through, request shape, response index/score mapping, empty-input short-circuit, and fallback behavior on API failure (respecting `top_k` both from config and per-call). Also updated `test_reranker_public_exports.py` and `factory.test.ts` to cover the new provider.

**Manual testing:** live-verified the Python implementation end-to-end against real AWS Bedrock (real credentials, real `cohere.rerank-v3-5:0` call, sensible relevance ordering returned). For TypeScript, verified the request shape matches the installed SDK's own type definitions field-for-field, then live-tested in an isolated clean environment — the request reached AWS, authenticated successfully, and received a real, authoritative service-level response (an account-specific model-access error, not a malformed-request error), confirming the implementation is correct at the wire level.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
