### PR TITLE
docs(openapi): complete parameter and description coverage for current v1 memory routes

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1878,6 +1878,24 @@
 				],
 				"description": "Despite the endpoint name, this returns memory history entries (the same shape as `GET /v1/memories/{memory_id}/history/`), not event/ingestion-job records. For event/ingestion-job status, use `GET /v1/event/{event_id}/`.",
 				"operationId": "memories_events_list",
+				"parameters": [
+					{
+						"name": "page",
+						"in": "query",
+						"schema": {
+							"type": "integer"
+						},
+						"description": "Page number for pagination. Default: 1."
+					},
+					{
+						"name": "page_size",
+						"in": "query",
+						"schema": {
+							"type": "integer"
+						},
+						"description": "Number of items per page. Default: 100."
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "Successfully retrieved memory history entries.",
@@ -3114,7 +3132,50 @@
 				"tags": [
 					"memories"
 				],
+				"description": "Returns a paginated list of memories belonging to the given entity.",
 				"operationId": "memories_entity_read",
+				"parameters": [
+					{
+						"name": "entity_type",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"enum": [
+								"user",
+								"agent",
+								"run",
+								"app"
+							]
+						},
+						"description": "The type of entity to retrieve memories for. Any other value returns `400 {\"error\": \"Invalid entity type\"}`."
+					},
+					{
+						"name": "entity_id",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						},
+						"description": "The identifier of the entity whose memories to retrieve."
+					},
+					{
+						"name": "page",
+						"in": "query",
+						"schema": {
+							"type": "integer"
+						},
+						"description": "Page number for pagination. Default: 1."
+					},
+					{
+						"name": "page_size",
+						"in": "query",
+						"schema": {
+							"type": "integer"
+						},
+						"description": "Number of items per page. Default: 100."
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "Successfully retrieved memories.",
@@ -3220,32 +3281,7 @@
 						}
 					}
 				}
-			},
-			"parameters": [
-				{
-					"name": "entity_type",
-					"in": "path",
-					"required": true,
-					"schema": {
-						"type": "string",
-						"enum": [
-							"user",
-							"agent",
-							"run",
-							"app"
-						]
-					},
-					"description": "The type of entity to retrieve memories for."
-				},
-				{
-					"name": "entity_id",
-					"in": "path",
-					"required": true,
-					"schema": {
-						"type": "string"
-					}
-				}
-			]
+			}
 		},
 		"/v1/memories/{memory_id}/": {
 			"get": {
@@ -3387,7 +3423,7 @@
 				"tags": [
 					"memories"
 				],
-				"description": "Get or Update or delete a memory.",
+				"description": "Update a memory's text, metadata, or expiration date.",
 				"operationId": "memories_update",
 				"parameters": [
 					{
@@ -3398,7 +3434,7 @@
 							"type": "string",
 							"format": "uuid"
 						},
-						"description": "The unique identifier of the memory to retrieve."
+						"description": "The unique identifier of the memory to update."
 					}
 				],
 				"requestBody": {
@@ -3532,7 +3568,7 @@
 				"tags": [
 					"memories"
 				],
-				"description": "Get or Update or delete a memory.",
+				"description": "Delete a memory.",
 				"operationId": "memories_delete",
 				"parameters": [
 					{
@@ -3543,7 +3579,7 @@
 							"type": "string",
 							"format": "uuid"
 						},
-						"description": "The unique identifier of the memory to retrieve."
+						"description": "The unique identifier of the memory to delete."
 					},
 					{
 						"name": "delete_linked",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1885,10 +1885,10 @@
 						"schema": {
 							"type": "integer"
 						},
-						"description": "Page number for pagination. Default: 1."
+						"description": "Page number for pagination. Default: 1. Default page size is 100."
 					},
 					{
-						"name": "page_size",
+						"name": "limit",
 						"in": "query",
 						"schema": {
 							"type": "integer"
@@ -1958,6 +1958,21 @@
 														"type": "string",
 														"description": "The identifier of the user associated with this memory"
 													},
+													"agent_id": {
+														"type": "string",
+														"nullable": true,
+														"description": "The identifier of the agent associated with this memory, if any."
+													},
+													"app_id": {
+														"type": "string",
+														"nullable": true,
+														"description": "The identifier of the app associated with this memory, if any."
+													},
+													"session_id": {
+														"type": "string",
+														"nullable": true,
+														"description": "The run identifier associated with this memory, returned as `session_id`."
+													},
 													"categories": {
 														"type": "array",
 														"nullable": true,
@@ -2019,6 +2034,22 @@
 										"previous",
 										"results"
 									]
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Invalid page.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"detail": {
+											"type": "string",
+											"example": "Invalid page."
+										}
+									}
 								}
 							}
 						}
