### PR TITLE
fix(search): reject NaN threshold in search parameter validation

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -4,6 +4,7 @@ import gc
 import hashlib
 import json
 import logging
+import math
 import os
 import time
 import uuid
@@ -190,7 +191,7 @@ def _validate_search_params(threshold: Optional[float] = None, top_k: Optional[i
     if threshold is not None:
         if not isinstance(threshold, (int, float)):
             raise ValueError("threshold must be a valid number")
-        if threshold < 0 or threshold > 1:
+        if math.isnan(threshold) or threshold < 0 or threshold > 1:
             raise ValueError(
                 f"Invalid threshold: {threshold}. Must be between 0 and 1 (inclusive)."
             )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -451,6 +451,17 @@ class TestSearchParamValidation:
         with pytest.raises(ValueError, match="Invalid threshold.*Must be between 0 and 1"):
             memory_instance.search("test query", filters={"user_id": "test"}, threshold=-0.5)
 
+    def test_search_rejects_nan_threshold(self, memory_instance):
+        """Search should reject NaN threshold before any embedding/vector-store work."""
+        memory_instance.embedding_model.embed = Mock()
+
+        with pytest.raises(ValueError, match="Invalid threshold.*Must be between 0 and 1"):
+            memory_instance.search(
+                "test query", filters={"user_id": "test"}, threshold=float("nan")
+            )
+
+        memory_instance.embedding_model.embed.assert_not_called()
+
     def test_search_rejects_negative_top_k(self, memory_instance):
         """Search should reject negative top_k."""
         with pytest.raises(ValueError, match="Invalid top_k.*Must be a non-negative"):


### PR DESCRIPTION
## Description

Closes #6713

`Memory.search(..., threshold=float("nan"))` (and `AsyncMemory.search`) silently accepted NaN: since every comparison with NaN evaluates to `False`, the `[0, 1]` range check in `_validate_search_params()` let it through, and the downstream `semantic_score < threshold` gate also never fired — effectively disabling score filtering.

This adds an explicit NaN check in `_validate_search_params()` before the range check, so a NaN threshold raises `ValueError` before any embedding or vector-store work, matching the behavior for negative values and values above 1.

## Test Plan

- Added `test_search_rejects_nan_threshold` to `TestSearchParamValidation` (asserts `ValueError` and that the embedding model was never invoked).
- `pytest tests/test_main.py::TestSearchParamValidation` — 12 passed.
- `ruff check` on `tests/test_main.py` passes; no new lint findings on `mem0/memory/main.py` (pre-existing findings unchanged).
