### PR TITLE
fix(vector_stores/azure_ai_search): guard __del__ against missing clients

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -386,8 +386,13 @@ class AzureAISearch(VectorStoreBase):
 
     def __del__(self):
         """Close the search client when the object is deleted."""
-        self.search_client.close()
-        self.index_client.close()
+        try:
+            if hasattr(self, "search_client"):
+                self.search_client.close()
+            if hasattr(self, "index_client"):
+                self.index_client.close()
+        except Exception:
+            pass
 
     def reset(self):
         """Reset the index by deleting and recreating it."""

--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -389,6 +389,9 @@ class AzureAISearch(VectorStoreBase):
         try:
             if hasattr(self, "search_client"):
                 self.search_client.close()
+        except Exception:
+            pass
+        try:
             if hasattr(self, "index_client"):
                 self.index_client.close()
         except Exception:

--- a/tests/vector_stores/test_azure_ai_search.py
+++ b/tests/vector_stores/test_azure_ai_search.py
@@ -719,3 +719,9 @@ def test_build_filter_escapes_quotes(azure_ai_search_instance):
     instance, _, _ = azure_ai_search_instance
     expr = instance._build_filter_expression({"name": "O'Brien"})
     assert "name eq 'O''Brien'" in expr
+
+
+def test_del_does_not_crash_when_clients_are_missing():
+    """__del__ must not raise if __init__ failed before clients were assigned."""
+    instance = object.__new__(AzureAISearch)
+    instance.__del__()  # should not raise

--- a/tests/vector_stores/test_azure_ai_search.py
+++ b/tests/vector_stores/test_azure_ai_search.py
@@ -725,3 +725,15 @@ def test_del_does_not_crash_when_clients_are_missing():
     """__del__ must not raise if __init__ failed before clients were assigned."""
     instance = object.__new__(AzureAISearch)
     instance.__del__()  # should not raise
+
+
+def test_del_closes_both_clients_even_if_one_raises():
+    """__del__ must close both clients even if one close() call raises."""
+    instance = object.__new__(AzureAISearch)
+    instance.search_client = Mock()
+    instance.index_client = Mock()
+    instance.search_client.close.side_effect = Exception("search_client close failed")
+
+    instance.__del__()
+
+    instance.index_client.close.assert_called_once()


### PR DESCRIPTION
## Linked Issue

Closes #6732

## Description

`AzureAISearch.__del__()` had no `try/except` or `hasattr` guard. If `__init__` raises before `search_client` or `index_client` is assigned (e.g., `DefaultAzureCredential()` fails, or line 98 accessing Azure SDK internals raises), `__del__` raises `AttributeError` during garbage collection.

Added `hasattr` guards matching the pattern used by mongodb, cassandra, and oracledb vector stores.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [x] Added test that verifies `__del__` does not crash when clients are missing
- [x] New and existing tests pass locally

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally