### PR TITLE
fix(llms/gemini): map tool_choice="required" to ANY and accept **kwargs

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -161,6 +161,7 @@ class GeminiLLM(LLMBase):
         response_format=None,
         tools: Optional[List[Dict]] = None,
         tool_choice: str = "auto",
+        **kwargs,
     ):
         """
         Generate a response based on the given messages using Gemini.
@@ -170,6 +171,8 @@ class GeminiLLM(LLMBase):
             response_format (str or object, optional): Format for the response. Defaults to "text".
             tools (list, optional): List of tools that the model can call. Defaults to None.
             tool_choice (str, optional): Tool choice method. Defaults to "auto".
+            **kwargs: Additional Gemini-specific parameters. A per-call ``max_tokens``
+                overrides the configured value.
 
         Returns:
             str: The generated response.
@@ -178,13 +181,17 @@ class GeminiLLM(LLMBase):
         # Extract system instruction and reformat messages
         system_instruction, contents = self._reformat_messages(messages)
 
+        # A per-call max_tokens overrides the configured value, matching the
+        # per-call override contract the other providers honour via kwargs.
+        max_tokens = kwargs.get("max_tokens", self.config.max_tokens)
+
         # Prepare generation config — only include non-None values so the
         # Gemini SDK uses its own defaults instead of rejecting None.
         config_params = {}
         if self.config.temperature is not None:
             config_params["temperature"] = self.config.temperature
-        if self.config.max_tokens is not None:
-            config_params["max_output_tokens"] = self.config.max_tokens
+        if max_tokens is not None:
+            config_params["max_output_tokens"] = max_tokens
         if self.config.top_p is not None:
             config_params["top_p"] = self.config.top_p
 
@@ -202,9 +209,13 @@ class GeminiLLM(LLMBase):
             config_params["tools"] = formatted_tools
 
             if tool_choice:
+                # "required" is the cross-provider value for "must call a tool"
+                # (see LLMBase and the OpenAI/Anthropic providers); Gemini spells
+                # that mode ANY. Anything else falls back to NONE.
+                force_tool_call = tool_choice in ("any", "required")
                 if tool_choice == "auto":
                     mode = types.FunctionCallingConfigMode.AUTO
-                elif tool_choice == "any":
+                elif force_tool_call:
                     mode = types.FunctionCallingConfigMode.ANY
                 else:
                     mode = types.FunctionCallingConfigMode.NONE
@@ -213,7 +224,7 @@ class GeminiLLM(LLMBase):
                     function_calling_config=types.FunctionCallingConfig(
                         mode=mode,
                         allowed_function_names=(
-                            [tool["function"]["name"] for tool in tools] if tool_choice == "any" else None
+                            [tool["function"]["name"] for tool in tools] if force_tool_call else None
                         ),
                     )
                 )

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -232,6 +232,86 @@ def test_explicit_config_values_passed_to_generation_config(mock_gemini_client: 
     assert config_arg.top_p == 0.9
 
 
+# --- tool_choice mapping and per-call kwargs (issue #5430) ---
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "add_memory",
+            "description": "Add a memory",
+            "parameters": {
+                "type": "object",
+                "properties": {"data": {"type": "string", "description": "Data to add to memory"}},
+                "required": ["data"],
+            },
+        },
+    }
+]
+
+
+def _mock_text_response():
+    """A minimal successful Gemini response carrying a single text part."""
+    mock_part = Mock(text="ok", function_call=None)
+    mock_content = Mock(parts=[mock_part])
+    mock_candidate = Mock(content=mock_content)
+    return Mock(candidates=[mock_candidate])
+
+
+@pytest.mark.parametrize("tool_choice", ["any", "required"])
+def test_tool_choice_forcing_maps_to_any_mode(mock_gemini_client: Mock, tool_choice: str):
+    """The cross-provider value "required" means "must call a tool"; like "any" it
+    must map to Gemini's ANY mode, not NONE (which silently disables tool calling)."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+    mock_gemini_client.models.generate_content.return_value = _mock_text_response()
+
+    llm.generate_response([{"role": "user", "content": "hi"}], tools=TOOLS, tool_choice=tool_choice)
+
+    config_arg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    function_calling_config = config_arg.tool_config.function_calling_config
+    assert function_calling_config.mode == types.FunctionCallingConfigMode.ANY
+    assert function_calling_config.allowed_function_names == ["add_memory"]
+
+
+def test_tool_choice_none_maps_to_none_mode(mock_gemini_client: Mock):
+    """An explicit "none" still disables tool calling and sets no allowed names."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+    mock_gemini_client.models.generate_content.return_value = _mock_text_response()
+
+    llm.generate_response([{"role": "user", "content": "hi"}], tools=TOOLS, tool_choice="none")
+
+    config_arg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    function_calling_config = config_arg.tool_config.function_calling_config
+    assert function_calling_config.mode == types.FunctionCallingConfigMode.NONE
+    assert function_calling_config.allowed_function_names is None
+
+
+def test_generate_response_accepts_kwargs(mock_gemini_client: Mock):
+    """The base contract allows per-call kwargs; Gemini must not raise TypeError."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+    mock_gemini_client.models.generate_content.return_value = _mock_text_response()
+
+    response = llm.generate_response([{"role": "user", "content": "hi"}], some_unused_param=True)
+
+    assert response == "ok"
+
+
+def test_per_call_max_tokens_overrides_config(mock_gemini_client: Mock):
+    """A per-call max_tokens kwarg overrides config.max_tokens as max_output_tokens."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+    mock_gemini_client.models.generate_content.return_value = _mock_text_response()
+
+    llm.generate_response([{"role": "user", "content": "hi"}], max_tokens=4096)
+
+    config_arg = mock_gemini_client.models.generate_content.call_args.kwargs["config"]
+    assert config_arg.max_output_tokens == 4096
+
+
 # --- Vertex AI backend initialization (issue #3990, PR #4030) ---
 
 


### PR DESCRIPTION
## Linked Issue

Closes #5430

## Description

Two tool-handling bugs in `mem0/llms/gemini.py`, both in `generate_response`. Both were confirmed on `main` in the triage notes on the issue.

**1. `tool_choice="required"` silently disables tool calling.**

`"required"` is the cross-provider value for "must call a tool" (it is what `LLMBase` and the OpenAI/Anthropic providers use), but the mapping only handled `"auto"` and `"any"`, so `"required"` fell through to `else` and became `FunctionCallingConfigMode.NONE` — which turns tool calling *off*. Asking Gemini to force a tool produced no tool call at all, with no error.

The same `"any"`-only condition also gated `allowed_function_names`, so even reaching `ANY` mode via `"required"` would have passed `None` there. This PR fixes both halves through a single `force_tool_call` flag:

```python
force_tool_call = tool_choice in ("any", "required")
```

`"auto"` → `AUTO` and everything else → `NONE` are unchanged.

**2. `generate_response` did not accept `**kwargs`.**

The base `LLMBase.generate_response` contract and the other providers accept `**kwargs` for per-call overrides, so any caller passing one raised `TypeError`. This adds `**kwargs` and applies a per-call `max_tokens` as `max_output_tokens`, falling back to the configured value.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. `"auto"`, `"any"` and unrecognised values behave exactly as before; `"required"` previously produced a silently broken result that no caller could have depended on.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Five tests added to `tests/llms/test_gemini.py`, matching the file's existing `mock_gemini_client` fixture style. No existing test was modified.

**Red-green proof.** With the tests in place and only `mem0/llms/gemini.py` reverted to `main`:

```
FAILED tests/llms/test_gemini.py::test_tool_choice_forcing_maps_to_any_mode[required]
E       AssertionError: assert <FunctionCall....NONE: 'NONE'> == <FunctionCall...de.ANY: 'ANY'>
E         - ANY
E         + NONE
FAILED tests/llms/test_gemini.py::test_generate_response_accepts_kwargs
E       TypeError: GeminiLLM.generate_response() got an unexpected keyword argument 'some_unused_param'
FAILED tests/llms/test_gemini.py::test_per_call_max_tokens_overrides_config
E       TypeError: GeminiLLM.generate_response() got an unexpected keyword argument 'max_tokens'
3 failed, 19 passed
```

With the fix restored: `22 passed`.

To be explicit about what is and isn't red: the parametrised `[any]` case and the `"none"` guard pass on both sides *by design* — they pin the pre-existing correct behaviour so the `force_tool_call` refactor cannot regress it. The three failures above are the genuine reproduction.

Full provider suite: `pytest tests/llms/` → **177 passed, 2 skipped**, no regressions.

`ruff check`, `ruff format --check` and `isort --check-only` are clean on both touched files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

## Note on existing PRs

#5452 and #5948 are open against this issue. #5452 has been conflicting and untouched since 2026-06-08, and #5948's CLA check reports its author is not a resolvable GitHub account, so neither looked live. No claim on that work intended — happy to close this in favour of either if an author is still on it.
