### PR TITLE
fix(ts-oss): stop add() from mutating the caller's filters object

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -749,7 +749,11 @@ export class Memory {
       has_filters: !!config.filters,
       infer: config.infer,
     });
-    const { filters = {}, infer = true } = config;
+    // Copy: the scope keys below are written into this object, and mutating the
+    // caller's would carry this call's scope into their next add(). search() and
+    // getAll() already build a fresh object from config.filters.
+    const filters: SearchFilters = { ...(config.filters ?? {}) };
+    const { infer = true } = config;
     const metadata = stripIdentityKeys(config.metadata);
 
     // Validate and trim entity IDs

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -756,7 +756,11 @@ export class Memory {
       has_filters: !!config.filters,
       infer: config.infer,
     });
-    const { filters = {}, infer = true } = config;
+    // Copy: the scope keys below are written into this object, and mutating the
+    // caller's would carry this call's scope into their next add(). search() and
+    // getAll() already build a fresh object from config.filters.
+    const filters: SearchFilters = { ...(config.filters ?? {}) };
+    const { infer = true } = config;
     const metadata = stripIdentityKeys(config.metadata);
 
     // Validate and trim entity IDs

--- a/mem0-ts/src/oss/tests/memory.add-filters-isolation.test.ts
+++ b/mem0-ts/src/oss/tests/memory.add-filters-isolation.test.ts
@@ -1,0 +1,115 @@
+/// <reference types="jest" />
+/**
+ * add() writes the resolved scope (user_id / agent_id / run_id) into its
+ * filters object. If that object is the caller's, the scope survives the call
+ * and leaks into the next add() that reuses it, which also defeats the
+ * "one of userId, agentId or runId is required" guard.
+ *
+ * search() and getAll() already build a fresh object from config.filters.
+ */
+jest.mock("../src/utils/telemetry", () => ({
+  captureClientEvent: jest.fn().mockResolvedValue(undefined),
+  isTelemetryEnabled: jest.fn(() => false),
+}));
+
+import { Memory } from "../src/memory";
+
+const DIM = 1536;
+let seq = 0;
+
+function createMemory(): Memory {
+  const m = new Memory({
+    disableHistory: true,
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-add-filters-${seq++}`,
+        dimension: DIM,
+        dbPath: ":memory:",
+      },
+    },
+    historyDbPath: ":memory:",
+    embedder: { provider: "openai", config: { apiKey: "test-key" } },
+    llm: { provider: "openai", config: { apiKey: "test-key" } },
+  } as any);
+
+  // infer:false is enough to exercise the scope handling, so the LLM is never
+  // called; the embedder just has to return a well-formed vector.
+  (m as any).embedder = {
+    embed: async () => new Array(DIM).fill(0.1),
+    embedBatch: async (texts: string[]) =>
+      texts.map(() => new Array(DIM).fill(0.1)),
+  };
+  return m;
+}
+
+describe("add() does not mutate the caller's filters object", () => {
+  it("leaves the caller's object untouched", async () => {
+    const memory = createMemory();
+    const filters: Record<string, any> = {};
+
+    await memory.add([{ role: "user", content: "alice note" }], {
+      userId: "alice",
+      infer: false,
+      filters,
+    });
+
+    expect(filters).toEqual({});
+  });
+
+  it("still throws when a reused object is the only source of scope", async () => {
+    const memory = createMemory();
+    const filters: Record<string, any> = {};
+
+    await memory.add([{ role: "user", content: "alice note" }], {
+      userId: "alice",
+      infer: false,
+      filters,
+    });
+
+    // No userId/agentId/runId on this call, so the required-scope guard must
+    // fire rather than reading a value left behind by the previous call.
+    await expect(
+      memory.add([{ role: "user", content: "bob note" }], {
+        infer: false,
+        filters,
+      }),
+    ).rejects.toThrow(
+      "One of the filters: userId, agentId or runId is required!",
+    );
+  });
+
+  it("does not store one user's memory under another user's scope", async () => {
+    const memory = createMemory();
+    const filters: Record<string, any> = {};
+
+    await memory.add([{ role: "user", content: "alice note" }], {
+      userId: "alice",
+      infer: false,
+      filters,
+    });
+    // A second caller reuses the object and supplies no scope of its own. This
+    // must not be silently attributed to alice.
+    await memory
+      .add([{ role: "user", content: "bob note" }], {
+        infer: false,
+        filters,
+      })
+      .catch(() => undefined);
+
+    const alice = await memory.getAll({ filters: { user_id: "alice" } });
+    expect(alice.results.map((r) => r.memory)).toEqual(["alice note"]);
+  });
+
+  it("keeps scope keys the caller passed in", async () => {
+    const memory = createMemory();
+
+    await memory.add([{ role: "user", content: "scoped note" }], {
+      infer: false,
+      filters: { user_id: "carol" },
+    });
+
+    const carol = await memory.getAll({ filters: { user_id: "carol" } });
+    expect(carol.results.map((r) => r.memory)).toEqual(["scoped note"]);
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6796

## Description

`add()` destructured `filters` by reference and wrote the resolved scope into it:

```ts
const { filters = {}, infer = true } = config;
if (userId) filters.user_id = metadata.user_id = userId;
```

So the caller's object came back carrying `user_id`. Reuse it on the next `add()` and that scope comes along, and since the required-scope guard reads the same object, a call with no scope at all passes the check:

```ts
const shared = {};
await memory.add([{ role: "user", content: "alice note" }], { userId: "alice", infer: false, filters: shared });
await memory.add([{ role: "user", content: "bob note" }], { infer: false, filters: shared });
await memory.getAll({ filters: { user_id: "alice" } });
// -> ["alice note", "bob note"]
```

10 runs out of 10: no throw, and bob's memory is stored under alice.

The fix is to copy the object before writing into it. `search()` and `getAll()` already build a fresh object from `config.filters`, so this makes `add()` consistent with them rather than adding a new pattern. Same class of scope-integrity fix as #6343.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

None. The only behaviour that changes is the mutation of an input object, which was not documented and defeats a validation check.

## Test Coverage

- [x] I added/updated unit tests

`mem0-ts/src/oss/tests/memory.add-filters-isolation.test.ts`, 4 tests. The first three fail on current `main` and pass with the fix. The fourth covers scope keys passed in via `filters` and passes either way, so the fix does not narrow existing behaviour.

Full suite: 1443 passed. The 2 failing files (`memory.embedding-action`, `memory.rerank`) fail the same way on a clean `main` worktree and are unrelated to this change. `pnpm run build` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (no public API change)
