### PR TITLE
fix(llms/openai_structured): parse tool calls instead of returning only content

### DIFF
--- a/mem0/llms/openai_structured.py
+++ b/mem0/llms/openai_structured.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Dict, List, Optional
 
@@ -5,6 +6,7 @@ from openai import OpenAI
 
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.llms.base import LLMBase
+from mem0.memory.utils import extract_json
 
 
 class OpenAIStructuredLLM(LLMBase):
@@ -18,23 +20,55 @@ class OpenAIStructuredLLM(LLMBase):
         base_url = self.config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
         self.client = OpenAI(api_key=api_key, base_url=base_url)
 
+    def _parse_response(self, response, tools):
+        """
+        Process the response based on whether tools are used or not.
+
+        Args:
+            response: The raw response from API.
+            tools: The list of tools provided in the request.
+
+        Returns:
+            str or dict: The processed response.
+        """
+        if tools:
+            processed_response = {
+                "content": response.choices[0].message.content,
+                "tool_calls": [],
+            }
+
+            if response.choices[0].message.tool_calls:
+                for tool_call in response.choices[0].message.tool_calls:
+                    processed_response["tool_calls"].append(
+                        {
+                            "name": tool_call.function.name,
+                            "arguments": json.loads(extract_json(tool_call.function.arguments)),
+                        }
+                    )
+
+            return processed_response
+        else:
+            return response.choices[0].message.content
+
     def generate_response(
         self,
         messages: List[Dict[str, str]],
         response_format: Optional[str] = None,
         tools: Optional[List[Dict]] = None,
         tool_choice: str = "auto",
-    ) -> str:
+    ):
         """
         Generate a response based on the given messages using OpenAI.
 
         Args:
             messages (List[Dict[str, str]]): A list of dictionaries, each containing a 'role' and 'content' key.
             response_format (Optional[str]): The desired format of the response. Defaults to None.
-
+            tools (Optional[List[Dict]]): The list of tools the model may call. Defaults to None.
+            tool_choice (str): Tool choice method. Defaults to "auto".
 
         Returns:
-            str: The generated response.
+            str or dict: The generated response. A string when no tools are passed, otherwise a dict with
+                "content" and "tool_calls" keys.
         """
         params = self._get_supported_params(messages=messages)
         params["model"] = self.config.model
@@ -46,4 +80,4 @@ class OpenAIStructuredLLM(LLMBase):
             params["tool_choice"] = tool_choice
 
         response = self.client.beta.chat.completions.parse(**params)
-        return response.choices[0].message.content
+        return self._parse_response(response, tools)

--- a/tests/llms/test_openai_structured.py
+++ b/tests/llms/test_openai_structured.py
@@ -51,6 +51,63 @@ def test_regular_model_sends_sampling_params(mock_openai_client):
     assert call_kwargs["model"] == "gpt-4o"
 
 
+def test_generate_response_with_tools(mock_openai_client):
+    """Tool calls must be returned, not dropped (#6420)."""
+    config = OpenAIConfig(model="gpt-4o")
+    llm = OpenAIStructuredLLM(config)
+
+    mock_tool_call = Mock()
+    mock_tool_call.function.name = "add_memory"
+    mock_tool_call.function.arguments = '{"data": "sunny day"}'
+
+    mock_message = Mock()
+    mock_message.content = "I've added the memory."
+    mock_message.tool_calls = [mock_tool_call]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_openai_client.beta.chat.completions.parse.return_value = mock_response
+
+    tools = [{"type": "function", "function": {"name": "add_memory"}}]
+    response = llm.generate_response([{"role": "user", "content": "Remember sunny day"}], tools=tools)
+
+    assert response["content"] == "I've added the memory."
+    assert len(response["tool_calls"]) == 1
+    assert response["tool_calls"][0]["name"] == "add_memory"
+    assert response["tool_calls"][0]["arguments"] == {"data": "sunny day"}
+
+
+def test_generate_response_with_tools_no_tool_calls(mock_openai_client):
+    """With tools passed but none called, the dict shape is still returned."""
+    config = OpenAIConfig(model="gpt-4o")
+    llm = OpenAIStructuredLLM(config)
+
+    mock_message = Mock()
+    mock_message.content = "No tools needed."
+    mock_message.tool_calls = None
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_openai_client.beta.chat.completions.parse.return_value = mock_response
+
+    tools = [{"type": "function", "function": {"name": "add_memory"}}]
+    response = llm.generate_response([{"role": "user", "content": "Hello"}], tools=tools)
+
+    assert response["content"] == "No tools needed."
+    assert response["tool_calls"] == []
+
+
+def test_generate_response_without_tools_returns_content(mock_openai_client):
+    """Without tools the return value stays a plain string."""
+    config = OpenAIConfig(model="gpt-4o")
+    llm = OpenAIStructuredLLM(config)
+    _mock_parse(mock_openai_client, content="plain content")
+
+    response = llm.generate_response([{"role": "user", "content": "Hello"}])
+
+    assert response == "plain content"
+
+
 def test_uses_openai_base_url_environment_variable(monkeypatch):
     base_url = "https://gateway.example/v1"
     monkeypatch.setenv("OPENAI_API_BASE", "https://legacy.example/v1")


