### PR TITLE
docs: correct openapi.json against live API behavior

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2276,12 +2276,6 @@
 												},
 												"description": "Categories associated with the memory"
 											},
-											"immutable": {
-												"type": "boolean",
-												"description": "Whether the memory is immutable.",
-												"title": "Immutable",
-												"default": false
-											},
 											"expiration_date": {
 												"type": "string",
 												"format": "date",
@@ -2299,6 +2293,26 @@
 												"type": "string",
 												"format": "date-time",
 												"description": "The timestamp when the memory was last updated."
+											},
+											"score": {
+												"type": "number",
+												"format": "float",
+												"minimum": 0,
+												"maximum": 1,
+												"description": "Combined multi-signal relevance score in [0, 1] (search responses only)."
+											},
+											"agent_id": {
+												"type": "string",
+												"nullable": true
+											},
+											"app_id": {
+												"type": "string",
+												"nullable": true
+											},
+											"session_id": {
+												"type": "string",
+												"nullable": true,
+												"description": "Run/session the memory is scoped to. Note: this endpoint returns this field as `session_id`, matching `POST /v3/memories/`."
 											}
 										},
 										"required": [
@@ -2406,12 +2420,16 @@
 									},
 									"categories": {
 										"type": "array",
-										"items": {"type": "string"},
+										"items": {
+											"type": "string"
+										},
 										"description": "Restrict results to memories tagged with any of these categories."
 									},
 									"fields": {
 										"type": "array",
-										"items": {"type": "string"},
+										"items": {
+											"type": "string"
+										},
 										"description": "Restrict the fields returned per memory, e.g. [\"id\", \"memory\"]."
 									},
 									"keywords": {
@@ -4999,7 +5017,7 @@
 											},
 											"name": {
 												"type": "string",
-												"description": "Name of the project."
+												"description": "Name of the project"
 											},
 											"description": {
 												"type": "string",
@@ -5027,10 +5045,97 @@
 														"role": {
 															"type": "string",
 															"description": "Role of the member in the project."
+														},
+														"email": {
+															"type": "string",
+															"description": "Email address of the project member."
 														}
 													}
 												},
-												"description": "List of members belonging to the project."
+												"description": "List of members belonging to the project"
+											},
+											"usecase": {
+												"type": "string",
+												"nullable": true,
+												"description": "Configured use case for the project."
+											},
+											"memory_depth": {
+												"type": "string",
+												"description": "Memory extraction depth setting for this project."
+											},
+											"inclusion_prompt": {
+												"type": "string",
+												"nullable": true,
+												"description": "Custom prompt describing what should be included when extracting memories."
+											},
+											"exclusion_prompt": {
+												"type": "string",
+												"nullable": true,
+												"description": "Custom prompt describing what should be excluded when extracting memories."
+											},
+											"custom_categories": {
+												"type": "array",
+												"items": {
+													"type": "object"
+												},
+												"description": "List of custom categories configured for memory categorization in this project."
+											},
+											"custom_instructions": {
+												"type": "string",
+												"description": "Custom instructions for memory processing in this project."
+											},
+											"update_custom_instructions": {
+												"type": "string",
+												"nullable": true,
+												"description": "Custom instructions applied when updating existing memories."
+											},
+											"summary_custom_instructions": {
+												"type": "string",
+												"nullable": true,
+												"description": "Custom instructions applied when generating summaries."
+											},
+											"summary_batch_size": {
+												"type": "integer",
+												"description": "Number of items processed per batch when generating summaries."
+											},
+											"summary_max_tokens": {
+												"type": "integer",
+												"nullable": true,
+												"description": "Maximum tokens allowed in a generated summary."
+											},
+											"expiration_date": {
+												"type": "string",
+												"nullable": true,
+												"description": "Default expiration date applied to memories created in this project."
+											},
+											"enable_graph": {
+												"type": "boolean",
+												"description": "Whether graph memory is enabled for this project."
+											},
+											"multilingual": {
+												"type": "boolean",
+												"description": "Whether to use the input language for memory storage and retrieval."
+											},
+											"version": {
+												"type": "string",
+												"description": "API version used by this project."
+											},
+											"is_default": {
+												"type": "boolean",
+												"description": "Whether this is the organization's default project."
+											},
+											"active_prompt_profile": {
+												"type": "string",
+												"nullable": true,
+												"description": "Identifier of the active prompt profile for this project."
+											},
+											"decay": {
+												"type": "boolean",
+												"description": "Whether memory decay is enabled for this project."
+											},
+											"user_role": {
+												"type": "string",
+												"description": "Role of the requesting user within this project."
 											}
 										}
 									}
@@ -6537,10 +6642,12 @@
 							"application/json": {
 								"schema": {
 									"type": "object",
-									"properties": {
-										"error": {
-											"type": "string"
-										}
+									"description": "Field-keyed validation errors. Each key is a request field name; the value is an array of message strings or a nested object of messages.",
+									"additionalProperties": true,
+									"example": {
+										"name": [
+											"This field is required."
+										]
 									}
 								}
 							}
@@ -6670,10 +6777,12 @@
 							"application/json": {
 								"schema": {
 									"type": "object",
-									"properties": {
-										"error": {
-											"type": "string"
-										}
+									"description": "Field-keyed validation errors. Each key is a request field name; the value is an array of message strings or a nested object of messages.",
+									"additionalProperties": true,
+									"example": {
+										"name": [
+											"This field is required."
+										]
 									}
 								}
 							}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -45,7 +45,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/CreateAgent"
+									"$ref": "#/components/schemas/AgentResponse"
 								}
 							}
 						}
@@ -77,7 +77,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/CreateApp"
+									"$ref": "#/components/schemas/AppResponse"
 								}
 							}
 						}
@@ -116,65 +116,97 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"type": "object",
-										"properties": {
-											"id": {
-												"type": "string",
-												"description": "Unique identifier for the entity."
-											},
-											"name": {
-												"type": "string",
-												"description": "Name of the entity."
-											},
-											"created_at": {
-												"type": "string",
-												"format": "date-time",
-												"description": "Timestamp of when the entity was created."
-											},
-											"updated_at": {
-												"type": "string",
-												"format": "date-time",
-												"description": "Timestamp of when the entity was last updated."
-											},
-											"total_memories": {
-												"type": "integer",
-												"description": "Total number of memories associated with the entity."
-											},
-											"owner": {
-												"type": "string",
-												"description": "Owner of the entity."
-											},
-											"organization": {
-												"type": "string",
-												"description": "Organization the entity belongs to."
-											},
-											"metadata": {
+									"type": "object",
+									"properties": {
+										"count": {
+											"type": "integer",
+											"description": "Total number of entities matching the filters."
+										},
+										"next": {
+											"type": "string",
+											"nullable": true,
+											"description": "URL of the next page of results, or null if this is the last page."
+										},
+										"previous": {
+											"type": "string",
+											"nullable": true,
+											"description": "URL of the previous page of results, or null if this is the first page."
+										},
+										"results": {
+											"type": "array",
+											"items": {
 												"type": "object",
-												"description": "Additional metadata associated with the entity"
-											},
-											"type": {
-												"type": "string",
-												"enum": [
-													"user",
-													"agent",
-													"app",
-													"run"
+												"properties": {
+													"id": {
+														"type": "string",
+														"description": "Unique identifier for the entity."
+													},
+													"name": {
+														"type": "string",
+														"description": "Name of the entity."
+													},
+													"created_at": {
+														"type": "string",
+														"format": "date-time",
+														"description": "Timestamp of when the entity was created."
+													},
+													"updated_at": {
+														"type": "string",
+														"format": "date-time",
+														"description": "Timestamp of when the entity was last updated."
+													},
+													"owner": {
+														"type": "string",
+														"description": "Owner of the entity."
+													},
+													"metadata": {
+														"type": "object",
+														"nullable": true,
+														"description": "Additional metadata associated with the entity."
+													},
+													"type": {
+														"type": "string",
+														"enum": [
+															"user",
+															"agent",
+															"app",
+															"run"
+														]
+													}
+												},
+												"required": [
+													"id",
+													"name",
+													"created_at",
+													"updated_at",
+													"owner",
+													"type"
 												]
 											}
 										},
-										"required": [
-											"id",
-											"name",
-											"created_at",
-											"updated_at",
-											"total_memories",
-											"owner",
-											"organization",
-											"type"
-										]
-									}
+										"total_users": {
+											"type": "integer",
+											"description": "Total number of user entities in the project."
+										},
+										"total_agents": {
+											"type": "integer",
+											"description": "Total number of agent entities in the project."
+										},
+										"total_apps": {
+											"type": "integer",
+											"description": "Total number of app entities in the project."
+										},
+										"total_runs": {
+											"type": "integer",
+											"description": "Total number of run entities in the project."
+										}
+									},
+									"required": [
+										"count",
+										"next",
+										"previous",
+										"results"
+									]
 								}
 							}
 						}
@@ -217,9 +249,161 @@
 				"responses": {
 					"200": {
 						"description": "Successfully retrieved entity filters.",
-						"content": {}
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"event_type": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											},
+											"description": "Event types that can be filtered on.",
+											"example": [
+												"ADD",
+												"UPDATE",
+												"DELETE",
+												"SEARCH",
+												"GET_ALL",
+												"GET",
+												"DELETE_ALL",
+												"DELETE_USER"
+											]
+										},
+										"categories": {
+											"type": "array",
+											"items": {},
+											"description": "Memory categories that can be filtered on."
+										},
+										"users": {
+											"type": "array",
+											"items": {
+												"type": "string"
+											},
+											"description": "User IDs that can be filtered on."
+										},
+										"parameters": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"name": {
+														"type": "string"
+													},
+													"label": {
+														"type": "string"
+													},
+													"type": {
+														"type": "string"
+													},
+													"placeholder": {
+														"type": "string"
+													},
+													"options": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"value": {
+																	"type": "string"
+																},
+																"label": {
+																	"type": "string"
+																}
+															}
+														}
+													}
+												}
+											},
+											"description": "Filter UI field definitions used by the Mem0 dashboard."
+										}
+									}
+								}
+							}
+						}
 					}
 				}
+			}
+		},
+		"/v1/entities/{entity_type}/{entity_id}/": {
+			"delete": {
+				"tags": [
+					"entities"
+				],
+				"deprecated": true,
+				"description": "Delete an entity by its numeric ID. Deprecated in favor of `DELETE /v2/entities/{entity_type}/{entity_id}/`, which takes the entity's string name instead of this numeric ID.",
+				"operationId": "entities_delete_v1",
+				"parameters": [
+					{
+						"name": "entity_type",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": [
+								"user",
+								"agent",
+								"app",
+								"run"
+							]
+						},
+						"description": "The type of the entity (user, agent, app, or run)."
+					},
+					{
+						"name": "entity_id",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "integer"
+						},
+						"description": "The numeric identifier of the entity, as returned in the `id` field by `GET /v1/entities/`."
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Entity deletion has been queued for background (async) execution.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"message": {
+											"type": "string",
+											"example": "Delete in progress. This may take some time."
+										},
+										"event_id": {
+											"type": "string",
+											"format": "uuid"
+										}
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid entity ID. The path parameter must be an integer.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string",
+											"example": "Invalid entity ID. Must be an integer."
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"x-code-samples": [
+					{
+						"lang": "cURL",
+						"source": "curl --request DELETE \\\n  --url https://api.mem0.ai/v1/entities/user/12345/ \\\n  --header 'Authorization: Token <api-key>'"
+					}
+				]
 			}
 		},
 		"/v2/entities/{entity_type}/{entity_id}/": {
@@ -257,7 +441,42 @@
 				"responses": {
 					"200": {
 						"description": "Successfully retrieved entity details.",
-						"content": {}
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"id": {
+												"type": "string"
+											},
+											"name": {
+												"type": "string"
+											},
+											"created_at": {
+												"type": "string",
+												"format": "date-time"
+											},
+											"updated_at": {
+												"type": "string",
+												"format": "date-time"
+											},
+											"owner": {
+												"type": "string"
+											},
+											"metadata": {
+												"type": "object",
+												"nullable": true
+											},
+											"type": {
+												"type": "string"
+											}
+										}
+									}
+								}
+							}
+						}
 					}
 				}
 			},
@@ -293,8 +512,8 @@
 					}
 				],
 				"responses": {
-					"204": {
-						"description": "Entity deleted successfully!",
+					"200": {
+						"description": "Entity deletion has been queued for background (async) execution.",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -302,7 +521,11 @@
 									"properties": {
 										"message": {
 											"type": "string",
-											"example": "Entity deleted successfully!"
+											"example": "Delete in progress. This may take some time."
+										},
+										"event_id": {
+											"type": "string",
+											"format": "uuid"
 										}
 									}
 								}
@@ -568,6 +791,16 @@
 										"latency": {
 											"type": "number",
 											"description": "Processing time in milliseconds."
+										},
+										"graph_status": {
+											"type": "string",
+											"nullable": true,
+											"description": "Status of graph memory processing for this event, if graph memory is enabled."
+										},
+										"error": {
+											"type": "string",
+											"nullable": true,
+											"description": "Error message if the event failed to process."
 										}
 									}
 								}
