### PR TITLE
fix(embeddings): forward api_key on HuggingFace base_url path

### DIFF
--- a/mem0/embeddings/huggingface.py
+++ b/mem0/embeddings/huggingface.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Literal, Optional
 
 from openai import OpenAI
@@ -17,7 +18,8 @@ class HuggingFaceEmbedding(EmbeddingBase):
         super().__init__(config)
 
         if self.config.huggingface_base_url:
-            self.client = OpenAI(base_url=self.config.huggingface_base_url)
+            api_key = self.config.api_key or os.getenv("HUGGINGFACE_API_KEY") or "hf"
+            self.client = OpenAI(base_url=self.config.huggingface_base_url, api_key=api_key)
             self.config.model = self.config.model or "tei"
         else:
             self.config.model = self.config.model or "multi-qa-MiniLM-L6-cos-v1"

--- a/tests/embeddings/test_huggingface_embeddings.py
+++ b/tests/embeddings/test_huggingface_embeddings.py
@@ -94,13 +94,39 @@ def test_embed_with_huggingface_base_url():
         embedder = HuggingFaceEmbedding(config)
         result = embedder.embed("Hello from custom endpoint")
 
-        mock_openai.assert_called_once_with(base_url="http://localhost:8080")
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="hf")
         mock_client.embeddings.create.assert_called_once_with(
             input="Hello from custom endpoint",
             model="my-custom-model",
             truncate=True,
         )
         assert result == [0.1, 0.2, 0.3]
+
+
+def test_base_url_uses_config_api_key():
+    config = BaseEmbedderConfig(
+        huggingface_base_url="http://localhost:8080",
+        api_key="hf_myEndpointToken",
+    )
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="hf_myEndpointToken")
+
+
+def test_base_url_falls_back_to_huggingface_env_key(monkeypatch):
+    monkeypatch.setenv("HUGGINGFACE_API_KEY", "hf_from_env")
+    config = BaseEmbedderConfig(huggingface_base_url="http://localhost:8080")
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="hf_from_env")
+
+
+def test_base_url_defaults_to_hf_key(monkeypatch):
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    config = BaseEmbedderConfig(huggingface_base_url="http://localhost:8080")
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="hf")
 
 
 def test_embed_batch_sentence_transformer(mock_sentence_transformer):


### PR DESCRIPTION
## Fix

Fixes #6301

### Problem

`HuggingFaceEmbedding.__init__` built the OpenAI-compatible client with only `base_url` and never forwarded `api_key` (`mem0/embeddings/huggingface.py`), so:

1. A user-set `api_key` in `BaseEmbedderConfig` was silently dropped on the `huggingface_base_url` path (TEI server / HF Inference Endpoint), and the OpenAI SDK fell back to `OPENAI_API_KEY` — sending the wrong credential.
2. With neither an explicit key nor `OPENAI_API_KEY` set, client construction raised `OpenAIError: Missing credentials` even for a no-auth local TEI endpoint, crashing `Memory.from_config(...)`.

### Change

Forward the key with `config > env > default` precedence, matching the TypeScript sibling (`mem0-ts` uses `config.apiKey || HUGGINGFACE_API_KEY || "hf"`) and the documented contract in `docs/components/embedders/models/huggingface.mdx`:

```python
api_key = self.config.api_key or os.getenv("HUGGINGFACE_API_KEY") or "hf"
self.client = OpenAI(base_url=self.config.huggingface_base_url, api_key=api_key)
```

The no-auth default `"hf"` keeps local TEI endpoints working out of the box, just as `lmstudio.py` uses a placeholder key for its OpenAI-compatible client.

### Tests

- Updated `test_embed_with_huggingface_base_url` to expect `api_key="hf"`.
- New: config `api_key` is forwarded, `HUGGINGFACE_API_KEY` env fallback, and default `"hf"` when neither is set.
