### PR TITLE
fix(ts-sdk): stop re-firing the ping handshake on every client call; add lazyInit option

### DIFF
--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -1169,6 +1169,16 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 
 <Tab title="TypeScript">
 
+<Update label="2026-08-03" description="v3.1.4">
+
+**New Features:**
+- **Client:** Add a `lazyInit` option to `MemoryClient` that skips the automatic `/v1/ping/` handshake at construction, so latency-sensitive paths (e.g. serverless) make no extra network call before their first request
+
+**Bug Fixes:**
+- **Client:** Memory operations no longer wait on or re-fire the `/v1/ping/` handshake. Previously every call re-pinged when the handshake had not resolved a telemetry identity (e.g. API keys with no user email, or hosts without the endpoint), adding a full round-trip per request. Project/webhook management methods now resolve org/project ids with a single lazy ping only when first needed
+
+</Update>
+
 <Update label="2026-08-01" description="v3.1.3">
 
 **New Features:**

--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -1172,10 +1172,10 @@ See the [OSS v2 to v3 migration guide](https://docs.mem0.ai/migration/oss-v2-to-
 <Update label="2026-08-03" description="v3.1.4">
 
 **New Features:**
-- **Client:** Add a `lazyInit` option to `MemoryClient` that skips the automatic `/v1/ping/` handshake at construction, so latency-sensitive paths (e.g. serverless) make no extra network call before their first request
+- **Client:** Add a `lazyInit` option to `MemoryClient` that skips the automatic `/v1/ping/` handshake at construction, so latency-sensitive paths (e.g. serverless) make no extra network call before their first request ([#6741](https://github.com/mem0ai/mem0/pull/6741))
 
 **Bug Fixes:**
-- **Client:** Memory operations no longer wait on or re-fire the `/v1/ping/` handshake. Previously every call re-pinged when the handshake had not resolved a telemetry identity (e.g. API keys with no user email, or hosts without the endpoint), adding a full round-trip per request. Project/webhook management methods now resolve org/project ids with a single lazy ping only when first needed
+- **Client:** Memory operations no longer wait on or re-fire the `/v1/ping/` handshake. Previously every call re-pinged when the handshake had not resolved a telemetry identity (e.g. API keys with no user email, or hosts without the endpoint), adding a full round-trip per request. Project/webhook management methods now resolve org/project ids with a single lazy ping only when first needed ([#6741](https://github.com/mem0ai/mem0/pull/6741))
 
 </Update>
 

--- a/mem0-ts/package.json
+++ b/mem0-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0ai",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "The Memory Layer For Your AI Apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -81,6 +81,8 @@ class APIError extends Error {
 interface ClientOptions {
   apiKey: string;
   host?: string;
+  /** Skip the automatic /v1/ping/ init handshake at construction. */
+  lazyInit?: boolean;
 }
 
 export default class MemoryClient {
@@ -91,6 +93,7 @@ export default class MemoryClient {
   headers: Record<string, string>;
   client: any;
   telemetryId: string;
+  private lazyInit: boolean;
 
   _validateApiKey(): any {
     if (!this.apiKey) {
@@ -109,6 +112,7 @@ export default class MemoryClient {
     this.host = options.host || "https://api.mem0.ai";
     this.organizationId = null;
     this.projectId = null;
+    this.lazyInit = options.lazyInit === true;
 
     this.headers = {
       Authorization: `Token ${this.apiKey}`,
@@ -122,17 +126,17 @@ export default class MemoryClient {
     });
 
     this._validateApiKey();
-    this.telemetryId = "";
-    this._initializeClient();
+    // Set a local telemetry identity synchronously so no API call ever has to
+    // wait on the ping handshake; ping upgrades it to the account email.
+    this.telemetryId = generateHash(this.apiKey);
+    if (!this.lazyInit) {
+      this._initializeClient();
+    }
   }
 
   private async _initializeClient() {
     try {
       await this.ping();
-
-      if (!this.telemetryId) {
-        this.telemetryId = generateHash(this.apiKey);
-      }
 
       await this._maybeAliasAnonToEmail();
 
@@ -262,8 +266,6 @@ export default class MemoryClient {
       throw new Error("Cannot process an empty messages payload.");
     }
 
-    if (this.telemetryId === "") await this.ping();
-
     const payload = this._preparePayload(messages, options);
     const payloadKeys = Object.keys(payload);
     this._captureEvent("add", [payloadKeys]);
@@ -304,7 +306,6 @@ export default class MemoryClient {
       );
     }
 
-    if (this.telemetryId === "") await this.ping();
     const payload: Record<string, any> = {};
     if (text !== undefined) payload.text = text;
     if (metadata !== undefined) payload.metadata = metadata;
@@ -326,7 +327,6 @@ export default class MemoryClient {
   }
 
   async get(memoryId: string): Promise<Memory> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("get", []);
     return this._fetchWithErrorHandling(
       `${this.host}/v1/memories/${encodePathSegment(memoryId)}/`,
@@ -340,7 +340,6 @@ export default class MemoryClient {
     // Reject top-level entity params - must use filters instead
     rejectTopLevelEntityParams(options as Record<string, any>, "getAll");
 
-    if (this.telemetryId === "") await this.ping();
     const payloadKeys = Object.keys(options || {});
     this._captureEvent("get_all", [payloadKeys]);
     const { page, pageSize, filters, ...rest } = options ?? {};
@@ -369,7 +368,6 @@ export default class MemoryClient {
     // Reject top-level entity params - must use filters instead
     rejectTopLevelEntityParams(options as Record<string, any>, "search");
 
-    if (this.telemetryId === "") await this.ping();
     const payloadKeys = Object.keys(options || {});
     this._captureEvent("search", [payloadKeys]);
     const { filters, ...rest } = options ?? {};
@@ -395,7 +393,6 @@ export default class MemoryClient {
     memoryId: string,
     options: DeleteMemoryOptions = {},
   ): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("delete", [Object.keys(options || {})]);
     const snakeOptions = camelToSnakeKeys(this._prepareParams(options));
     // @ts-ignore
@@ -412,7 +409,6 @@ export default class MemoryClient {
   async deleteAll(
     options: DeleteAllMemoryOptions = {},
   ): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
     const payloadKeys = Object.keys(options || {});
     this._captureEvent("delete_all", [payloadKeys]);
     const snakeOptions = camelToSnakeKeys(this._prepareParams(options));
@@ -429,7 +425,6 @@ export default class MemoryClient {
   }
 
   async history(memoryId: string): Promise<Array<MemoryHistory>> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("history", []);
     const response = await this._fetchWithErrorHandling(
       `${this.host}/v1/memories/${encodePathSegment(memoryId)}/history/`,
@@ -444,7 +439,6 @@ export default class MemoryClient {
     page?: number;
     pageSize?: number;
   }): Promise<AllUsers> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("users", []);
     let url = `${this.host}/v1/entities/`;
     const params: string[] = [];
@@ -464,7 +458,6 @@ export default class MemoryClient {
     entity_id: number;
     entity_type: string;
   }): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("delete_user", []);
     if (!data.entity_type) {
       data.entity_type = "user";
@@ -487,8 +480,6 @@ export default class MemoryClient {
       runId?: string;
     } = {},
   ): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
-
     let to_delete: Array<{ type: string; name: string }> = [];
     const { userId, agentId, appId, runId } = params;
 
@@ -537,7 +528,6 @@ export default class MemoryClient {
   }
 
   async batchUpdate(memories: Array<MemoryUpdateBody>): Promise<string> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("batch_update", []);
     const memoriesBody = memories.map((memory) => ({
       memory_id: memory.memoryId,
@@ -555,7 +545,6 @@ export default class MemoryClient {
   }
 
   async batchDelete(memories: Array<string>): Promise<string> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("batch_delete", []);
     const memoriesBody = memories.map((memory) => ({
       memory_id: memory,
@@ -572,11 +561,13 @@ export default class MemoryClient {
   }
 
   async getProject(options: ProjectOptions): Promise<ProjectResponse> {
-    if (this.telemetryId === "") await this.ping();
     const payloadKeys = Object.keys(options || {});
     this._captureEvent("get_project", [payloadKeys]);
     const { fields } = options;
 
+    if (this.organizationId == null || this.projectId == null) {
+      await this.ping();
+    }
     if (!(this.organizationId && this.projectId)) {
       throw new Error(
         "organizationId and projectId must be set to access instructions or categories",
@@ -598,8 +589,10 @@ export default class MemoryClient {
   async updateProject(
     prompts: PromptUpdatePayload,
   ): Promise<Record<string, any>> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("update_project", []);
+    if (this.organizationId == null || this.projectId == null) {
+      await this.ping();
+    }
     if (!(this.organizationId && this.projectId)) {
       throw new Error(
         "organizationId and projectId must be set to update instructions or categories",
@@ -619,8 +612,10 @@ export default class MemoryClient {
 
   // WebHooks
   async getWebhooks(data?: { projectId?: string }): Promise<Array<Webhook>> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("get_webhooks", []);
+    if (!data?.projectId && this.projectId == null) {
+      await this.ping();
+    }
     const project_id = data?.projectId || this.projectId;
     const response = await this._fetchWithErrorHandling(
       `${this.host}/api/v1/webhooks/projects/${project_id}/`,
@@ -632,8 +627,10 @@ export default class MemoryClient {
   }
 
   async createWebhook(webhook: WebhookCreatePayload): Promise<Webhook> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("create_webhook", []);
+    if (this.projectId == null) {
+      await this.ping();
+    }
     const body = {
       name: webhook.name,
       url: webhook.url,
@@ -653,7 +650,6 @@ export default class MemoryClient {
   async updateWebhook(
     webhook: WebhookUpdatePayload,
   ): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("update_webhook", []);
     const body: Record<string, any> = {};
     if (webhook.name != null) body.name = webhook.name;
@@ -673,7 +669,6 @@ export default class MemoryClient {
   async deleteWebhook(data: {
     webhookId: string;
   }): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("delete_webhook", []);
     const webhook_id = data.webhookId || data;
     const response = await this._fetchWithErrorHandling(
@@ -687,7 +682,6 @@ export default class MemoryClient {
   }
 
   async feedback(data: FeedbackPayload): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
     const payloadKeys = Object.keys(data || {});
     this._captureEvent("feedback", [payloadKeys]);
     const response = await this._fetchWithErrorHandling(
@@ -704,7 +698,6 @@ export default class MemoryClient {
   async createMemoryExport(
     data: CreateMemoryExportPayload,
   ): Promise<{ message: string; id: string }> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("create_memory_export", []);
 
     if (!data.filters || !data.schema) {
@@ -734,7 +727,6 @@ export default class MemoryClient {
   async getMemoryExport(
     data: GetMemoryExportPayload,
   ): Promise<{ message: string; id: string }> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("get_memory_export", []);
 
     if (!data.memoryExportId && !data.filters) {

--- a/mem0-ts/src/client/tests/memoryClient.init.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.init.test.ts
@@ -7,7 +7,13 @@ import {
   ValidationError,
   MemoryError,
 } from "../../common/exceptions";
-import { createMockFetch, TEST_API_KEY, TEST_HOST } from "./helpers";
+import {
+  createMockFetch,
+  TEST_API_KEY,
+  TEST_HOST,
+  TEST_ORG_ID,
+  TEST_PROJECT_ID,
+} from "./helpers";
 import {
   setupMockFetch,
   installConsoleSuppression,
@@ -102,6 +108,146 @@ describe("MemoryClient - ping()", () => {
 
     const client = new MemoryClient({ apiKey: TEST_API_KEY });
     await expect(client.ping()).rejects.toThrow("API Key is invalid");
+  });
+});
+
+// ─── Single constructor ping (no per-call ping) ──────────
+
+describe("MemoryClient - single constructor ping", () => {
+  const countPings = (mock: jest.Mock) =>
+    mock.mock.calls.filter((c: [string, RequestInit]) =>
+      c[0].includes("/v1/ping/"),
+    ).length;
+
+  test("pings at most once across constructor and multiple API calls", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v1/memories/mem_1/", { status: 200, body: { id: "mem_1" } });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.get("mem_1");
+    await client.get("mem_1");
+    await client.get("mem_1");
+
+    expect(countPings(mock)).toBe(1);
+  });
+
+  test("concurrent first calls do not trigger extra pings", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v1/memories/mem_1/", { status: 200, body: { id: "mem_1" } });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await Promise.all([
+      client.get("mem_1"),
+      client.get("mem_1"),
+      client.get("mem_1"),
+    ]);
+
+    expect(countPings(mock)).toBe(1);
+  });
+
+  test("does not re-ping per call when ping returns no user_email", async () => {
+    const responses = new Map<string, { status: number; body: unknown }>();
+    responses.set("/v1/ping/", { status: 200, body: { status: "ok" } });
+    responses.set("/v1/memories/mem_1/", {
+      status: 200,
+      body: { id: "mem_1" },
+    });
+    const mock = createMockFetch(responses);
+    global.fetch = mock;
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.get("mem_1");
+    await client.get("mem_1");
+
+    expect(countPings(mock)).toBe(1);
+    expect(client.telemetryId).not.toBe("");
+  });
+
+  test("API calls still work when the ping endpoint is unavailable", async () => {
+    const responses = new Map<string, { status: number; body: unknown }>();
+    responses.set("/v1/ping/", { status: 500, body: "no ping here" });
+    responses.set("/v1/memories/mem_1/", {
+      status: 200,
+      body: { id: "mem_1" },
+    });
+    const mock = createMockFetch(responses);
+    global.fetch = mock;
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await expect(client.get("mem_1")).resolves.toEqual({ id: "mem_1" });
+    await client.get("mem_1");
+
+    expect(countPings(mock)).toBe(1);
+  });
+});
+
+// ─── lazyInit option ──────────────────────────────────
+
+describe("MemoryClient - lazyInit option", () => {
+  const countPings = (mock: jest.Mock) =>
+    mock.mock.calls.filter((c: [string, RequestInit]) =>
+      c[0].includes("/v1/ping/"),
+    ).length;
+
+  test("never calls /v1/ping/ and API calls work", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v1/memories/mem_1/", { status: 200, body: { id: "mem_1" } });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({
+      apiKey: TEST_API_KEY,
+      lazyInit: true,
+    });
+    await expect(client.get("mem_1")).resolves.toEqual({ id: "mem_1" });
+    await client.get("mem_1");
+
+    expect(countPings(mock)).toBe(0);
+    expect(client.telemetryId).not.toBe("");
+  });
+
+  test("getProject resolves org/project ids with a single lazy ping", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/api/v1/orgs/organizations/", {
+      status: 200,
+      body: { custom_instructions: "Be helpful" },
+    });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({
+      apiKey: TEST_API_KEY,
+      lazyInit: true,
+    });
+    await client.getProject({ fields: ["custom_instructions"] });
+    await client.getProject({ fields: ["custom_instructions"] });
+
+    expect(countPings(mock)).toBe(1);
+    const call = mock.mock.calls.find((c: [string, RequestInit]) =>
+      c[0].includes("/api/v1/orgs/organizations/"),
+    );
+    expect(call![0]).toContain(
+      `/api/v1/orgs/organizations/${TEST_ORG_ID}/projects/${TEST_PROJECT_ID}/`,
+    );
+  });
+
+  test("explicit ping() still works as an escape hatch", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/api/v1/orgs/organizations/", {
+      status: 200,
+      body: { custom_instructions: "Be helpful" },
+    });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({
+      apiKey: TEST_API_KEY,
+      lazyInit: true,
+    });
+    await client.ping();
+    await client.getProject({ fields: ["custom_instructions"] });
+
+    expect(countPings(mock)).toBe(1);
+    expect(client.telemetryId).toBe("test@example.com");
   });
 });
 


### PR DESCRIPTION
## Linked Issue

No public issue — this addresses a latency report from a customer: the TypeScript client was adding a `/v1/ping/` round-trip to memory operations.

## Description

The per-call guard `if (this.telemetryId === "") await this.ping()` in every `MemoryClient` method re-fired the `/v1/ping/` handshake on each request whenever the handshake could not resolve a telemetry identity — API keys whose ping response has no `user_email` (e.g. unclaimed agent-mode keys), or hosts without the endpoint — adding a full network round-trip per call. It also raced the constructor's own background ping, so even the happy path fired duplicate pings on first use.

This PR removes the reason any call ever waited on ping:

- The constructor sets a local telemetry identity synchronously (`generateHash`), so **no memory operation ever waits on or triggers the handshake**; ping upgrades the identity to the account email when it resolves in the background.
- The four project/webhook management methods that embed org/project ids in their URLs (`getProject`, `updateProject`, `getWebhooks`, `createWebhook`) resolve the ids with a **single lazy ping** only when the ids are actually missing.
- A new `lazyInit` client option skips the automatic constructor handshake entirely, for latency-sensitive paths such as serverless — with it, data operations make **zero** ping calls:

```ts
const client = new MemoryClient({ apiKey: "m0-...", lazyInit: true });
```

Also bumps `mem0ai` (TS) to **3.1.4** and adds the docs changelog entry.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A — public API is additive (`lazyInit`); `ping()` behavior is unchanged. Behavioral note: the earliest requests may carry a locally generated `Mem0-User-ID` instead of the account email until the background ping resolves; the platform's server-side alias stitching (`ensure_aliases`) already reconciles these on every authenticated request.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Unit:** 7 new tests in `memoryClient.init.test.ts` pin the semantics (single constructor ping across sequential and concurrent calls, no re-ping when ping returns no `user_email`, data ops working when the ping endpoint is unavailable, zero pings under `lazyInit`, lazy org/project resolution, explicit `ping()` escape hatch). All 133 client unit tests pass.

**Manual (live against api.mem0.ai):** with a fetch spy on the built bundle — default client made exactly 1 ping with `add`/`search`/`getAll`/`get` adding none; `lazyInit` client made 0 pings across data ops and resolved `getProject` with exactly 1 lazy ping. The repo's live integration suite (42 tests) was run on this branch **and** on pre-change `main` with the same restricted key: identical results (18 pass / 24 fail, failure sets byte-identical; all failures are server-side key-permission errors reproduced with raw curl).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
