### PR TITLE
docs(memory): note filters-based scoping for search/get_all on add()

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -753,6 +753,11 @@ class Memory(MemoryBase):
                 are treated as general conversational/factual memories.
             prompt (str, optional): Prompt to use for the memory creation. Defaults to None.
 
+        Note:
+            `search()` and `get_all()` scope queries via `filters={"user_id": "...", "agent_id": "...", "run_id": "..."}` —
+            they reject top-level `user_id`/`agent_id`/`run_id` arguments. `add()` accepts them top-level, but passing
+            the same arguments to `search()`/`get_all()` raises a `ValueError`; use the `filters` form there instead.
+
 
         Returns:
             dict: A dictionary containing the result of the memory addition operation, typically
@@ -2386,6 +2391,12 @@ class AsyncMemory(MemoryBase):
                                          Pass "procedural_memory" to create procedural memories.
             prompt (str, optional): Prompt to use for the memory creation. Defaults to None.
             llm (BaseChatModel, optional): LLM class to use for generating procedural memories. Defaults to None. Useful when user is using LangChain ChatModel.
+
+        Note:
+            `search()` and `get_all()` scope queries via `filters={"user_id": "...", "agent_id": "...", "run_id": "..."}` —
+            they reject top-level `user_id`/`agent_id`/`run_id` arguments. `add()` accepts them top-level, but passing
+            the same arguments to `search()`/`get_all()` raises a `ValueError`; use the `filters` form there instead.
+
         Returns:
             dict: A dictionary containing the result of the memory addition operation.
         """


### PR DESCRIPTION
## Fix: surface the add()/search() entity-arg asymmetry before ingestion

Closes #6723

### Problem

`Memory.add()` accepts `user_id`/`agent_id`/`run_id` as top-level keyword arguments (its documented contract), but `search()` and `get_all()` reject top-level entity params and require `filters={"user_id": ...}`. The mismatch is only discoverable on the first `search()` call — which, with a local LLM, happens after an expensive multi-document ingestion has already completed (the reporter hit ~40 minutes for 255 documents, then lost the run because the ephemeral store wasn't persisted).

The API contract itself is documented and deliberate, so this change does not alter it. It moves the signal to where the reader is: the `add()` docstring.

### Change

Added a `Note:` section to both the sync and async `add()` docstrings in `mem0/memory/main.py`:

- `add()` accepts top-level entity params (correct usage), but
- `search()`/`get_all()` require `filters={"user_id": ..., "agent_id": ..., "run_id": ...}` and raise `ValueError` on top-level entity args.

### Why this approach

The issue proposes three options; option 1 ("make `add()` reject top-level entity params too") would break `add()`'s documented contract — `_reject_top_level_entity_params` rejects exactly the parameters `add()` legitimately accepts. Option 2 (fold top-level params into filters with a deprecation warning) changes the documented contract. Option 3 — a docstring note — is zero-risk and directly addresses the discovery cost. This implements option 3.

### Verification

- `ruff check mem0/memory/main.py` — 146 pre-existing findings before and after the change; no new findings introduced (verified via stash comparison).
