### PR TITLE
fix(ts-sdk): take /v1/ping/ off the request critical path

### DIFF
--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -89,9 +89,7 @@ interface ClientIdentity {
   projectId: string | number | null;
 }
 
-// Module scope, so a fresh client on a warm serverless container reuses the
-// ping instead of repeating it. Keyed by host + key, FIFO-capped so a process
-// cycling through many keys degrades to one ping per construction, not a leak.
+// Shares one ping per (host, api key) across clients; FIFO-capped, not a leak.
 const IDENTITY_CACHE_MAX = 50;
 const identityByCredentials = new Map<string, Promise<ClientIdentity>>();
 

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -89,7 +89,7 @@ interface ClientIdentity {
   projectId: string | number | null;
 }
 
-// Shares one ping per (host, api key) across clients; FIFO-capped, not a leak.
+// Shares one ping per (host, api key) across clients; FIFO-capped.
 const IDENTITY_CACHE_MAX = 50;
 const identityByCredentials = new Map<string, Promise<ClientIdentity>>();
 

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -91,6 +91,7 @@ export default class MemoryClient {
   headers: Record<string, string>;
   client: any;
   telemetryId: string;
+  private initialized: Promise<void>;
 
   _validateApiKey(): any {
     if (!this.apiKey) {
@@ -123,15 +124,18 @@ export default class MemoryClient {
 
     this._validateApiKey();
 
-    // Seeded synchronously so no request waits on ping(); the async ping below
-    // upgrades it to the user's email.
-    this.telemetryId = generateHash(this.apiKey);
-    void this._initializeClient();
+    this.telemetryId = "";
+    // Requests no longer wait on this; only telemetry does.
+    this.initialized = this._initializeClient();
   }
 
   private async _initializeClient() {
     try {
       await this.ping();
+
+      if (!this.telemetryId) {
+        this.telemetryId = generateHash(this.apiKey);
+      }
 
       await this._maybeAliasAnonToEmail();
 
@@ -174,13 +178,18 @@ export default class MemoryClient {
   }
 
   private _captureEvent(methodName: string, args: any[]) {
-    captureClientEvent(methodName, this, {
-      success: true,
-      args_count: args.length,
-      keys: args.length > 0 ? args[0] : [],
-    }).catch((error: any) => {
-      console.error("Failed to capture event:", error);
-    });
+    // Deferred until ping() has resolved telemetryId, off the request path.
+    this.initialized
+      .then(() =>
+        captureClientEvent(methodName, this, {
+          success: true,
+          args_count: args.length,
+          keys: args.length > 0 ? args[0] : [],
+        }),
+      )
+      .catch((error: any) => {
+        console.error("Failed to capture event:", error);
+      });
   }
 
   async _fetchWithErrorHandling(url: string, options: any): Promise<any> {

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -83,6 +83,17 @@ interface ClientOptions {
   host?: string;
 }
 
+interface ClientIdentity {
+  telemetryId: string;
+  organizationId: string | number | null;
+  projectId: string | number | null;
+}
+
+// Module scope, so a fresh client on a warm serverless container reuses the
+// ping instead of repeating it. Keyed by host + key; a process holds one entry
+// per credential pair it actually uses.
+const identityByCredentials = new Map<string, Promise<ClientIdentity>>();
+
 export default class MemoryClient {
   apiKey: string;
   host: string;
@@ -125,11 +136,27 @@ export default class MemoryClient {
     this._validateApiKey();
 
     this.telemetryId = "";
-    // Requests no longer wait on this; only telemetry does.
-    this.initialized = this._initializeClient();
+
+    // Requests never wait on this; only telemetry does.
+    const credentials = `${this.host}\u0000${this.apiKey}`;
+    let shared = identityByCredentials.get(credentials);
+    if (!shared) {
+      shared = this._initializeClient();
+      identityByCredentials.set(credentials, shared);
+      // A failed ping must not be cached, or the process never recovers.
+      shared.then((identity) => {
+        if (!identity.telemetryId) identityByCredentials.delete(credentials);
+      });
+    }
+    this.initialized = shared.then((identity) => {
+      this.telemetryId = identity.telemetryId;
+      if (identity.organizationId != null)
+        this.organizationId = identity.organizationId;
+      if (identity.projectId != null) this.projectId = identity.projectId;
+    });
   }
 
-  private async _initializeClient() {
+  private async _initializeClient(): Promise<ClientIdentity> {
     try {
       await this.ping();
 
@@ -151,6 +178,12 @@ export default class MemoryClient {
         stack: error?.stack || "No stack trace",
       });
     }
+
+    return {
+      telemetryId: this.telemetryId,
+      organizationId: this.organizationId,
+      projectId: this.projectId,
+    };
   }
 
   private async _maybeAliasAnonToEmail(): Promise<void> {

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -506,8 +506,17 @@ export default class MemoryClient {
 
     for (const entity of to_delete) {
       try {
-        await this.client.delete(
-          `/v2/entities/${encodePathSegment(entity.type)}/${encodePathSegment(entity.name)}/`,
+        // Last axios call site in this class. Node's axios defaults to
+        // http.Agent({ keepAlive: false }) and no agent is configured here, so
+        // every iteration of this loop opened a fresh TCP+TLS connection.
+        // _fetchWithErrorHandling goes through the runtime's pooled dispatcher
+        // and reuses the connection the rest of the client already has open.
+        await this._fetchWithErrorHandling(
+          `${this.host}/v2/entities/${encodePathSegment(entity.type)}/${encodePathSegment(entity.name)}/`,
+          {
+            method: "DELETE",
+            headers: this.headers,
+          },
         );
       } catch (error: any) {
         throw new APIError(

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -123,14 +123,8 @@ export default class MemoryClient {
 
     this._validateApiKey();
 
-    // Seed the telemetry id synchronously so it is never "". Every API method
-    // used to do `if (this.telemetryId === "") await this.ping()`, which put a
-    // blocking /v1/ping/ round-trip on the critical path of the first call made
-    // by each client. Callers that construct a client per request (serverless
-    // handlers, per-request DI) paid that on every single request.
-    //
-    // ping() still runs exactly once per client, asynchronously, and upgrades
-    // this id to the user's email when it resolves. Nothing waits for it.
+    // Seeded synchronously so no request waits on ping(); the async ping below
+    // upgrades it to the user's email.
     this.telemetryId = generateHash(this.apiKey);
     void this._initializeClient();
   }
@@ -506,11 +500,8 @@ export default class MemoryClient {
 
     for (const entity of to_delete) {
       try {
-        // Last axios call site in this class. Node's axios defaults to
-        // http.Agent({ keepAlive: false }) and no agent is configured here, so
-        // every iteration of this loop opened a fresh TCP+TLS connection.
-        // _fetchWithErrorHandling goes through the runtime's pooled dispatcher
-        // and reuses the connection the rest of the client already has open.
+        // fetch() reuses the pooled connection; axios here defaulted to
+        // keepAlive: false, one handshake per entity.
         await this._fetchWithErrorHandling(
           `${this.host}/v2/entities/${encodePathSegment(entity.type)}/${encodePathSegment(entity.name)}/`,
           {

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -90,8 +90,9 @@ interface ClientIdentity {
 }
 
 // Module scope, so a fresh client on a warm serverless container reuses the
-// ping instead of repeating it. Keyed by host + key; a process holds one entry
-// per credential pair it actually uses.
+// ping instead of repeating it. Keyed by host + key, FIFO-capped so a process
+// cycling through many keys degrades to one ping per construction, not a leak.
+const IDENTITY_CACHE_MAX = 50;
 const identityByCredentials = new Map<string, Promise<ClientIdentity>>();
 
 export default class MemoryClient {
@@ -142,6 +143,11 @@ export default class MemoryClient {
     let shared = identityByCredentials.get(credentials);
     if (!shared) {
       shared = this._initializeClient();
+      if (identityByCredentials.size >= IDENTITY_CACHE_MAX) {
+        identityByCredentials.delete(
+          identityByCredentials.keys().next().value!,
+        );
+      }
       identityByCredentials.set(credentials, shared);
       // A failed ping must not be cached, or the process never recovers.
       shared.then((identity) => {

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -122,17 +122,22 @@ export default class MemoryClient {
     });
 
     this._validateApiKey();
-    this.telemetryId = "";
-    this._initializeClient();
+
+    // Seed the telemetry id synchronously so it is never "". Every API method
+    // used to do `if (this.telemetryId === "") await this.ping()`, which put a
+    // blocking /v1/ping/ round-trip on the critical path of the first call made
+    // by each client. Callers that construct a client per request (serverless
+    // handlers, per-request DI) paid that on every single request.
+    //
+    // ping() still runs exactly once per client, asynchronously, and upgrades
+    // this id to the user's email when it resolves. Nothing waits for it.
+    this.telemetryId = generateHash(this.apiKey);
+    void this._initializeClient();
   }
 
   private async _initializeClient() {
     try {
       await this.ping();
-
-      if (!this.telemetryId) {
-        this.telemetryId = generateHash(this.apiKey);
-      }
 
       await this._maybeAliasAnonToEmail();
 
@@ -262,8 +267,6 @@ export default class MemoryClient {
       throw new Error("Cannot process an empty messages payload.");
     }
 
-    if (this.telemetryId === "") await this.ping();
-
     const payload = this._preparePayload(messages, options);
     const payloadKeys = Object.keys(payload);
     this._captureEvent("add", [payloadKeys]);
@@ -304,7 +307,6 @@ export default class MemoryClient {
       );
     }
 
-    if (this.telemetryId === "") await this.ping();
     const payload: Record<string, any> = {};
     if (text !== undefined) payload.text = text;
     if (metadata !== undefined) payload.metadata = metadata;
@@ -326,7 +328,6 @@ export default class MemoryClient {
   }
 
   async get(memoryId: string): Promise<Memory> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("get", []);
     return this._fetchWithErrorHandling(
       `${this.host}/v1/memories/${encodePathSegment(memoryId)}/`,
@@ -340,7 +341,6 @@ export default class MemoryClient {
     // Reject top-level entity params - must use filters instead
     rejectTopLevelEntityParams(options as Record<string, any>, "getAll");
 
-    if (this.telemetryId === "") await this.ping();
     const payloadKeys = Object.keys(options || {});
     this._captureEvent("get_all", [payloadKeys]);
     const { page, pageSize, filters, ...rest } = options ?? {};
@@ -369,7 +369,6 @@ export default class MemoryClient {
     // Reject top-level entity params - must use filters instead
     rejectTopLevelEntityParams(options as Record<string, any>, "search");
 
-    if (this.telemetryId === "") await this.ping();
     const payloadKeys = Object.keys(options || {});
     this._captureEvent("search", [payloadKeys]);
     const { filters, ...rest } = options ?? {};
@@ -395,7 +394,6 @@ export default class MemoryClient {
     memoryId: string,
     options: DeleteMemoryOptions = {},
   ): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("delete", [Object.keys(options || {})]);
     const snakeOptions = camelToSnakeKeys(this._prepareParams(options));
     // @ts-ignore
@@ -412,7 +410,6 @@ export default class MemoryClient {
   async deleteAll(
     options: DeleteAllMemoryOptions = {},
   ): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
     const payloadKeys = Object.keys(options || {});
     this._captureEvent("delete_all", [payloadKeys]);
     const snakeOptions = camelToSnakeKeys(this._prepareParams(options));
@@ -429,7 +426,6 @@ export default class MemoryClient {
   }
 
   async history(memoryId: string): Promise<Array<MemoryHistory>> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("history", []);
     const response = await this._fetchWithErrorHandling(
       `${this.host}/v1/memories/${encodePathSegment(memoryId)}/history/`,
@@ -444,7 +440,6 @@ export default class MemoryClient {
     page?: number;
     pageSize?: number;
   }): Promise<AllUsers> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("users", []);
     let url = `${this.host}/v1/entities/`;
     const params: string[] = [];
@@ -464,7 +459,6 @@ export default class MemoryClient {
     entity_id: number;
     entity_type: string;
   }): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("delete_user", []);
     if (!data.entity_type) {
       data.entity_type = "user";
@@ -487,8 +481,6 @@ export default class MemoryClient {
       runId?: string;
     } = {},
   ): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
-
     let to_delete: Array<{ type: string; name: string }> = [];
     const { userId, agentId, appId, runId } = params;
 
@@ -537,7 +529,6 @@ export default class MemoryClient {
   }
 
   async batchUpdate(memories: Array<MemoryUpdateBody>): Promise<string> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("batch_update", []);
     const memoriesBody = memories.map((memory) => ({
       memory_id: memory.memoryId,
@@ -555,7 +546,6 @@ export default class MemoryClient {
   }
 
   async batchDelete(memories: Array<string>): Promise<string> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("batch_delete", []);
     const memoriesBody = memories.map((memory) => ({
       memory_id: memory,
@@ -572,7 +562,6 @@ export default class MemoryClient {
   }
 
   async getProject(options: ProjectOptions): Promise<ProjectResponse> {
-    if (this.telemetryId === "") await this.ping();
     const payloadKeys = Object.keys(options || {});
     this._captureEvent("get_project", [payloadKeys]);
     const { fields } = options;
@@ -598,7 +587,6 @@ export default class MemoryClient {
   async updateProject(
     prompts: PromptUpdatePayload,
   ): Promise<Record<string, any>> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("update_project", []);
     if (!(this.organizationId && this.projectId)) {
       throw new Error(
@@ -619,7 +607,6 @@ export default class MemoryClient {
 
   // WebHooks
   async getWebhooks(data?: { projectId?: string }): Promise<Array<Webhook>> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("get_webhooks", []);
     const project_id = data?.projectId || this.projectId;
     const response = await this._fetchWithErrorHandling(
@@ -632,7 +619,6 @@ export default class MemoryClient {
   }
 
   async createWebhook(webhook: WebhookCreatePayload): Promise<Webhook> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("create_webhook", []);
     const body = {
       name: webhook.name,
@@ -653,7 +639,6 @@ export default class MemoryClient {
   async updateWebhook(
     webhook: WebhookUpdatePayload,
   ): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("update_webhook", []);
     const body: Record<string, any> = {};
     if (webhook.name != null) body.name = webhook.name;
@@ -673,7 +658,6 @@ export default class MemoryClient {
   async deleteWebhook(data: {
     webhookId: string;
   }): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("delete_webhook", []);
     const webhook_id = data.webhookId || data;
     const response = await this._fetchWithErrorHandling(
@@ -687,7 +671,6 @@ export default class MemoryClient {
   }
 
   async feedback(data: FeedbackPayload): Promise<{ message: string }> {
-    if (this.telemetryId === "") await this.ping();
     const payloadKeys = Object.keys(data || {});
     this._captureEvent("feedback", [payloadKeys]);
     const response = await this._fetchWithErrorHandling(
@@ -704,7 +687,6 @@ export default class MemoryClient {
   async createMemoryExport(
     data: CreateMemoryExportPayload,
   ): Promise<{ message: string; id: string }> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("create_memory_export", []);
 
     if (!data.filters || !data.schema) {
@@ -734,7 +716,6 @@ export default class MemoryClient {
   async getMemoryExport(
     data: GetMemoryExportPayload,
   ): Promise<{ message: string; id: string }> {
-    if (this.telemetryId === "") await this.ping();
     this._captureEvent("get_memory_export", []);
 
     if (!data.memoryExportId && !data.filters) {

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -139,6 +139,11 @@ export default class MemoryClient {
     this.telemetryId = "";
 
     // Requests never wait on this; only telemetry does.
+    this.initialized = this._resolveIdentity();
+  }
+
+  // One ping per credential pair per process, shared via identityByCredentials.
+  private _resolveIdentity(): Promise<void> {
     const credentials = `${this.host}\u0000${this.apiKey}`;
     let shared = identityByCredentials.get(credentials);
     if (!shared) {
@@ -154,7 +159,7 @@ export default class MemoryClient {
         if (!identity.telemetryId) identityByCredentials.delete(credentials);
       });
     }
-    this.initialized = shared.then((identity) => {
+    return shared.then((identity) => {
       this.telemetryId = identity.telemetryId;
       if (identity.organizationId != null)
         this.organizationId = identity.organizationId;

--- a/mem0-ts/src/client/telemetry.ts
+++ b/mem0-ts/src/client/telemetry.ts
@@ -15,12 +15,23 @@ try {
 const POSTHOG_API_KEY = "phc_hgJkUVJFYtmaJqrvf6CYN67TIQ8yhXAkWzUn9AMU4yX";
 const POSTHOG_HOST = "https://us.i.posthog.com/i/v0/e/";
 
-// Simple hash function using random strings
+// Deterministic, dependency-free hash (FNV-1a, 32-bit) over the input.
+//
+// This is used as the telemetry distinct_id before/without a successful ping.
+// It used to ignore `input` and return Math.random(), which minted a brand new
+// id per client instance and orphaned every event from a client that could not
+// ping. Deterministic means one id per API key, in every runtime, with no I/O
+// and no platform APIs (works in Node, browsers, edge runtimes, Deno, Bun).
+//
+// Not cryptographic and not reversible into the key: 32 bits of a secret is not
+// a secret, and only the digest is ever transmitted.
 function generateHash(input: string): string {
-  const randomStr =
-    Math.random().toString(36).substring(2, 15) +
-    Math.random().toString(36).substring(2, 15);
-  return randomStr;
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return `anon-${hash.toString(36)}`;
 }
 
 class UnifiedTelemetry implements TelemetryClient {

--- a/mem0-ts/src/client/telemetry.ts
+++ b/mem0-ts/src/client/telemetry.ts
@@ -15,16 +15,7 @@ try {
 const POSTHOG_API_KEY = "phc_hgJkUVJFYtmaJqrvf6CYN67TIQ8yhXAkWzUn9AMU4yX";
 const POSTHOG_HOST = "https://us.i.posthog.com/i/v0/e/";
 
-// Deterministic, dependency-free hash (FNV-1a, 32-bit) over the input.
-//
-// This is used as the telemetry distinct_id before/without a successful ping.
-// It used to ignore `input` and return Math.random(), which minted a brand new
-// id per client instance and orphaned every event from a client that could not
-// ping. Deterministic means one id per API key, in every runtime, with no I/O
-// and no platform APIs (works in Node, browsers, edge runtimes, Deno, Bun).
-//
-// Not cryptographic and not reversible into the key: 32 bits of a secret is not
-// a secret, and only the digest is ever transmitted.
+// FNV-1a: one distinct_id per API key, in any runtime, with no I/O.
 function generateHash(input: string): string {
   let hash = 0x811c9dc5;
   for (let i = 0; i < input.length; i++) {

--- a/mem0-ts/src/client/telemetry.ts
+++ b/mem0-ts/src/client/telemetry.ts
@@ -15,14 +15,12 @@ try {
 const POSTHOG_API_KEY = "phc_hgJkUVJFYtmaJqrvf6CYN67TIQ8yhXAkWzUn9AMU4yX";
 const POSTHOG_HOST = "https://us.i.posthog.com/i/v0/e/";
 
-// FNV-1a: one distinct_id per API key, in any runtime, with no I/O.
+// Simple hash function using random strings
 function generateHash(input: string): string {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < input.length; i++) {
-    hash ^= input.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193) >>> 0;
-  }
-  return `anon-${hash.toString(36)}`;
+  const randomStr =
+    Math.random().toString(36).substring(2, 15) +
+    Math.random().toString(36).substring(2, 15);
+  return randomStr;
 }
 
 class UnifiedTelemetry implements TelemetryClient {

--- a/mem0-ts/src/client/tests/memoryClient.users.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.users.test.ts
@@ -98,16 +98,23 @@ describe("MemoryClient - deleteUser() (deprecated)", () => {
 
 describe("MemoryClient - deleteUsers()", () => {
   test("URL-encodes entity path segments", async () => {
-    setupMockFetch();
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/v2/entities/user/org%2Fteam%3Factive%23frag/", {
+      status: 200,
+      body: { message: "Entity deleted successfully!" },
+    });
+    const mock = setupMockFetch(extra);
+
     const client = new MemoryClient({ apiKey: TEST_API_KEY });
-    client.telemetryId = "test@example.com";
-    const deleteMock = jest.fn().mockResolvedValue({});
-    client.client = { delete: deleteMock };
 
     await client.deleteUsers({ userId: "org/team?active#frag" });
 
-    expect(deleteMock).toHaveBeenCalledWith(
-      "/v2/entities/user/org%2Fteam%3Factive%23frag/",
-    );
+    expect(
+      findFetchCall(
+        mock,
+        "/v2/entities/user/org%2Fteam%3Factive%23frag/",
+        "DELETE",
+      ),
+    ).toBeDefined();
   });
 });


### PR DESCRIPTION
## Problem

Every `MemoryClient` method began with `if (this.telemetryId === "") await this.ping();` (22 call sites), while the constructor kicked off `_initializeClient()` → `ping()` **without awaiting it**. With a client constructed per request — serverless handlers, per-request DI — the constructor's ping has not resolved when the first API call runs, so that call fires a *second* `/v1/ping/` and awaits it before doing any work.

`telemetryId` is only used for the `Mem0-User-ID` header and PostHog, so nothing about the request needed that wait. `org_id`/`project_id` are resolved server-side from the API key when absent.

## Fix

1. **Remove the 22 blocking `await this.ping()` guards.** Requests no longer wait on telemetry setup.
2. **Hold the init promise** (`this.initialized`) and let `_captureEvent` chain off it. `_captureEvent` was already fire-and-forget, so telemetry still carries the same `telemetryId` it does today without the request paying for it.
3. **Share one ping per credential pair per process** — the init promise is cached in a module-scope `Map` keyed by host + API key, so a fresh client on a warm container reuses the resolved identity. Keyed rather than a single slot because a process can use more than one key; a failed ping is evicted so the process recovers.
4. `deleteUsers()` was the last axios call site here, and Node's axios defaults to `http.Agent({ keepAlive: false })` with no agent configured — each iteration opened a fresh TCP+TLS connection. Routed through `_fetchWithErrorHandling` so it reuses the pooled connection, which matters now that `delete_all` drains every page.

`generateHash` and `telemetry.ts` are untouched; the fallback keeps its original behaviour and its original call site.

This is also what the Python SDK already does: `md5(api_key)` as `Mem0-User-ID`, one ping in `__init__`, no per-method ping check.

## Benchmark

AWS Lambda, Node 22, 512 MB, us-east-1, against production. This branch vs stock `3.1.3` built from the same tree, invocations interleaved, **one fresh `MemoryClient` constructed inside the handler per invocation** (the pattern that triggers the bug).

Warm invocations:

| | n | total p50 | p90 | p95 | API p50 | SDK overhead p50 | pings/req | HTTP calls/req |
|---|---|---|---|---|---|---|---|---|
| stock `3.1.3` | 12 | 342 ms | 467 ms | 716 ms | 263 ms | **85 ms** | 2 | 5 |
| this branch | 11 | **264 ms** | **284 ms** | **372 ms** | 263 ms | **1 ms** | **0** | **2** |

API p50 is identical on both sides — the difference is entirely client-side overhead. `total_ms` now tracks the API call itself.

Cold start on this branch: 454 ms total, 1 ping, 4 HTTP calls — the ping runs concurrently with the request rather than in front of it.

## Notes / trade-offs

- No API change and no caller change required.
- An invalid API key is no longer surfaced by the first method call waiting on a ping — the call's own 401 surfaces it instead. `ping()` stays public for callers that want fail-fast validation.
- `client.init` telemetry now fires once per process per credential pair rather than once per client instance. Per-method events are unchanged in count and content.
- `Mem0-User-ID` is empty on requests issued before the first ping resolves.
- The identity cache holds one entry per credential pair a process actually uses (FIFO-capped at 50; overflow degrades to stock one-ping-per-construction), and stores a promise, not the key material beyond the map key itself.

## Tests

- [x] `npx jest src/client/` — 128 passed, 0 failed (includes an updated `deleteUsers` test that asserts the fetch call rather than an injected axios double)
- [x] `prettier --check .` at the version pinned in `pnpm-lock.yaml`
- [x] `tsup` build; built artifact contains exactly 1 `await this.ping()`
- [x] `tsc --noEmit` clean for the changed file
- [x] Full `test:unit` matches a control run on pristine `main` with the same toolchain (identical pre-existing failures from optional peers)
- [x] Deployed bundle verified to contain the change before each measurement