### PR TITLE
fix(ts-sdk): await identity before building project-scoped URLs

### DIFF
--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -136,8 +136,7 @@ export default class MemoryClient {
 
     this.telemetryId = "";
 
-    // Memory requests never wait on this; telemetry and the project-scoped
-    // endpoints (_awaitIdentity) do.
+    // Memory requests never wait on this; telemetry and _awaitIdentity do.
     this.initialized = this._resolveIdentity();
   }
 
@@ -166,10 +165,7 @@ export default class MemoryClient {
     });
   }
 
-  // getProject/updateProject/getWebhooks/createWebhook build their URL from
-  // organizationId/projectId, which only exist once the ping has landed. The
-  // memory endpoints don't need this — the server derives org/project from the
-  // API key. Resolved promise on a warm process, so this costs one microtask.
+  // Blocks until the ping has populated organizationId/projectId.
   private async _awaitIdentity(): Promise<void> {
     await this.initialized;
   }

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -136,7 +136,8 @@ export default class MemoryClient {
 
     this.telemetryId = "";
 
-    // Requests never wait on this; only telemetry does.
+    // Memory requests never wait on this; telemetry and the project-scoped
+    // endpoints (_awaitIdentity) do.
     this.initialized = this._resolveIdentity();
   }
 
@@ -163,6 +164,14 @@ export default class MemoryClient {
         this.organizationId = identity.organizationId;
       if (identity.projectId != null) this.projectId = identity.projectId;
     });
