### PR TITLE
fix(utils): support non-English spaCy pipelines (model selection, noun_chunks, lemmas)

### DIFF
--- a/mem0/utils/entity_extraction.py
+++ b/mem0/utils/entity_extraction.py
@@ -588,7 +588,13 @@ def _add_quoted_candidates(text: str, candidates: list[_EntityCandidate]) -> Non
 
 
 def _add_topic_phrase_candidates(doc, candidates: list[_EntityCandidate]) -> None:
-    for chunk in doc.noun_chunks:
+    try:
+        chunks = list(doc.noun_chunks)
+    except (NotImplementedError, ValueError, AttributeError):
+        # Pipelines without a noun-chunk iterator (e.g. zh, ja) raise E894;
+        # docs without DEP annotation raise E895. Neither should crash extraction.
+        return
+    for chunk in chunks:
         chunk_tokens = list(chunk)
         split_indices: list[int] = []
         poss_splits: list[int] = []

--- a/mem0/utils/lemmatization.py
+++ b/mem0/utils/lemmatization.py
@@ -38,7 +38,7 @@ def lemmatize_for_bm25(text: str) -> str:
         if token.is_punct or token.is_stop:
             continue
 
-        lemma = token.lemma_
+        lemma = token.lemma_ or token.text
         if lemma.isalnum():
             tokens.append(lemma)
 

