### PR TITLE
fix(memory): parse leading JSON before scanning for code fences in extract_json

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import re
 from typing import Any, Dict, List
@@ -135,6 +136,19 @@ def extract_json(text):
     If that also fails, returns the text as-is.
     """
     text = text.strip()
+    # If the text already starts with a JSON object, parse it directly instead of
+    # scanning its string contents for markdown code fences (a fence inside a
+    # string value must not be mistaken for an enclosing block).
+    if text.startswith("{"):
+        start_idx = text.find("{")
+        end_idx = text.rfind("}")
+        if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
+            candidate = text[start_idx : end_idx + 1]
+            try:
+                json.loads(candidate)
+                return candidate
+            except (json.JSONDecodeError, TypeError):
+                pass  # fall through to code-fence handling
     match = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
     if match:
         json_str = match.group(1)

--- a/tests/test_chatty_llm_parsing.py
+++ b/tests/test_chatty_llm_parsing.py
@@ -72,6 +72,14 @@ That's the result."""
         parsed = json.loads(result)
         assert parsed["memory"][0]["text"] == "User likes gaming"
 
+    def test_code_fence_inside_json_string(self):
+        """A markdown code fence inside a JSON string value must not be mistaken
+        for an enclosing block — the leading JSON object wins."""
+        payload = {"snippet": "```python\nx = 1\n```", "user_id": "u1"}
+        encoded = json.dumps(payload)
+        result = extract_json(encoded)
+        assert json.loads(result) == payload
+
     def test_no_json_at_all(self):
         """No JSON in the text — should return as-is."""
         text = "I don't have any memory updates."


### PR DESCRIPTION
## What

Fixes #6427 — `extract_json` checked an **unanchored** markdown code-fence regex before looking for a JSON object. When valid JSON contained a code fence inside a *string value*, the inner fence was mistaken for an enclosing response fence and the JSON was corrupted.

## Why it matters

Callers such as `databricks.py`, `redis.py`, `valkey.py`, and `azure_ai_search.py` read stored metadata via `json.loads(extract_json(...))`. A memory whose payload contains a code snippet (e.g. `{"snippet": "```python\nx = 1\n```"}`) could be written successfully and then fail on read-back with `JSONDecodeError`.

## Change

`mem0/memory/utils.py` — `extract_json` now checks first whether the stripped text already starts with `{`; if the balanced `{...}` slice validates with `json.loads`, it is returned directly. Only when that fails (or the text doesn't start with `{`) does it fall back to the existing code-fence stripping, so responses like ```` ```json\n{...}\n``` ```` keep working unchanged.

## Verification

- Added regression test `test_code_fence_inside_json_string` in `tests/test_chatty_llm_parsing.py` mirroring the issue's reproduction.
- `tests/test_chatty_llm_parsing.py`: **22 passed** (21 existing + 1 new), including all prior fence/chatty/boundary cases.
