### PR TITLE
fix(zapier): require user_id on Add Memory

### DIFF
--- a/integrations/zapier-mem0/src/creates/add_memory.ts
+++ b/integrations/zapier-mem0/src/creates/add_memory.ts
@@ -115,7 +115,7 @@ export default {
 				choices: { user: 'User', assistant: 'Assistant', system: 'System' },
 				default: 'user',
 			},
-			{ key: 'user_id', label: 'User ID', type: 'string' },
+			{ key: 'user_id', label: 'User ID', type: 'string', required: true, helpText: 'Scope this memory to a user. Mem0 requires at least one entity ID.' },
 			{ key: 'agent_id', label: 'Agent ID', type: 'string' },
 			{ key: 'run_id', label: 'Run ID', type: 'string' },
 			{ key: 'metadata', label: 'Metadata (JSON)', type: 'string' },


### PR DESCRIPTION
## Problem

The Add Memory step lets users submit with **no entity ID**, then fails at run time with a confusing API error:

```
Mem0 API request failed (HTTP 400): At least one entity ID is required (user_id, agent_id, app_id, or run_id).
```

`user_id` was marked optional on `add_memory`, even though **Search Memories and Get Memories already require it**. So the requirement was inconsistent across the integration and only surfaced as a 400 after the user built and tested the Zap.

## Fix

Make `user_id` required on Add Memory (matching the search operations) and add help text pointing to the entity-ID requirement, so Zapier flags it in the editor **before** the step runs:

```ts
{ key: 'user_id', label: 'User ID', type: 'string', required: true,
  helpText: 'Scope this memory to a user. Mem0 requires at least one entity ID.' },
```

## Notes

- Mem0 accepts any one of `user_id`/`agent_id`/`app_id`/`run_id`, but Zapier field schemas can't express "at least one of." `user_id` is the overwhelmingly common scope for Zapier automations and is already the required entity on the search actions, so requiring it here is the consistent, lowest-surprise default.
- Reproduced live in the private app (v0.0.1): an Add step with empty entity fields returned the 400 above; setting User ID fixed it.