### PR TITLE
fix(embeddings/fastembed): return list from embed() instead of numpy.ndarray

### DIFF
--- a/mem0/embeddings/fastembed.py
+++ b/mem0/embeddings/fastembed.py
@@ -29,4 +29,5 @@ class FastEmbedEmbedding(EmbeddingBase):
         """
         text = text.replace("\n", " ")
         embeddings = list(self.dense_model.embed(text))
-        return embeddings[0].tolist()
+        vector = embeddings[0]
+        return vector.tolist() if hasattr(vector, "tolist") else list(vector)

--- a/mem0/embeddings/fastembed.py
+++ b/mem0/embeddings/fastembed.py
@@ -29,4 +29,5 @@ class FastEmbedEmbedding(EmbeddingBase):
         """
         text = text.replace("\n", " ")
         embeddings = list(self.dense_model.embed(text))
-        return embeddings[0]
+        vector = embeddings[0]
+        return vector.tolist() if hasattr(vector, "tolist") else list(vector)

--- a/tests/embeddings/test_fastembed_embeddings.py
+++ b/tests/embeddings/test_fastembed_embeddings.py
@@ -44,3 +44,20 @@ def test_embed_removes_newlines(mock_fastembed_client):
     
     mock_fastembed_client.embed.assert_called_once_with("Hello world")
     assert list(embedding) == [0.7, 0.8, 0.9]
+
+
+def test_embed_returns_plain_list(mock_fastembed_client):
+    """embed() must return a JSON-serializable list, not a numpy.ndarray."""
+    import json
+
+    config = BaseEmbedderConfig(model="jinaai/jina-embeddings-v2-base-en", embedding_dims=768)
+    embedder = FastEmbedEmbedding(config)
+
+    mock_embedding = np.array([0.1, 0.2, 0.3])
+    mock_fastembed_client.embed.return_value = iter([mock_embedding])
+
+    embedding = embedder.embed("Sample text")
+
+    assert isinstance(embedding, list)
+    assert embedding == [0.1, 0.2, 0.3]
+    json.dumps(embedding)  # must not raise


### PR DESCRIPTION
## Description

Fixes #6621

`FastEmbedEmbedding.embed()` returned the raw `numpy.ndarray` produced by FastEmbed instead of a plain Python `list[float]`. Every other dense embedder normalizes to a list (`HuggingFace` and `AWS Bedrock` use `.tolist()`, the OpenAI family returns JSON lists), and call sites plus several vector stores assume JSON-serializable lists — a bare `ndarray` fails `json.dumps` and can break providers that validate `isinstance(vector, list)`.

The existing tests only compared `list(embedding) == [...]`, which passes for ndarrays too, so the contract slip was invisible in CI. The new test asserts the return is a `list` and is JSON-serializable.

## Changes

- `mem0/embeddings/fastembed.py`: normalize the returned vector via `.tolist()` when available, falling back to `list(vector)`.
- `tests/embeddings/test_fastembed_embeddings.py`: add `test_embed_returns_plain_list`.

## Test Plan

```
pytest tests/embeddings/test_fastembed_embeddings.py -q
3 passed in ~7s
```

Before the fix, the new test fails with `isinstance(array([0.1, 0.2, 0.3]), list)` being `False`.