### PR DESCRIPTION
## Linked Issue

Closes #6420

## Description

`OpenAIStructuredLLM.generate_response` forwards `tools` / `tool_choice` to the API but then returns `response.choices[0].message.content` unconditionally. On a tool call that attribute is `None`, so **every tool call is silently dropped** and the caller gets `None` instead of the invoked tool.

The two sibling providers already solve this with a `_parse_response` helper that returns `{"content": ..., "tool_calls": [...]}` when `tools` is passed and a plain string otherwise:

- `mem0/llms/openai.py:55`
- `mem0/llms/azure_openai_structured.py:125`

Both implementations are identical, so this PR mirrors that helper into `openai_structured.py` rather than inventing a third shape — including reusing `extract_json` when decoding tool-call arguments, so a model that wraps its arguments in a code fence is handled the same way it is everywhere else.

Also in this diff:
- Dropped the `-> str` return annotation on `generate_response`, which became wrong once the tools path returns a dict (the sibling providers are annotation-free here for the same reason).
- Documented the previously-undocumented `tools` / `tool_choice` args and the two possible return shapes.

**No behaviour change when `tools` is not passed** — the return value stays a plain string, pinned by a test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — the no-tools path is unchanged. The tools path previously returned `None` (or a string that callers could not use as a tool call), so no working caller depends on the old shape.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Three tests added to `tests/llms/test_openai_structured.py`, following the mock style already in that file and in `test_azure_openai_structured.py`:

| Test | Asserts |
|---|---|
| `test_generate_response_with_tools` | tool name and decoded arguments survive |
| `test_generate_response_with_tools_no_tool_calls` | dict shape with an empty `tool_calls` list |
| `test_generate_response_without_tools_returns_content` | string path unchanged (regression guard) |

**Red-green proof.** With the source change reverted and the tests kept, the two tool tests fail on `main`:

```
FAILED tests/llms/test_openai_structured.py::test_generate_response_with_tools
FAILED tests/llms/test_openai_structured.py::test_generate_response_with_tools_no_tool_calls
E       TypeError: string indices must be integers, not 'str'
2 failed, 4 passed
```

That `TypeError` is the reported bug reproducing directly — a string is returned where a dict is expected. With the fix applied, 6/6 pass. The third test passes both ways by design; it is a no-regression guard, not a bug reproducer.

Full provider suite, with every optional provider SDK installed so nothing is skipped for missing imports:

```
$ pytest tests/llms/
175 passed, 2 skipped
```

`ruff check`, `ruff format --check` and `isort --check-only` are clean on both touched files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

---

### Note on overlap with #6399

#6399 is open against this same issue and takes a similar direction. It has had no review activity since 2026-07-19 and the issue text refers to it as a draft, so I picked this up assuming it had stalled — no claim on that work intended, and happy to close this in its favour if the author is still on it.

The difference in this version is that it stays strictly on the existing `_parse_response` contract shared by `openai.py` and `azure_openai_structured.py` (no third variant), and it ships the red-green proof plus a guard test for the unchanged no-tools path.
