### PR TITLE
fix(cli): read config as utf-8

### DIFF
--- a/cli/python/src/mem0_cli/config.py
+++ b/cli/python/src/mem0_cli/config.py
@@ -90,7 +90,7 @@ def load_config() -> Mem0Config:
     config = Mem0Config()
 
     if CONFIG_FILE.exists():
-        with open(CONFIG_FILE) as f:
+        with open(CONFIG_FILE, encoding="utf-8") as f:
             data = json.load(f)
 
         config.version = data.get("version", CONFIG_VERSION)
@@ -174,7 +174,7 @@ def save_config(config: Mem0Config) -> None:
         },
     }
 
-    with open(CONFIG_FILE, "w") as f:
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 
     os.chmod(CONFIG_FILE, stat.S_IRUSR | stat.S_IWUSR)  # 0600

--- a/cli/python/tests/test_config.py
+++ b/cli/python/tests/test_config.py
@@ -40,11 +40,13 @@ class TestConfig:
     def test_save_and_load(self, isolate_config):
         config = Mem0Config()
         config.platform.api_key = "m0-test-key"
+        config.platform.user_email = "rolly+café@example.com"
 
         save_config(config)
 
         loaded = load_config()
         assert loaded.platform.api_key == "m0-test-key"
+        assert loaded.platform.user_email == "rolly+café@example.com"
 
     def test_env_var_override(self, isolate_config, monkeypatch):
         config = Mem0Config()
@@ -54,6 +56,26 @@ class TestConfig:
         monkeypatch.setenv("MEM0_API_KEY", "env-key")
         loaded = load_config()
         assert loaded.platform.api_key == "env-key"
+
+    def test_load_utf8_config_file(self, isolate_config):
+        import json
+
+        from mem0_cli.config import CONFIG_FILE, ensure_config_dir
+
+        ensure_config_dir()
+        data = {
+            "version": 1,
+            "platform": {
+                "api_key": "m0-test",
+                "base_url": "https://api.mem0.ai",
+                "user_email": "rolly+café@example.com",
+            },
+        }
+        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False)
+
+        loaded = load_config()
+        assert loaded.platform.user_email == "rolly+café@example.com"
 
     def test_load_nonexistent_config(self, isolate_config):
         config = load_config()
@@ -108,7 +130,7 @@ class TestConfig:
             "version": 1,
             "platform": {"api_key": "m0-test", "base_url": "https://api.mem0.ai"},
         }
-        with open(CONFIG_FILE, "w") as f:
+        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
             json.dump(data, f)
 
         loaded = load_config()


### PR DESCRIPTION
## Problem

The Python CLI config file is read and written without an explicit text encoding. On systems whose default encoding is not UTF-8, a manually edited `~/.mem0/config.json` containing non-ASCII values, such as a user email/comment field, can fail to load or be interpreted inconsistently.

## Before / after

Before, `load_config()` and `save_config()` relied on the platform default encoding for JSON config I/O.

After, config reads and writes use `encoding="utf-8"`, matching JSON's usual wire/storage encoding and making behavior consistent across platforms. The backward-compat test fixture was updated the same way, and a regression test covers loading a UTF-8 config file with a literal non-ASCII value.

## Verification

- `PYTHONPATH=cli/python/src python -m pytest cli/python/tests/test_config.py`
- `git diff --check`