### PR TITLE
feat(examples): add self-hosted Mem0 hooks + MCP setup for Claude Code and Codex

### DIFF
--- a/examples/claude-code-codex-self-hosted/README.md
+++ b/examples/claude-code-codex-self-hosted/README.md
@@ -1,0 +1,134 @@
+# Claude Code / Codex with self-hosted Mem0
+
+One-click memory integration for AI coding tools backed by a **self-hosted**
+Mem0 REST API — no Mem0 Cloud account required.
+
+The repo's `integrations/mem0-plugin` targets the hosted platform
+(`MEM0_API_KEY=m0-...` + `https://mcp.mem0.ai/mcp`). Self-hosted users run the
+local REST API instead (`MEM0_BASE_URL=http://localhost:8888`,
+`X-API-Key` auth) and had no first-party glue. This example fills that gap with
+two entry points:
+
+| Entry point | What it does |
+|---|---|
+| **Lifecycle hooks** (`hooks/`) | Implicit memory: recall relevant memories at session start and per prompt; persist at pre-compact and session end |
+| **MCP wrapper** (`mcp/`) | Explicit memory tools (`search_memories`, `add_memory`, `get_memories`, `update_memory`, `delete_memory`) exposed to the agent |
+
+```
+┌──────────────────────────────────────────────┐
+│ Claude Code / Codex                          │
+│                                              │
+│  hooks/                 mcp/mem0_mcp_server  │
+│  (bash + curl)          (FastMCP stdio)      │
+└───────────┬──────────────────────┬───────────┘
+            │ REST calls           │ REST calls
+            │ (X-API-Key header)   │ (X-API-Key header)
+            ▼                      ▼
+┌──────────────────────────────────────────────┐
+│  Self-hosted Mem0 REST API  (server/)        │
+│  http://localhost:8888                       │
+└──────────────────────────────────────────────┘
+```
+
+## Prerequisites
+
+1. **A running self-hosted Mem0 server.** From the repo root:
+
+   ```bash
+   cd server
+   make bootstrap        # or: make up, then finish the setup wizard at http://localhost:3000
+   ```
+
+   This starts the API on `http://localhost:8888` (OpenAPI docs at
+   `http://localhost:8888/docs`) and prints an admin email/password plus the
+   first API key.
+
+2. **An API key.** Create one in the dashboard (`Settings → API Keys`) or reuse
+   the one printed by `make bootstrap`. Keys look like `m0sk-...`.
+
+3. **`bash`, `curl`, `jq`** for the hooks, and **Python 3.10+** for the MCP
+   server. The hooks deliberately use only these three tools — no Python, no
+   extra dependencies.
+
+## Quick start (Claude Code)
+
+```bash
+# 1. Point the hooks and MCP server at your instance
+export MEM0_API_KEY=m0sk-YOUR_KEY
+export MEM0_BASE_URL=http://localhost:8888          # already the default
+export MEM0_USER_ID=you                             # any stable id
+export MEM0_AGENT_ID=my-project                     # per-project scope
+
+# 2. Install the hooks: merge claude-code/settings.json.example
+#    into .claude/settings.json (replace <ABS_PATH>)
+
+# 3. Install the MCP server: copy claude-code/.mcp.json.example
+#    to the project root as .mcp.json (replace <ABS_PATH> and the key)
+
+# 4. (optional) one-time dependency for the MCP server
+pip install "mcp"
+```
+
+Start a session. Previous learnings get injected as context, and every
+compaction/session end persists what would otherwise be lost.
+
+## Quick start (Codex)
+
+```bash
+# 1. Same env exports as above (MEM0_API_KEY, MEM0_BASE_URL, ...)
+
+# 2. Install the hooks: append codex/AGENTS.md.example to the project's
+#    AGENTS.md (replace <ABS_PATH>)
+
+# 3. Install the MCP server: merge codex/config.toml.example
+#    into ~/.codex/config.toml (replace <ABS_PATH> and the key)
+
+# 4. (optional) one-time dependency for the MCP server
+pip install "mcp"
+```
+
+## What each hook does
+
+| Hook | Event | Behavior |
+|---|---|---|
+| `on_session_start.sh` | `SessionStart` | Searches for project/user context and injects the top memories so the session starts with prior knowledge |
+| `on_user_prompt.sh` | `UserPromptSubmit` | Searches with the current prompt and injects the top matches (skips replies shorter than 20 chars) |
+| `on_pre_compact.sh` | `PostCompact` (Claude Code) / `PreCompact` (Codex) | Tails the transcript and stores it via `POST /memories` — the key persistence point, since this is when context is about to be dropped |
+| `on_stop.sh` | `Stop` | Tails the transcript and persists the session's final exchanges |
+
+All hooks **fail open**: if the API key is missing or the server is down, they
+exit 0 silently and never block your session.
+
+## Configuration reference
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MEM0_BASE_URL` | `http://localhost:8888` | Base URL of the self-hosted REST API |
+| `MEM0_API_KEY` | *(none — required)* | API key from the self-hosted dashboard |
+| `MEM0_USER_ID` | `default` | Stable identifier for the user (scopes all reads/writes) |
+| `MEM0_AGENT_ID` | `default` | Identifier for the agent/project (scopes all reads/writes) |
+| `MEM0_TOP_K` | `5` | Max results per search |
+| `MEM0_THRESHOLD` | `0.0` | Minimum similarity for search results |
+
+## REST endpoints used
+
+| Tool (MCP) | Endpoint |
+|---|---|
+| `search_memories(query)` | `POST /search` |
+| `add_memory(text, infer=True)` | `POST /memories` |
+| `get_memories()` | `GET /memories?user_id=...&agent_id=...` |
+| `update_memory(memory_id, text)` | `PUT /memories/{memory_id}` |
+| `delete_memory(memory_id)` | `DELETE /memories/{memory_id}` |
+
+All requests authenticate with the `X-API-Key` header. The MCP server reads
+`MEM0_BASE_URL`, `MEM0_API_KEY`, `MEM0_USER_ID`, and `MEM0_AGENT_ID` from its
+environment.
+
+## Security notes
+
+- The API key is a **secret**: prefer exporting `MEM0_API_KEY` in your shell
+  over hardcoding it in `.mcp.json` / `config.toml`. The examples show both,
+  but the env-var route keeps the key out of your repo.
+- Auth is enabled by default on the self-hosted server. `AUTH_DISABLED=true`
+  exists for local development only — never use it on a machine you share.
+- Hooks are local-only by design: transcripts never leave your machine.

