### PR TITLE
fix(vector-stores): stop mongodb and vertex_ai from calling logging.basicConfig

### DIFF
--- a/mem0/vector_stores/mongodb.py
+++ b/mem0/vector_stores/mongodb.py
@@ -15,7 +15,6 @@ except ImportError:
 from mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 _DRIVER_METADATA = DriverInfo(name="Mem0", version=version("mem0ai"))
 

--- a/mem0/vector_stores/vertex_ai_vector_search.py
+++ b/mem0/vector_stores/vertex_ai_vector_search.py
@@ -21,8 +21,6 @@ from mem0.configs.vector_stores.vertex_ai_vector_search import (
 )
 from mem0.vector_stores.base import VectorStoreBase
 
-# Configure logging
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## What

Fixes #6384 — `mem0.vector_stores.mongodb` and `mem0.vector_stores.vertex_ai_vector_search` were calling `logging.basicConfig(...)` at import time, mutating the **root logger** of any host application that imports them.

## Why it matters

`logging.basicConfig` is a process-wide, call-once configuration API. When a *library* module calls it:

- the MongoDB store silently forces `INFO` on the root logger, and
- the Vertex AI Matching Engine store forces `DEBUG`, flooding host apps that import the Vertex backend with debug logs (or, per the [Logging HOWTO for libraries](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library), silently does nothing if the host already configured its own handlers — either way the library is hijacking application logging).

Library modules should only create a module logger via `logging.getLogger(__name__)` and leave handler/level configuration to the application.

## Changes

- `mem0/vector_stores/mongodb.py`: removed `logging.basicConfig(level=logging.INFO)`; kept `logger = logging.getLogger(__name__)`.
- `mem0/vector_stores/vertex_ai_vector_search.py`: removed `# Configure logging` + `logging.basicConfig(level=logging.DEBUG)`; kept the module logger.

## Verification

- After importing both modules in a fresh process, the root logger remains at `NOTSET` with zero handlers (previously it became `INFO`/`DEBUG` on import).
- `tests/vector_stores/test_mongodb.py` and `tests/vector_stores/test_vertex_ai_vector_search.py`: **28 passed**.
