### PR TITLE
feat(llms): support custom HTTP headers on OpenAI LLM requests

### DIFF
--- a/mem0/configs/llms/openai.py
+++ b/mem0/configs/llms/openai.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from mem0.configs.llms.base import BaseLlmConfig
 
@@ -31,6 +31,7 @@ class OpenAIConfig(BaseLlmConfig):
         site_url: Optional[str] = None,
         app_name: Optional[str] = None,
         store: Optional[bool] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
         # Response monitoring callback
         response_callback: Optional[Callable[[Any, dict, dict], None]] = None,
     ):
@@ -62,6 +63,10 @@ class OpenAIConfig(BaseLlmConfig):
                 want the value forwarded to the OpenAI API. Leaving it None
                 avoids leaking the field into OpenAI-compatible backends that
                 reject unknown fields (Gemini, Groq, vLLM, etc.).
+            extra_headers: Custom HTTP headers to send with every outbound request,
+                e.g. {"Helicone-Auth": "Bearer <token>"} for observability proxies
+                or corporate API gateways. Applied as the client's default headers.
+                Defaults to None (no extra headers are sent).
             response_callback: Optional callback for monitoring LLM responses.
         """
         # Initialize base parameters
@@ -87,6 +92,7 @@ class OpenAIConfig(BaseLlmConfig):
         self.site_url = site_url
         self.app_name = app_name
         self.store = store
+        self.extra_headers = extra_headers
 
         # Response monitoring
         self.response_callback = response_callback

--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -39,18 +39,30 @@ class OpenAILLM(LLMBase):
         if not self.config.model:
             self.config.model = "gpt-5-mini"
 
+        # User-supplied HTTP headers (observability proxies such as Helicone,
+        # corporate API gateways, ...) are attached to the client rather than to
+        # individual requests, mirroring how azure_openai.py wires
+        # `default_headers`. The OpenAI SDK merges these with any per-request
+        # `extra_headers`, so the OpenRouter attribution headers set in
+        # `generate_response` still win for the keys they own. Only pass the
+        # kwarg when configured so existing setups are byte-for-byte unchanged.
+        client_kwargs = {}
+        if self.config.extra_headers:
+            client_kwargs["default_headers"] = self.config.extra_headers
+
         if os.environ.get("OPENROUTER_API_KEY"):  # Use OpenRouter
             self.client = OpenAI(
                 api_key=os.environ.get("OPENROUTER_API_KEY"),
                 base_url=self.config.openrouter_base_url
                 or os.getenv("OPENROUTER_API_BASE")
                 or "https://openrouter.ai/api/v1",
+                **client_kwargs,
             )
         else:
             api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
             base_url = self.config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 
-            self.client = OpenAI(api_key=api_key, base_url=base_url)
+            self.client = OpenAI(api_key=api_key, base_url=base_url, **client_kwargs)
 
     def _parse_response(self, response, tools):
         """

--- a/mem0/llms/openai_structured.py
+++ b/mem0/llms/openai_structured.py
@@ -16,7 +16,16 @@ class OpenAIStructuredLLM(LLMBase):
 
         api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
         base_url = self.config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+        # This provider is mapped to OpenAIConfig in the LLM factory, so it accepts