@@ -581,8 +814,9 @@
 								"schema": {
 									"type": "object",
 									"properties": {
-										"detail": {
-											"type": "string"
+										"error": {
+											"type": "string",
+											"example": "Event not found or you don't have permission to access it."
 										}
 									}
 								}
@@ -641,21 +875,7 @@
 									},
 									"filters": {
 										"type": "object",
-										"properties": {
-											"user_id": {
-												"type": "string"
-											},
-											"agent_id": {
-												"type": "string"
-											},
-											"app_id": {
-												"type": "string"
-											},
-											"run_id": {
-												"type": "string"
-											}
-										},
-										"description": "Filters to apply while exporting memories. Available fields are: user_id, agent_id, app_id, run_id."
+										"description": "Filters to apply while exporting memories, using the structured AND/OR filter format (see `/v2/memories/search/`), e.g. `{\"AND\": [{\"user_id\": \"<user_id>\"}]}`. Available fields are: user_id, agent_id, app_id, run_id. Flat filter objects (e.g. `{\"user_id\": \"<user_id>\"}`) are rejected with a 400 error."
 									},
 									"org_id": {
 										"type": "string",
@@ -702,13 +922,28 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"type": "object",
-									"properties": {
-										"message": {
-											"type": "string",
-											"example": "Schema is required and must be a valid object"
+									"oneOf": [
+										{
+											"type": "object",
+											"description": "Returned when the schema is missing or invalid.",
+											"properties": {
+												"message": {
+													"type": "string",
+													"example": "Schema is required and must be a valid object"
+												}
+											}
+										},
+										{
+											"type": "object",
+											"description": "Returned when filters are missing or not in the required structured AND/OR format.",
+											"properties": {
+												"error": {
+													"type": "string",
+													"example": "One of the filters: app_id, user_id, agent_id, run_id, memory_export_id is required!"
+												}
+											}
 										}
-									}
+									]
 								}
 							}
 						}
@@ -742,7 +977,7 @@
 				]
 			}
 		},
-		"/v1/exports/get": {
+		"/v1/exports/get/": {
 			"post": {
 				"tags": [
 					"exports"
@@ -877,6 +1112,7 @@
 				],
 				"description": "Get all memories.",
 				"operationId": "memories_list",
+				"deprecated": true,
 				"parameters": [
 					{
 						"name": "user_id",
@@ -1005,73 +1241,172 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"type": "object",
-										"properties": {
-											"id": {
-												"type": "string"
-											},
-											"memory": {
-												"type": "string"
-											},
-											"input": {
-												"type": "array",
-												"items": {
-													"type": "object",
-													"properties": {
-														"role": {
-															"type": "string"
-														},
-														"content": {
+									"oneOf": [
+										{
+											"type": "array",
+											"description": "Returned when the `page` and `page_size` query parameters are not both supplied.",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string"
+													},
+													"memory": {
+														"type": "string"
+													},
+													"user_id": {
+														"type": "string",
+														"nullable": true,
+														"description": "ID of the user this memory belongs to, if scoped to a user."
+													},
+													"metadata": {
+														"type": "object",
+														"additionalProperties": true,
+														"description": "User-supplied metadata attached to the memory."
+													},
+													"categories": {
+														"type": "array",
+														"nullable": true,
+														"items": {
 															"type": "string"
 														}
+													},
+													"created_at": {
+														"type": "string",
+														"format": "date-time"
+													},
+													"updated_at": {
+														"type": "string",
+														"format": "date-time"
+													},
+													"expiration_date": {
+														"type": "string",
+														"format": "date",
+														"description": "The date when the memory will expire. Format: YYYY-MM-DD.",
+														"nullable": true,
+														"default": null
+													},
+													"structured_attributes": {
+														"type": "object",
+														"additionalProperties": true,
+														"description": "System-derived temporal breakdown of the memory's creation time (e.g. year, month, day_of_week)."
+													},
+													"replaced_by": {
+														"type": "string",
+														"nullable": true,
+														"description": "ID of the memory that superseded this one, if any."
+													},
+													"synthesized": {
+														"type": "boolean",
+														"description": "Whether this memory was synthesized rather than directly extracted."
+													},
+													"lifecycle_state": {
+														"type": "string",
+														"description": "Lifecycle state of the memory."
+													}
+												},
+												"required": [
+													"id",
+													"memory",
+													"created_at",
+													"updated_at"
+												]
+											}
+										},
+										{
+											"type": "object",
+											"description": "Returned when both the `page` and `page_size` query parameters are supplied.",
+											"properties": {
+												"count": {
+													"type": "integer"
+												},
+												"next": {
+													"type": "string",
+													"nullable": true
+												},
+												"previous": {
+													"type": "string",
+													"nullable": true
+												},
+												"results": {
+													"type": "array",
+													"items": {
+														"type": "object",
+														"properties": {
+															"id": {
+																"type": "string"
+															},
+															"memory": {
+																"type": "string"
+															},
+															"user_id": {
+																"type": "string",
+																"nullable": true,
+																"description": "ID of the user this memory belongs to, if scoped to a user."
+															},
+															"metadata": {
+																"type": "object",
+																"additionalProperties": true,
+																"description": "User-supplied metadata attached to the memory."
+															},
+															"categories": {
+																"type": "array",
+																"nullable": true,
+																"items": {
+																	"type": "string"
+																}
+															},
+															"created_at": {
+																"type": "string",
+																"format": "date-time"
+															},
+															"updated_at": {
+																"type": "string",
+																"format": "date-time"
+															},
+															"expiration_date": {
+																"type": "string",
+																"format": "date",
+																"description": "The date when the memory will expire. Format: YYYY-MM-DD.",
+																"nullable": true,
+																"default": null
+															},
+															"structured_attributes": {
+																"type": "object",
+																"additionalProperties": true,
+																"description": "System-derived temporal breakdown of the memory's creation time (e.g. year, month, day_of_week)."
+															},
+															"replaced_by": {
+																"type": "string",
+																"nullable": true,
+																"description": "ID of the memory that superseded this one, if any."
+															},
+															"synthesized": {
+																"type": "boolean",
+																"description": "Whether this memory was synthesized rather than directly extracted."
+															},
+															"lifecycle_state": {
+																"type": "string",
+																"description": "Lifecycle state of the memory."
+															}
+														},
+														"required": [
+															"id",
+															"memory",
+															"created_at",
+															"updated_at"
+														]
 													}
 												}
 											},
-											"created_at": {
-												"type": "string",
-												"format": "date-time"
-											},
-											"updated_at": {
-												"type": "string",
-												"format": "date-time"
-											},
-											"owner": {
-												"type": "string"
-											},
-											"immutable": {
-												"type": "boolean",
-												"description": "Whether the memory is immutable.",
-												"title": "Immutable",
-												"default": false
-											},
-											"expiration_date": {
-												"type": "string",
-												"format": "date",
-												"description": "The date when the memory will expire. Format: YYYY-MM-DD.",
-												"title": "Expiration date",
-												"nullable": true,
-												"default": null
-											},
-											"organization": {
-												"type": "string"
-											},
-											"metadata": {
-												"type": "object"
-											}
-										},
-										"required": [
-											"id",
-											"memory",
-											"created_at",
-											"updated_at",
-											"total_memories",
-											"owner",
-											"organization",
-											"type"
-										]
-									}
+											"required": [
+												"count",
+												"next",
+												"previous",
+												"results"
+											]
+										}
+									]
 								}
 							}
 						}
@@ -1126,6 +1461,7 @@
 				],
 				"description": "Add memories.",
 				"operationId": "memories_create",
+				"deprecated": true,
 				"requestBody": {
 					"content": {
 						"application/json": {
@@ -1138,43 +1474,77 @@
 				},
 				"responses": {
 					"200": {
-						"description": "Successful memory creation.",
+						"description": "Memory processing has been queued for background (async) execution. The response reports queueing status, not the final memory content; poll `GET /v1/event/{event_id}/` with the returned `event_id` to see the processed result. By default (or with `version=v1` / `output_format=v1.0`) the response is a bare array. When both `output_format=v1.1` and `version=v2` are requested, the response is an object wrapping the same array under `results`.",
 						"content": {
 							"application/json": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"type": "object",
-										"properties": {
-											"id": {
-												"type": "string"
-											},
-											"data": {
+									"oneOf": [
+										{
+											"type": "array",
+											"description": "Default response shape.",
+											"items": {
 												"type": "object",
 												"properties": {
-													"memory": {
-														"type": "string"
+													"message": {
+														"type": "string",
+														"example": "Memory processing has been queued for background execution"
+													},
+													"status": {
+														"type": "string",
+														"example": "PENDING"
+													},
+													"event_id": {
+														"type": "string",
+														"format": "uuid"
 													}
 												},
 												"required": [
-													"memory"
-												]
-											},
-											"event": {
-												"type": "string",
-												"enum": [
-													"ADD",
-													"UPDATE",
-													"DELETE"
+													"message",
+													"status",
+													"event_id"
 												]
 											}
 										},
-										"required": [
-											"id",
-											"data",
-											"event"
-										]
-									}
+										{
+											"type": "object",
+											"description": "Response shape when both `output_format=v1.1` and `version=v2` are requested.",
+											"properties": {
+												"results": {
+													"type": "array",
+													"items": {
+														"type": "object",
+														"properties": {
+															"message": {
+																"type": "string",
+																"example": "Memory processing has been queued for background execution"
+															},
+															"status": {
+																"type": "string",
+																"example": "PENDING"
+															},
+															"event_id": {
+																"type": "string",
+																"format": "uuid"
+															}
+														},
+														"required": [
+															"message",
+															"status",
+															"event_id"
+														]
+													}
+												},
+												"relations": {
+													"type": "array",
+													"items": {}
+												}
+											},
+											"required": [
+												"results",
+												"relations"
+											]
+										}
+									]
 								}
 							}
 						}
@@ -1295,8 +1665,8 @@
 					}
 				],
 				"responses": {
-					"204": {
-						"description": "Successful deletion of memories.",
+					"200": {
+						"description": "Deletion of memories has been queued for background (async) execution.",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -1304,7 +1674,11 @@
 									"properties": {
 										"message": {
 											"type": "string",
-											"example": "Memories deleted successfully!"
+											"example": "Delete in progress. This may take some time."
+										},
+										"event_id": {
+											"type": "string",
+											"format": "uuid"
 										}
 									}
 								}
@@ -1348,6 +1722,7 @@
 				],
 				"description": "Get all memories.",
 				"operationId": "memories_list_v2",
+				"deprecated": true,
 				"requestBody": {
 					"content": {
 						"application/json": {
@@ -1369,52 +1744,77 @@
 										"type": "object",
 										"properties": {
 											"id": {
-												"type": "string"
+												"type": "string",
+												"format": "uuid",
+												"description": "Unique memory identifier."
 											},
 											"memory": {
-												"type": "string"
+												"type": "string",
+												"description": "The extracted memory fact."
+											},
+											"user_id": {
+												"type": "string",
+												"nullable": true,
+												"description": "User the memory is scoped to."
+											},
+											"app_id": {
+												"type": "string",
+												"nullable": true,
+												"description": "App the memory is scoped to."
+											},
+											"session_id": {
+												"type": "string",
+												"nullable": true,
+												"description": "Run/session the memory is scoped to. Note: this endpoint returns this field as `session_id`, matching `POST /v3/memories/`."
+											},
+											"metadata": {
+												"type": "object",
+												"additionalProperties": true,
+												"description": "Additional metadata associated with the memory"
+											},
+											"categories": {
+												"type": "array",
+												"nullable": true,
+												"items": {
+													"type": "string"
+												}
 											},
 											"created_at": {
 												"type": "string",
-												"format": "date-time"
+												"format": "date-time",
+												"description": "Timestamp of when the memory was created."
 											},
 											"updated_at": {
 												"type": "string",
-												"format": "date-time"
-											},
-											"owner": {
-												"type": "string"
-											},
-											"immutable": {
-												"type": "boolean",
-												"description": "Whether the memory is immutable.",
-												"title": "Immutable",
-												"default": false
+												"format": "date-time",
+												"description": "Timestamp of when the memory was last updated."
 											},
 											"expiration_date": {
 												"type": "string",
 												"format": "date",
-												"description": "The date when the memory will expire. Format: YYYY-MM-DD.",
-												"title": "Expiration date",
 												"nullable": true,
-												"default": null
+												"description": "The date when the memory will expire. Format: YYYY-MM-DD."
 											},
-											"organization": {
-												"type": "string"
+											"structured_attributes": {
+												"type": "object",
+												"additionalProperties": true,
+												"description": "System-derived temporal breakdown of the memory's creation time (e.g. year, month, day_of_week)."
 											},
-											"metadata": {
-												"type": "object"
+											"replaced_by": {
+												"type": "string",
+												"nullable": true,
+												"description": "ID of the memory that superseded this one, if any."
+											},
+											"synthesized": {
+												"type": "boolean",
+												"description": "Whether this memory was synthesized rather than directly extracted."
 											}
 										},
 										"required": [
 											"id",
 											"memory",
 											"created_at",
-											"updated_at",
-											"total_memories",
-											"owner",
-											"organization",
-											"type"
+											"updated_at"
 										]
 									}
 								}
@@ -1471,11 +1871,134 @@
 				"tags": [
 					"memories"
 				],
+				"description": "Despite the endpoint name, this returns memory history entries (the same shape as `GET /v1/memories/{memory_id}/history/`), not event/ingestion-job records. For event/ingestion-job status, use `GET /v1/event/{event_id}/`.",
 				"operationId": "memories_events_list",
 				"responses": {
 					"200": {
-						"description": "Successfully retrieved memory events.",
-						"content": {}
+						"description": "Successfully retrieved memory history entries.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"count": {
+											"type": "integer"
+										},
+										"next": {
+											"type": "string",
+											"nullable": true
+										},
+										"previous": {
+											"type": "string",
+											"nullable": true
+										},
+										"results": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string",
+														"format": "uuid",
+														"description": "Unique identifier for the history entry."
+													},
+													"memory_id": {
+														"type": "string",
+														"format": "uuid",
+														"description": "Unique identifier of the associated memory."
+													},
+													"input": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"role": {
+																	"type": "string"
+																},
+																"content": {
+																	"type": "string"
+																}
+															}
+														},
+														"description": "The conversation input that led to this memory change"
+													},
+													"old_memory": {
+														"type": "string",
+														"nullable": true,
+														"description": "The previous state of the memory, if applicable"
+													},
+													"new_memory": {
+														"type": "string",
+														"description": "The new or updated state of the memory"
+													},
+													"user_id": {
+														"type": "string",
+														"description": "The identifier of the user associated with this memory"
+													},
+													"categories": {
+														"type": "array",
+														"nullable": true,
+														"items": {
+															"type": "string"
+														},
+														"description": "Categories associated with the memory at this point in its history"
+													},
+													"created_at": {
+														"type": "string",
+														"format": "date-time",
+														"description": "The timestamp when this history entry was created."
+													},
+													"event": {
+														"type": "string",
+														"enum": [
+															"ADD",
+															"UPDATE",
+															"DELETE"
+														],
+														"description": "The type of event that occurred"
+													},
+													"previous_embedding_qwen": {
+														"type": "string",
+														"nullable": true,
+														"description": "Previous internal embedding representation (Qwen model), if applicable"
+													},
+													"embedding_qwen": {
+														"type": "string",
+														"nullable": true,
+														"description": "Internal embedding representation (Qwen model), if available"
+													},
+													"metadata": {
+														"type": "object",
+														"nullable": true,
+														"description": "Additional metadata associated with the memory change"
+													},
+													"updated_at": {
+														"type": "string",
+														"format": "date-time",
+														"description": "The timestamp when this history entry was last updated."
+													}
+												},
+												"required": [
+													"id",
+													"memory_id",
+													"new_memory",
+													"user_id",
+													"event",
+													"created_at",
+													"updated_at"
+												]
+											}
+										}
+									},
+									"required": [
+										"count",
+										"next",
+										"previous",
+										"results"
+									]
+								}
+							}
+						}
 					}
 				}
 			}