--- a/mem0/utils/spacy_models.py
+++ b/mem0/utils/spacy_models.py
@@ -7,9 +7,17 @@ each loading their own copy from disk.
 """
 
 import logging
+import os
 import threading
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL = "en_core_web_sm"
+
+
+def _get_model_name() -> str:
+    """Return the spaCy model name, overridable via the MEM0_SPACY_MODEL env var."""
+    return os.getenv("MEM0_SPACY_MODEL", _DEFAULT_MODEL)
 
 _nlp_full = None
 _nlp_lemma = None
@@ -19,7 +27,7 @@ _lock = threading.Lock()
 
 
 def _ensure_model_available():
-    """Download en_core_web_sm if spaCy is installed but model is missing."""
+    """Download the configured spaCy model if spaCy is installed but the model is missing."""
     try:
         import spacy
     except ImportError:
@@ -27,17 +35,18 @@ def _ensure_model_available():
             "spaCy is not installed. Install it with: pip install mem0ai[nlp]"
         )
 
-    if not spacy.util.is_package("en_core_web_sm"):
-        logger.info("Downloading spaCy model en_core_web_sm...")
+    model_name = _get_model_name()
+    if not spacy.util.is_package(model_name):
+        logger.info("Downloading spaCy model %s...", model_name)
         try:
             from spacy.cli import download
 
-            download("en_core_web_sm")
-            logger.info("spaCy model en_core_web_sm downloaded successfully")
+            download(model_name)
+            logger.info("spaCy model %s downloaded successfully", model_name)
         except Exception as e:
             raise RuntimeError(
-                f"Failed to download spaCy model en_core_web_sm: {e}. "
-                "Please install manually: python -m spacy download en_core_web_sm"
+                f"Failed to download spaCy model {model_name}: {e}. "
+                f"Please install manually: python -m spacy download {model_name}"
             ) from e
 
 
@@ -57,7 +66,7 @@ def get_nlp_full():
             _ensure_model_available()
             import spacy
 
-            _nlp_full = spacy.load("en_core_web_sm")
+            _nlp_full = spacy.load(_get_model_name())
             logger.info("spaCy full model loaded")
         except Exception as e:
             logger.warning(f"Failed to load spaCy full model: {e}")
@@ -82,7 +91,7 @@ def get_nlp_lemma():
             _ensure_model_available()
             import spacy
 
-            _nlp_lemma = spacy.load("en_core_web_sm", disable=["ner", "parser"])
+            _nlp_lemma = spacy.load(_get_model_name(), disable=["ner", "parser"])
             logger.info("spaCy lemma model loaded")
         except Exception as e:
             logger.warning(f"Failed to load spaCy lemma model: {e}")

--- a/tests/utils/test_entity_extraction.py
+++ b/tests/utils/test_entity_extraction.py
@@ -110,6 +110,21 @@ class TestExtractEntities:
         assert not {"8,916", "2,573", "656", "2026-05-27", "90"}.intersection(entity_texts)
 
 
+class TestNonEnglishPipelines:
+    def test_noun_chunks_unsupported_does_not_crash(self, monkeypatch):
+        """Languages without a noun-chunk iterator (zh, ja, ...) must not crash extraction."""
+        import spacy
+
+        from mem0.utils import entity_extraction
+
+        nlp = spacy.blank("xx")
+        monkeypatch.setattr("mem0.utils.spacy_models.get_nlp_full", lambda: nlp)
+
+        entities = entity_extraction.extract_entities("张三 是 阿里巴巴 的 工程师")
+
+        assert entities == []
+
+
 class TestExtractEntitiesBatch:
     def test_batch_processing(self):
         from mem0.utils.entity_extraction import extract_entities_batch

--- a/tests/utils/test_lemmatization.py
+++ b/tests/utils/test_lemmatization.py
@@ -65,3 +65,17 @@ class TestLemmatizeForBm25:
         tokens = result.split()
         for stop in ["this", "is", "a", "very", "of", "the"]:
             assert stop not in tokens
+
+    def test_non_english_lemmas_fallback_to_text(self, monkeypatch):
+        """Pipelines that return empty lemmas (zh, ja, ...) must fall back to token text."""
+        import spacy
+
+        from mem0.utils import lemmatization
+
+        nlp = spacy.blank("xx")
+        monkeypatch.setattr("mem0.utils.spacy_models.get_nlp_lemma", lambda: nlp)
+
+        result = lemmatization.lemmatize_for_bm25("张三 是 阿里巴巴 的 工程师")
+
+        assert "张三" in result
+        assert "阿里巴巴" in result

--- a/tests/utils/test_spacy_models.py
+++ b/tests/utils/test_spacy_models.py
@@ -1,0 +1,102 @@
+"""Tests for the shared spaCy model loader.
+
+The model name is configurable via the MEM0_SPACY_MODEL env var so that
+non-English pipelines (zh_core_web_sm, ja_core_news_sm, ...) can be used.
+These tests mock spacy.load / download so no real model is required.
+"""
+
+import pytest
+
+spacy = pytest.importorskip("spacy")
+
+
+class TestModelName:
+    def test_default_model_name(self):
+        from mem0.utils import spacy_models
+
+        assert spacy_models._get_model_name() == "en_core_web_sm"
+
+    def test_env_override(self, monkeypatch):
+        from mem0.utils import spacy_models
+
+        monkeypatch.setenv("MEM0_SPACY_MODEL", "zh_core_web_sm")
+        assert spacy_models._get_model_name() == "zh_core_web_sm"
+
+
+class TestGetNlpFull:
+    def test_loads_default_model(self, monkeypatch):
+        from mem0.utils import spacy_models
+
+        monkeypatch.delenv("MEM0_SPACY_MODEL", raising=False)
+        monkeypatch.setattr(spacy.util, "is_package", lambda name: True)
+        monkeypatch.setattr(spacy_models, "_nlp_full", None)
+        monkeypatch.setattr(spacy_models, "_load_failed_full", False)
+        loaded = {}
+
+        def fake_load(name, **kwargs):
+            loaded["name"] = name
+            return object()
+
+        monkeypatch.setattr(spacy, "load", fake_load)
+
+        spacy_models.get_nlp_full()
+
+        assert loaded["name"] == "en_core_web_sm"
+
+    def test_loads_env_model(self, monkeypatch):
+        from mem0.utils import spacy_models
+
+        monkeypatch.setenv("MEM0_SPACY_MODEL", "ja_core_news_sm")
+        monkeypatch.setattr(spacy.util, "is_package", lambda name: True)
+        monkeypatch.setattr(spacy_models, "_nlp_full", None)
+        monkeypatch.setattr(spacy_models, "_load_failed_full", False)
+        loaded = {}
+
+        def fake_load(name, **kwargs):
+            loaded["name"] = name
+            return object()
+
+        monkeypatch.setattr(spacy, "load", fake_load)
+
+        spacy_models.get_nlp_full()
+
+        assert loaded["name"] == "ja_core_news_sm"
+
+
+class TestGetNlpLemma:
+    def test_loads_env_model_with_disabled_pipes(self, monkeypatch):
+        from mem0.utils import spacy_models
+
+        monkeypatch.setenv("MEM0_SPACY_MODEL", "zh_core_web_sm")
+        monkeypatch.setattr(spacy.util, "is_package", lambda name: True)
+        monkeypatch.setattr(spacy_models, "_nlp_lemma", None)
+        monkeypatch.setattr(spacy_models, "_load_failed_lemma", False)
+        loaded = {}
+
+        def fake_load(name, **kwargs):
+            loaded["name"] = name
+            loaded["kwargs"] = kwargs
+            return object()
+
+        monkeypatch.setattr(spacy, "load", fake_load)
+
+        spacy_models.get_nlp_lemma()
+
+        assert loaded["name"] == "zh_core_web_sm"
+        assert loaded["kwargs"] == {"disable": ["ner", "parser"]}
+
+
+class TestEnsureModelAvailable:
+    def test_downloads_env_model_when_missing(self, monkeypatch):
+        import spacy.cli
+
+        from mem0.utils import spacy_models
+
+        monkeypatch.setenv("MEM0_SPACY_MODEL", "de_core_news_sm")
+        monkeypatch.setattr(spacy.util, "is_package", lambda name: False)
+        downloaded = []
+        monkeypatch.setattr(spacy.cli, "download", lambda name: downloaded.append(name))
+
+        spacy_models._ensure_model_available()
+
+        assert downloaded == ["de_core_news_sm"]


### PR DESCRIPTION
Closes #6717

The optional spaCy NLP utilities (`mem0ai[nlp]`) only worked for English text. Three issues broke non-English users (Chinese, Japanese, German, ...):

1. **Hardcoded model** — `mem0/utils/spacy_models.py` hardcoded `en_core_web_sm` for the package check, auto-download, and both loaders. Users could not select language-specific pipelines (`zh_core_web_sm`, `ja_core_news_sm`, ...). The model name is now configurable via the `MEM0_SPACY_MODEL` env var (default `en_core_web_sm`), used consistently by `_ensure_model_available`, `get_nlp_full`, and `get_nlp_lemma`.

2. **Crash on `doc.noun_chunks`** — `_add_topic_phrase_candidates` iterated `doc.noun_chunks`, which raises `NotImplementedError [E894]` for languages without a noun-chunk iterator (zh, ja, ...) and `ValueError [E895]` for docs without DEP annotation. The iteration is now guarded: unsupported languages return no TOPIC candidates instead of crashing `extract_entities()`.

3. **Empty BM25 lemmas** — `lemmatize_for_bm25` used `token.lemma_` only. Pipelines like `zh_core_web_sm` return empty lemmas for every token, so the stored BM25 text became an empty string, defeating keyword matching. The code now falls back to `token.text` when the lemma is empty.

### Tests

- New `tests/utils/test_spacy_models.py`: env-var model selection for both loaders (mocked `spacy.load`/`download`, no real model required), including the disabled pipes on the lemma loader.
- `tests/utils/test_entity_extraction.py`: non-English doc (no noun-chunk support) returns `[]` instead of raising.
- `tests/utils/test_lemmatization.py`: pipelines with empty lemmas fall back to the original token text.