+        # `extra_headers` too; honour it here rather than silently ignoring it.
+        # getattr keeps a plain BaseLlmConfig (the annotated type) working.
+        client_kwargs = {}
+        extra_headers = getattr(self.config, "extra_headers", None)
+        if extra_headers:
+            client_kwargs["default_headers"] = extra_headers
+
+        self.client = OpenAI(api_key=api_key, base_url=base_url, **client_kwargs)
 
     def generate_response(
         self,

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -464,3 +464,53 @@ def test_openai_llm_preserves_proxies_from_base_config(mock_openai_client):
     llm = OpenAILLM(config)
     assert llm.config.http_client_proxies == "http://proxy.local:8080"
     assert isinstance(llm.config.http_client, httpx.Client)
+
+
+def test_extra_headers_forwarded_to_client(mock_openai_client):
+    """Custom headers configured by the user must reach the OpenAI client.
+
+    Users of observability proxies (Helicone) and corporate API gateways need to
+    attach headers such as `Helicone-Auth` to outbound LLM calls. See
+    https://github.com/mem0ai/mem0/issues/3851
+    """
+    headers = {"Helicone-Auth": "Bearer sk-helicone-test", "Custom-Header": "value"}
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", api_key="api_key", extra_headers=headers)
+
+    with patch("mem0.llms.openai.OpenAI") as mock_openai:
+        mock_openai.return_value = mock_openai_client
+        llm = OpenAILLM(config)
+
+    assert mock_openai.call_args.kwargs["default_headers"] == headers
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+    llm.generate_response([{"role": "user", "content": "Hello"}])
+
+    # Headers ride on the client, so the per-request payload stays untouched.
+    assert "extra_headers" not in mock_openai_client.chat.completions.create.call_args.kwargs
+
+
+def test_extra_headers_absent_by_default(mock_openai_client):
+    """With `extra_headers` unset, nothing changes: no stray kwarg is passed."""
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", api_key="api_key")
+    assert config.extra_headers is None
+
+    with patch("mem0.llms.openai.OpenAI") as mock_openai:
+        mock_openai.return_value = mock_openai_client
+        OpenAILLM(config)
+
+    assert "default_headers" not in mock_openai.call_args.kwargs
+
+
+def test_extra_headers_forwarded_on_openrouter_path(monkeypatch, mock_openai_client):
+    """The OpenRouter client branch must honour `extra_headers` too."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
+    headers = {"Helicone-Auth": "Bearer sk-helicone-test"}
+    config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", extra_headers=headers)
+
+    with patch("mem0.llms.openai.OpenAI") as mock_openai:
+        mock_openai.return_value = mock_openai_client
+        OpenAILLM(config)
+
+    assert mock_openai.call_args.kwargs["default_headers"] == headers

--- a/tests/llms/test_openai_structured.py
+++ b/tests/llms/test_openai_structured.py
@@ -60,3 +60,21 @@ def test_uses_openai_base_url_environment_variable(monkeypatch):
         OpenAIStructuredLLM(OpenAIConfig(api_key="test-api-key"))
 
     mock_openai.assert_called_once_with(api_key="test-api-key", base_url=base_url)
+
+
+def test_extra_headers_forwarded_to_client():
+    """This provider is mapped to OpenAIConfig, so it must honour `extra_headers` too."""
+    headers = {"Helicone-Auth": "Bearer token-abc", "X-Gateway": "internal"}
+
+    with patch("mem0.llms.openai_structured.OpenAI") as mock_openai:
+        OpenAIStructuredLLM(OpenAIConfig(api_key="test-api-key", extra_headers=headers))
+
+    assert mock_openai.call_args.kwargs["default_headers"] == headers
+
+
+def test_extra_headers_absent_by_default():
+    """With `extra_headers` unset, no stray kwarg reaches the client."""
+    with patch("mem0.llms.openai_structured.OpenAI") as mock_openai:
+        OpenAIStructuredLLM(OpenAIConfig(api_key="test-api-key"))
+
+    assert "default_headers" not in mock_openai.call_args.kwargs


### PR DESCRIPTION
## Linked Issue

Closes #3851

## Description

Adds an optional `extra_headers` dict to the OpenAI LLM config, so users routing mem0's LLM traffic through observability proxies (Helicone) or corporate API gateways can attach headers such as `Helicone-Auth`. Today there is no supported way to do this — the workaround in the issue is monkey-patching `OpenAI.__init__` before constructing `Memory`.

```python
config = {"llm": {"provider": "openai", "config": {
    "model": "gpt-4",
    "api_key": "...",
    "extra_headers": {"Helicone-Auth": "Bearer <token>"},
}}}
```

### Design choice: client-level `default_headers=`, not per-request `extra_headers=`

The headers are applied on the `OpenAI(...)` constructor rather than on `chat.completions.create`. Three reasons:

1. **Precedent in this repo.** `mem0/llms/azure_openai.py` and `azure_openai_structured.py` both wire a configured `default_headers` into the client constructor.
2. **It avoids a collision.** `generate_response` already writes the per-request `extra_headers` key for OpenRouter's `HTTP-Referer` / `X-Title` attribution. Putting user headers into that same key would either clobber those or require merge logic. Client-level composes for free — the OpenAI SDK merges client `default_headers` with per-request `extra_headers`, per-request winning per key — so OpenRouter attribution keeps working and user headers ride alongside.
3. **Category.** Headers are a transport-level knob, the same class as the `http_client_proxies` / `http_client` already on this config, not a model parameter.

### Scope

Both providers that the factory maps to `OpenAIConfig` honour the field: `OpenAILLM` and `OpenAIStructuredLLM`. `mem0/utils/factory.py:48` maps `openai_structured` to `OpenAIConfig`, so the field is *accepted* there — leaving it unread would have made it a silent no-op. The structured provider reads it via `getattr` so a plain `BaseLlmConfig` (its annotated type) keeps working.

Python only; `mem0-ts/` is untouched.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. The client kwarg is built conditionally — when `extra_headers` is unset, the `OpenAI(...)` call is constructed with byte-identical arguments to before. The pre-existing `test_uses_openai_base_url_environment_variable` asserts the exact constructor signature and still passes unmodified, which pins this.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Five tests added across `tests/llms/test_openai.py` and `tests/llms/test_openai_structured.py`, matching each file's existing mocking style. **No existing test was modified.** Coverage: header forwarding on the standard path, on the OpenRouter branch, and on the structured provider; plus two guards asserting that with `extra_headers` unset *no stray kwarg* reaches the client.

**Red-green proof.** With tests in place and only the source reverted:

```
FAILED tests/llms/test_openai.py::test_extra_headers_forwarded_to_client
E       TypeError: OpenAIConfig.__init__() got an unexpected keyword argument 'extra_headers'
FAILED tests/llms/test_openai.py::test_extra_headers_absent_by_default
E       AttributeError: 'OpenAIConfig' object has no attribute 'extra_headers'
FAILED tests/llms/test_openai.py::test_extra_headers_forwarded_on_openrouter_path
3 failed, 21 passed
```

and for the structured provider:

```
FAILED tests/llms/test_openai_structured.py::test_extra_headers_forwarded_to_client
E       KeyError: 'default_headers'
1 failed, 4 passed
```

Restored → both files green.

Full provider suite: `pytest tests/llms/` → **177 passed, 2 skipped**, no regressions.

Manual check: driven end-to-end through `LlmFactory` with the issue's literal dict config and an unmocked client — both headers land on `client.default_headers`, the SDK's own `Authorization` header is intact, and a config without `extra_headers` carries none.

`ruff check` (what `make lint` runs) and `isort --check-only` are clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

## Note on #4962

#4962 is open against this issue. It has been conflicting and has not moved since 2026-07-01, and at 12 files it reaches considerably wider than the OpenAI LLM layer the triage note scoped this to. This version is deliberately narrow. No claim on that work intended — happy to close this in its favour if the author is still on it.

## Open question for the reviewer

I named the config field `extra_headers` because that is the wording in the issue and in how users ask for it — but it maps to the SDK's `default_headers` kwarg, and the Azure config in this repo calls the same concept `default_headers`. If you would prefer cross-provider naming consistency, renaming is trivial and I'm happy to do it.