@@ -1487,6 +2010,7 @@
 				],
 				"description": "Perform a semantic search on memories.",
 				"operationId": "memories_search_create",
+				"deprecated": true,
 				"requestBody": {
 					"content": {
 						"application/json": {
@@ -1503,68 +2027,147 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"type": "array",
-									"items": {
-										"type": "object",
-										"properties": {
-											"id": {
-												"type": "string",
-												"format": "uuid",
-												"description": "Unique identifier for the memory."
-											},
-											"memory": {
-												"type": "string",
-												"description": "The content of the memory"
-											},
-											"user_id": {
-												"type": "string",
-												"description": "The identifier of the user associated with this memory"
-											},
-											"metadata": {
+									"oneOf": [
+										{
+											"type": "array",
+											"description": "Default response shape. Returned when `output_format` is omitted or set to `v1.0`.",
+											"items": {
 												"type": "object",
-												"nullable": true,
-												"description": "Additional metadata associated with the memory"
-											},
-											"categories": {
-												"type": "array",
-												"items": {
-													"type": "string"
+												"properties": {
+													"id": {
+														"type": "string",
+														"format": "uuid",
+														"description": "Unique identifier for the memory."
+													},
+													"memory": {
+														"type": "string",
+														"description": "The content of the memory"
+													},
+													"user_id": {
+														"type": "string",
+														"description": "The identifier of the user associated with this memory"
+													},
+													"score": {
+														"type": "number",
+														"description": "Relevance score of the memory for the search query."
+													},
+													"metadata": {
+														"type": "object",
+														"nullable": true,
+														"description": "Additional metadata associated with the memory"
+													},
+													"categories": {
+														"type": "array",
+														"items": {
+															"type": "string"
+														},
+														"description": "Categories associated with the memory"
+													},
+													"expiration_date": {
+														"type": "string",
+														"format": "date",
+														"description": "The date when the memory will expire. Format: YYYY-MM-DD.",
+														"title": "Expiration date",
+														"nullable": true,
+														"default": null
+													},
+													"created_at": {
+														"type": "string",
+														"format": "date-time",
+														"description": "The timestamp when the memory was created."
+													},
+													"updated_at": {
+														"type": "string",
+														"format": "date-time",
+														"description": "The timestamp when the memory was last updated."
+													}
 												},
-												"description": "Categories associated with the memory"
-											},
-											"immutable": {
-												"type": "boolean",
-												"description": "Whether the memory is immutable.",
-												"title": "Immutable",
-												"default": false
-											},
-											"expiration_date": {
-												"type": "string",
-												"format": "date",
-												"description": "The date when the memory will expire. Format: YYYY-MM-DD.",
-												"title": "Expiration date",
-												"nullable": true,
-												"default": null
-											},
-											"created_at": {
-												"type": "string",
-												"format": "date-time",
-												"description": "The timestamp when the memory was created."
-											},
-											"updated_at": {
-												"type": "string",
-												"format": "date-time",
-												"description": "The timestamp when the memory was last updated."
+												"required": [
+													"id",
+													"memory",
+													"user_id",
+													"created_at",
+													"updated_at"
+												]
 											}
 										},
-										"required": [
-											"id",
-											"memory",
-											"user_id",
-											"created_at",
-											"updated_at"
-										]
-									}
+										{
+											"type": "object",
+											"description": "Returned when `output_format=v1.1` is requested.",
+											"properties": {
+												"results": {
+													"type": "array",
+													"items": {
+														"type": "object",
+														"properties": {
+															"id": {
+																"type": "string",
+																"format": "uuid",
+																"description": "Unique identifier for the memory."
+															},
+															"memory": {
+																"type": "string",
+																"description": "The content of the memory"
+															},
+															"user_id": {
+																"type": "string",
+																"description": "The identifier of the user associated with this memory"
+															},
+															"score": {
+																"type": "number",
+																"description": "Relevance score of the memory for the search query."
+															},
+															"metadata": {
+																"type": "object",
+																"nullable": true,
+																"description": "Additional metadata associated with the memory"
+															},
+															"categories": {
+																"type": "array",
+																"items": {
+																	"type": "string"
+																},
+																"description": "Categories associated with the memory"
+															},
+															"expiration_date": {
+																"type": "string",
+																"format": "date",
+																"description": "The date when the memory will expire. Format: YYYY-MM-DD.",
+																"title": "Expiration date",
+																"nullable": true,
+																"default": null
+															},
+															"created_at": {
+																"type": "string",
+																"format": "date-time",
+																"description": "The timestamp when the memory was created."
+															},
+															"updated_at": {
+																"type": "string",
+																"format": "date-time",
+																"description": "The timestamp when the memory was last updated."
+															}
+														},
+														"required": [
+															"id",
+															"memory",
+															"user_id",
+															"created_at",
+															"updated_at"
+														]
+													}
+												},
+												"relations": {
+													"type": "array",
+													"items": {}
+												}
+											},
+											"required": [
+												"results",
+												"relations"
+											]
+										}
+									]
 								}
 							}
 						}
@@ -1622,6 +2225,7 @@
 				],
 				"description": "Search memories based on a query and filters.",
 				"operationId": "memories_search_v2",
+				"deprecated": true,
 				"requestBody": {
 					"content": {
 						"application/json": {
@@ -1784,6 +2388,38 @@
 										"type": "boolean",
 										"default": false,
 										"description": "When true, include memories whose `expiration_date` has passed. Expired memories are hidden by default."
+									},
+									"start_date": {
+										"type": "string",
+										"format": "date",
+										"description": "Only include memories created on or after this date (YYYY-MM-DD)."
+									},
+									"end_date": {
+										"type": "string",
+										"format": "date",
+										"description": "Only include memories created on or before this date (YYYY-MM-DD)."
+									},
+									"categories": {
+										"type": "array",
+										"items": {"type": "string"},
+										"description": "Restrict results to memories tagged with any of these categories."
+									},
+									"fields": {
+										"type": "array",
+										"items": {"type": "string"},
+										"description": "Restrict the fields returned per memory, e.g. [\"id\", \"memory\"]."
+									},
+									"keywords": {
+										"type": "string",
+										"description": "Free-text keyword filter applied on top of filters."
+									},
+									"page": {
+										"type": "integer",
+										"description": "1-indexed page number. Also accepted here in the request body; the query parameter of the same name takes precedence."
+									},
+									"page_size": {
+										"type": "integer",
+										"description": "Results per page. Also accepted here in the request body; the query parameter of the same name takes precedence."
 									}
 								}
 							},
@@ -1833,6 +2469,21 @@
 														"type": "string",
 														"description": "The extracted memory fact."
 													},
+													"user_id": {
+														"type": "string",
+														"nullable": true,
+														"description": "User the memory is scoped to."
+													},
+													"app_id": {
+														"type": "string",
+														"nullable": true,
+														"description": "App the memory is scoped to."
+													},
+													"session_id": {
+														"type": "string",
+														"nullable": true,
+														"description": "Run/session the memory is scoped to. Note: this endpoint returns this field as `session_id`, while `POST /v3/memories/search/` returns the same value as `run_id`."
+													},
 													"score": {
 														"type": "number",
 														"format": "float",
@@ -1847,9 +2498,30 @@
 													},
 													"categories": {
 														"type": "array",
+														"nullable": true,
 														"items": {
 															"type": "string"
 														}
+													},
+													"structured_attributes": {
+														"type": "object",
+														"additionalProperties": true,
+														"description": "System-derived temporal breakdown of the memory's creation time (e.g. year, month, day_of_week)."
+													},
+													"replaced_by": {
+														"type": "string",
+														"nullable": true,
+														"description": "ID of the memory that superseded this one, if any."
+													},
+													"synthesized": {
+														"type": "boolean",
+														"description": "Whether this memory was synthesized rather than directly extracted."
+													},
+													"expiration_date": {
+														"type": "string",
+														"format": "date",
+														"nullable": true,
+														"description": "Date after which the memory is hidden from search and get-all unless `show_expired` is true."
 													},
 													"created_at": {
 														"type": "string",
@@ -2007,6 +2679,65 @@
 										"type": "boolean",
 										"default": true,
 										"description": "When `false`, stores each message verbatim without running the extraction LLM."
+									},
+									"app_id": {
+										"type": "string",
+										"description": "Scope memories to this app."
+									},
+									"immutable": {
+										"type": "boolean",
+										"default": false,
+										"description": "Mark stored memories as immutable, excluding them from future update/consolidation."
+									},
+									"includes": {
+										"type": "string",
+										"description": "Free-text hint of what to include during extraction, e.g. \"vehicles\"."
+									},
+									"excludes": {
+										"type": "string",
+										"description": "Free-text hint of what to exclude during extraction, e.g. \"politics\"."
+									},
+									"enable_graph": {
+										"type": "boolean",
+										"description": "Enable graph memory extraction for this call."
+									},
+									"structured_data_schema": {
+										"type": "object",
+										"nullable": true,
+										"additionalProperties": true,
+										"description": "Optional schema constraining structured extraction. Exact shape not fully characterized; observed only as null in captured traffic."
+									},
+									"output_format": {
+										"type": "string",
+										"nullable": true,
+										"description": "Response envelope version, e.g. \"v1.1\". Full set of accepted values not confirmed."
+									},
+									"prompt_profile_id": {
+										"type": "string",
+										"nullable": true,
+										"description": "ID of a saved prompt profile to use for extraction."
+									},
+									"temporal_reasoning": {
+										"type": "boolean",
+										"description": "Enable temporal reasoning during extraction."
+									},
+									"timezone": {
+										"type": "string",
+										"description": "IANA timezone used to interpret observation_datetime and observation_date, e.g. \"UTC\"."
+									},
+									"observation_datetime": {
+										"type": "string",
+										"format": "date-time",
+										"description": "ISO 8601 datetime the conversation was observed."
+									},
+									"observation_date": {
+										"type": "string",
+										"format": "date",
+										"description": "Date the conversation was observed (YYYY-MM-DD)."
+									},
+									"timestamp": {
+										"type": "integer",
+										"description": "Unix epoch seconds used to backdate created_at on the stored memories. Not echoed back in the event payload but confirmed applied."
 									}
 								}
 							},
