### PR TITLE
chore(n8n): route package contact to integrations@mem0.ai

### DIFF
--- a/integrations/n8n-nodes-mem0/package.json
+++ b/integrations/n8n-nodes-mem0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem0/n8n-nodes-mem0",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "n8n community node for Mem0 — the memory layer for AI agents. Add, search, get, update, and delete long-term memories.",
   "keywords": [
     "n8n-community-node-package",
@@ -14,7 +14,7 @@
   "homepage": "https://mem0.ai",
   "author": {
     "name": "Mem0",
-    "email": "founders@mem0.ai"
+    "email": "integrations@mem0.ai"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What

Change `author.email` in `integrations/n8n-nodes-mem0/package.json` from `founders@mem0.ai` to **`integrations@mem0.ai`**, and bump `0.1.1 → 0.1.2`.

## Why

The npm `author.email` is the package contact shown on the npm listing and read by n8n's Creator Portal verification submission. It currently points at the `founders@` alias; it should reach the **integrations** inbox that owns marketplace/listing work.

That value is baked into the published tarball, so a repo edit alone doesn't update the registry — the version bump lets the CD republish it.

## Publish

After merge, publish 0.1.2 via **Actions → n8n-nodes-mem0-cd → Run workflow**, tag `n8n-nodes-mem0-v0.1.2`. The workflow publishes with `--provenance` via OIDC trusted publishing (satisfies n8n's May-2026 provenance mandate). Then submit the node at creators.n8n.io/nodes.

## Note

Only `author.email` carried the founders alias; npm maintainers are personal accounts and are unaffected.