@@ -3165,15 +3196,7 @@
 						"schema": {
 							"type": "integer"
 						},
-						"description": "Page number for pagination. Default: 1."
-					},
-					{
-						"name": "page_size",
-						"in": "query",
-						"schema": {
-							"type": "integer"
-						},
-						"description": "Number of items per page. Default: 100."
+						"description": "Page number for pagination. Default: 1. Page size is fixed at 100 and is not client-configurable."
 					}
 				],
 				"responses": {
@@ -3279,6 +3302,22 @@
 								}
 							}
 						}
+					},
+					"404": {
+						"description": "Invalid page.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"detail": {
+											"type": "string",
+											"example": "Invalid page."
+										}
+									}
+								}
+							}
+						}
 					}
 				}
 			}
@@ -3323,6 +3362,21 @@
 											"type": "string",
 											"nullable": true,
 											"description": "Identifier of the user associated with this memory"
+										},
+										"agent_id": {
+											"type": "string",
+											"nullable": true,
+											"description": "The identifier of the agent associated with this memory, if any."
+										},
+										"app_id": {
+											"type": "string",
+											"nullable": true,
+											"description": "The identifier of the app associated with this memory, if any."
+										},
+										"session_id": {
+											"type": "string",
+											"nullable": true,
+											"description": "The run identifier associated with this memory, returned as `session_id`."
 										},
 										"metadata": {
 											"type": "object",
@@ -3369,6 +3423,22 @@
 										"lifecycle_state": {
 											"type": "string",
 											"description": "Lifecycle state of the memory."
+										}
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid memory ID.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string",
+											"example": "memory_id should be a valid UUID"
 										}
 									}
 								}
@@ -3484,6 +3554,21 @@
 											"nullable": true,
 											"description": "Identifier of the user associated with this memory"
 										},
+										"agent_id": {
+											"type": "string",
+											"nullable": true,
+											"description": "The identifier of the agent associated with this memory, if any."
+										},
+										"app_id": {
+											"type": "string",
+											"nullable": true,
+											"description": "The identifier of the app associated with this memory, if any."
+										},
+										"session_id": {
+											"type": "string",
+											"nullable": true,
+											"description": "The run identifier associated with this memory, returned as `session_id`."
+										},
 										"metadata": {
 											"type": "object",
 											"additionalProperties": true,
@@ -3529,6 +3614,38 @@
 										"lifecycle_state": {
 											"type": "string",
 											"description": "Lifecycle state of the memory."
+										}
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid memory ID.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string",
+											"example": "memory_id should be a valid UUID"
+										}
+									}
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Memory not found.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string",
+											"example": "Memory not found!"
 										}
 									}
 								}
@@ -3606,6 +3723,38 @@
 										"cascade_count": {
 											"type": "integer",
 											"description": "Number of linked memories also deleted. Only present when `delete_linked=true` was passed."
+										}
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid memory ID.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string",
+											"example": "memory_id should be a valid UUID"
+										}
+									}
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Memory not found.",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"error": {
+											"type": "string",
+											"example": "Memory not found!"
 										}
 									}
 								}
