### PR TITLE
fix(llms): map assistant role to model in Gemini provider

### DIFF
--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -106,9 +106,12 @@ class GeminiLLM(LLMBase):
             if message["role"] == "system":
                 system_instruction = message["content"]
             else:
+                # The Gemini API only accepts "user" and "model" roles, so map
+                # the OpenAI-style "assistant" role used throughout mem0.
+                role = "model" if message["role"] == "assistant" else message["role"]
                 content = types.Content(
                     parts=[types.Part(text=message["content"])],
-                    role=message["role"],
+                    role=role,
                 )
                 contents.append(content)
 

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -232,6 +232,30 @@ def test_explicit_config_values_passed_to_generation_config(mock_gemini_client: 
     assert config_arg.top_p == 0.9
 
 
+def test_assistant_role_mapped_to_model_in_multi_turn(mock_gemini_client: Mock):
+    """OpenAI-style 'assistant' turns must map to Gemini's 'model' role, not pass through."""
+    config = BaseLlmConfig(model="gemini-2.0-flash", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = GeminiLLM(config)
+    messages = [
+        {"role": "user", "content": "Remember that I live in Paris."},
+        {"role": "assistant", "content": "Got it, you live in Paris."},
+        {"role": "user", "content": "What city do I live in?"},
+    ]
+
+    mock_part = Mock(text="Paris")
+    mock_content = Mock(parts=[mock_part])
+    mock_candidate = Mock(content=mock_content)
+    mock_response = Mock(candidates=[mock_candidate])
+    mock_gemini_client.models.generate_content.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    contents = mock_gemini_client.models.generate_content.call_args.kwargs["contents"]
+    assert len(contents) == 3
+    assert [c.role for c in contents] == ["user", "model", "user"]
+    assert contents[1].parts[0].text == "Got it, you live in Paris."
+
+
 # --- Vertex AI backend initialization (issue #3990, PR #4030) ---
 
 


### PR DESCRIPTION
## Fix

Fixes #6393

### Problem

`GeminiLLM._reformat_messages` copied message roles straight into `types.Content`, but the Gemini API only accepts `user` and `model` roles. Any conversation containing an OpenAI-style `assistant` turn (e.g. `Memory.add(..., memory_type="procedural_memory")` on a normal multi-turn conversation) failed with `400 Please use a valid role: user, model`. Other providers already handle this mapping (LangChain maps `assistant` → `ai`, Anthropic filters/hoists it); Gemini was the only one passing it through unchanged.

### Change

Map `assistant` → `model` when building `types.Content`:

```python
role = "model" if message["role"] == "assistant" else message["role"]
```

System messages keep going to `system_instruction`; `user` and `model` pass through as before.

### Tests

New regression test `test_assistant_role_mapped_to_model_in_multi_turn`: a user/assistant/user conversation produces `contents` roles `["user", "model", "user"]` and preserves the assistant text.
