### PR TITLE
fix(zapier): add root index.js entry shim so deployed app resolves

### DIFF
--- a/integrations/zapier-mem0/index.js
+++ b/integrations/zapier-mem0/index.js
@@ -1,0 +1,10 @@
+// Root entry point for the Zapier CLI app.
+//
+// Zapier's deployed Lambda wrapper hardcodes `require(path.resolve(__dirname, 'index.js'))`
+// at the deployment root and ignores package.json "main". Because this is a
+// TypeScript app that compiles to dist/, the wrapper would otherwise fail with
+// "Cannot find module '/var/task/index.js'" and every auth/action would break.
+//
+// This shim re-exports the compiled app so the entry point exists where Zapier
+// looks for it. Run `npm run build` before `zapier-platform push` so dist/ exists.
+module.exports = require('./dist/index.js');

--- a/integrations/zapier-mem0/index.js
+++ b/integrations/zapier-mem0/index.js
@@ -1,10 +1,3 @@
-// Root entry point for the Zapier CLI app.
-//
-// Zapier's deployed Lambda wrapper hardcodes `require(path.resolve(__dirname, 'index.js'))`
-// at the deployment root and ignores package.json "main". Because this is a
-// TypeScript app that compiles to dist/, the wrapper would otherwise fail with
-// "Cannot find module '/var/task/index.js'" and every auth/action would break.
-//
-// This shim re-exports the compiled app so the entry point exists where Zapier
-// looks for it. Run `npm run build` before `zapier-platform push` so dist/ exists.
+// Zapier's Lambda wrapper requires `<root>/index.js` and ignores package.json
+// "main", so re-export the compiled app from the root. Run `npm run build` first.
 module.exports = require('./dist/index.js');

--- a/integrations/zapier-mem0/package.json
+++ b/integrations/zapier-mem0/package.json
@@ -20,7 +20,7 @@
     "directory": "integrations/zapier-mem0"
   },
   "license": "Apache-2.0",
-  "main": "dist/index.js",
+  "main": "index.js",
   "scripts": {
     "build": "tsc",
     "test": "jest --testTimeout 180000",


### PR DESCRIPTION
## Problem

The Zapier integration deployed but **every authentication and action failed at runtime** with:

```
Cannot find module '/var/task/index.js'
```

### Root cause

Zapier's deployed Lambda wrapper (`zapierwrapper.js`) resolves the app entry like this:

```js
const appPath = path.resolve(__dirname, 'index.js');   // -> /var/task/index.js
module.exports = { handler: zapier.createAppHandler(appPath) };
```

It **hardcodes `index.js` at the deployment root and ignores `package.json` "main"**. This is a TypeScript app that compiles to `dist/index.js` (`"main": "dist/index.js"`), so no `/var/task/index.js` exists and the app can never load — the failure happens before any request reaches the Mem0 API, which is why it looks like an auth/API-key problem but isn't.

## Fix

- Add a root `integrations/zapier-mem0/index.js` shim that re-exports the compiled app:
  ```js
  module.exports = require('./dist/index.js');
  ```
- Point `"main"` at the root shim (`"index.js"`) so the entry exists where Zapier looks for it.

## Verification

- `require('./index.js')` loads the app the same way Zapier does: 4 actions/searches + custom auth resolve.
- `zapier-platform validate` passes (warnings only, no errors).
- A build with this fix was pushed live as **version 0.0.1** (platform 19.0.0) on app 244633, replacing the broken 0.0.0.

## Note for maintainers

There is no CI workflow for the Zapier push today; it is manual. Whoever pushes must run `npm run build` before `zapier-platform push` so `dist/` exists (`dist/` is gitignored). If we add CI later, it should `npm ci && npm run build && zapier-platform push`.