### PR TITLE
test(mem0-ts): stop the test suite from sending telemetry to production

### DIFF
--- a/mem0-ts/jest.setup.ts
+++ b/mem0-ts/jest.setup.ts
@@ -1,3 +1,12 @@
 import pkg from "./package.json";
 
 (globalThis as any).__MEM0_SDK_VERSION__ = pkg.version;
+
+// Tests must never POST to the production PostHog project. Both telemetry
+// modules read MEM0_TELEMETRY once at import time, and setupFiles run before
+// the test module is loaded, so setting it here reaches them. Set after
+// "dotenv/config" in the setupFiles order so a stray .env cannot re-enable it.
+// Suites that assert on the sender opt back in explicitly: see
+// src/oss/tests/telemetry-sampling.test.ts and
+// src/client/tests/telemetry-aliasing.test.ts.
+process.env.MEM0_TELEMETRY = "false";

--- a/mem0-ts/src/client/tests/enable-telemetry.ts
+++ b/mem0-ts/src/client/tests/enable-telemetry.ts
@@ -1,0 +1,4 @@
+// jest.setup.ts disables telemetry for every suite so tests never POST to the
+// production PostHog project. A suite that asserts on the sender imports this
+// first, before any module that reads MEM0_TELEMETRY at import time.
+process.env.MEM0_TELEMETRY = "true";

--- a/mem0-ts/src/client/tests/telemetry-aliasing.test.ts
+++ b/mem0-ts/src/client/tests/telemetry-aliasing.test.ts
@@ -4,6 +4,9 @@
  * Covers $identify firing, idempotency via pair markers, and the node/browser
  * gate. Mocks fs and fetch; never touches the real ~/.mem0/config.json.
  */
+// Must precede every import below: this suite asserts on the telemetry sender,
+// and ../telemetry reads MEM0_TELEMETRY at import time.
+import "./enable-telemetry";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";

--- a/mem0-ts/src/oss/tests/telemetry-sampling.test.ts
+++ b/mem0-ts/src/oss/tests/telemetry-sampling.test.ts
@@ -29,8 +29,16 @@ describe("telemetry sampling", () => {
   let originalFetch: typeof global.fetch;
   let fetchMock: jest.Mock;
   let randomSpy: jest.SpyInstance;
+  let originalTelemetry: string | undefined;
 
   beforeEach(() => {
+    // jest.setup.ts disables telemetry for the whole suite. This file is the
+    // one that exercises the sender, so re-enable it and drop the module
+    // registry, since telemetry.ts reads MEM0_TELEMETRY at import time and the
+    // tests below import it dynamically. fetch is mocked, so nothing leaves.
+    originalTelemetry = process.env.MEM0_TELEMETRY;
+    process.env.MEM0_TELEMETRY = "true";
+    jest.resetModules();
     originalFetch = global.fetch;
     fetchMock = jest.fn().mockResolvedValue({
       ok: true,
@@ -41,6 +49,11 @@ describe("telemetry sampling", () => {
   });
 
   afterEach(() => {
+    if (originalTelemetry === undefined) {
+      delete process.env.MEM0_TELEMETRY;
+    } else {
+      process.env.MEM0_TELEMETRY = originalTelemetry;
+    }
     global.fetch = originalFetch;
     randomSpy.mockRestore();
     jest.resetModules();


### PR DESCRIPTION
## Linked Issue

Closes #6798

## Description

The TS test suite sends real events to the production PostHog project, because both telemetry modules default `MEM0_TELEMETRY` to true and nothing in the jest config turns it off. `captureClientEvent` is awaited on the critical path, so each event also blocks the test on a network round trip of about five seconds.

That is what makes the TS CI flaky. Measured on a clean checkout of `main`, same machine, back to back:

| | `pnpm run test` |
|---|---|
| before | 198s, 4 failures, failing test varies between runs |
| after | 10.1s, 0 failures |

`memory.embedding-action.test.ts` and `memory.rerank.test.ts` both pass with this change.

## What it does

Sets `MEM0_TELEMETRY=false` in `jest.setup.ts`. `setupFiles` runs it before the test module is loaded and after `dotenv/config`, so a stray `.env` cannot re-enable it.

That alone breaks 18 tests, in `telemetry-sampling.test.ts` (14) and `telemetry-aliasing.test.ts` (4), which legitimately assert on the sender, so both opt back in. They need different opt-ins: sampling imports the telemetry module dynamically, so it re-enables per test around `jest.resetModules()`; aliasing imports it statically, so it imports a three-line side-effect module first. Both still run the real telemetry module against a mocked `fetch`, so assertion coverage is unchanged.

One deliberate call worth flagging: the assignment is unconditional rather than a `??=` default, so `MEM0_TELEMETRY=true npx jest` no longer re-arms telemetry suite-wide. A default would let a shell var or a contributor's `.env` quietly put the leak back. The per-suite opt-in is the escape hatch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

None. Test-only, no production source file is touched.

## Test Coverage

- [x] No tests needed (this is a test configuration fix; the evidence is the suite itself)

Full suite: 1443 passed, 0 failed, 90 of 90 suites, 10.1s. `pnpm run build` clean including `prettier --check`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (none required)
