### PR TITLE
fix(cli): recover from a corrupted or malformed config.json

### DIFF
--- a/cli/python/src/mem0_cli/config.py
+++ b/cli/python/src/mem0_cli/config.py
@@ -90,31 +90,40 @@ def load_config() -> Mem0Config:
     config = Mem0Config()
 
     if CONFIG_FILE.exists():
-        with open(CONFIG_FILE) as f:
-            data = json.load(f)
+        data = None
+        try:
+            with open(CONFIG_FILE) as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                data = loaded
+        except (json.JSONDecodeError, OSError):
+            data = None
 
-        config.version = data.get("version", CONFIG_VERSION)
+        # A missing, corrupted, or wrong-shape config file falls back to
+        # defaults below, same as a config file that doesn't exist at all.
+        if data is not None:
+            config.version = data.get("version", CONFIG_VERSION)
 
-        plat = data.get("platform", {})
-        config.platform.api_key = plat.get("api_key", "")
-        config.platform.base_url = plat.get("base_url", DEFAULT_BASE_URL)
-        config.platform.user_email = plat.get("user_email", "")
-        config.platform.agent_mode = bool(plat.get("agent_mode", False))
-        config.platform.created_via = plat.get("created_via", "")
-        config.platform.agent_caller = plat.get("agent_caller", "")
-        config.platform.claimed_at = plat.get("claimed_at", "")
-        config.platform.default_user_id = plat.get("default_user_id", "")
+            plat = data.get("platform", {})
+            config.platform.api_key = plat.get("api_key", "")
+            config.platform.base_url = plat.get("base_url", DEFAULT_BASE_URL)
+            config.platform.user_email = plat.get("user_email", "")
+            config.platform.agent_mode = bool(plat.get("agent_mode", False))
+            config.platform.created_via = plat.get("created_via", "")
+            config.platform.agent_caller = plat.get("agent_caller", "")
+            config.platform.claimed_at = plat.get("claimed_at", "")
+            config.platform.default_user_id = plat.get("default_user_id", "")
 
-        defaults = data.get("defaults", {})
-        config.defaults.user_id = defaults.get("user_id", "")
-        config.defaults.agent_id = defaults.get("agent_id", "")
-        config.defaults.app_id = defaults.get("app_id", "")
-        config.defaults.run_id = defaults.get("run_id", "")
-        telemetry = data.get("telemetry", {})
-        config.telemetry.anonymous_id = telemetry.get("anonymous_id", "")
+            defaults = data.get("defaults", {})
+            config.defaults.user_id = defaults.get("user_id", "")
+            config.defaults.agent_id = defaults.get("agent_id", "")
+            config.defaults.app_id = defaults.get("app_id", "")
+            config.defaults.run_id = defaults.get("run_id", "")
+            telemetry = data.get("telemetry", {})
+            config.telemetry.anonymous_id = telemetry.get("anonymous_id", "")
 
-        agent_rush = data.get("agent_rush", {})
-        config.agent_rush.acknowledged_at = agent_rush.get("acknowledged_at", "")
+            agent_rush = data.get("agent_rush", {})
+            config.agent_rush.acknowledged_at = agent_rush.get("acknowledged_at", "")
 
     # Environment variable overrides
     env_key = os.environ.get("MEM0_API_KEY")
@@ -174,10 +183,13 @@ def save_config(config: Mem0Config) -> None:
         },
     }
 
-    with open(CONFIG_FILE, "w") as f:
+    # Write to a temp file and rename into place so a crash, kill, or disk-full
+    # mid-write can never leave a truncated (unparseable) config.json behind.
+    tmp_file = CONFIG_FILE.with_suffix(".json.tmp")
+    with open(tmp_file, "w") as f:
         json.dump(data, f, indent=2)
-
-    os.chmod(CONFIG_FILE, stat.S_IRUSR | stat.S_IWUSR)  # 0600
+    os.chmod(tmp_file, stat.S_IRUSR | stat.S_IWUSR)  # 0600
+    os.replace(tmp_file, CONFIG_FILE)
 
     # Propagate the active api_key to ecosystem touchpoints (Claude Code
     # plugin env injection, shell rc exports). Idempotent — only updates