@@ -3717,6 +3866,21 @@
 											"user_id": {
 												"type": "string",
 												"description": "The identifier of the user associated with this memory"
+											},
+											"agent_id": {
+												"type": "string",
+												"nullable": true,
+												"description": "The identifier of the agent associated with this memory, if any."
+											},
+											"app_id": {
+												"type": "string",
+												"nullable": true,
+												"description": "The identifier of the app associated with this memory, if any."
+											},
+											"session_id": {
+												"type": "string",
+												"nullable": true,
+												"description": "The run identifier associated with this memory, returned as `session_id`."
 											},
 											"categories": {
 												"type": "array",


### PR DESCRIPTION
## Linked Issue

No linked issue: follow-up to #6771, which corrected the spec against live API behavior but left these current v1 memory operations incomplete.

## Description

These routes are current (`deprecated: false`) and still called by both the Python and TypeScript SDKs. `docs/openapi.json` documented them incompletely or, in one case, incorrectly.

**First commit** fixed structural gaps on four routes:

- `GET /v1/memories/{entity_type}/{entity_id}/` (`memories_entity_read`) had no operation-level `parameters`. `entity_type` and `entity_id` were only declared at the path-item level, `entity_type` had no note about the `400 {"error": "Invalid entity type"}` response, `entity_id` had no description, and the operation itself had no `description`. Moved both path params into the `get` operation's `parameters` array and added the missing descriptions.
- `GET /v1/memories/events/` (`memories_events_list`) had no `parameters` at all despite returning a paginated envelope.
- `PUT /v1/memories/{memory_id}/` (`memories_update`) and `DELETE /v1/memories/{memory_id}/` (`memories_delete`) both had the copy-pasted operation description `"Get or Update or delete a memory."` and a `memory_id` parameter description that always read "to retrieve" regardless of the operation. Replaced with accurate, operation-specific one-liners. These fixes are unchanged by the second commit below.

**Second commit** corrects the first commit and extends coverage, based on **testing the live production API directly** (api.mem0.ai, a real API key, throwaway memories, cleaned up afterward) rather than inferring parameter shapes from sibling operations:

- The `page_size` parameters added in the first commit were wrong on both routes:
  - `GET /v1/memories/{entity_type}/{entity_id}/` **has no client-controllable page size at all**. Its `page_size` parameter was removed entirely; `page`'s description now says the page size is fixed at 100 and is not configurable.
  - `GET /v1/memories/events/` **does not accept `page_size`** either. Its actual page-size parameter is named **`limit`**. The `page_size` parameter was renamed to `limit`.
- Both routes were missing their `404 {"detail": "Invalid page."}` response, confirmed by requesting an out-of-range page.
- `GET`/`PUT`/`DELETE /v1/memories/{memory_id}/` and `GET /v1/memories/{memory_id}/history/` were missing `agent_id`, `app_id`, and `session_id` on their response schemas, which the live API does return (all nullable strings; `session_id` carries the run identifier).
- `GET`, `PUT`, and `DELETE /v1/memories/{memory_id}/` were missing their `400 {"error": "memory_id should be a valid UUID"}` response, confirmed by requesting a malformed `memory_id`.
- `PUT` and `DELETE /v1/memories/{memory_id}/` were missing the `404 {"error": "Memory not found!"}` response already documented on `GET`.
- Confirmed the events route ignores decoy entity-filter parameters (`user_id`, `agent_id`, `memory_id`); none were added, since they have no effect on the live API.

No response schemas beyond the above, deprecation flags, or any other operation were touched.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

This is a spec-only change (`docs/openapi.json`). Every parameter, field, and error shape added in the second commit was verified directly against the live production API (api.mem0.ai) with a real API key and throwaway data (cleaned up after testing): pagination boundaries were probed to capture the `404` shape, decoy parameter names (`page_size`, `limit`, `per_page`, `size`) were fuzzed to determine which one the server actually honors per route, and malformed `memory_id` values were sent to capture the `400` shape. Response bodies were inspected directly to confirm `agent_id`/`app_id`/`session_id` presence.

Also validated with `python3 -c "import json; json.load(open('docs/openapi.json'))"` for JSON validity, plus an invariant check that the total operation count (55) and the set of operations with `deprecated: true` (6, same operations) are unchanged before and after the edits.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
