### PR TITLE
fix(embeddings/ollama): default embedding_dims to 768 to match nomic-embed-text

### DIFF
--- a/mem0/embeddings/ollama.py
+++ b/mem0/embeddings/ollama.py
@@ -26,7 +26,7 @@ class OllamaEmbedding(EmbeddingBase):
         super().__init__(config)
 
         self.config.model = self.config.model or "nomic-embed-text"
-        self.config.embedding_dims = self.config.embedding_dims or 512
+        self.config.embedding_dims = self.config.embedding_dims or 768
 
         self.client = Client(host=self.config.ollama_base_url)
         self._ensure_model_exists()

--- a/tests/embeddings/test_ollama_embeddings.py
+++ b/tests/embeddings/test_ollama_embeddings.py
@@ -94,3 +94,11 @@ def test_embed_batch_count_mismatch_raises(mock_ollama_client):
 
     with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
         embedder.embed_batch(["first text", "second text"])
+
+
+def test_default_embedding_dims_match_default_model(mock_ollama_client):
+    """Default embedding_dims must match the default model's output dims (nomic-embed-text is 768-d)."""
+    embedder = OllamaEmbedding(BaseEmbedderConfig())
+
+    assert embedder.config.model == "nomic-embed-text"
+    assert embedder.config.embedding_dims == 768


### PR DESCRIPTION
## Description

Fixes #6734

`OllamaEmbedding` defaults the model to `nomic-embed-text`, which produces **768-dimensional** embeddings, but defaulted `embedding_dims` to `512`. Any user creating an `OllamaEmbedding` without an explicit `embedding_dims` got a vector store initialized with the wrong dimension count, causing dimension-mismatch errors at search time.

The default is now `768` to match the default model. Explicitly configured values (e.g. `embedding_dims=512` for a matryoshka variant like `nomic-embed-text-v1.5`) are still respected via the existing `or` idiom.

## Changes

- `mem0/embeddings/ollama.py`: default `embedding_dims` `512` → `768`.
- `tests/embeddings/test_ollama_embeddings.py`: add `test_default_embedding_dims_match_default_model`, which builds an `OllamaEmbedding` with an empty config and asserts both the default model (`nomic-embed-text`) and `embedding_dims == 768`.

## Test Plan

```
pytest tests/embeddings/test_ollama_embeddings.py -q
8 passed in ~4s
```

Before the fix, the new test fails with `embedding_dims` still `512`.