+  }
+
+  // getProject/updateProject/getWebhooks/createWebhook build their URL from
+  // organizationId/projectId, which only exist once the ping has landed. The
+  // memory endpoints don't need this — the server derives org/project from the
+  // API key. Resolved promise on a warm process, so this costs one microtask.
+  private async _awaitIdentity(): Promise<void> {
+    await this.initialized;
   }
 
   private async _initializeClient(): Promise<ClientIdentity> {
@@ -616,6 +625,7 @@ export default class MemoryClient {
     const payloadKeys = Object.keys(options || {});
     this._captureEvent("get_project", [payloadKeys]);
     const { fields } = options;
+    await this._awaitIdentity();
 
     if (!(this.organizationId && this.projectId)) {
       throw new Error(
@@ -639,6 +649,7 @@ export default class MemoryClient {
     prompts: PromptUpdatePayload,
   ): Promise<Record<string, any>> {
     this._captureEvent("update_project", []);
+    await this._awaitIdentity();
     if (!(this.organizationId && this.projectId)) {
       throw new Error(
         "organizationId and projectId must be set to update instructions or categories",
@@ -659,6 +670,7 @@ export default class MemoryClient {
   // WebHooks
   async getWebhooks(data?: { projectId?: string }): Promise<Array<Webhook>> {
     this._captureEvent("get_webhooks", []);
+    if (!data?.projectId) await this._awaitIdentity();
     const project_id = data?.projectId || this.projectId;
     const response = await this._fetchWithErrorHandling(
       `${this.host}/api/v1/webhooks/projects/${project_id}/`,
@@ -671,6 +683,7 @@ export default class MemoryClient {
 
   async createWebhook(webhook: WebhookCreatePayload): Promise<Webhook> {
     this._captureEvent("create_webhook", []);
+    await this._awaitIdentity();
     const body = {
       name: webhook.name,
       url: webhook.url,

--- a/mem0-ts/src/client/mem0.ts
+++ b/mem0-ts/src/client/mem0.ts
@@ -81,6 +81,8 @@ class APIError extends Error {
 interface ClientOptions {
   apiKey: string;
   host?: string;
+  /** Max cached identities per process. Defaults to 50. */
+  identityCacheMax?: number;
 }
 
 interface ClientIdentity {
@@ -90,7 +92,7 @@ interface ClientIdentity {
 }
 
 // Shares one ping per (host, api key) across clients; FIFO-capped.
-const IDENTITY_CACHE_MAX = 50;
+const IDENTITY_CACHE_MAX_DEFAULT = 50;
 const identityByCredentials = new Map<string, Promise<ClientIdentity>>();
 
 export default class MemoryClient {
@@ -102,6 +104,7 @@ export default class MemoryClient {
   client: any;
   telemetryId: string;
   private initialized: Promise<void>;
+  private identityCacheMax: number;
 
   _validateApiKey(): any {
     if (!this.apiKey) {
@@ -120,6 +123,8 @@ export default class MemoryClient {
     this.host = options.host || "https://api.mem0.ai";
     this.organizationId = null;
     this.projectId = null;
+    this.identityCacheMax =
+      options.identityCacheMax ?? IDENTITY_CACHE_MAX_DEFAULT;
 
     this.headers = {
       Authorization: `Token ${this.apiKey}`,
@@ -146,7 +151,7 @@ export default class MemoryClient {
     let shared = identityByCredentials.get(credentials);
     if (!shared) {
       shared = this._initializeClient();
-      if (identityByCredentials.size >= IDENTITY_CACHE_MAX) {
+      if (identityByCredentials.size >= this.identityCacheMax) {
         identityByCredentials.delete(
           identityByCredentials.keys().next().value!,
         );
@@ -668,6 +673,9 @@ export default class MemoryClient {
     this._captureEvent("get_webhooks", []);
     if (!data?.projectId) await this._awaitIdentity();
     const project_id = data?.projectId || this.projectId;
+    if (!project_id) {
+      throw new Error("projectId must be set to access webhooks");
+    }
     const response = await this._fetchWithErrorHandling(
       `${this.host}/api/v1/webhooks/projects/${project_id}/`,
       {
@@ -680,6 +688,9 @@ export default class MemoryClient {
   async createWebhook(webhook: WebhookCreatePayload): Promise<Webhook> {
     this._captureEvent("create_webhook", []);
     await this._awaitIdentity();
+    if (!this.projectId) {
+      throw new Error("projectId must be set to create a webhook");
+    }
     const body = {
       name: webhook.name,
       url: webhook.url,

--- a/mem0-ts/src/client/tests/memoryClient.identity.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.identity.test.ts
@@ -17,10 +17,13 @@ const freshClient = () =>
   new MemoryClient({ apiKey: `test-api-key-identity-${keySeq++}` });
 
 // Selects by path; the ping and PostHog calls also land in the mock.
-const findUrl = (mock: jest.Mock, needle: string): string => {
-  const url = mock.mock.calls
+const findUrlOrNone = (mock: jest.Mock, needle: string): string | undefined =>
+  mock.mock.calls
     .map((c: [string, RequestInit]) => c[0])
     .find((u: string) => u.includes(needle));
+
+const findUrl = (mock: jest.Mock, needle: string): string => {
+  const url = findUrlOrNone(mock, needle);
   expect(url).toBeDefined();
   return url as string;
 };
@@ -121,5 +124,105 @@ describe("MemoryClient - memory endpoints do not wait on identity", () => {
     ).resolves.toBeDefined();
 
     expect(findUrl(mock, "/v3/memories/search/")).toBeDefined();
+  });
+});
+
+describe("MemoryClient - identity cache overflow", () => {
+  const pingCount = (mock: jest.Mock) =>
+    mock.mock.calls.filter((c: [string, RequestInit]) =>
+      c[0].includes("/v1/ping/"),
+    ).length;
+
+  // The cache is module scope, so each test needs its own module registry.
+  const isolatedClient = (): typeof MemoryClient => {
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require("../mem0").MemoryClient;
+  };
+
+  const projectOk = () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/api/v1/orgs/organizations/", { status: 200, body: {} });
+    return setupMockFetch(extra);
+  };
+
+  test("a reused credential pair pings once", async () => {
+    const mock = projectOk();
+    const Client = isolatedClient();
+
+    const opts = { apiKey: "cache-warm-key", identityCacheMax: 1 };
+    await new Client(opts).getProject({ fields: [] });
+    await new Client(opts).getProject({ fields: [] });
+
+    expect(pingCount(mock)).toBe(1);
+  });
+
+  test("an evicted credential pair re-pings and still resolves identity", async () => {
+    const mock = projectOk();
+    const Client = isolatedClient();
+    const opts = (apiKey: string) => ({ apiKey, identityCacheMax: 1 });
+
+    await new Client(opts("key-a")).getProject({ fields: [] });
+    // Evicts key-a.
+    await new Client(opts("key-b")).getProject({ fields: [] });
+    expect(pingCount(mock)).toBe(2);
+
+    await new Client(opts("key-a")).getProject({ fields: [] });
+
+    // Eviction costs a ping; it never yields an unresolved identity.
+    expect(pingCount(mock)).toBe(3);
+    expect(findUrl(mock, "/api/v1/orgs/organizations/")).toContain(
+      `/api/v1/orgs/organizations/${TEST_ORG_ID}/`,
+    );
+  });
+});
+
+describe("MemoryClient - unresolved identity", () => {
+  const pingFails = () => {
+    const mock = jest.fn((url: string) => {
+      if (url.includes("/v1/ping/")) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve("boom"),
+          json: () => Promise.resolve({}),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([]),
+        text: () => Promise.resolve(""),
+      });
+    });
+    global.fetch = mock as unknown as typeof global.fetch;
+    return mock;
+  };
+
+  test("getProject reports the unset ids", async () => {
+    pingFails();
+    await expect(freshClient().getProject({ fields: [] })).rejects.toThrow(
+      "organizationId and projectId must be set",
+    );
+  });
+
+  test("getWebhooks reports the unset project instead of requesting null", async () => {
+    const mock = pingFails();
+    await expect(freshClient().getWebhooks()).rejects.toThrow(
+      "projectId must be set",
+    );
+    expect(findUrlOrNone(mock, "/api/v1/webhooks/")).toBeUndefined();
+  });
+
+  test("createWebhook reports the unset project instead of requesting null", async () => {
+    const mock = pingFails();
+    await expect(
+      freshClient().createWebhook({
+        name: "hook",
+        url: "https://example.com/hook",
+        eventTypes: ["memory_add"],
+      }),
+    ).rejects.toThrow("projectId must be set");
+    expect(findUrlOrNone(mock, "/api/v1/webhooks/")).toBeUndefined();
   });
 });

--- a/mem0-ts/src/client/tests/memoryClient.identity.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.identity.test.ts
@@ -1,0 +1,137 @@
+/**
+ * MemoryClient unit tests — identity (org/project) resolution ordering.
+ *
+ * getProject/updateProject/getWebhooks/createWebhook build their URL from
+ * organizationId/projectId, which are only populated once the constructor's
+ * ping resolves. These tests call each method as the FIRST awaited operation on
+ * a freshly constructed client — the serverless / per-request-DI pattern — and
+ * assert the resolved IDs reach the URL.
+ *
+ * Do not add an `await client.ping()` (or any other await on the instance)
+ * before the call under test: a single microtask tick is enough to hide the bug
+ * these tests exist to catch.
+ */
+import { MemoryClient } from "../mem0";
+import { TEST_ORG_ID, TEST_PROJECT_ID } from "./helpers";
+import { setupMockFetch, installConsoleSuppression } from "./setup";
+
+installConsoleSuppression();
+
+// A distinct key per client keeps each test off the module-scope identity
+// cache, so results never depend on test ordering.
+let keySeq = 0;
+const freshClient = () =>
+  new MemoryClient({ apiKey: `test-api-key-identity-${keySeq++}` });
+
+// Selects the request under test by path. Never index by position: the ping
+// and the PostHog telemetry call also land in the mock, and their ordering
+// relative to the API call is deliberately unspecified.
+const findUrl = (mock: jest.Mock, needle: string): string => {
+  const url = mock.mock.calls
+    .map((c: [string, RequestInit]) => c[0])
+    .find((u: string) => u.includes(needle));
+  expect(url).toBeDefined();
+  return url as string;
+};
+
+describe("MemoryClient - project-scoped URLs on a fresh client", () => {
+  test("getProject uses the resolved org and project ids", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/api/v1/orgs/organizations/", {
+      status: 200,
+      body: { custom_instructions: "Be helpful" },
+    });
+    const mock = setupMockFetch(extra);
+
+    // First awaited call on the instance — no ping() beforehand.
+    await freshClient().getProject({ fields: ["custom_instructions"] });
+
+    const url = findUrl(mock, "/api/v1/orgs/organizations/");
+    expect(url).toContain(`/api/v1/orgs/organizations/${TEST_ORG_ID}/`);
+    expect(url).toContain(`/projects/${TEST_PROJECT_ID}/`);
+  });
+
+  test("updateProject uses the resolved org and project ids", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/api/v1/orgs/organizations/", {
+      status: 200,
+      body: { custom_instructions: "Updated" },
+    });
+    const mock = setupMockFetch(extra);
+
+    await freshClient().updateProject({ customInstructions: "Updated" });
+
+    const url = findUrl(mock, "/api/v1/orgs/organizations/");
+    expect(url).toContain(`/api/v1/orgs/organizations/${TEST_ORG_ID}/`);
+    expect(url).toContain(`/projects/${TEST_PROJECT_ID}/`);
+  });
+
+  test("getWebhooks targets the resolved project, not null", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/api/v1/webhooks/projects/", { status: 200, body: [] });
+    const mock = setupMockFetch(extra);
+
+    await freshClient().getWebhooks();
+
+    const url = findUrl(mock, "/api/v1/webhooks/projects/");
+    expect(url).toContain(`/api/v1/webhooks/projects/${TEST_PROJECT_ID}/`);
+    expect(url).not.toContain("/projects/null/");
+    expect(url).not.toContain("/projects/undefined/");
+  });
+
+  test("createWebhook targets the resolved project, not null", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/api/v1/webhooks/projects/", {
+      status: 200,
+      body: { webhook_id: "wh_1" },
+    });
+    const mock = setupMockFetch(extra);
+
+    await freshClient().createWebhook({
+      name: "hook",
+      url: "https://example.com/hook",
+      eventTypes: ["memory_add"],
+    });
+
+    const url = findUrl(mock, "/api/v1/webhooks/projects/");
+    expect(url).toContain(`/api/v1/webhooks/projects/${TEST_PROJECT_ID}/`);
+    expect(url).not.toContain("/projects/null/");
+    expect(url).not.toContain("/projects/undefined/");
+  });
+
+  test("an explicit projectId is honored without waiting on identity", async () => {
+    const extra = new Map<string, { status: number; body: unknown }>();
+    extra.set("/api/v1/webhooks/projects/", { status: 200, body: [] });
+    const mock = setupMockFetch(extra);
+
+    await freshClient().getWebhooks({ projectId: "proj_explicit_789" });
+
+    expect(findUrl(mock, "/api/v1/webhooks/projects/")).toContain(
+      "/api/v1/webhooks/projects/proj_explicit_789/",
+    );
+  });
+});
+
+describe("MemoryClient - memory endpoints do not wait on identity", () => {
+  test("search completes while the ping is still pending", async () => {
+    // The ping never settles. A memory call must still complete, since the
+    // server derives org/project from the API key. This is what keeps
+    // telemetry setup off the request critical path.
+    const mock = jest.fn((url: string) => {
+      if (url.includes("/v1/ping/")) return new Promise(() => {});
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ results: [] }),
+        text: () => Promise.resolve(""),
+      });
+    });
+    global.fetch = mock as unknown as typeof global.fetch;
+
+    await expect(
+      freshClient().search("query", { filters: { user_id: "alice" } }),
+    ).resolves.toBeDefined();
+
+    expect(findUrl(mock, "/v3/memories/search/")).toBeDefined();
+  });
+});

--- a/mem0-ts/src/client/tests/memoryClient.identity.test.ts
+++ b/mem0-ts/src/client/tests/memoryClient.identity.test.ts
@@ -1,15 +1,9 @@
 /**
- * MemoryClient unit tests — identity (org/project) resolution ordering.
+ * MemoryClient unit tests — org/project identity resolution ordering.
  *
- * getProject/updateProject/getWebhooks/createWebhook build their URL from
- * organizationId/projectId, which are only populated once the constructor's
- * ping resolves. These tests call each method as the FIRST awaited operation on
- * a freshly constructed client — the serverless / per-request-DI pattern — and
- * assert the resolved IDs reach the URL.
- *
- * Do not add an `await client.ping()` (or any other await on the instance)
- * before the call under test: a single microtask tick is enough to hide the bug
- * these tests exist to catch.
+ * Each test calls the method under test as the first awaited operation on a
+ * fresh client. Any earlier await on the instance resolves identity and voids
+ * the test.
  */
 import { MemoryClient } from "../mem0";
 import { TEST_ORG_ID, TEST_PROJECT_ID } from "./helpers";
@@ -17,15 +11,12 @@ import { setupMockFetch, installConsoleSuppression } from "./setup";
 
 installConsoleSuppression();
 
-// A distinct key per client keeps each test off the module-scope identity
-// cache, so results never depend on test ordering.
+// Distinct key per client keeps each test off the module-scope identity cache.
 let keySeq = 0;
 const freshClient = () =>
   new MemoryClient({ apiKey: `test-api-key-identity-${keySeq++}` });
 
-// Selects the request under test by path. Never index by position: the ping
-// and the PostHog telemetry call also land in the mock, and their ordering
-// relative to the API call is deliberately unspecified.
+// Selects by path; the ping and PostHog calls also land in the mock.
 const findUrl = (mock: jest.Mock, needle: string): string => {
   const url = mock.mock.calls
     .map((c: [string, RequestInit]) => c[0])
@@ -43,7 +34,6 @@ describe("MemoryClient - project-scoped URLs on a fresh client", () => {
     });
     const mock = setupMockFetch(extra);
 
-    // First awaited call on the instance — no ping() beforehand.
     await freshClient().getProject({ fields: ["custom_instructions"] });
 
     const url = findUrl(mock, "/api/v1/orgs/organizations/");
@@ -114,9 +104,7 @@ describe("MemoryClient - project-scoped URLs on a fresh client", () => {
 
 describe("MemoryClient - memory endpoints do not wait on identity", () => {
   test("search completes while the ping is still pending", async () => {
-    // The ping never settles. A memory call must still complete, since the
-    // server derives org/project from the API key. This is what keeps
-    // telemetry setup off the request critical path.
+    // The ping never settles.
     const mock = jest.fn((url: string) => {
       if (url.includes("/v1/ping/")) return new Promise(() => {});
       return Promise.resolve({


### PR DESCRIPTION
## Problem

Follow-up to #6788. That PR removed the 22 per-method `await this.ping()` guards — correct for every memory endpoint, because the server derives org/project from the API key. But four methods interpolate `organizationId`/`projectId` **into the URL client-side**:

`getProject`, `updateProject`, `getWebhooks`, `createWebhook`.

Both fields are populated by the constructor's ping, which assigns them inside a `.then()`. A method body that runs synchronously up to its first `await` still sees `null`. On a freshly constructed client in `3.1.4`:

```
getProject      Error: organizationId and projectId must be set to access instructions...
updateProject   Error: organizationId and projectId must be set to update instructions...
getWebhooks     -> GET  /api/v1/webhooks/projects/null/   ("No Project matches the given query")
createWebhook   -> POST /api/v1/webhooks/projects/null/
```

All four work on `3.1.3`. The webhook pair is the worse half — no clear error, it just targets `/projects/null/`.

**It is deterministic, not a timing race.** A warm module-scope identity cache does not help, because the assignment is still one microtask behind the call:

```
client #2 (identity cache already warm) getProject immediately   ERR
client #3 after `await search()` on the same instance            ok
client #4 after a single `await null`                            ok
```

Any single `await` on the instance beforehand hides it — which is why the existing suite missed it. `memoryClient.project.test.ts` calls `await client.ping()` first, and `memoryClient.webhooks.test.ts` asserts only that the URL *contains* `/api/v1/webhooks/projects/`, a substring that `/projects/null/` also satisfies.

This hits exactly the per-request-client pattern #6788 was optimizing for (serverless, per-request DI).

## Fix

`await this.initialized` — via a private `_awaitIdentity()` — in those four methods only.

- Memory endpoints keep the fast path and never wait. The latency win from #6788 is unchanged.
- On a warm process the promise is already resolved, so the cost is one microtask.
- `initialized` is `private`, so callers have no supported way to work around this themselves.
- `getWebhooks` skips the wait when an explicit `projectId` is passed.
- A failed ping still resolves `initialized`, so the existing "must be set" error remains reachable and nothing hangs.

## Tests

New `mem0-ts/src/client/tests/memoryClient.identity.test.ts` — 6 tests. Each calls the method as the **first awaited operation** on a fresh client and asserts the resolved ids reach the URL, plus two controls (explicit `projectId` short-circuit; a memory call completing while the ping is still pending).

Verified the tests fail on the bug and pass on the fix:

| | `origin/main` | with fix |
|---|---|---|
| getProject / updateProject / getWebhooks / createWebhook | 4 fail | 4 pass |
| explicit projectId; search with pending ping (controls) | 2 pass | 2 pass |

- [x] `npx jest src/client/` — 134 passed, 42 skipped, 0 failed
- [x] `npx prettier@3.8.4 --check .` (version pinned in `pnpm-lock.yaml`) — clean
- [x] `tsc --noEmit` — 113 errors, identical count to a control run on pristine `main` (jest types absent from tsconfig + community optional peers); none in the changed files
- [x] `tsup` JS bundle emitted; contains 1 `await this.ping()` and the new wait. Its dts step fails on `@aws-sdk/client-bedrock-runtime` under `npm i` on `main` too — pnpm optional-peer artifact, not this diff
- [x] Full 26-method live smoke against production: **25/26, 0 hard failures — identical to the `3.1.3` baseline**. (The one expected miss is `delete` after `batchDelete` already removed the memory.)
- [x] AWS Lambda A/B, `3.1.4` vs this branch, 10 warm invocations per mode: no latency regression — SDK overhead p50 stays 1 ms, 0 pings/req, 2 HTTP calls/req

| mode | 3.1.4 p50 | this branch p50 |
|---|---|---|
| search | 273 ms | 265 ms |
| add | 376 ms | 378 ms |
| getAll | 213 ms | 210 ms |

## Notes

No API change, no caller change. Scope is the four project-scoped methods; nothing on the memory path is touched.