@@ -2049,6 +2780,31 @@
 										"event_id": {
 											"type": "string",
 											"format": "uuid"
+										},
+										"results": {
+											"type": "array",
+											"description": "Only present when `infer` is `false`, where processing is synchronous and memories are stored verbatim without extraction.",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string",
+														"format": "uuid"
+													},
+													"data": {
+														"type": "object",
+														"properties": {
+															"memory": {
+																"type": "string"
+															}
+														}
+													},
+													"event": {
+														"type": "string",
+														"example": "ADD"
+													}
+												}
+											}
 										}
 									}
 								},
@@ -2154,6 +2910,25 @@
 										],
 										"nullable": true,
 										"description": "Optional query anchor time for relative temporal interpretation. Accepts Unix epoch, YYYY-MM-DD, or ISO datetime."
+									},
+									"fields": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										},
+										"description": "Restrict the fields returned per memory."
+									},
+									"categories": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										},
+										"description": "Filter results to memories tagged with any of these categories."
+									},
+									"metadata": {
+										"type": "object",
+										"additionalProperties": true,
+										"description": "Filter results to memories matching this metadata."
 									}
 								}
 							},
@@ -2189,12 +2964,51 @@
 														"type": "string",
 														"description": "The extracted memory fact."
 													},
+													"user_id": {
+														"type": "string",
+														"nullable": true,
+														"description": "User the memory is scoped to."
+													},
 													"score": {
 														"type": "number",
 														"format": "float",
 														"minimum": 0,
 														"maximum": 1,
 														"description": "Combined multi-signal relevance score in [0, 1] (search responses only)."
+													},
+													"score_breakdown": {
+														"type": "object",
+														"description": "Per-signal breakdown of the relevance score.",
+														"properties": {
+															"semantic": {
+																"type": "number"
+															},
+															"bm25": {
+																"type": "number"
+															},
+															"entity": {
+																"type": "number"
+															}
+														}
+													},
+													"agent_id": {
+														"type": "string",
+														"nullable": true
+													},
+													"app_id": {
+														"type": "string",
+														"nullable": true
+													},
+													"run_id": {
+														"type": "string",
+														"nullable": true,
+														"description": "Run/session the memory is scoped to. Note: this endpoint returns this field as `run_id`, while `POST /v3/memories/` returns the same value as `session_id`."
+													},
+													"expiration_date": {
+														"type": "string",
+														"format": "date",
+														"nullable": true,
+														"description": "Date after which the memory is hidden from search unless `show_expired` is true."
 													},
 													"metadata": {
 														"type": "object",
@@ -2283,7 +3097,106 @@
 				"responses": {
 					"200": {
 						"description": "Successfully retrieved memories.",
-						"content": {}
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"count": {
+											"type": "integer"
+										},
+										"next": {
+											"type": "string",
+											"nullable": true
+										},
+										"previous": {
+											"type": "string",
+											"nullable": true
+										},
+										"results": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"id": {
+														"type": "string"
+													},
+													"memory": {
+														"type": "string"
+													},
+													"metadata": {
+														"type": "object",
+														"nullable": true,
+														"additionalProperties": true
+													},
+													"categories": {
+														"type": "array",
+														"nullable": true,
+														"items": {
+															"type": "string"
+														}
+													},
+													"created_at": {
+														"type": "string",
+														"format": "date-time"
+													},
+													"updated_at": {
+														"type": "string",
+														"format": "date-time"
+													},
+													"input": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"role": {
+																	"type": "string"
+																},
+																"content": {
+																	"type": "string"
+																}
+															}
+														},
+														"description": "The conversation input that produced this memory."
+													},
+													"is_updated": {
+														"type": "boolean"
+													}
+												},
+												"required": [
+													"id",
+													"memory",
+													"created_at",
+													"updated_at"
+												]
+											}
+										}
+									},
+									"required": [
+										"count",
+										"next",
+										"previous",
+										"results"
+									]
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid entity type.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string",
+											"example": "Invalid entity type"
+										}
+									}
+								}
+							}
+						}
 					}
 				}
 			},
@@ -2293,8 +3206,15 @@
 					"in": "path",
 					"required": true,
 					"schema": {
-						"type": "string"
-					}
+						"type": "string",
+						"enum": [
+							"user",
+							"agent",
+							"run",
+							"app"
+						]
+					},
+					"description": "The type of entity to retrieve memories for."
 				},
 				{
 					"name": "entity_id",
@@ -2344,30 +3264,20 @@
 										},
 										"user_id": {
 											"type": "string",
+											"nullable": true,
 											"description": "Identifier of the user associated with this memory"
-										},
-										"agent_id": {
-											"type": "string",
-											"nullable": true,
-											"description": "The agent ID associated with the memory, if any"
-										},
-										"app_id": {
-											"type": "string",
-											"nullable": true,
-											"description": "The app ID associated with the memory, if any"
-										},
-										"run_id": {
-											"type": "string",
-											"nullable": true,
-											"description": "The run ID associated with the memory, if any"
-										},
-										"hash": {
-											"type": "string",
-											"description": "Hash of the memory content"
 										},
 										"metadata": {
 											"type": "object",
+											"additionalProperties": true,
 											"description": "Additional metadata associated with the memory"
+										},
+										"categories": {
+											"type": "array",
+											"nullable": true,
+											"items": {
+												"type": "string"
+											}
 										},
 										"created_at": {
 											"type": "string",
@@ -2378,6 +3288,30 @@
 											"type": "string",
 											"format": "date-time",
 											"description": "Timestamp of when the memory was last updated."
+										},
+										"expiration_date": {
+											"type": "string",
+											"format": "date",
+											"nullable": true,
+											"description": "The date when the memory will expire. Format: YYYY-MM-DD."
+										},
+										"structured_attributes": {
+											"type": "object",
+											"additionalProperties": true,
+											"description": "System-derived temporal breakdown of the memory's creation time (e.g. year, month, day_of_week)."
+										},
+										"replaced_by": {
+											"type": "string",
+											"nullable": true,
+											"description": "ID of the memory that superseded this one, if any."
+										},
+										"synthesized": {
+											"type": "boolean",
+											"description": "Whether this memory was synthesized rather than directly extracted."
+										},
+										"lifecycle_state": {
+											"type": "string",
+											"description": "Lifecycle state of the memory."
 										}
 									}
 								}
@@ -2484,37 +3418,26 @@
 											"format": "uuid",
 											"description": "The unique identifier of the updated memory."
 										},
-										"text": {
+										"memory": {
 											"type": "string",
-											"description": "The updated text content of the memory"
+											"description": "The updated content of the memory."
 										},
 										"user_id": {
 											"type": "string",
 											"nullable": true,
-											"description": "The user ID associated with the memory, if any"
-										},
-										"agent_id": {
-											"type": "string",
-											"nullable": true,
-											"description": "The agent ID associated with the memory, if any"
-										},
-										"app_id": {
-											"type": "string",
-											"nullable": true,
-											"description": "The app ID associated with the memory, if any"
-										},
-										"run_id": {
-											"type": "string",
-											"nullable": true,
-											"description": "The run ID associated with the memory, if any"
-										},
-										"hash": {
-											"type": "string",
-											"description": "Hash of the memory content"
+											"description": "Identifier of the user associated with this memory"
 										},
 										"metadata": {
 											"type": "object",
+											"additionalProperties": true,
 											"description": "Additional metadata associated with the memory"
+										},
+										"categories": {
+											"type": "array",
+											"nullable": true,
+											"items": {
+												"type": "string"
+											}
 										},
 										"created_at": {
 											"type": "string",
@@ -2525,6 +3448,30 @@
 											"type": "string",
 											"format": "date-time",
 											"description": "Timestamp of when the memory was last updated."
+										},
+										"expiration_date": {
+											"type": "string",
+											"format": "date",
+											"nullable": true,
+											"description": "The date when the memory will expire. Format: YYYY-MM-DD."
+										},
+										"structured_attributes": {
+											"type": "object",
+											"additionalProperties": true,
+											"description": "System-derived temporal breakdown of the memory's creation time (e.g. year, month, day_of_week)."
+										},
+										"replaced_by": {
+											"type": "string",
+											"nullable": true,
+											"description": "ID of the memory that superseded this one, if any."
+										},
+										"synthesized": {
+											"type": "boolean",
+											"description": "Whether this memory was synthesized rather than directly extracted."
+										},
+										"lifecycle_state": {
+											"type": "string",
+											"description": "Lifecycle state of the memory."
 										}
 									}
 								}
@@ -2576,10 +3523,19 @@
 							"format": "uuid"
 						},
 						"description": "The unique identifier of the memory to retrieve."
+					},
+					{
+						"name": "delete_linked",
+						"in": "query",
+						"schema": {
+							"type": "boolean",
+							"default": false
+						},
+						"description": "If true, also delete memories linked to this one. The response then includes a `cascade_count` field with the number of linked memories deleted."
 					}
 				],
 				"responses": {
-					"204": {
+					"200": {
 						"description": "Successful deletion of memory.",
 						"content": {
 							"application/json": {
@@ -2589,6 +3545,10 @@
 										"message": {
 											"type": "string",
 											"example": "Memory deleted successfully!"
+										},
+										"cascade_count": {
+											"type": "integer",
+											"description": "Number of linked memories also deleted. Only present when `delete_linked=true` was passed."
 										}
 									}
 								}
@@ -2701,6 +3661,14 @@
 												"type": "string",
 												"description": "The identifier of the user associated with this memory"
 											},
+											"categories": {
+												"type": "array",
+												"nullable": true,
+												"items": {
+													"type": "string"
+												},
+												"description": "Categories associated with the memory at this point in its history"
+											},
 											"event": {
 												"type": "string",
 												"enum": [
@@ -2709,6 +3677,16 @@
 													"DELETE"
 												],
 												"description": "The type of event that occurred"
+											},
+											"previous_embedding_qwen": {
+												"type": "string",
+												"nullable": true,
+												"description": "Previous internal embedding representation (Qwen model), if applicable"
+											},
+											"embedding_qwen": {
+												"type": "string",
+												"nullable": true,
+												"description": "Internal embedding representation (Qwen model), if available"
 											},
 											"metadata": {
 												"type": "object",
@@ -2793,7 +3771,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/CreateRun"
+									"$ref": "#/components/schemas/RunResponse"
 								}
 							}
 						}
@@ -2813,9 +3791,162 @@
 				"responses": {
 					"200": {
 						"description": "Successfully retrieved statistics.",
-						"content": {}
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"total_memories": {
+											"type": "integer"
+										},
+										"total_retrieval_events": {
+											"type": "integer"
+										},
+										"total_add_events": {
+											"type": "integer"
+										},
+										"total_api_retrieval_events": {
+											"type": "integer"
+										},
+										"total_retrieval_events_limit": {
+											"type": "integer"
+										},
+										"total_users_with_memories": {
+											"type": "integer"
+										},
+										"total_agents_with_memories": {
+											"type": "integer"
+										},
+										"total_runs_with_memories": {
+											"type": "integer"
+										},
+										"memories_per_user": {
+											"type": "integer"
+										},
+										"memories_per_agent": {
+											"type": "integer"
+										},
+										"memories_per_run": {
+											"type": "integer"
+										}
+									}
+								}
+							}
+						}
 					}
 				}
