### PR TITLE
fix(embeddings): default OllamaEmbedding dims to 768 for nomic-embed-text

### DIFF
--- a/mem0/embeddings/ollama.py
+++ b/mem0/embeddings/ollama.py
@@ -26,7 +26,7 @@ class OllamaEmbedding(EmbeddingBase):
         super().__init__(config)
 
         self.config.model = self.config.model or "nomic-embed-text"
-        self.config.embedding_dims = self.config.embedding_dims or 512
+        self.config.embedding_dims = self.config.embedding_dims or 768
 
         self.client = Client(host=self.config.ollama_base_url)
         self._ensure_model_exists()

--- a/tests/embeddings/test_ollama_embeddings.py
+++ b/tests/embeddings/test_ollama_embeddings.py
@@ -43,6 +43,15 @@ def test_ensure_model_exists(mock_ollama_client):
     mock_ollama_client.pull.assert_called_once_with("nomic-embed-text")
 
 
+def test_default_embedding_dims_matches_default_model(mock_ollama_client):
+    """Default embedding_dims must match the default model nomic-embed-text (768 dims)."""
+    config = BaseEmbedderConfig()
+    embedder = OllamaEmbedding(config)
+
+    assert embedder.config.model == "nomic-embed-text"
+    assert embedder.config.embedding_dims == 768
+
+
 def test_ensure_model_exists_normalizes_latest_tag(mock_ollama_client):
     """Model 'nomic-embed-text' should match 'nomic-embed-text:latest' from ollama list."""
     mock_ollama_client.list.return_value = {"models": [{"name": "nomic-embed-text:latest"}]}


### PR DESCRIPTION
Closes #6734

The default model for OllamaEmbedding is \
omic-embed-text\, which produces 768-dimensional embeddings, but the default \embedding_dims\ was 512. When a user instantiates OllamaEmbedding without setting embedding_dims, the config advertises 512 dims while the actual vectors are 768 — causing downstream mismatches (collection dimension errors, wrong chunking).

Fix the default to 768 and add a regression test asserting the default dims match the default model.