### PR TITLE
fix(vector-stores): guard AzureAISearch.__del__ against partial init

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -386,8 +386,16 @@ class AzureAISearch(VectorStoreBase):
 
     def __del__(self):
         """Close the search client when the object is deleted."""
-        self.search_client.close()
-        self.index_client.close()
+        try:
+            if hasattr(self, "search_client"):
+                self.search_client.close()
+        except Exception:
+            pass
+        try:
+            if hasattr(self, "index_client"):
+                self.index_client.close()
+        except Exception:
+            pass
 
     def reset(self):
         """Reset the index by deleting and recreating it."""


### PR DESCRIPTION
Closes #6732

## Summary

\AzureAISearch.__del__()\ unconditionally calls \self.search_client.close()\ and \self.index_client.close()\. If \__init__\ raises before either client is assigned (e.g. \DefaultAzureCredential()\ fails or the Azure SDK internals access raises), the destructor re-raises an \AttributeError\ during garbage collection, producing confusing post-mortem errors.

## Fix

Guard both closes with \hasattr\ checks and swallow exceptions, matching the existing convention in \zure_mysql.py\, \cassandra.py\, \oracledb.py\, and \pgvector.py\:

- \hasattr(self, ...)\ guard skips clients that were never assigned after a partial init
- \	ry/except Exception: pass\ prevents any close failure from surfacing in the GC path