+			}
+		},
+		"/v1/ping/": {
+			"get": {
+				"tags": [
+					"stats"
+				],
+				"summary": "Check API key validity and resolve organization/project context.",
+				"description": "Both the Python and TypeScript SDKs call this endpoint on client construction to validate the API key and resolve the default `org_id` and `project_id`.",
+				"operationId": "ping_read",
+				"responses": {
+					"200": {
+						"description": "The API key is valid.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"status": {
+											"type": "string",
+											"example": "ok"
+										},
+										"org_id": {
+											"type": "string"
+										},
+										"project_id": {
+											"type": "string"
+										},
+										"user_email": {
+											"type": "string",
+											"format": "email"
+										}
+									}
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Invalid API key.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"detail": {
+											"type": "string",
+											"example": "Invalid API key. You can find your API key on https://app.mem0.ai/dashboard/api-keys."
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"x-code-samples": [
+					{
+						"lang": "cURL",
+						"source": "curl --request GET \\\n  --url https://api.mem0.ai/v1/ping/ \\\n  --header 'Authorization: Token <api-key>'"
+					}
+				]
+			}
+		},
+		"/v1/summary/": {
+			"post": {
+				"tags": [
+					"memories"
+				],
+				"summary": "Get a summary of memories matching the given filters.",
+				"description": "Backs the Python SDK's `client.get_summary()`. Not currently exposed by the TypeScript SDK.",
+				"operationId": "summary_create",
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"filters": {
+										"type": "object",
+										"description": "Either flat field:value pairs (e.g. `{\"user_id\": \"<user_id>\"}`) or the structured AND/OR filter format used by `/v2/memories/search/`."
+									}
+								},
+								"required": [
+									"filters"
+								]
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Successfully retrieved the summary.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {}
+								}
+							}
+						}
+					}
+				},
+				"x-code-samples": [
+					{
+						"lang": "Python",
+						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\")\n\nsummary = client.get_summary(filters={\"user_id\": \"<user_id>\"})\nprint(summary)"
+					},
+					{
+						"lang": "cURL",
+						"source": "curl --request POST \\\n  --url https://api.mem0.ai/v1/summary/ \\\n  --header 'Authorization: Token <api-key>' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\n  \"filters\": {\"user_id\": \"<user_id>\"}\n}'"
+					}
+				]
 			}
 		},
 		"/v1/users/": {
@@ -2841,7 +3972,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/CreateUser"
+									"$ref": "#/components/schemas/UserResponse"
 								}
 							}
 						}
@@ -2963,10 +4094,6 @@
 									"items": {
 										"type": "object",
 										"properties": {
-											"id": {
-												"type": "integer",
-												"description": "Unique identifier for the organization."
-											},
 											"org_id": {
 												"type": "string",
 												"description": "Organization's unique string identifier."
@@ -2974,30 +4101,6 @@
 											"name": {
 												"type": "string",
 												"description": "Name of the organization."
-											},
-											"description": {
-												"type": "string",
-												"description": "Brief description of the organization"
-											},
-											"address": {
-												"type": "string",
-												"description": "Physical address of the organization"
-											},
-											"contact_email": {
-												"type": "string",
-												"description": "Primary contact email for the organization"
-											},
-											"phone_number": {
-												"type": "string",
-												"description": "Contact phone number for the organization"
-											},
-											"website": {
-												"type": "string",
-												"description": "Official website URL of the organization"
-											},
-											"on_paid_plan": {
-												"type": "boolean",
-												"description": "Indicates whether the organization is on a paid plan"
 											},
 											"created_at": {
 												"type": "string",
@@ -3009,16 +4112,48 @@
 												"format": "date-time",
 												"description": "Timestamp of when the organization was last updated."
 											},
-											"owner": {
-												"type": "integer",
-												"description": "Identifier of the organization's owner"
-											},
 											"members": {
 												"type": "array",
 												"items": {
-													"type": "integer"
+													"type": "object",
+													"properties": {
+														"username": {
+															"type": "string"
+														},
+														"role": {
+															"type": "string"
+														},
+														"email": {
+															"type": "string"
+														}
+													}
 												},
-												"description": "List of member identifiers belonging to the organization."
+												"description": "Members belonging to the organization."
+											},
+											"is_default": {
+												"type": "boolean",
+												"description": "Whether this is the caller's default organization."
+											},
+											"byok_enabled": {
+												"type": "boolean",
+												"description": "Whether bring-your-own-key is enabled for the organization."
+											},
+											"invitations": {
+												"type": "array",
+												"items": {},
+												"description": "Pending invitations for the organization."
+											},
+											"owner_pricing_plan": {
+												"type": "string",
+												"description": "Pricing plan of the organization owner."
+											},
+											"is_owner": {
+												"type": "boolean",
+												"description": "Whether the caller owns the organization."
+											},
+											"user_role": {
+												"type": "string",
+												"description": "The caller's role within the organization."
 											}
 										}
 									}
@@ -3179,43 +4314,13 @@
 								"schema": {
 									"type": "object",
 									"properties": {
-										"id": {
-											"type": "integer",
-											"description": "Unique identifier for the organization."
-										},
 										"org_id": {
 											"type": "string",
-											"description": "Unique organization ID"
+											"description": "Organization's unique string identifier."
 										},
 										"name": {
 											"type": "string",
 											"description": "Name of the organization."
-										},
-										"description": {
-											"type": "string",
-											"description": "Description of the organization"
-										},
-										"address": {
-											"type": "string",
-											"description": "Address of the organization"
-										},
-										"contact_email": {
-											"type": "string",
-											"format": "email",
-											"description": "Contact email for the organization"
-										},
-										"phone_number": {
-											"type": "string",
-											"description": "Phone number of the organization"
-										},
-										"website": {
-											"type": "string",
-											"format": "uri",
-											"description": "Website of the organization"
-										},
-										"on_paid_plan": {
-											"type": "boolean",
-											"description": "Indicates if the organization is on a paid plan"
 										},
 										"created_at": {
 											"type": "string",
@@ -3227,16 +4332,48 @@
 											"format": "date-time",
 											"description": "Timestamp of when the organization was last updated."
 										},
-										"owner": {
-											"type": "integer",
-											"description": "Identifier of the organization's owner"
-										},
 										"members": {
 											"type": "array",
 											"items": {
-												"type": "integer"
+												"type": "object",
+												"properties": {
+													"username": {
+														"type": "string"
+													},
+													"role": {
+														"type": "string"
+													},
+													"email": {
+														"type": "string"
+													}
+												}
 											},
-											"description": "List of member identifiers belonging to the organization."
+											"description": "Members belonging to the organization."
+										},
+										"is_default": {
+											"type": "boolean",
+											"description": "Whether this is the caller's default organization."
+										},
+										"byok_enabled": {
+											"type": "boolean",
+											"description": "Whether bring-your-own-key is enabled for the organization."
+										},
+										"invitations": {
+											"type": "array",
+											"items": {},
+											"description": "Pending invitations for the organization."
+										},
+										"owner_pricing_plan": {
+											"type": "string",
+											"description": "Pricing plan of the organization owner."
+										},
+										"is_owner": {
+											"type": "boolean",
+											"description": "Whether the caller owns the organization."
+										},
+										"user_role": {
+											"type": "string",
+											"description": "The caller's role within the organization."
 										}
 									}
 								}
@@ -4124,10 +5261,97 @@
 													"role": {
 														"type": "string",
 														"description": "Role of the member in the project."
+													},
+													"email": {
+														"type": "string",
+														"description": "Email address of the project member."
 													}
 												}
 											},
 											"description": "List of members belonging to the project"
+										},
+										"usecase": {
+											"type": "string",
+											"nullable": true,
+											"description": "Configured use case for the project."
+										},
+										"memory_depth": {
+											"type": "string",
+											"description": "Memory extraction depth setting for this project."
+										},
+										"inclusion_prompt": {
+											"type": "string",
+											"nullable": true,
+											"description": "Custom prompt describing what should be included when extracting memories."
+										},
+										"exclusion_prompt": {
+											"type": "string",
+											"nullable": true,
+											"description": "Custom prompt describing what should be excluded when extracting memories."
+										},
+										"custom_categories": {
+											"type": "array",
+											"items": {
+												"type": "object"
+											},
+											"description": "List of custom categories configured for memory categorization in this project."
+										},
+										"custom_instructions": {
+											"type": "string",
+											"description": "Custom instructions for memory processing in this project."
+										},
+										"update_custom_instructions": {
+											"type": "string",
+											"nullable": true,
+											"description": "Custom instructions applied when updating existing memories."
+										},
+										"summary_custom_instructions": {
+											"type": "string",
+											"nullable": true,
+											"description": "Custom instructions applied when generating summaries."
+										},
+										"summary_batch_size": {
+											"type": "integer",
+											"description": "Number of items processed per batch when generating summaries."
+										},
+										"summary_max_tokens": {
+											"type": "integer",
+											"nullable": true,
+											"description": "Maximum tokens allowed in a generated summary."
+										},
+										"expiration_date": {
+											"type": "string",
+											"nullable": true,
+											"description": "Default expiration date applied to memories created in this project."
+										},
+										"enable_graph": {
+											"type": "boolean",
+											"description": "Whether graph memory is enabled for this project."
+										},
+										"multilingual": {
+											"type": "boolean",
+											"description": "Whether to use the input language for memory storage and retrieval."
+										},
+										"version": {
+											"type": "string",
+											"description": "API version used by this project."
+										},
+										"is_default": {
+											"type": "boolean",
+											"description": "Whether this is the organization's default project."
+										},
+										"active_prompt_profile": {
+											"type": "string",
+											"nullable": true,
+											"description": "Identifier of the active prompt profile for this project."
+										},
+										"decay": {
+											"type": "boolean",
+											"description": "Whether memory decay is enabled for this project."
+										},
+										"user_role": {
+											"type": "string",
+											"description": "Role of the requesting user within this project."
 										}
 									}
 								}
@@ -4236,6 +5460,22 @@
 									"multilingual": {
 										"type": "boolean",
 										"description": "Whether to use the input language for memory storage and retrieval."
+									},
+									"memory_depth": {
+										"type": "string",
+										"description": "Memory extraction depth setting for this project."
+									},
+									"decay": {
+										"type": "boolean",
+										"description": "Whether memory decay is enabled for this project."
+									},
+									"enable_graph": {
+										"type": "boolean",
+										"description": "Whether graph memory is enabled for this project."
+									},
+									"version": {
+										"type": "string",
+										"description": "API version used by this project."
 									}
 								}
 							}
@@ -5110,6 +6350,10 @@
 												},
 												"description": "List of event types the webhook subscribes to."
 											},