--- a/examples/claude-code-codex-self-hosted/claude-code/.mcp.json.example
+++ b/examples/claude-code-codex-self-hosted/claude-code/.mcp.json.example
@@ -1,0 +1,17 @@
+{
+  // Claude Code MCP servers — copy this file to the project root as .mcp.json.
+  // Replace <ABS_PATH> with the absolute path to this example's mcp/ dir and
+  // set your self-hosted API key. The server reads MEM0_API_KEY from env too,
+  // so you can leave it out of this file and export it in your shell instead.
+  "mcpServers": {
+    "mem0": {
+      "type": "stdio",
+      "command": "python",
+      "args": ["<ABS_PATH>/mcp/mem0_mcp_server.py"],
+      "env": {
+        "MEM0_BASE_URL": "http://localhost:8888",
+        "MEM0_API_KEY": "m0sk-REPLACE_WITH_YOUR_KEY"
+      }
+    }
+  }
+}

--- a/examples/claude-code-codex-self-hosted/claude-code/settings.json.example
+++ b/examples/claude-code-codex-self-hosted/claude-code/settings.json.example
@@ -1,0 +1,51 @@
+{
+  // Claude Code project settings — merge this into .claude/settings.json.
+  // Replace <ABS_PATH> with the absolute path to this example's hooks/ dir.
+  // Hooks are wired to the self-hosted Mem0 REST API (see hooks/mem0_env.sh).
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "MEM0_API_KEY=${MEM0_API_KEY} bash <ABS_PATH>/hooks/on_session_start.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "MEM0_API_KEY=${MEM0_API_KEY} bash <ABS_PATH>/hooks/on_user_prompt.sh",
+            "timeout": 8
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "MEM0_API_KEY=${MEM0_API_KEY} bash <ABS_PATH>/hooks/on_pre_compact.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "MEM0_API_KEY=${MEM0_API_KEY} bash <ABS_PATH>/hooks/on_stop.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/claude-code-codex-self-hosted/codex/AGENTS.md.example
+++ b/examples/claude-code-codex-self-hosted/codex/AGENTS.md.example
@@ -1,0 +1,14 @@
+# Codex hooks — append this section to the project's AGENTS.md
+# (or a global ~/.codex/AGENTS.md) and replace <ABS_PATH> with the absolute
+# path to this example's hooks/ dir.
+#
+# Codex event names: SessionStart, UserPromptSubmit, PreCompact, Stop.
+# PreCompact fires right before context is summarized — the key persistence
+# point for a memory layer.
+
+[hooks]
+
+SessionStart = "MEM0_API_KEY=${MEM0_API_KEY} bash <ABS_PATH>/hooks/on_session_start.sh"
+UserPromptSubmit = "MEM0_API_KEY=${MEM0_API_KEY} bash <ABS_PATH>/hooks/on_user_prompt.sh"
+PreCompact = "MEM0_API_KEY=${MEM0_API_KEY} bash <ABS_PATH>/hooks/on_pre_compact.sh"
+Stop = "MEM0_API_KEY=${MEM0_API_KEY} bash <ABS_PATH>/hooks/on_stop.sh"

--- a/examples/claude-code-codex-self-hosted/codex/config.toml.example
+++ b/examples/claude-code-codex-self-hosted/codex/config.toml.example
@@ -1,0 +1,7 @@
+# Codex MCP servers — merge into ~/.codex/config.toml.
+# Replace <ABS_PATH> with the absolute path to this example's mcp/ dir.
+
+[mcp_servers.mem0]
+command = "python"
+args = ["<ABS_PATH>/mcp/mem0_mcp_server.py"]
+env = { "MEM0_BASE_URL" = "http://localhost:8888", "MEM0_API_KEY" = "m0sk-REPLACE_WITH_YOUR_KEY" }

--- a/examples/claude-code-codex-self-hosted/hooks/mem0_env.sh
+++ b/examples/claude-code-codex-self-hosted/hooks/mem0_env.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Shared environment + REST helpers for the self-hosted Mem0 hooks.
+#
+# Sources this file from every hook script. All values can be overridden
+# through environment variables so a single setup works across projects.
+#
+# Required:
+#   MEM0_API_KEY   API key created in the self-hosted dashboard (Settings -> API Keys)
+# Optional:
+#   MEM0_BASE_URL  Defaults to http://localhost:8888 (the self-hosted REST API)
+#   MEM0_USER_ID   Defaults to "default"
+#   MEM0_AGENT_ID  Defaults to "claude-code" or "codex" depending on MEM0_PLATFORM
+#   MEM0_TOP_K     Defaults to 5
+#   MEM0_THRESHOLD Defaults to 0.0 (no minimum similarity)
+
+set -uo pipefail
+
+MEM0_BASE_URL="${MEM0_BASE_URL:-http://localhost:8888}"
+MEM0_USER_ID="${MEM0_USER_ID:-default}"
+MEM0_PLATFORM="${MEM0_PLATFORM:-claude}"
+if [ -z "${MEM0_AGENT_ID:-}" ]; then
+  MEM0_AGENT_ID="default"
+fi
+MEM0_TOP_K="${MEM0_TOP_K:-5}"
+MEM0_THRESHOLD="${MEM0_THRESHOLD:-0.0}"
+
+# Fail open: if no API key is set, every helper becomes a no-op so a missing
+# credential can never block or break a coding session.
+mem0_ready() {
+  [ -n "${MEM0_API_KEY:-}" ]
+}
+
+# POST /search  ->  search memories relevant to a query
+# Usage: mem0_search "the query" [top_k]
+mem0_search() {
+  local query="$1"
+  local top_k="${2:-$MEM0_TOP_K}"
+  curl -sS --max-time 5 -X POST "${MEM0_BASE_URL}/search" \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: ${MEM0_API_KEY}" \
+    -d "{\"query\": $(jq -Rn --arg q "$query" '$q' 2>/dev/null || printf '"%s"' "$query"), \"filters\": {\"user_id\": \"${MEM0_USER_ID}\", \"agent_id\": \"${MEM0_AGENT_ID}\"}, \"top_k\": ${top_k}, \"threshold\": ${MEM0_THRESHOLD}}" \
+    2>/dev/null || echo '{"results": []}'
+}
+
+# POST /memories  ->  store new memories extracted from a message
+# Usage: mem0_add "the message content" [metadata_json]
+mem0_add() {
+  local content="$1"
+  local metadata="${2:-}"
+  if [ -z "$metadata" ]; then
+    metadata='{}'
+  fi
+  curl -sS --max-time 10 -X POST "${MEM0_BASE_URL}/memories" \
+    -H "Content-Type: application/json" \
+    -H "X-API-Key: ${MEM0_API_KEY}" \
+    -d "{\"messages\": [{\"role\": \"user\", \"content\": $(jq -Rn --arg c "$content" '$c' 2>/dev/null || printf '"%s"' "$content")}], \"user_id\": \"${MEM0_USER_ID}\", \"agent_id\": \"${MEM0_AGENT_ID}\", \"metadata\": ${metadata}}" \
+    2>/dev/null || echo '{"results": []}'
+}
+
+# Format search results as a compact, human-readable context block.
+# Emits nothing when there are no results.
+mem0_format_results() {
+  local json="$1"
+  jq -r '.results[]? | select(.score == null or .score >= '"${MEM0_THRESHOLD}"') | "- " + (.memory // .text // "")' <<<"$json" 2>/dev/null | sed '/^[[:space:]]*$/d'
+}
+
+# Emit context in the format expected by the calling platform.
+# Claude Code expects hookSpecificOutput JSON; Codex appends stdout directly.
+# Usage: mem0_emit_context "hookEventName" "context text"
+mem0_emit_context() {
+  local event="$1"
+  local context="$2"
+  if [ "${MEM0_PLATFORM}" = "codex" ]; then
+    printf '%s\n' "${context}"
+  else
+    jq -cn --arg event "$event" --arg ctx "$context" \
+      '{hookSpecificOutput: {hookEventName: $event, additionalContext: $ctx}}'
+  fi
+}

--- a/examples/claude-code-codex-self-hosted/hooks/on_pre_compact.sh
+++ b/examples/claude-code-codex-self-hosted/hooks/on_pre_compact.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Hook: PostCompact (Claude Code) / PreCompact (Codex)
+#
+# Fires right before the session context is summarized and compacted — the
+# last chance to persist what is about to be dropped from the window. This is
+# the most valuable persistence point for a memory layer.
+#
+# Reads the tail of the session transcript and stores it via POST /memories.
+# The self-hosted server runs its own LLM extraction (infer=true by default),
+# so the hook stays dependency-free: no summarization logic in bash.
+#
+# Input:  JSON on stdin (session_id, transcript_path, cwd)
+# Output: none (side effect: memory persistence)
+#
+# Must never block compaction: any failure exits 0 silently.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=mem0_env.sh
+. "$SCRIPT_DIR/mem0_env.sh" 2>/dev/null || exit 0
+
+if ! mem0_ready; then
+  exit 0
+fi
+
+INPUT=$(cat)
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")
+
+if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
+  exit 0
+fi
+
+# Persist the last exchanges (tail) as one message so the server extracts
+# facts/decisions from them. 12000 chars keeps the request small while still
+# covering the most recent work.
+TAIL=$(tail -c 12000 "$TRANSCRIPT_PATH" 2>/dev/null || echo "")
+
+if [ -z "$TAIL" ]; then
+  exit 0
+fi
+
+MEM0_SOURCE="pre_compact"
+mem0_add "Session transcript excerpt to remember (extract durable facts, decisions, and preferences): ${TAIL}" \
+  "{\"source\": \"${MEM0_SOURCE}\"}"
+
+exit 0

--- a/examples/claude-code-codex-self-hosted/hooks/on_session_start.sh
+++ b/examples/claude-code-codex-self-hosted/hooks/on_session_start.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Hook: SessionStart
+#
+# Fires when a session starts (or resumes). Recalls memories relevant to the
+# current project and user, then injects them as context so the agent starts
+# with prior knowledge instead of a blank slate.
+#
+# Input:  JSON on stdin (session_id, cwd)
+# Output: hookSpecificOutput.additionalContext (Claude Code) or plain text (Codex)
+#
+# Must never block the session: any failure exits 0 silently.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=mem0_env.sh
+. "$SCRIPT_DIR/mem0_env.sh" 2>/dev/null || exit 0
+
+if ! mem0_ready; then
+  exit 0
+fi
+
+INPUT=$(cat)
+PROJECT_DIR=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || echo "")
+PROJECT_NAME=$(basename "${PROJECT_DIR:-$(pwd)}")
+
+# Bootstrap queries: pull project context, the user's stated preferences,
+# and any recent decisions/learnings from previous sessions.
+BOOTSTRAP_QUERY="Project context for ${PROJECT_NAME}: goals, architecture, conventions, and the user's stated preferences."
+RESULTS=$(mem0_search "${BOOTSTRAP_QUERY}")
+CONTEXT=$(mem0_format_results "${RESULTS}")
+
+if [ -z "$CONTEXT" ]; then
+  exit 0
+fi
+
+HEADER="Relevant memories from previous sessions (self-hosted Mem0, project: ${PROJECT_NAME}):"
+BODY="${HEADER}
+${CONTEXT}
+Use these memories as context for this session. New learnings will be persisted automatically on session end."
+
+mem0_emit_context "SessionStart" "$BODY"
+exit 0

--- a/examples/claude-code-codex-self-hosted/hooks/on_stop.sh
+++ b/examples/claude-code-codex-self-hosted/hooks/on_stop.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Hook: Stop
+#
+# Fires when the session ends. Persists the final exchanges so nothing is
+# lost between sessions. Complements on_pre_compact (which covers the
+# mid-session compaction point).
+#
+# Input:  JSON on stdin (session_id, transcript_path, cwd)
+# Output: none (side effect: memory persistence)
+#
+# Must never block session end: any failure exits 0 silently.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=mem0_env.sh
+. "$SCRIPT_DIR/mem0_env.sh" 2>/dev/null || exit 0
+
+if ! mem0_ready; then
+  exit 0
+fi
+
+INPUT=$(cat)
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")
+
+if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
+  exit 0
+fi
+
+TAIL=$(tail -c 12000 "$TRANSCRIPT_PATH" 2>/dev/null || echo "")
+
+if [ -z "$TAIL" ]; then
+  exit 0
+fi
+
+mem0_add "Session transcript excerpt from session end (extract durable facts, decisions, and preferences): ${TAIL}" \
+  "{\"source\": \"session_end\"}"
+
+exit 0

--- a/examples/claude-code-codex-self-hosted/hooks/on_user_prompt.sh
+++ b/examples/claude-code-codex-self-hosted/hooks/on_user_prompt.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Hook: UserPromptSubmit
+#
+# Fires on every user message. Searches memories relevant to the current
+# prompt and injects the top matches so relevant context is guaranteed to be
+# in the agent's context window, not left for the agent to fetch lazily.
+#
+# Input:  JSON on stdin (prompt, session_id, cwd)
+# Output: hookSpecificOutput.additionalContext (Claude Code) or plain text (Codex)
+#
+# Must never block the prompt: any failure exits 0 silently.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=mem0_env.sh
+. "$SCRIPT_DIR/mem0_env.sh" 2>/dev/null || exit 0
+
+if ! mem0_ready; then
+  exit 0
+fi
+
+INPUT=$(cat)
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // ""' 2>/dev/null || echo "")
+
+# Acknowledgements and short replies don't warrant memory context.
+if [ ${#PROMPT} -lt 20 ]; then
+  exit 0
+fi
+
+RESULTS=$(mem0_search "${PROMPT}")
+CONTEXT=$(mem0_format_results "${RESULTS}")
+
+if [ -z "$CONTEXT" ]; then
+  exit 0
+fi
+
+HEADER="Relevant memories from previous sessions (self-hosted Mem0):"
+BODY="${HEADER}
+${CONTEXT}"
+
+mem0_emit_context "UserPromptSubmit" "$BODY"
+exit 0

--- a/examples/claude-code-codex-self-hosted/mcp/mem0_mcp_server.py
+++ b/examples/claude-code-codex-self-hosted/mcp/mem0_mcp_server.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""MCP server exposing a self-hosted Mem0 REST API as native MCP tools.
+
+This is the "explicit memory tools" entry point from the self-hosted
+integration: agents (Claude Code, Codex, and anything else that speaks MCP)
+get search/add/get/update/delete memory tools that forward to the local
+self-hosted Mem0 REST API (``server/``, default http://localhost:8888).
+
+Environment:
+    MEM0_BASE_URL   Base URL of the self-hosted REST API (default http://localhost:8888)
+    MEM0_API_KEY     API key created in the self-hosted dashboard (required)
+    MEM0_USER_ID     Default user id (default "default")
+    MEM0_AGENT_ID    Default agent id (default "default")
+
+Run (stdio transport):
+    pip install "mcp"
+    MEM0_API_KEY=m0sk-... python mem0_mcp_server.py
+
+Then register it in Claude Code (.mcp.json) or Codex (~/.codex/config.toml) —
+see the README in this directory for the exact snippets.
+"""
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("mem0-self-hosted")
+
+BASE_URL = os.environ.get("MEM0_BASE_URL", "http://localhost:8888").rstrip("/")
+API_KEY = os.environ.get("MEM0_API_KEY", "")
+USER_ID = os.environ.get("MEM0_USER_ID", "default")
+AGENT_ID = os.environ.get("MEM0_AGENT_ID", "default")
+
+
+def _request(method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Forward a request to the self-hosted REST API and return parsed JSON."""
+    if not API_KEY:
+        return {"error": "MEM0_API_KEY is not set. Create an API key in the self-hosted dashboard."}
+    url = f"{BASE_URL}{path}"
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = urllib.request.Request(url, data=body, method=method)
+    req.add_header("X-API-Key", API_KEY)
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        return {"error": f"Mem0 API returned {e.code}: {detail}"}
+    except urllib.error.URLError as e:
+        return {"error": f"Cannot reach Mem0 API at {BASE_URL}: {e.reason}"}
+
+
+@mcp.tool(
+    description=(
+        "Search through stored memories. This method is called whenever the user asks anything that "
+        "might depend on past context, preferences, or previous decisions."
+    )
+)
+def search_memories(query: str, user_id: str = USER_ID, agent_id: str = AGENT_ID) -> str:
+    """Search memories relevant to a query, scoped to a user and agent."""
+    payload = {"query": query, "filters": {"user_id": user_id, "agent_id": agent_id}, "top_k": 10}
+    return json.dumps(_request("POST", "/search", payload), indent=2)
+
+
+@mcp.tool(
+    description=(
+        "Add a new memory. Call this whenever the user shares a preference, fact, decision, or anything "
+        "else worth remembering for future conversations. Set infer to False to store the text verbatim "
+        "without LLM fact extraction."
+    )
+)
+def add_memory(text: str, user_id: str = USER_ID, agent_id: str = AGENT_ID, infer: bool = True) -> str:
+    """Store a new memory, optionally extracting facts from the raw text."""
+    payload = {
+        "messages": [{"role": "user", "content": text}],
+        "user_id": user_id,
+        "agent_id": agent_id,
+        "infer": infer,
+    }
+    return json.dumps(_request("POST", "/memories", payload), indent=2)
+
+
+@mcp.tool(description="List all memories stored for a user/agent.")
+def get_memories(user_id: str = USER_ID, agent_id: str = AGENT_ID) -> str:
+    """Retrieve stored memories for a user/agent scope."""
+    path = f"/memories?user_id={urllib.request.quote(user_id)}&agent_id={urllib.request.quote(agent_id)}"
+    return json.dumps(_request("GET", path), indent=2)
+
+
+@mcp.tool(description="Update the text of an existing memory by its id.")
+def update_memory(memory_id: str, text: str) -> str:
+    """Replace the content of a stored memory."""
+    path = f"/memories/{urllib.request.quote(memory_id)}"
+    return json.dumps(_request("PUT", path, {"text": text}), indent=2)
+
+
+@mcp.tool(description="Delete a specific memory by its id.")
+def delete_memory(memory_id: str) -> str:
+    """Delete a single stored memory."""
+    path = f"/memories/{urllib.request.quote(memory_id)}"
+    return json.dumps(_request("DELETE", path), indent=2)
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/examples/claude-code-codex-self-hosted/mcp/requirements.txt
+++ b/examples/claude-code-codex-self-hosted/mcp/requirements.txt
@@ -1,0 +1,5 @@
+# Dependencies for the MCP wrapper (mcp/mem0_mcp_server.py).
+# The lifecycle hooks (hooks/) need no Python — only bash, curl, and jq.
+# FastMCP (mcp.server.fastmcp) exists in the 1.x line. The 2.x rewrite
+# removed it, so pin <2.0.0 to keep `from mcp.server.fastmcp import FastMCP` working.
+mcp>=1.25.4,<2.0.0


### PR DESCRIPTION
## Summary

Adds a self-contained, copy-paste example under `examples/claude-code-codex-self-hosted/` that wires Claude Code and Codex (OpenAI) to a **self-hosted Mem0 REST API** using one-click hooks plus an optional stdio MCP server.

Closes #5413

## What's included

- **`hooks/`** — bash + curl + jq lifecycle hooks (zero Python deps, fail-open, always exit 0):
  - `on_session_start.sh` — recalls relevant memories at session start
  - `on_user_prompt.sh` — searches memories per prompt (skips prompts under 20 chars)
  - `on_pre_compact.sh` / `on_stop.sh` — saves a tail of the session to Mem0 with source metadata
  - `mem0_env.sh` — shared env loader + helpers (`MEM0_BASE_URL`, `MEM0_API_KEY`, `MEM0_USER_ID`, `MEM0_AGENT_ID`, `MEM0_TOP_K`, `MEM0_THRESHOLD`)
- **`mcp/`** — FastMCP stdio wrapper (`mem0_mcp_server.py`) exposing explicit tools: `search_memories`, `add_memory`, `get_memories`, `update_memory`, `delete_memory` — forwards to the self-hosted REST API with `X-API-Key` auth
- **`claude-code/`** — `settings.json.example` (hooks) and `.mcp.json.example` (stdio MCP entry)
- **`codex/`** — `AGENTS.md.example` (`[hooks]`) and `config.toml.example` (`[mcp_servers.mem0]`)
- **`README.md`** — architecture diagram, prerequisites, quick starts for both tools, env var reference, endpoint reference, and security notes

## Verification

- All 5 hook scripts pass `bash -n`; smoke-tested with a fake curl/jq harness — emit valid `hookSpecificOutput` JSON for Claude Code and plain text for Codex; silent (exit 0) when `MEM0_API_KEY` is unset
- MCP server passes `ruff check`, `py_compile`, and an end-to-end stdio smoke test against a live self-hosted server (list tools, search, add, get all OK)
- `mcp` is pinned to `>=1.25.4,<2.0.0` because FastMCP (`mcp.server.fastmcp`) was removed in the 2.x rewrite

The existing `integrations/mem0-plugin/` (cloud-mode) is intentionally untouched — this example targets self-hosted deployments.
