### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/components/llms/models/openai.mdx
+++ b/docs/components/llms/models/openai.mdx
@@ -38,6 +38,19 @@ config = {
 #    }
 # }
 
+# OpenAI-compatible multi-model gateways also work via openai_base_url (or base_url)
+# Example: DaoXE (https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=mem0&utm_content=openai) at https://api.daoxe.com/v1
+# config = {
+#    "llm": {
+#        "provider": "openai",
+#        "config": {
+#            "model": "gpt-4o-mini",
+#            "openai_base_url": "https://api.daoxe.com/v1",
+#            "api_key": "YOUR_GATEWAY_KEY",
+#        }
+#    }
+# }
+
 m = Memory.from_config(config)
 messages = [
     {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},

--- a/docs/components/llms/models/openai.mdx
+++ b/docs/components/llms/models/openai.mdx
@@ -39,7 +39,7 @@ config = {
 # }
 
 # OpenAI-compatible multi-model gateways also work via openai_base_url (or base_url)
-# Example: DaoXE (https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=mem0&utm_content=openai) at https://api.daoxe.com/v1
+# Example: DaoXE (https://daoxe.com/) at https://api.daoxe.com/v1
 # config = {
 #    "llm": {
 #        "provider": "openai",


### PR DESCRIPTION
## Summary

Document that OpenAI-compatible multi-model gateways work via `openai_base_url` (same OpenAI provider path), using [DaoXE](https://daoxe.com/) (`https://api.daoxe.com/v1`) as one concrete example alongside OpenRouter.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Docs render correctly
- [ ] Existing OpenAI / OpenRouter examples unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>