+											"owner": {
+												"type": "string",
+												"description": "Username of the webhook's owner."
+											},
 											"is_active": {
 												"type": "boolean",
 												"description": "Whether the webhook is active"
@@ -5154,27 +6398,27 @@
 				"x-code-samples": [
 					{
 						"lang": "Python",
-						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\")\n\n# Get all webhooks\nwebhooks = client.get_webhooks(project_id=\"your_project_id\")\nprint(webhooks)\n\n# Create a webhook\nwebhook = client.create_webhook(\n    url=\"https://your-webhook-url.com\",\n    name=\"My Webhook\",\n    project_id=\"your_project_id\",\n    event_types=[\"memory:add\", \"memory:categorize\"]\n)\nprint(webhook)"
+						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\")\n\n# Get all webhooks\nwebhooks = client.get_webhooks(project_id=\"your_project_id\")\nprint(webhooks)\n\n# Create a webhook\nwebhook = client.create_webhook(\n    url=\"https://your-webhook-url.com\",\n    name=\"My Webhook\",\n    project_id=\"your_project_id\",\n    event_types=[\"memory_add\", \"memory_categorize\"]\n)\nprint(webhook)"
 					},
 					{
 						"lang": "JavaScript",
-						"source": "// To use the JavaScript SDK, install the package:\n// npm i mem0ai\n\nimport MemoryClient from 'mem0ai';\nconst client = new MemoryClient({ apiKey: 'your-api-key' });\n\n// Get all webhooks\nclient.getWebhooks('your_project_id')\n  .then(webhooks => console.log(webhooks))\n  .catch(err => console.error(err));\n\n// Create a webhook\nclient.createWebhook({\n  url: 'https://your-webhook-url.com',\n  name: 'My Webhook',\n  project_id: 'your_project_id',\n  event_types: ['memory:add']\n})\n  .then(webhook => console.log(webhook))\n  .catch(err => console.error(err));"
+						"source": "// To use the JavaScript SDK, install the package:\n// npm i mem0ai\n\nimport MemoryClient from 'mem0ai';\nconst client = new MemoryClient({ apiKey: 'your-api-key' });\n\n// Get all webhooks\nclient.getWebhooks('your_project_id')\n  .then(webhooks => console.log(webhooks))\n  .catch(err => console.error(err));\n\n// Create a webhook\nclient.createWebhook({\n  url: 'https://your-webhook-url.com',\n  name: 'My Webhook',\n  project_id: 'your_project_id',\n  event_types: ['memory_add']\n})\n  .then(webhook => console.log(webhook))\n  .catch(err => console.error(err));"
 					},
 					{
 						"lang": "cURL",
-						"source": "# Get all webhooks\ncurl --request GET \\\n  --url 'https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/' \\\n  --header 'Authorization: Token your-api-key'\n\n# Create a webhook\ncurl --request POST \\\n  --url 'https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/' \\\n  --header 'Authorization: Token your-api-key' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\n    \"url\": \"https://your-webhook-url.com\",\n    \"name\": \"My Webhook\",\n    \"event_types\": [\"memory:add\"]\n  }'"
+						"source": "# Get all webhooks\ncurl --request GET \\\n  --url 'https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/' \\\n  --header 'Authorization: Token your-api-key'\n\n# Create a webhook\ncurl --request POST \\\n  --url 'https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/' \\\n  --header 'Authorization: Token your-api-key' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\n    \"url\": \"https://your-webhook-url.com\",\n    \"name\": \"My Webhook\",\n    \"event_types\": [\"memory_add\"]\n  }'"
 					},
 					{
 						"lang": "PHP",
-						"source": "<?php\n\n$curl = curl_init();\n\n// Get all webhooks\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_HTTPHEADER => [\"Authorization: Token your-api-key\"],\n]);\n\n$response = curl_exec($curl);\n\n// Create a webhook\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_POST => true,\n  CURLOPT_POSTFIELDS => json_encode([\n    \"url\" => \"https://your-webhook-url.com\",\n    \"name\" => \"My Webhook\",\n    \"event_types\" => [\"memory:add\"]\n  ]),\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: Token your-api-key\",\n    \"Content-Type: application/json\"\n  ],\n]);\n\n$response = curl_exec($curl);\ncurl_close($curl);"
+						"source": "<?php\n\n$curl = curl_init();\n\n// Get all webhooks\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_HTTPHEADER => [\"Authorization: Token your-api-key\"],\n]);\n\n$response = curl_exec($curl);\n\n// Create a webhook\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_POST => true,\n  CURLOPT_POSTFIELDS => json_encode([\n    \"url\" => \"https://your-webhook-url.com\",\n    \"name\" => \"My Webhook\",\n    \"event_types\" => [\"memory_add\"]\n  ]),\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: Token your-api-key\",\n    \"Content-Type: application/json\"\n  ],\n]);\n\n$response = curl_exec($curl);\ncurl_close($curl);"
 					},
 					{
 						"lang": "Go",
-						"source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io/ioutil\"\n)\n\nfunc main() {\n\t// Get all webhooks\n\treq, _ := http.NewRequest(\"GET\", \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\", nil)\n\treq.Header.Add(\"Authorization\", \"Token your-api-key\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\tfmt.Println(string(body))\n\n\t// Create a webhook\n\tpayload := strings.NewReader(`{\n\t\t\"url\": \"https://your-webhook-url.com\",\n\t\t\"name\": \"My Webhook\",\n\t\t\"event_types\": [\"memory:add\"]\n\t}`)\n\n\treq, _ = http.NewRequest(\"POST\", \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\", payload)\n\treq.Header.Add(\"Authorization\", \"Token your-api-key\")\n\treq.Header.Add(\"Content-Type\", \"application/json\")\n\n\tres, _ = http.DefaultClient.Do(req)\n\tdefer res.Body.Close()\n\tbody, _ = ioutil.ReadAll(res.Body)\n\tfmt.Println(string(body))\n}"
+						"source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io/ioutil\"\n)\n\nfunc main() {\n\t// Get all webhooks\n\treq, _ := http.NewRequest(\"GET\", \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\", nil)\n\treq.Header.Add(\"Authorization\", \"Token your-api-key\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\tfmt.Println(string(body))\n\n\t// Create a webhook\n\tpayload := strings.NewReader(`{\n\t\t\"url\": \"https://your-webhook-url.com\",\n\t\t\"name\": \"My Webhook\",\n\t\t\"event_types\": [\"memory_add\"]\n\t}`)\n\n\treq, _ = http.NewRequest(\"POST\", \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\", payload)\n\treq.Header.Add(\"Authorization\", \"Token your-api-key\")\n\treq.Header.Add(\"Content-Type\", \"application/json\")\n\n\tres, _ = http.DefaultClient.Do(req)\n\tdefer res.Body.Close()\n\tbody, _ = ioutil.ReadAll(res.Body)\n\tfmt.Println(string(body))\n}"
 					},
 					{
 						"lang": "Java",
-						"source": "// Get all webhooks\nHttpResponse<String> response = Unirest.get(\"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\")\n  .header(\"Authorization\", \"Token your-api-key\")\n  .asString();\n\n// Create a webhook\nHttpResponse<String> response = Unirest.post(\"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\")\n  .header(\"Authorization\", \"Token your-api-key\")\n  .header(\"Content-Type\", \"application/json\")\n  .body(\"{\n    \\\"url\\\": \\\"https://your-webhook-url.com\\\",\n    \\\"name\\\": \\\"My Webhook\\\",\n    \\\"event_types\\\": [\\\"memory:add\\\"]\n  }\")\n  .asString();"
+						"source": "// Get all webhooks\nHttpResponse<String> response = Unirest.get(\"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\")\n  .header(\"Authorization\", \"Token your-api-key\")\n  .asString();\n\n// Create a webhook\nHttpResponse<String> response = Unirest.post(\"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\")\n  .header(\"Authorization\", \"Token your-api-key\")\n  .header(\"Content-Type\", \"application/json\")\n  .body(\"{\n    \\\"url\\\": \\\"https://your-webhook-url.com\\\",\n    \\\"name\\\": \\\"My Webhook\\\",\n    \\\"event_types\\\": [\\\"memory_add\\\"]\n  }\")\n  .asString();"
 					}
 				]
 			},
