### PR TITLE
fix(llms,embeddings): pass http_client to OpenAI client when proxies set

### DIFF
--- a/mem0/embeddings/openai.py
+++ b/mem0/embeddings/openai.py
@@ -32,7 +32,11 @@ class OpenAIEmbedding(EmbeddingBase):
                 DeprecationWarning,
             )
 
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            http_client=self.config.http_client,
+        )
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -50,7 +50,11 @@ class OpenAILLM(LLMBase):
             api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
             base_url = self.config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 
-            self.client = OpenAI(api_key=api_key, base_url=base_url)
+            self.client = OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                http_client=self.config.http_client,
+            )
 
     def _parse_response(self, response, tools):
         """

--- a/tests/embeddings/test_openai_embeddings.py
+++ b/tests/embeddings/test_openai_embeddings.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+import httpx
 import pytest
 
 from mem0.configs.embeddings.base import BaseEmbedderConfig
@@ -149,3 +150,18 @@ def test_embed_batch_count_mismatch_raises(mock_openai_client):
 
     with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
         embedder.embed_batch(["first text", "second text"])
+
+
+def test_openai_embedding_uses_configured_http_client():
+    """The OpenAI client must route through config.http_client when proxies are set.
+
+    Regression test for #6651 — previously the client was built without
+    http_client=, so the SDK's internal httpx client ignored http_client_proxies.
+    """
+    config = BaseEmbedderConfig(
+        api_key="api_key",
+        http_client_proxies="http://proxy.local:8080",
+    )
+    embedder = OpenAIEmbedding(config)
+    assert isinstance(config.http_client, httpx.Client)
+    assert embedder.client._client is config.http_client

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -464,3 +464,18 @@ def test_openai_llm_preserves_proxies_from_base_config(mock_openai_client):
     llm = OpenAILLM(config)
     assert llm.config.http_client_proxies == "http://proxy.local:8080"
     assert isinstance(llm.config.http_client, httpx.Client)
+
+
+def test_openai_llm_uses_configured_http_client():
+    """The OpenAI client must route through config.http_client when proxies are set.
+
+    Regression test for #6651 — previously the client was built without
+    http_client=, so the SDK's internal httpx client ignored http_client_proxies.
+    """
+    config = BaseLlmConfig(
+        model="gpt-4.1-nano-2025-04-14",
+        api_key="api_key",
+        http_client_proxies="http://proxy.local:8080",
+    )
+    llm = OpenAILLM(config)
+    assert llm.client._client is llm.config.http_client


### PR DESCRIPTION
## Summary
`OpenAILLM` and `OpenAIEmbedding` built their `OpenAI` client without `http_client=`, so the `httpx.Client` built from `http_client_proxies` (in `mem0/utils/http.py`) was silently discarded. Users configuring proxies/SSL via `http_client_proxies` got an OpenAI client that never routed through it.

This passes `self.config.http_client` through to the `OpenAI(...)` constructor in both classes, mirroring the existing `azure_openai` implementations.

## Changes
- `mem0/llms/openai.py` — pass `http_client=self.config.http_client` in the non-OpenRouter branch
- `mem0/embeddings/openai.py` — pass `http_client=self.config.http_client`
- Regression tests for both asserting `client._client is config.http_client` when `http_client_proxies` is set

## Test plan
- `pytest tests/llms/test_openai.py tests/embeddings/test_openai_embeddings.py` — 32 passed
- `ruff check` on changed files — clean

Closes #6651