--- a/cli/python/tests/test_config.py
+++ b/cli/python/tests/test_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 
 from mem0_cli.config import (
@@ -115,6 +116,59 @@ class TestConfig:
         assert loaded.platform.api_key == "m0-test"
         assert loaded.defaults.user_id == ""
         assert loaded.defaults.agent_id == ""
+
+    def test_load_malformed_json_falls_back_to_defaults(self, isolate_config):
+        """A truncated/invalid JSON file must not crash the CLI."""
+        from mem0_cli.config import CONFIG_FILE, ensure_config_dir
+
+        ensure_config_dir()
+        CONFIG_FILE.write_text('{"version": 1, "platform": {')
+
+        loaded = load_config()
+        assert loaded.platform.api_key == ""
+        assert loaded.version == 1
+
+    def test_load_non_dict_json_falls_back_to_defaults(self, isolate_config):
+        """Valid JSON that isn't an object (e.g. a list) must not crash the CLI."""
+        from mem0_cli.config import CONFIG_FILE, ensure_config_dir
+
+        ensure_config_dir()
+        CONFIG_FILE.write_text("[1, 2, 3]")
+
+        loaded = load_config()
+        assert loaded.platform.api_key == ""
+        assert loaded.version == 1
+
+    def test_save_config_does_not_leave_tmp_file(self, isolate_config):
+        """save_config() writes atomically: no leftover .json.tmp file."""
+        from mem0_cli.config import CONFIG_FILE
+
+        config = Mem0Config()
+        config.platform.api_key = "m0-test"
+        save_config(config)
+
+        tmp_file = CONFIG_FILE.with_suffix(".json.tmp")
+        assert not tmp_file.exists()
+        assert CONFIG_FILE.exists()
+        assert load_config().platform.api_key == "m0-test"
+
+    def test_save_config_failure_does_not_corrupt_existing_file(self, isolate_config, monkeypatch):
+        """An interrupted write must not truncate a previously-valid config.json."""
+        config = Mem0Config()
+        config.platform.api_key = "original"
+        save_config(config)
+
+        def _boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("json.dump", _boom)
+        new_config = Mem0Config()
+        new_config.platform.api_key = "should-not-be-written"
+        with contextlib.suppress(OSError):
+            save_config(new_config)
+
+        loaded = load_config()
+        assert loaded.platform.api_key == "original"
 
     def test_default_config_has_empty_defaults(self):
         config = Mem0Config()


### PR DESCRIPTION
## Linked Issue

Closes #6805

## Description

Any `mem0` CLI command crashed with a raw Python traceback if `~/.mem0/config.json` was malformed — even under `--json`/`--agent`, which the CLI documents as sanitizing all errors into JSON.

`load_config()` (`cli/python/src/mem0_cli/config.py:92-117`) called `json.load()` with no exception handling and no check that the parsed value was the expected `dict` shape. Two distinct malformed inputs hit this:

- Invalid JSON (e.g. a config file truncated by an interrupted write) → unhandled `json.JSONDecodeError`.
- Valid JSON that isn't an object, e.g. a top-level list → unhandled `AttributeError` from the unconditional `.get()` calls on it.

Both now fall back to `Mem0Config()` defaults — the same path already used, and already tested, when the config file doesn't exist at all.

Separately, `save_config()` (`config.py:156-189`) wrote in place with `open(CONFIG_FILE, "w")` + `json.dump(...)`. A kill, crash, or disk-full mid-write (e.g. Ctrl-C during `mem0 init`) can leave a truncated file on disk — exactly the state that triggers the crash above. This PR also makes the write atomic (temp file + `os.replace()`) so that scenario can no longer produce a corrupted file in the first place.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — `load_config()`'s signature and return type are unchanged. Behavior only changes for the two previously-crashing inputs, which had no defined or tested behavior before (they crashed). `save_config()`'s on-disk format and permissions (0600) are unchanged; only the write mechanism is now atomic.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Four new tests in `cli/python/tests/test_config.py`:

- `test_load_malformed_json_falls_back_to_defaults` — truncated JSON, asserts fallback instead of raising. Fails on `main` (`JSONDecodeError`), passes here.
- `test_load_non_dict_json_falls_back_to_defaults` — valid JSON, wrong shape (`[1, 2, 3]`), asserts the same fallback. Fails on `main` (`AttributeError`), passes here.
- `test_save_config_does_not_leave_tmp_file` — confirms the atomic write leaves no `.json.tmp` behind and the resulting file loads correctly.
- `test_save_config_failure_does_not_corrupt_existing_file` — simulates a write failure mid-`save_config()` and asserts a previously-valid `config.json` is left untouched rather than truncated.

All existing tests continue to pass unchanged (`test_save_and_load`, `test_load_nonexistent_config`, `test_backward_compat_no_defaults_key`, etc.) — the "file doesn't exist" and "valid file" paths aren't touched by this change.

```
$ ruff check .
All checks passed!
$ ruff format --check .
41 files already formatted
$ pytest -q
201 passed in 6.82s
```

Manually re-verified both original repros with the installed CLI end to end:

```
$ printf '{"version": 1, "platform": {' > ~/.mem0/config.json
$ mem0 status --json
{"status": "error", "command": "status", "error": "No API key configured.", "data": null}
# exit 1, clean JSON — no traceback

$ echo '[1, 2, 3]' > ~/.mem0/config.json
$ mem0 status --json
{"status": "error", "command": "status", "error": "No API key configured.", "data": null}
# same clean output
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed — no user-facing docs describe `load_config`/`save_config`'s internal error handling, so none needed.