@@ -5203,7 +6447,9 @@
 							"schema": {
 								"type": "object",
 								"required": [
-									"url"
+									"url",
+									"name",
+									"event_types"
 								],
 								"properties": {
 									"name": {
@@ -5219,13 +6465,17 @@
 										"items": {
 											"type": "string",
 											"enum": [
-												"memory:add",
-												"memory:update",
-												"memory:delete",
-												"memory:categorize"
+												"memory_add",
+												"memory_update",
+												"memory_delete",
+												"memory_categorize",
+												"ingest_job_completed",
+												"ingest_job_partially_completed",
+												"ingest_job_failed",
+												"ingest_job_cancelled"
 											]
 										},
-										"description": "List of event types to subscribe to."
+										"description": "List of event types to subscribe to. Required: omitting this field does not fall back to a usable default."
 									},
 									"is_active": {
 										"type": "boolean",
@@ -5262,6 +6512,10 @@
 											"items": {
 												"type": "string"
 											}
+										},
+										"owner": {
+											"type": "string",
+											"description": "Username of the webhook's owner."
 										},
 										"is_active": {
 											"type": "boolean"
@@ -5317,27 +6571,27 @@
 				"x-code-samples": [
 					{
 						"lang": "Python",
-						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\")\n\n# Create a webhook\nwebhook = client.create_webhook(\n    url=\"https://your-webhook-url.com\",\n    name=\"My Webhook\",\n    project_id=\"your_project_id\",\n    event_types=[\"memory:add\", \"memory:categorize\"]\n)\nprint(webhook)"
+						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\")\n\n# Create a webhook\nwebhook = client.create_webhook(\n    url=\"https://your-webhook-url.com\",\n    name=\"My Webhook\",\n    project_id=\"your_project_id\",\n    event_types=[\"memory_add\", \"memory_categorize\"]\n)\nprint(webhook)"
 					},
 					{
 						"lang": "JavaScript",
-						"source": "// To use the JavaScript SDK, install the package:\n// npm i mem0ai\n\nimport MemoryClient from 'mem0ai';\nconst client = new MemoryClient({ apiKey: \"your-api-key\" });\n\n// Create a webhook\nclient.createWebhook({\n    url: \"https://your-webhook-url.com\",\n    name: \"My Webhook\",\n    project_id: \"your_project_id\",\n    event_types: [\"memory:add\"]\n})\n    .then(response => console.log('Create webhook response:', response))\n    .catch(error => console.error(error));"
+						"source": "// To use the JavaScript SDK, install the package:\n// npm i mem0ai\n\nimport MemoryClient from 'mem0ai';\nconst client = new MemoryClient({ apiKey: \"your-api-key\" });\n\n// Create a webhook\nclient.createWebhook({\n    url: \"https://your-webhook-url.com\",\n    name: \"My Webhook\",\n    project_id: \"your_project_id\",\n    event_types: [\"memory_add\"]\n})\n    .then(response => console.log('Create webhook response:', response))\n    .catch(error => console.error(error));"
 					},
 					{
 						"lang": "cURL",
-						"source": "curl -X POST \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\" \\\n     -H \"Authorization: Token your-api-key\" \\\n     -H \"Content-Type: application/json\" \\\n     -d '{\n         \"url\": \"https://your-webhook-url.com\",\n         \"name\": \"My Webhook\",\n         \"event_types\": [\"memory:add\"]\n     }'"
+						"source": "curl -X POST \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\" \\\n     -H \"Authorization: Token your-api-key\" \\\n     -H \"Content-Type: application/json\" \\\n     -d '{\n         \"url\": \"https://your-webhook-url.com\",\n         \"name\": \"My Webhook\",\n         \"event_types\": [\"memory_add\"]\n     }'"
 					},
 					{
 						"lang": "PHP",
-						"source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n    CURLOPT_URL => \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\",\n    CURLOPT_RETURNTRANSFER => true,\n    CURLOPT_POST => true,\n    CURLOPT_POSTFIELDS => json_encode([\n        \"url\" => \"https://your-webhook-url.com\",\n        \"name\" => \"My Webhook\",\n        \"event_types\" => [\"memory:add\"]\n    ]),\n    CURLOPT_HTTPHEADER => [\n        \"Authorization: Token your-api-key\",\n        \"Content-Type: application/json\"\n    ],\n]);\n\n$response = curl_exec($curl);\ncurl_close($curl);\n\necho $response;"
+						"source": "<?php\n\n$curl = curl_init();\n\ncurl_setopt_array($curl, [\n    CURLOPT_URL => \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\",\n    CURLOPT_RETURNTRANSFER => true,\n    CURLOPT_POST => true,\n    CURLOPT_POSTFIELDS => json_encode([\n        \"url\" => \"https://your-webhook-url.com\",\n        \"name\" => \"My Webhook\",\n        \"event_types\" => [\"memory_add\"]\n    ]),\n    CURLOPT_HTTPHEADER => [\n        \"Authorization: Token your-api-key\",\n        \"Content-Type: application/json\"\n    ],\n]);\n\n$response = curl_exec($curl);\ncurl_close($curl);\n\necho $response;"
 					},
 					{
 						"lang": "Go",
-						"source": "package main\n\nimport (\n    \"fmt\"\n    \"strings\"\n    \"net/http\"\n    \"io/ioutil\"\n)\n\nfunc main() {\n    payload := strings.NewReader(`{\n        \"url\": \"https://your-webhook-url.com\",\n        \"name\": \"My Webhook\",\n        \"event_types\": [\"memory:add\"]\n    }`)\n\n    req, _ := http.NewRequest(\"POST\", \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\", payload)\n    req.Header.Add(\"Authorization\", \"Token your-api-key\")\n    req.Header.Add(\"Content-Type\", \"application/json\")\n\n    res, _ := http.DefaultClient.Do(req)\n    defer res.Body.Close()\n    body, _ := ioutil.ReadAll(res.Body)\n\n    fmt.Println(string(body))\n}"
+						"source": "package main\n\nimport (\n    \"fmt\"\n    \"strings\"\n    \"net/http\"\n    \"io/ioutil\"\n)\n\nfunc main() {\n    payload := strings.NewReader(`{\n        \"url\": \"https://your-webhook-url.com\",\n        \"name\": \"My Webhook\",\n        \"event_types\": [\"memory_add\"]\n    }`)\n\n    req, _ := http.NewRequest(\"POST\", \"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\", payload)\n    req.Header.Add(\"Authorization\", \"Token your-api-key\")\n    req.Header.Add(\"Content-Type\", \"application/json\")\n\n    res, _ := http.DefaultClient.Do(req)\n    defer res.Body.Close()\n    body, _ := ioutil.ReadAll(res.Body)\n\n    fmt.Println(string(body))\n}"
 					},
 					{
 						"lang": "Java",
-						"source": "import com.konghq.unirest.http.HttpResponse;\nimport com.konghq.unirest.http.Unirest;\n\n// Create a webhook\nHttpResponse<String> response = Unirest.post(\"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\")\n    .header(\"Authorization\", \"Token your-api-key\")\n    .header(\"Content-Type\", \"application/json\")\n    .body(\"{\n        \\\"url\\\": \\\"https://your-webhook-url.com\\\",\n        \\\"name\\\": \\\"My Webhook\\\",\n        \\\"event_types\\\": [\\\"memory:add\\\"]\n    }\")\n    .asString();\n\nSystem.out.println(response.getBody());"
+						"source": "import com.konghq.unirest.http.HttpResponse;\nimport com.konghq.unirest.http.Unirest;\n\n// Create a webhook\nHttpResponse<String> response = Unirest.post(\"https://api.mem0.ai/api/v1/webhooks/your_project_id/webhook/\")\n    .header(\"Authorization\", \"Token your-api-key\")\n    .header(\"Content-Type\", \"application/json\")\n    .body(\"{\n        \\\"url\\\": \\\"https://your-webhook-url.com\\\",\n        \\\"name\\\": \\\"My Webhook\\\",\n        \\\"event_types\\\": [\\\"memory_add\\\"]\n    }\")\n    .asString();\n\nSystem.out.println(response.getBody());"
 					}
 				]
 			}
@@ -5381,10 +6635,14 @@
 										"items": {
 											"type": "string",
 											"enum": [
-												"memory:add",
-												"memory:update",
-												"memory:delete",
-												"memory:categorize"
+												"memory_add",
+												"memory_update",
+												"memory_delete",
+												"memory_categorize",
+												"ingest_job_completed",
+												"ingest_job_partially_completed",
+												"ingest_job_failed",
+												"ingest_job_cancelled"
 											]
 										},
 										"description": "New list of event types to subscribe to"
@@ -5462,27 +6720,27 @@
 				"x-code-samples": [
 					{
 						"lang": "Python",
-						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\")\n\n# Update a webhook\nwebhook = client.update_webhook(\n    webhook_id=\"your_webhook_id\",\n    name=\"Updated Webhook\",\n    url=\"https://new-webhook-url.com\",\n    event_types=[\"memory:add\", \"memory:categorize\"]\n)\nprint(webhook)\n\n# Delete a webhook\nresponse = client.delete_webhook(webhook_id=\"your_webhook_id\")\nprint(response)"
+						"source": "# To use the Python SDK, install the package:\n# pip install mem0ai\n\nfrom mem0 import MemoryClient\nclient = MemoryClient(api_key=\"your_api_key\")\n\n# Update a webhook\nwebhook = client.update_webhook(\n    webhook_id=\"your_webhook_id\",\n    name=\"Updated Webhook\",\n    url=\"https://new-webhook-url.com\",\n    event_types=[\"memory_add\", \"memory_categorize\"]\n)\nprint(webhook)\n\n# Delete a webhook\nresponse = client.delete_webhook(webhook_id=\"your_webhook_id\")\nprint(response)"
 					},
 					{
 						"lang": "JavaScript",
-						"source": "// To use the JavaScript SDK, install the package:\n// npm i mem0ai\n\nimport MemoryClient from 'mem0ai';\nconst client = new MemoryClient({ apiKey: 'your-api-key' });\n\n// Update a webhook\nclient.updateWebhook('your_webhook_id', {\n  name: 'Updated Webhook',\n  url: 'https://new-webhook-url.com',\n  event_types: ['memory:add', 'memory:categorize']\n})\n  .then(webhook => console.log(webhook))\n  .catch(err => console.error(err));\n\n// Delete a webhook\nclient.deleteWebhook('your_webhook_id')\n  .then(response => console.log(response))\n  .catch(err => console.error(err));"
+						"source": "// To use the JavaScript SDK, install the package:\n// npm i mem0ai\n\nimport MemoryClient from 'mem0ai';\nconst client = new MemoryClient({ apiKey: 'your-api-key' });\n\n// Update a webhook\nclient.updateWebhook('your_webhook_id', {\n  name: 'Updated Webhook',\n  url: 'https://new-webhook-url.com',\n  event_types: ['memory_add', 'memory_categorize']\n})\n  .then(webhook => console.log(webhook))\n  .catch(err => console.error(err));\n\n// Delete a webhook\nclient.deleteWebhook('your_webhook_id')\n  .then(response => console.log(response))\n  .catch(err => console.error(err));"
 					},
 					{
 						"lang": "cURL",
-						"source": "# Update a webhook\ncurl --request PUT \\\n  --url 'https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/' \\\n  --header 'Authorization: Token your-api-key' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\n    \"name\": \"Updated Webhook\",\n    \"url\": \"https://new-webhook-url.com\",\n    \"event_types\": [\"memory:add\"]\n  }'\n\n# Delete a webhook\ncurl --request DELETE \\\n  --url 'https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/' \\\n  --header 'Authorization: Token your-api-key'"
+						"source": "# Update a webhook\ncurl --request PUT \\\n  --url 'https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/' \\\n  --header 'Authorization: Token your-api-key' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\n    \"name\": \"Updated Webhook\",\n    \"url\": \"https://new-webhook-url.com\",\n    \"event_types\": [\"memory_add\"]\n  }'\n\n# Delete a webhook\ncurl --request DELETE \\\n  --url 'https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/' \\\n  --header 'Authorization: Token your-api-key'"
 					},
 					{
 						"lang": "PHP",
-						"source": "<?php\n\n$curl = curl_init();\n\n// Update a webhook\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_CUSTOMREQUEST => \"PUT\",\n  CURLOPT_POSTFIELDS => json_encode([\n    \"name\" => \"Updated Webhook\",\n    \"url\" => \"https://new-webhook-url.com\",\n    \"event_types\" => [\"memory:add\"]\n  ]),\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: Token your-api-key\",\n    \"Content-Type: application/json\"\n  ],\n]);\n\n$response = curl_exec($curl);\n\n// Delete a webhook\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_CUSTOMREQUEST => \"DELETE\",\n  CURLOPT_HTTPHEADER => [\"Authorization: Token your-api-key\"],\n]);\n\n$response = curl_exec($curl);\ncurl_close($curl);"
+						"source": "<?php\n\n$curl = curl_init();\n\n// Update a webhook\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_CUSTOMREQUEST => \"PUT\",\n  CURLOPT_POSTFIELDS => json_encode([\n    \"name\" => \"Updated Webhook\",\n    \"url\" => \"https://new-webhook-url.com\",\n    \"event_types\" => [\"memory_add\"]\n  ]),\n  CURLOPT_HTTPHEADER => [\n    \"Authorization: Token your-api-key\",\n    \"Content-Type: application/json\"\n  ],\n]);\n\n$response = curl_exec($curl);\n\n// Delete a webhook\ncurl_setopt_array($curl, [\n  CURLOPT_URL => \"https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/\",\n  CURLOPT_RETURNTRANSFER => true,\n  CURLOPT_CUSTOMREQUEST => \"DELETE\",\n  CURLOPT_HTTPHEADER => [\"Authorization: Token your-api-key\"],\n]);\n\n$response = curl_exec($curl);\ncurl_close($curl);"
 					},
 					{
 						"lang": "Go",
-						"source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io/ioutil\"\n)\n\nfunc main() {\n\t// Update a webhook\n\tpayload := strings.NewReader(`{\n\t\t\"name\": \"Updated Webhook\",\n\t\t\"url\": \"https://new-webhook-url.com\",\n\t\t\"event_types\": [\"memory:add\"]\n\t}`)\n\n\treq, _ := http.NewRequest(\"PUT\", \"https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/\", payload)\n\treq.Header.Add(\"Authorization\", \"Token your-api-key\")\n\treq.Header.Add(\"Content-Type\", \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\tfmt.Println(string(body))\n\n\t// Delete a webhook\n\treq, _ = http.NewRequest(\"DELETE\", \"https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/\", nil)\n\treq.Header.Add(\"Authorization\", \"Token your-api-key\")\n\n\tres, _ = http.DefaultClient.Do(req)\n\tdefer res.Body.Close()\n\tbody, _ = ioutil.ReadAll(res.Body)\n\tfmt.Println(string(body))\n}"
+						"source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io/ioutil\"\n)\n\nfunc main() {\n\t// Update a webhook\n\tpayload := strings.NewReader(`{\n\t\t\"name\": \"Updated Webhook\",\n\t\t\"url\": \"https://new-webhook-url.com\",\n\t\t\"event_types\": [\"memory_add\"]\n\t}`)\n\n\treq, _ := http.NewRequest(\"PUT\", \"https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/\", payload)\n\treq.Header.Add(\"Authorization\", \"Token your-api-key\")\n\treq.Header.Add(\"Content-Type\", \"application/json\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\tfmt.Println(string(body))\n\n\t// Delete a webhook\n\treq, _ = http.NewRequest(\"DELETE\", \"https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/\", nil)\n\treq.Header.Add(\"Authorization\", \"Token your-api-key\")\n\n\tres, _ = http.DefaultClient.Do(req)\n\tdefer res.Body.Close()\n\tbody, _ = ioutil.ReadAll(res.Body)\n\tfmt.Println(string(body))\n}"
 					},
 					{
 						"lang": "Java",
-						"source": "// Update a webhook\nHttpResponse<String> response = Unirest.put(\"https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/\")\n  .header(\"Authorization\", \"Token your-api-key\")\n  .header(\"Content-Type\", \"application/json\")\n  .body(\"{\n    \\\"name\\\": \\\"Updated Webhook\\\",\n    \\\"url\\\": \\\"https://new-webhook-url.com\\\",\n    \\\"event_types\\\": [\\\"memory:add\\\"]\n  }\")\n  .asString();\n\n// Delete a webhook\nHttpResponse<String> response = Unirest.delete(\"https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/\")\n  .header(\"Authorization\", \"Token your-api-key\")\n  .asString();"
+						"source": "// Update a webhook\nHttpResponse<String> response = Unirest.put(\"https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/\")\n  .header(\"Authorization\", \"Token your-api-key\")\n  .header(\"Content-Type\", \"application/json\")\n  .body(\"{\n    \\\"name\\\": \\\"Updated Webhook\\\",\n    \\\"url\\\": \\\"https://new-webhook-url.com\\\",\n    \\\"event_types\\\": [\\\"memory_add\\\"]\n  }\")\n  .asString();\n\n// Delete a webhook\nHttpResponse<String> response = Unirest.delete(\"https://api.mem0.ai/api/v1/webhooks/your_webhook_id/webhook/\")\n  .header(\"Authorization\", \"Token your-api-key\")\n  .asString();"
 					}
 				]
 			},
@@ -5587,7 +6845,8 @@
 		"schemas": {
 			"CreateAgent": {
 				"required": [
-					"agent_id"
+					"agent_id",
+					"name"
 				],
 				"type": "object",
 				"properties": {
@@ -5608,9 +6867,58 @@
 					}
 				}
 			},
+			"AgentResponse": {
+				"type": "object",
+				"description": "Response returned after creating an Agent.",
+				"properties": {
+					"id": {
+						"title": "Id",
+						"type": "integer",
+						"description": "Internal numeric identifier."
+					},
+					"agent_id": {
+						"title": "Agent id",
+						"type": "string"
+					},
+					"name": {
+						"title": "Name",
+						"type": "string"
+					},
+					"metadata": {
+						"title": "Metadata",
+						"type": "object",
+						"properties": {}
+					},
+					"created_at": {
+						"title": "Created at",
+						"type": "string",
+						"format": "date-time"
+					},
+					"updated_at": {
+						"title": "Updated at",
+						"type": "string",
+						"format": "date-time"
+					},
+					"graph_entities": {
+						"title": "Graph entities",
+						"nullable": true,
+						"description": "Graph entities linked to this record, if any."
+					},
+					"is_deleted": {
+						"title": "Is deleted",
+						"type": "boolean"
+					},
+					"project": {
+						"title": "Project",
+						"type": "integer",
+						"description": "Internal numeric identifier of the project this record belongs to."
+					}
+				}
+			},
 			"CreateApp": {
 				"required": [
-					"app_id"
+					"app_id",
+					"name"
 				],
 				"type": "object",
 				"properties": {
@@ -5628,6 +6936,54 @@
 						"title": "Metadata",
 						"type": "object",
 						"properties": {}
+					}
+				}
+			},
+			"AppResponse": {
+				"type": "object",
+				"description": "Response returned after creating an App.",
+				"properties": {
+					"id": {
+						"title": "Id",
+						"type": "integer",
+						"description": "Internal numeric identifier."
+					},
+					"app_id": {
+						"title": "App id",
+						"type": "string"
+					},
+					"name": {
+						"title": "Name",
+						"type": "string"
+					},
+					"metadata": {
+						"title": "Metadata",
+						"type": "object",
+						"properties": {}
+					},
+					"created_at": {
+						"title": "Created at",
+						"type": "string",
+						"format": "date-time"
+					},
+					"updated_at": {
+						"title": "Updated at",
+						"type": "string",
+						"format": "date-time"
+					},
+					"graph_entities": {
+						"title": "Graph entities",
+						"nullable": true,
+						"description": "Graph entities linked to this record, if any."
+					},
+					"is_deleted": {
+						"title": "Is deleted",
+						"type": "boolean"
+					},
+					"project": {
+						"title": "Project",
+						"type": "integer",
+						"description": "Internal numeric identifier of the project this record belongs to."
 					}
 				}
 			},
