### PR TITLE
fix(embeddings/ollama): correct default embedding_dims from 512 to 768

### DIFF
--- a/mem0/embeddings/ollama.py
+++ b/mem0/embeddings/ollama.py
@@ -26,7 +26,7 @@ class OllamaEmbedding(EmbeddingBase):
         super().__init__(config)
 
         self.config.model = self.config.model or "nomic-embed-text"
-        self.config.embedding_dims = self.config.embedding_dims or 512
+        self.config.embedding_dims = self.config.embedding_dims or 768
 
         self.client = Client(host=self.config.ollama_base_url)
         self._ensure_model_exists()

--- a/tests/embeddings/test_ollama_embeddings.py
+++ b/tests/embeddings/test_ollama_embeddings.py
@@ -94,3 +94,10 @@ def test_embed_batch_count_mismatch_raises(mock_ollama_client):
 
     with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
         embedder.embed_batch(["first text", "second text"])
+
+
+def test_default_embedding_dims_matches_default_model(mock_ollama_client):
+    """Default embedding_dims should be 768 to match nomic-embed-text."""
+    config = BaseEmbedderConfig(model="nomic-embed-text")
+    embedder = OllamaEmbedding(config)
+    assert embedder.config.embedding_dims == 768


### PR DESCRIPTION
## Linked Issue

Closes #6734

## Description

`OllamaEmbedding` defaults to model `nomic-embed-text` (line 28) which produces **768-dimensional** embeddings, but `embedding_dims` was set to `512` (line 29). This causes dimension mismatch errors when users rely on the defaults without specifying `embedding_dims`.

Changed the default from 512 to 768 to match the default model.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — only affects users who rely on the undocumented default dims value.

## Test Coverage

- [x] Added test verifying default dims match the default model
- [x] All 8 ollama embedding tests pass locally

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally