### PR TITLE
docs: correct add-memories endpoint to /v3/memories/add/ in entity-scoped memory guide

### DIFF
--- a/docs/platform/features/entity-scoped-memory.mdx
+++ b/docs/platform/features/entity-scoped-memory.mdx
@@ -83,7 +83,7 @@ Passing both `user_id` and `agent_id` to `client.add` does **not** produce recor
 As a result, `{"AND": [{"user_id": ...}, {"agent_id": ...}]}` returns nothing for memories created this way. Use `OR` to match either scope. Records with both fields populated only come from [Direct Import](/platform/features/direct-import) (`infer=False`), which writes your text verbatim without attribution splitting.
 </Warning>
 
-The HTTP equivalent uses `POST /v1/memories/` with the same identifiers in the JSON body. See the Add Memories API reference for REST details.
+The HTTP equivalent uses `POST /v3/memories/add/` with the same identifiers in the JSON body. See the [Add Memories](/api-reference/memory/add-memories) API reference for REST details.
 
 ## See it in action
 


### PR DESCRIPTION
## Linked Issue

No issue filed — a one-line factual correction found while reading the page. Follows the same convention as #6771 (`docs: correct openapi.json against live API behavior`).

## Description

[`docs/platform/features/entity-scoped-memory.mdx`](https://github.com/mem0ai/mem0/blob/main/docs/platform/features/entity-scoped-memory.mdx) told readers the HTTP equivalent of `client.add` is `POST /v1/memories/`. That is wrong on two counts:

1. **`POST /v1/memories/` is deprecated.** `docs/openapi.json` marks it `"deprecated": true`; `POST /v3/memories/add/` is the current, non-deprecated add endpoint (`"summary": "Add memories (V3)"`).
2. **It is not what `client.add` sends.** Both SDKs post to `/v3/memories/add/`:
   - `mem0/client/main.py:217` (sync) and `:1153` (async)
   - `mem0-ts/src/client/mem0.ts:272`

Since the sentence explicitly presents itself as "the HTTP equivalent" of the Python snippet directly above it, a reader translating that example to REST would have hit a deprecated endpoint.

This is leftover from the v1→v3 migration (#4741, then #4856 / #4916) — the rest of the docs were updated and this line was missed. It had gone stale enough to contradict the very page it points at: `docs/api-reference/memory/add-memories.mdx` is declared `openapi: post /v3/memories/add/`, and `docs/platform/quickstart.mdx:90` already curls `/v3/memories/add/`.

Also converts "Add Memories API reference" from dead plain text into a link to that page.

## Scope note for reviewers

**This is deliberately not a blanket `v1` → `v3` replacement.** Only add / search / get-all moved to v3. These v1 routes are still current (`"deprecated": false` in `openapi.json`) and are still called by both SDKs:

| Route | Status |
|---|---|
| `DELETE /v1/memories/` | current |
| `GET /v1/memories/events/` | current |
| `GET /v1/memories/{entity_type}/{entity_id}/` | current |
| `GET` / `PUT` / `DELETE /v1/memories/{memory_id}/` | current |
| `GET /v1/memories/{memory_id}/history/` | current |


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [x] No tests needed (docs-only, single prose line)

Verification performed:
- `python3 scripts/check-llms-txt-coverage.py` → `docs/llms.txt is in sync with docs/**/*.mdx.` (this is the CI gate for `docs/**/*.mdx` changes; no new page added, so no index entry was needed)
- Confirmed the deprecation flags and the v3 add path directly from `docs/openapi.json`
- Confirmed both SDK call sites at the line numbers cited above
- Confirmed the new link target `/api-reference/memory/add-memories` matches the path convention used in `docs/api-reference.mdx` and `docs/platform/cli.mdx:499`, and is registered in `docs/docs.json`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Tests added that prove my fix/feature works — N/A, docs-only
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed — this **is** the documentation update