@@ -5697,11 +7053,11 @@
 						"default": true
 					},
 					"output_format": {
-						"description": "Controls the response format structure. `v1.0` (deprecated) returns a direct array of memory objects: `[{...}, {...}]`. `v1.1` (recommended) returns an object with a 'results' key containing the array: `{\"results\": [...]}`. The `v1.0` format will be removed in future versions.",
+						"description": "Controls the response format structure. `v1.0` (default) returns a direct array of memory objects: `[{...}, {...}]`. `v1.1` returns an object with a 'results' key containing the array: `{\"results\": [...]}`.",
 						"title": "Output format",
 						"type": "string",
 						"nullable": true,
-						"default": "v1.1"
+						"default": "v1.0"
 					},
 					"custom_categories": {
 						"description": "A list of categories with category name and its description.",
@@ -5834,7 +7190,7 @@
 						"title": "Output format",
 						"type": "string",
 						"nullable": true,
-						"default": "v1.1",
+						"default": "v1.0",
 						"description": "The search method supports two output formats: `v1.0` (default) and `v1.1`. We recommend using `v1.1` as `v1.0` will be deprecated soon."
 					},
 					"org_id": {
@@ -6145,7 +7501,8 @@
 			},
 			"CreateRun": {
 				"required": [
-					"run_id"
+					"run_id",
+					"name"
 				],
 				"type": "object",
 				"properties": {
@@ -6166,6 +7523,54 @@
 					}
 				}
 			},
+			"RunResponse": {
+				"type": "object",
+				"description": "Response returned after creating a Run.",
+				"properties": {
+					"id": {
+						"title": "Id",
+						"type": "integer",
+						"description": "Internal numeric identifier."
+					},
+					"run_id": {
+						"title": "Run id",
+						"type": "string"
+					},
+					"name": {
+						"title": "Name",
+						"type": "string"
+					},
+					"metadata": {
+						"title": "Metadata",
+						"type": "object",
+						"properties": {}
+					},
+					"created_at": {
+						"title": "Created at",
+						"type": "string",
+						"format": "date-time"
+					},
+					"updated_at": {
+						"title": "Updated at",
+						"type": "string",
+						"format": "date-time"
+					},
+					"graph_entities": {
+						"title": "Graph entities",
+						"nullable": true,
+						"description": "Graph entities linked to this record, if any."
+					},
+					"is_deleted": {
+						"title": "Is deleted",
+						"type": "boolean"
+					},
+					"project": {
+						"title": "Project",
+						"type": "integer",
+						"description": "Internal numeric identifier of the project this record belongs to."
+					}
+				}
+			},
 			"CreateUser": {
 				"required": [
 					"user_id"
@@ -6181,6 +7586,50 @@
 						"title": "Metadata",
 						"type": "object",
 						"properties": {}
+					}
+				}
+			},
+			"UserResponse": {
+				"type": "object",
+				"description": "Response returned after creating a User.",
+				"properties": {
+					"id": {
+						"title": "Id",
+						"type": "integer",
+						"description": "Internal numeric identifier."
+					},
+					"user_id": {
+						"title": "User id",
+						"type": "string"
+					},
+					"metadata": {
+						"title": "Metadata",
+						"type": "object",
+						"properties": {}
+					},
+					"created_at": {
+						"title": "Created at",
+						"type": "string",
+						"format": "date-time"
+					},
+					"updated_at": {
+						"title": "Updated at",
+						"type": "string",
+						"format": "date-time"
+					},
+					"graph_entities": {
+						"title": "Graph entities",
+						"nullable": true,
+						"description": "Graph entities linked to this record, if any."
+					},
+					"is_deleted": {
+						"title": "Is deleted",
+						"type": "boolean"
+					},
+					"project": {
+						"title": "Project",
+						"type": "integer",
+						"description": "Internal numeric identifier of the project this record belongs to."
 					}
 				}
 			},

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1757,6 +1757,11 @@
 												"nullable": true,
 												"description": "User the memory is scoped to."
 											},
+											"agent_id": {
+												"type": "string",
+												"nullable": true,
+												"description": "Agent the memory is scoped to."
+											},
 											"app_id": {
 												"type": "string",
 												"nullable": true,
@@ -2474,6 +2479,11 @@
 														"nullable": true,
 														"description": "User the memory is scoped to."
 													},
+													"agent_id": {
+														"type": "string",
+														"nullable": true,
+														"description": "Agent the memory is scoped to."
+													},
 													"app_id": {
 														"type": "string",
 														"nullable": true,
@@ -2483,13 +2493,6 @@
 														"type": "string",
 														"nullable": true,
 														"description": "Run/session the memory is scoped to. Note: this endpoint returns this field as `session_id`, while `POST /v3/memories/search/` returns the same value as `run_id`."
-													},
-													"score": {
-														"type": "number",
-														"format": "float",
-														"minimum": 0,
-														"maximum": 1,
-														"description": "Combined multi-signal relevance score in [0, 1] (search responses only)."
 													},
 													"metadata": {
 														"type": "object",
@@ -4990,10 +4993,6 @@
 									"items": {
 										"type": "object",
 										"properties": {
-											"id": {
-												"type": "integer",
-												"description": "Unique numeric identifier of the project"
-											},
 											"project_id": {
 												"type": "string",
 												"description": "Unique string identifier of the project"
@@ -5223,10 +5222,6 @@
 								"schema": {
 									"type": "object",
 									"properties": {
-										"id": {
-											"type": "integer",
-											"description": "Unique numeric identifier of the project"
-										},
 										"project_id": {
 											"type": "string",
 											"description": "Unique string identifier of the project"


### PR DESCRIPTION
## Linked Issue

Closes #<!-- no pre-existing issue: this PR was produced from a manual, endpoint-by-endpoint audit of the Mem0 Platform API (api.mem0.ai) against docs/openapi.json, run outside of any tracked issue. Every change below is backed by a captured live HTTP response or a fresh live API call made during the audit; no field was added, removed, or renamed on inference alone. -->

## Description

`docs/openapi.json` had drifted from the live Mem0 Platform API (`https://api.mem0.ai`). This PR brings it back in line, verified endpoint by endpoint against real HTTP responses (not inferred, not "made consistent").

Scope: `docs/openapi.json` only. No SDK code, no server code, no CI/CD workflow changes.

### Endpoints added (were missing from the spec entirely)

- `GET /v1/ping/` - returns `{org_id, project_id, user_email}`, used by SDKs to resolve the caller's org/project.
- `POST /v1/summary/` - memory summarization endpoint.
- `DELETE /v1/entities/{entity_type}/{entity_id}/` - the v1 (non-deprecated-in-practice) entity delete path actually used by one of the SDKs; returns `200` with `message` + `event_id`.

### Broken path fixed

- `POST /v1/exports/get` -> `POST /v1/exports/get/`. The spec was missing the trailing slash; the live API 404s without it (confirmed with a fresh request against the corrected path, which returned the expected export payload).

### Delete operations: 204 -> 200 with async body

Every delete endpoint that touches memories/entities is actually async and returns `200` with `{"message": "...", "event_id": "<uuid>"}`, not the previously documented `204 No Content`:

- `DELETE /v1/memories/` (`memories_delete_all`): confirmed via `param_results.json` ("delete_all with user_id") and `round3_results.json` ("delete_all"), both `200` with `message` + `event_id`.
- `DELETE /v1/memories/{memory_id}/` (`memories_delete`): confirmed `200` with `{"message": "Memory deleted successfully!"}` (`param_results.json`); also documented the previously-undocumented `delete_linked` query parameter, which adds a `cascade_count` integer to the response when set (`round3_results.json`, "delete with delete_linked=true").

### Memory object schema corrections

Response schemas for memory objects had drifted badly from what the API returns. Corrected against direct evidence for each endpoint individually (not copy-pasted across endpoints without verification):

- `GET /v1/memories/{memory_id}/` and `PUT /v1/memories/{memory_id}/` (update): removed never-returned fields (`text`, `agent_id`, `app_id`, `run_id`, `hash`); added the fields actually returned (`memory`, `user_id`, `categories`, `structured_attributes`, `replaced_by`, `synthesized`, `lifecycle_state`, `expiration_date`). Evidence: `raw_results.json` "update memory" entry, cross-checked against the already-correct `GET` schema.
- `POST /v2/memories/` (`memories_list_v2`, deprecated list): removed `owner`, `immutable`, `organization` (never returned), fixed a `required` array that referenced two properties (`total_memories`, `type`) not present anywhere in the schema, and added `user_id`, `app_id`, `session_id`, `categories`, `structured_attributes`, `replaced_by`, `synthesized`. Evidence: `raw_results.json` "get_all v2" and `param_results.json` "v2 filters AND/OR syntax" (both unprojected baseline responses for the same memory record).
- Documented the `session_id` vs `run_id` naming divergence: `/v2/memories/` and `/v3/memories/` (list) return the field as `session_id`; `/v3/memories/search/` returns the identical value as `run_id`. Confirmed with the same underlying memory record (`e373c776-0e07-484a-beec-fec1a26242ed`) returned by both endpoints.

### Other response schema corrections (evidence-backed)

- `GET /v1/entities/`: added pagination envelope (`count`/`next`/`previous`/`results`) and aggregate counts (`total_users`, `total_agents`, `total_apps`, `total_runs`).
- `POST /v3/memories/search/`: added `score_breakdown` (`semantic`/`bm25`/`entity`), `agent_id`, `app_id`, `run_id`, `expiration_date`, `metadata`, `categories`, `created_at`, `updated_at`.
- `GET /v1/memories/{memory_id}/history/`: added `categories`, `previous_embedding_qwen`, `embedding_qwen` (an embedding-vector leak worth flagging to the API team, but documenting it here reflects reality).
- `GET /v1/event/{event_id}/`: added `graph_status`, `error`.
- Organization and project object schemas corrected to match actually-returned fields.
- Added response schemas to operations that previously had none: `GET /v1/stats/`, `GET /v1/entities/filters/`, `GET /v1/memories/events/`, `GET /v2/entities/{entity_type}/{entity_id}/`, `GET /v1/memories/{entity_type}/{entity_id}/`.

### Request schema corrections (evidence-backed)

- `POST /v3/memories/add/`: added 12 accepted-but-undocumented body fields (`app_id`, `immutable`, `includes`, `excludes`, `enable_graph`, `structured_data_schema`, `output_format`, `prompt_profile_id`, `temporal_reasoning`, `timezone`, `observation_datetime`/`observation_date`, `timestamp`).
- `POST /v3/memories/`: added `start_date`, `end_date`, `categories`, `fields`, `keywords`, `page`, `page_size`.
- `POST /v3/memories/search/`: added `fields`, `categories`, `metadata`.
- Project `PATCH`: added `memory_depth`, `decay`, `enable_graph`, `version`.
- `name` marked `required` on `POST /v1/agents/`, `POST /v1/apps/`, `POST /v1/runs/` (server 400s without it; the spec previously only required the entity id).
- `POST /v1/exports/` and `POST /v1/exports/get/`: typed `filters` as the structured AND/OR form (a flat filter object is rejected with a 400 on the live API) and documented `memory_export_id` on the `get` endpoint.
- Webhook creation: `name` marked required, `event_types` constrained to the actual accepted enum (including the four undocumented `ingest_job_*` values).
- `POST /v1/feedback/`: `feedback` constrained to the actual enum (`POSITIVE`, `NEGATIVE`, `VERY_NEGATIVE`); invalid values 400.

### Undocumented conventions documented

- The `*` wildcard for bulk delete filters (`DELETE /v1/memories/`) is now called out per-parameter.
- The `401` `{"detail": "..."}` error shape is documented where directly verified (e.g. `GET /v1/ping/`).

## Not changed, needs confirmation

These were flagged by the audit but deliberately left untouched because no direct live evidence exists for them in this pass, per the rule that every change must be backed by an observed response:

- Delete response shapes for organization, organization-member, project, project-member, and `/v1/batch/` (batch delete) were **already** documented as `200`, so no change was needed, but no live delete call was made against any of these in the audit (deleting an org/project was explicitly out of scope for safety). If their actual shape ever diverges from the documented `{"message": "..."}` form, that would need a fresh, separate verification pass.
- The malformed/stringified-Python-repr `400` validation error body (Django REST Framework internals leaking as a string) is a live API bug, not documented here on purpose. Documenting it would freeze a bug as intended behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A. This only changes the OpenAPI description of the API surface to match what already exists in production; it does not change any code path.

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Every change in this PR was verified against a captured live HTTP response from `https://api.mem0.ai` (recorded during a dedicated audit session using throwaway `spec-fix-`/`oas-`-prefixed test entities) or a fresh live API call made while preparing this PR. `docs/openapi.json` was validated with `python3 -c "import json; json.load(open('docs/openapi.json'))"` after every edit, and the final operation count/list was diffed against a pre-edit snapshot to confirm no operations were accidentally dropped (55 operations after, vs. 52 before plus the 3 newly-added endpoints, with the `/v1/exports/get` -> `/v1/exports/get/` rename accounted for).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (N/A: this is a JSON spec file with no automated test suite; verification was manual, against live API responses, as described above)
- [x] New and existing tests pass locally (`python3 -c "import json; json.load(open('docs/openapi.json'))"` passes)
- [x] I have updated documentation if needed
