### PR TITLE
fix(claude-plugin): resolve the venv interpreter on Windows

### DIFF
--- a/integrations/mem0-plugin/scripts/ensure_deps.sh
+++ b/integrations/mem0-plugin/scripts/ensure_deps.sh
@@ -13,9 +13,25 @@ mkdir -p "${DATA_DIR}"
 
 LOCKDIR="${DATA_DIR}/.install-lock"
 
+# A venv puts its interpreter in bin/ on POSIX and Scripts/ on Windows.
+# Echoes the venv interpreter path, or nothing if the venv is absent/incomplete.
+venv_python() {
+  for _candidate in \
+    "${VENV_DIR}/bin/python3" \
+    "${VENV_DIR}/bin/python" \
+    "${VENV_DIR}/Scripts/python.exe"
+  do
+    if [ -x "${_candidate}" ]; then
+      echo "${_candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
 needs_install=false
 
-if [ ! -f "${VENV_DIR}/bin/python3" ]; then
+if ! venv_python >/dev/null; then
   needs_install=true
 elif ! diff -q "${REQ_SRC}" "${REQ_STAMP}" >/dev/null 2>&1; then
   needs_install=true
@@ -26,8 +42,12 @@ if [ "${needs_install}" = "true" ]; then
     # We acquired the lock — proceed with installation
     trap 'rmdir "${LOCKDIR}" 2>/dev/null || true' EXIT
     python3 -m venv "${VENV_DIR}" 2>/dev/null || python -m venv "${VENV_DIR}"
-    "${VENV_DIR}/bin/pip" install --quiet --upgrade pip >/dev/null 2>&1 || true
-    if "${VENV_DIR}/bin/pip" install --quiet -r "${REQ_SRC}" 2>/dev/null; then
+    # Resolve after creation, and go through `-m pip` so only one path needs resolving.
+    VENV_PY="$(venv_python || true)"
+    if [ -n "${VENV_PY}" ]; then
+      "${VENV_PY}" -m pip install --quiet --upgrade pip >/dev/null 2>&1 || true
+    fi
+    if [ -n "${VENV_PY}" ] && "${VENV_PY}" -m pip install --quiet -r "${REQ_SRC}" 2>/dev/null; then
       cp "${REQ_SRC}" "${REQ_STAMP}"
       rm -f "${DATA_DIR}/.install-failed"
     else

--- a/integrations/mem0-plugin/scripts/on_session_start.sh
+++ b/integrations/mem0-plugin/scripts/on_session_start.sh
@@ -177,8 +177,16 @@ if [ "$SOURCE" = "startup" ]; then
 
   # Configure the coding-category taxonomy in the background (idempotent, never blocks).
   # Prefer the venv python since this path needs the mem0ai SDK.
-  _VENV_PY="${CLAUDE_PLUGIN_DATA:-$HOME/.mem0/plugin-data}/venv/bin/python3"
-  if [ -x "$_VENV_PY" ]; then
+  # bin/ on POSIX, Scripts/ on Windows — mirrors the lookup in ensure_deps.sh.
+  _VENV_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.mem0/plugin-data}/venv"
+  _VENV_PY=""
+  for _candidate in "$_VENV_DIR/bin/python3" "$_VENV_DIR/bin/python" "$_VENV_DIR/Scripts/python.exe"; do
+    if [ -x "$_candidate" ]; then
+      _VENV_PY="$_candidate"
+      break
+    fi
+  done
+  if [ -n "$_VENV_PY" ]; then
     MEM0_CWD="$MEM0_CWD_RESOLVED" "$_VENV_PY" "$SCRIPT_DIR/auto_setup_categories.py" 2>/dev/null &
   else
     MEM0_CWD="$MEM0_CWD_RESOLVED" python3 "$SCRIPT_DIR/auto_setup_categories.py" 2>/dev/null &


### PR DESCRIPTION
## The bug

The plugin's dependency installer assumes a POSIX venv layout:

| File | Line | Assumes |
| --- | --- | --- |
| `integrations/mem0-plugin/scripts/ensure_deps.sh` | 18 | `venv/bin/python3` exists |
| `integrations/mem0-plugin/scripts/ensure_deps.sh` | 29–30 | `venv/bin/pip` is executable |
| `integrations/mem0-plugin/scripts/on_session_start.sh` | 180 | `venv/bin/python3` exists |

A venv created by `python -m venv` on Windows has no `bin/` at all — the
interpreter lives at `venv/Scripts/python.exe`. So on Windows:

1. the line 18 probe never matches, so `needs_install=true` every session;
2. `venv/bin/pip` does not exist, so the install is treated as failed;
3. the failure branch runs `rm -f "${REQ_STAMP}"` and `touch .install-failed`.

Step 3 is what makes it stick. The SessionStart guard is

```sh
diff -q "${CLAUDE_PLUGIN_ROOT}/requirements.txt" "${CLAUDE_PLUGIN_DATA}/requirements.txt" \
  >/dev/null 2>&1 || "${CLAUDE_PLUGIN_ROOT}/scripts/ensure_deps.sh"
```

Once the stamp is deleted the `diff` fails forever, so `ensure_deps.sh` re-runs
and re-fails on every session, each time showing `Installing mem0 SDK...` for the
duration of the lock wait. A `.install-lock` directory left behind by a session
that was killed mid-install adds a 60s stall on top. The mem0ai SDK is never
importable, so the `_VENV_PY` check at `on_session_start.sh:181` falls through to
a system `python3` that does not have it — `auto_setup_categories.py` then fails
at its lazy `from mem0 import MemoryClient`.

## The fix

Resolve the interpreter across both layouts — `bin/python3`, `bin/python`,
`Scripts/python.exe` — and install through `python -m pip` so only one path has
to be resolved rather than one per executable.

No behaviour change on POSIX: `bin/python3` is still the first candidate and
still matches.

## Verification

Windows 11, Git Bash, CPython 3.14.6, venv at `Scripts/`:

| | before | after |
| --- | --- | --- |
| fresh install into an empty `CLAUDE_PLUGIN_DATA` | `mem0 plugin: failed to install Python dependencies` | exits 0, silent |
| requirements stamp | deleted | written |
| `.install-failed` | created | absent |
| `import mem0` in the venv | `ModuleNotFoundError` | mem0ai 2.0.16 |
| second run | full re-install, fails again | 0.3s no-op |

`bash -n` clean on both scripts.

## Not addressed here

`.install-lock` has no staleness check, so a session killed mid-install (the
`trap ... EXIT` does not cover SIGKILL or a reboot) leaves a lock directory that
makes every later session wait the full 60s and then give up. Happy to send that
as a separate PR if you want it — it seemed better not to mix it with the path
fix.
