### PR TITLE
fix(ts): forward metadata in batchUpdate request body

### DIFF
--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -542,6 +542,7 @@ export default class MemoryClient {
     const memoriesBody = memories.map((memory) => ({
       memory_id: memory.memoryId,
       text: memory.text,
+      ...(memory.metadata !== undefined ? { metadata: memory.metadata } : {}),
     }));
     const response = await this._fetchWithErrorHandling(
       `${this.host}/v1/batch/`,

--- a/mem0-ts/src/client/mem0.types.ts
+++ b/mem0-ts/src/client/mem0.types.ts
@@ -145,6 +145,7 @@ export interface MemoryHistory {
 export interface MemoryUpdateBody {
   memoryId: string;
   text: string;
+  metadata?: Record<string, any>;
 }
 
 export interface User {

--- a/mem0-ts/src/client/tests/memoryClient.batch.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.batch.test.ts
@@ -46,6 +46,25 @@ describe("MemoryClient - batchUpdate()", () => {
     ]);
   });
 
+  test("forwards metadata on memories that provide it", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v1/batch/", { status: 200, body: { message: "OK" } });
+    const mock = setupMockFetch(extra);
+
+    const client = new MemoryClient({ apiKey: TEST_API_KEY });
+    await client.batchUpdate([
+      { memoryId: "mem_1", text: "updated 1", metadata: { tag: "work" } },
+      { memoryId: "mem_2", text: "updated 2" },
+    ]);
+
+    const call = findFetchCall(mock, "/v1/batch/", "PUT");
+    const body = getFetchBody(call!);
+    expect(body.memories).toEqual([
+      { memory_id: "mem_1", text: "updated 1", metadata: { tag: "work" } },
+      { memory_id: "mem_2", text: "updated 2" },
+    ]);
+  });
+
   test("handles empty array without crashing", async () => {
     const extra = new Map<string, { status: number; body: unknown }>();
     extra.set("/v1/batch/", { status: 200, body: { message: "OK" } });


### PR DESCRIPTION
## Fix: forward `metadata` in `batchUpdate` request body

Closes #6392

### Problem

`MemoryClient.batchUpdate()` only serialized `memoryId` → `memory_id` and `text` when building the `PUT /v1/batch/` request body. Any `metadata` supplied by the caller was silently dropped, even though:

- the OpenAPI schema documents `metadata` as a supported batch update item field, and
- the Python SDK forwards batch update dictionaries as provided, and
- the single-memory `MemoryClient.update()` already forwards `metadata`.

### Change

- `mem0-ts/src/client/mem0.ts` — `batchUpdate` now spreads `metadata` onto the request item when the caller provided it (`...(memory.metadata !== undefined ? { metadata: memory.metadata } : {})`), preserving the existing payload shape for items without metadata.
- `mem0-ts/src/client/mem0.types.ts` — `MemoryUpdateBody` gains an optional `metadata?: Record<string, any>` field so callers get type support.

### Tests

Added a regression test to `mem0-ts/src/client/tests/memoryClient.batch.test.ts` covering a mixed batch (one item with `metadata`, one without) and asserting the exact request body.

- `pnpm exec jest src/client/tests` — 10 suites passed, 127 tests passed
- `prettier --check` — clean on all changed files
