### PR TITLE
fix(vector-stores/azure-ai-search): guard __del__ against partially-initialized instances

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -386,8 +386,13 @@ class AzureAISearch(VectorStoreBase):
 
     def __del__(self):
         """Close the search client when the object is deleted."""
-        self.search_client.close()
-        self.index_client.close()
+        try:
+            if hasattr(self, "search_client") and self.search_client:
+                self.search_client.close()
+            if hasattr(self, "index_client") and self.index_client:
+                self.index_client.close()
+        except Exception:
+            pass
 
     def reset(self):
         """Reset the index by deleting and recreating it."""

--- a/tests/vector_stores/test_azure_ai_search.py
+++ b/tests/vector_stores/test_azure_ai_search.py
@@ -719,3 +719,15 @@ def test_build_filter_escapes_quotes(azure_ai_search_instance):
     instance, _, _ = azure_ai_search_instance
     expr = instance._build_filter_expression({"name": "O'Brien"})
     assert "name eq 'O''Brien'" in expr
+
+
+def test_del_handles_partially_initialized_instance():
+    """__del__ must not raise when only some clients were initialized (mid-__init__ failure)."""
+    store = AzureAISearch.__new__(AzureAISearch)
+    # Simulate an exception raised after search_client was created but before
+    # index_client was assigned in __init__.
+    store.search_client = Mock()
+
+    store.__del__()  # must not raise AttributeError
+
+    store.search_client.close.assert_called_once()


### PR DESCRIPTION
## Description

Fixes #6732

`AzureAISearch.__del__` unconditionally accessed `self.search_client` and `self.index_client`. If `__init__` raises partway through (e.g. an invalid credential or endpoint failure after `search_client` is created but before `index_client` is assigned), the partially-initialized object is garbage-collected and `__del__` raises `AttributeError` — surfaced as `Exception ignored in: <function AzureAISearch.__del__>` during GC.

This applies the same defensive pattern already used by the other vector stores (`cassandra.py`, `azure_mysql.py`, `pgvector.py`): guard each client with `hasattr` and swallow exceptions, so `__del__` never propagates during interpreter shutdown.

## Changes

- `mem0/vector_stores/azure_ai_search.py`: guard `__del__` against partially-initialized instances and wrap the close calls in `try/except`.
- `tests/vector_stores/test_azure_ai_search.py`: add `test_del_handles_partially_initialized_instance`, which constructs the instance via `__new__` with only `search_client` set (simulating a mid-`__init__` failure) and asserts `__del__` closes what exists without raising.

## Test Plan

```
pytest tests/vector_stores/test_azure_ai_search.py -q
28 passed in ~4s
```

Before the fix, the new test fails with:

```
AttributeError: 'AzureAISearch' object has no attribute 'index_client'
```
