### PR TITLE
docs: frame graph memory as a Platform feature, removed from OSS

### DIFF
--- a/docs/core-concepts/how-it-works.mdx
+++ b/docs/core-concepts/how-it-works.mdx
@@ -46,7 +46,7 @@ When new messages arrive, Mem0 extracts durable facts and stores them with the i
 1. **Context lookup.** Mem0 checks related existing memories so it can avoid storing the same fact again.
 2. **Fact extraction.** An LLM extracts preferences, decisions, plans, and other details your agent can reuse.
 3. **Deduplication and embedding.** Redundant facts are removed, then each memory is embedded for semantic search.
-4. **Entity linking.** When configured, Mem0 links people, places, organizations, and concepts across memories.
+4. **Entity extraction.** Mem0 pulls out the people, places, organizations, and concepts each memory mentions and stores them for entity matching at search time. On Platform these entities also become the nodes of [Graph Memory](/platform/features/graph-memory).
 
 The automatic extraction path is additive. If a user says, "I moved from Austin to Seattle," Mem0 can store the new fact without silently rewriting the old one. Use explicit `update` or `delete` operations when your application needs to correct or remove a memory.
 
@@ -61,7 +61,7 @@ When you call `search`, Mem0 ranks stored memories against your query and filter
 | **Entity** | Boosts memories linked to entities in the query | Questions about a person, project, or account |
 | **Temporal** | Scores candidates on time metadata extracted at write time against the query's temporal intent | Temporal questions ("when did...", current state, recency) |
 
-Platform retrieval fuses these signals in the managed service. OSS retrieval depends on your configured vector store, optional reranker, and graph store.
+Platform retrieval fuses these signals in the managed service, where the entity signal is powered by built-in [Graph Memory](/platform/features/graph-memory). OSS retrieval depends on your configured vector store and optional reranker, and boosts on entity overlap alone: it has no graph memory.
 
 <Note>
   Always scope searches with filters such as `user_id`, `agent_id`, or `run_id`. This keeps memories from different users, agents, or sessions from mixing.
@@ -75,7 +75,7 @@ Mem0 stores different parts of a memory in stores built for different lookup pat
 |---|---|---|
 | **SQL database** | Facts and metadata | The source of truth for each memory |
 | **Vector database** | Embeddings | Semantic similarity search |
-| **Entity or graph store** | Entities and relationships | Relationship-aware retrieval when graph memory is enabled |
+| **Entity store** | Entities extracted from memory text | Boosts memories sharing entities with the query. On Platform it also backs [Graph Memory](/platform/features/graph-memory) |
 
 On Mem0 Platform, these stores are managed for you. In OSS, you choose and operate the backing stores through your configuration.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -177,14 +177,14 @@ If the user is on a pre-current major (Python < 2, TS < 3, or Platform `output_f
 - [Platform CLI](https://docs.mem0.ai/platform/cli) [Platform]: Use when the user wants to manage Platform memories from the terminal.
 - [Mem0 MCP Server](https://docs.mem0.ai/platform/mem0-mcp) [Platform]: Use when connecting memory to AI coding tools over MCP.
 - [Open Source Overview](https://docs.mem0.ai/open-source/overview) [OSS]: Use when the user needs full infra control and custom provider wiring.
-- [Open Source Configuration](https://docs.mem0.ai/open-source/configuration) [OSS]: Use when configuring `Memory` - LLM, embedder, vector store, graph store.
+- [Open Source Configuration](https://docs.mem0.ai/open-source/configuration) [OSS]: Use when configuring `Memory` - LLM, embedder, vector store, reranker.
 - [Open Source Python Quickstart](https://docs.mem0.ai/open-source/python-quickstart) [OSS]: Use for the first self-hosted Python integration.
 - [Open Source Node.js Quickstart](https://docs.mem0.ai/open-source/node-quickstart) [OSS]: Use for the first self-hosted Node integration.
 - [Self-Hosted Setup](https://docs.mem0.ai/open-source/setup) [OSS]: Use when standing up the bundled REST server and dashboard via Docker Compose, including auth, API keys, and the setup wizard.
 
 ## Core Concepts
 
-- [How Mem0 Works](https://docs.mem0.ai/core-concepts/how-it-works) [Both]: Use when explaining the end-to-end pipeline: extraction (ADD-only distillation), storage across vector/graph/history stores, and multi-signal retrieval.
+- [How Mem0 Works](https://docs.mem0.ai/core-concepts/how-it-works) [Both]: Use when explaining the end-to-end pipeline: extraction (ADD-only distillation), storage across vector/entity/history stores, and multi-signal retrieval.
 - [Memory Types](https://docs.mem0.ai/core-concepts/memory-types) [Both]: Use when explaining working, factual, episodic, and semantic memory distinctions.
 - [Memory Operations - Add](https://docs.mem0.ai/core-concepts/memory-operations/add) [Both]: Use when explaining how `add()` extracts facts, resolves conflicts, and writes to both stores.
 - [Memory Operations - Search](https://docs.mem0.ai/core-concepts/memory-operations/search) [Both]: Use when explaining how queries are processed and ranked.

--- a/docs/migration/oss-v2-to-v3.mdx
+++ b/docs/migration/oss-v2-to-v3.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Open Source: Migrating to the New Memory Algorithm"
-description: "Guide for self-hosted Mem0 users to upgrade to the new memory algorithm with ADD-only extraction, hybrid search, and entity linking."
+description: "Guide for self-hosted Mem0 users to upgrade to the new memory algorithm with ADD-only extraction, hybrid search, and entity-aware retrieval."
 icon: "arrow-right"
 iconType: "solid"
 ---
@@ -15,7 +15,8 @@ The new Mem0 release redesigns both extraction and retrieval, and cleans up the 
 
 - **Extraction**: Single-pass ADD-only (one LLM call, no UPDATE/DELETE)
 - **Retrieval**: Multi-signal hybrid search (semantic + BM25 keyword + entity matching)
-- **Entity linking**: Automatic entity extraction and cross-memory linking
+- **Entity matching**: Automatic entity extraction feeds a third scoring signal in hybrid search, boosting memories that share entities with the query
+- **Graph memory moved to Platform**: The external graph store integration is removed from OSS; graph memory is now a built-in, always-on [Mem0 Platform feature](/platform/features/graph-memory)
 - **SDK cleanup**: Deprecated parameters removed, naming conventions standardized
 - **API surface aligned with Platform**: Entity IDs now follow the same convention across OSS and Platform: top-level kwargs for `add()` / `delete_all()`, inside `filters` for `search()` / `get_all()`
 
@@ -37,7 +38,7 @@ These changes produce a **+20 point improvement on LoCoMo** (71.4 → 91.6) and 
 | `add()` events | Returns `ADD`, `UPDATE`, `DELETE` | Returns `ADD` only | Update code expecting UPDATE/DELETE |
 | Custom extraction prompt | `custom_fact_extraction_prompt` | `custom_instructions` | Rename in config |
 | Custom update prompt | `custom_update_memory_prompt` | Deprecated | Use `custom_instructions` instead |
-| Graph memory | `enable_graph` + `graph_store` in config | Removed | Graph store support has been removed entirely |
+| Graph memory | `enable_graph` + `graph_store` in config | Removed | Graph memory is removed from OSS. It's a built-in, always-on [Mem0 Platform feature](/platform/features/graph-memory) |
 | Qdrant client | `>=1.9.1` | `>=1.12.0` | Update dependency |
 | Upstash client | `>=0.1.0` | `>=0.6.0` | Update dependency |
 
@@ -53,8 +54,8 @@ These changes produce a **+20 point improvement on LoCoMo** (71.4 → 91.6) and 
 | `messages` in `add()` | Could be `null` / `undefined` | Required: throws on null/undefined | Always pass a string or array |
 | Payload key for lemmatized text | `text_lemmatized` (snake_case) | `textLemmatized` (camelCase) | TS-only internal field. If you share a vector store collection between Python and TS SDKs, lemma-based BM25 will not resolve across languages: keep collections language-scoped. |
 | Custom prompt | `customPrompt` | `customInstructions` | Rename in config |
-| Graph memory | `enableGraph` + `graphStore` in config | Removed | Graph store support has been removed entirely |
-| Default graph config | Neo4j default config applied | No default graph config | Graph store config is no longer used |
+| Graph memory | `enableGraph` + `graphStore` in config | Removed | Graph memory is removed from OSS. It's a built-in, always-on [Mem0 Platform feature](/platform/features/graph-memory) |
+| Default graph config | Neo4j default config applied | No default graph config | Graph store config is no longer read; OSS has no built-in graph config to fall back to |
 
 ### Python Client SDK
 
@@ -104,7 +105,7 @@ These changes produce a **+20 point improvement on LoCoMo** (71.4 → 91.6) and 
 </Tabs>
 
 <Info>
-The Python `[nlp]` extra installs [spaCy](https://spacy.io/) for entity extraction and keyword lemmatization. Without it, Mem0 still works but falls back to semantic-only search (no entity linking, no BM25 lemmatization).
+The Python `[nlp]` extra installs [spaCy](https://spacy.io/) for entity extraction and keyword lemmatization. Without it, Mem0 still works but falls back to semantic-only search (no entity matching, no BM25 lemmatization).
 </Info>
 
 <Warning>
@@ -135,7 +136,7 @@ pip install fastembed
     config = {
         "custom_instructions": "Focus on user preferences",  # [OK] New name
         # custom_update_memory_prompt removed: use custom_instructions
-        # enable_graph and graph_store removed: graph store support has been removed
+        # enable_graph and graph_store removed: graph memory is now a Mem0 Platform feature
     }
     ```
   </Tab>
@@ -154,7 +155,7 @@ pip install fastembed
     // After
     const config = {
       customInstructions: "Focus on user preferences",  // [OK] New name
-      // enableGraph and graphStore removed: graph store support has been removed
+      // enableGraph and graphStore removed: graph memory is now a Mem0 Platform feature
     };
     ```
   </Tab>
@@ -320,35 +321,31 @@ pip install "qdrant-client>=1.12.0"
 pip install "upstash-vector>=0.6.0"
 ```
 
-### 6. Entity Store Setup
+### 6. Entity Matching Store Setup
 
-The new algorithm automatically creates a parallel entity store collection named `{your_collection}_entities`. No manual setup is required: it's created on first use.
+The new algorithm automatically creates a parallel collection named `{your_collection}_entities` to power entity matching, the third signal in hybrid search. No manual setup is required: it's created on first use. This is separate from and unrelated to graph memory, which is a Mem0 Platform feature.
 
 <Warning>
 Make sure your vector store user/credentials have permission to create new collections. If you're using a managed vector database with restricted permissions, pre-create the `{collection_name}_entities` collection with the same embedding dimensions as your main collection.
 </Warning>
 
-## Graph Memory: Now Built-In
+## Graph Memory: Platform Only
 
-External graph **store** support has been removed from the open-source SDK and replaced by **built-in graph memory** (entity linking), which runs natively with no external dependencies.
+Graph memory is removed from the open-source SDK. It is not being replaced by an OSS equivalent: graph memory is a **Mem0 Platform** feature, built in and always on, with no external graph database required. See [Graph Memory](/platform/features/graph-memory) for what it does on Platform.
 
-**What was removed:**
+**What was removed from OSS:**
 - `enable_graph` / `enableGraph` config flag
-- `graph_store` / `graphStore` configuration block (Neo4j, Memgraph, Kuzu, Apache AGE, Neptune)
-- All external graph store code paths (~4000 lines)
-
-**What replaces it:**
-
-Mem0 now builds the graph itself. It extracts entities (proper nouns, quoted text, compound noun phrases) from every memory during the add pipeline and stores them in a parallel collection (`{collection}_entities`) inside your existing vector store. Memories that share an entity are linked, and at search time entities from the query are matched against this collection to boost connected memories. The boost is folded into the combined `score` on each result.
+- `graph_store` / `graphStore` configuration block
+- All external graph store drivers (Neo4j, Memgraph, Kuzu, Apache AGE, Neptune) and their code paths (~4000 lines)
 
 **Migration:**
 - Remove `enable_graph` / `enableGraph` from your config
 - Remove the `graph_store` / `graphStore` block: it is no longer read
 - Uninstall external graph drivers (neo4j, memgraph, etc.) if you were using them only for Mem0
-- No data migration is required. Built-in graph memory activates automatically on the next `add()` call.
+- If you need graph memory, use [Mem0 Platform](/platform/features/graph-memory) instead of self-hosted OSS
 
 <Warning>
-The old `relations` field on search results (populated by the external graph store) is no longer returned. Entity connections are now applied through retrieval ranking rather than exposed as a separate, directly traversable structure. If your application read or traversed the `relations` array, you will need to redesign that part against the new API.
+The old `relations` field on search results (populated by the external graph store) is no longer returned in OSS. OSS has no graph memory replacement, so there is nothing to populate this field with. If your application read or traversed the `relations` array, either move to Mem0 Platform to keep that data or redesign that part against the new OSS retrieval API.
 </Warning>
 
 ## How the New Algorithm Works
@@ -362,7 +359,7 @@ Input conversation
     → Batch embed extracted memories
     → Hash-based deduplication (MD5, prevents exact duplicates)
     → Batch insert into vector store
-    → Entity extraction + linking
+    → Entity extraction (for entity matching)
 ```
 
 The previous algorithm used two LLM calls: one to extract candidate facts, one to decide ADD/UPDATE/DELETE actions against existing memories. The new algorithm collapses this into a single call that only adds. The model spends its capacity on understanding the input rather than diffing against existing state.
@@ -375,7 +372,7 @@ Query
     → Parallel scoring:
         1. Semantic search (vector similarity)
         2. BM25 keyword search (normalized term matching)
-        3. Entity matching (entity graph boost)
+        3. Entity matching (entity overlap boost)
     → Score fusion → Top-K selection
 ```
 
@@ -408,8 +405,8 @@ The new features degrade gracefully when optional dependencies are missing:
 | Missing Dependency | Impact | Search Still Works? |
 |---|---|---|
 | spaCy (`mem0ai[nlp]`) | No entity extraction, no BM25 lemmatization | Yes (semantic-only) |
-| `fastembed` (Qdrant) | No BM25 keyword search | Yes (semantic + entity) |
-| Entity store unavailable | No entity boosting | Yes (semantic + BM25) |
+| `fastembed` (Qdrant) | No BM25 keyword search | Yes (semantic + entity matching) |
+| Entity matching store unavailable | No entity matching boost | Yes (semantic + BM25) |
 
 You always get semantic search. Hybrid search features layer on top when available.
 
@@ -449,13 +446,13 @@ These parameters have been removed across all SDKs. Remove them from your code:
 
 **Config:** `custom_update_memory_prompt` → deprecated, use `custom_instructions`
 
-**Config:** `enable_graph` + `graph_store` → removed (graph store support removed entirely)
+**Config:** `enable_graph` + `graph_store` → removed (graph memory is now a [Mem0 Platform feature](/platform/features/graph-memory))
 
 ### TypeScript OSS: Removed/renamed parameters
 
 **Config:** `customPrompt` → renamed to `customInstructions`
 
-**Config:** `enableGraph` + `graphStore` → removed (graph store support removed entirely)
+**Config:** `enableGraph` + `graphStore` → removed (graph memory is now a [Mem0 Platform feature](/platform/features/graph-memory))
 
 **search():** `limit` → renamed to `topK`
 
@@ -521,9 +518,9 @@ If spaCy is not installed at all, install the NLP extras:
 pip install "mem0ai[nlp]"
 ```
 
-### Entity store collection creation fails
+### Entity matching store collection creation fails
 
-The entity store tries to create a `{collection_name}_entities` collection automatically. If your vector database has restricted permissions, pre-create this collection with the same embedding dimensions as your main collection.
+The entity matching store tries to create a `{collection_name}_entities` collection automatically. If your vector database has restricted permissions, pre-create this collection with the same embedding dimensions as your main collection.
 
 ### Score values are different from before
 

--- a/docs/open-source/configuration.mdx
+++ b/docs/open-source/configuration.mdx
@@ -4,7 +4,7 @@ description: "Configure Mem0 OSS in Python or TypeScript with your own LLM, embe
 icon: "sliders"
 ---
 
-Mem0 OSS works out of the box with OpenAI defaults. Point it at your own LLM, embedder, and vector store by passing a config when you create `Memory`. The Python SDK also supports a reranker and graph memory.
+Mem0 OSS works out of the box with OpenAI defaults. Point it at your own LLM, embedder, vector store, and reranker by passing a config when you create `Memory`.
 
 <Info>
   **Prerequisites**
@@ -90,11 +90,11 @@ Set your provider keys as environment variables:
 
 ```bash
 export OPENAI_API_KEY="..."
-export COHERE_API_KEY="..."   # Python reranker only
+export COHERE_API_KEY="..."   # Cohere reranker only
 ```
 
 <Note>
-  The TypeScript OSS SDK configures the LLM, embedder, vector store, and history store. Reranker and graph memory are Python-only today.
+  The TypeScript OSS SDK configures the LLM, embedder, vector store, history store, and reranker. Graph memory is not part of OSS in either language: it is a built-in [Mem0 Platform feature](/platform/features/graph-memory).
 </Note>
 
 Prefer a config file? Load YAML into Python's `from_config`:


### PR DESCRIPTION
## Linked Issue

No issue filed. This is a docs accuracy fix reported directly: the OSS v2-to-v3 migration guide described graph memory as built into the open-source SDK, when graph memory is a Mem0 Platform feature.

## Description

`docs/migration/oss-v2-to-v3.mdx` told self-hosted users that the external graph store was "replaced by **built-in graph memory** (entity linking), which runs natively with no external dependencies." It also contradicted itself: the breaking-change tables said graph support was "removed entirely" while the section below said it was now built in.

Corrected framing across the docs: **graph memory is a Mem0 Platform feature**, built in and always on. In OSS the external graph store (Neo4j, Memgraph, Kuzu, Apache AGE, Neptune) is removed with no OSS replacement.

### `docs/migration/oss-v2-to-v3.mdx`

- `## Graph Memory: Now Built-In` → `## Graph Memory: Platform Only`. Removed the "What replaces it" paragraph claiming Mem0 builds the graph itself in OSS. Migration steps now end by pointing at Platform.
- Python and TypeScript breaking-change rows, both config code samples, and both removed-parameter bullets now link to `/platform/features/graph-memory`.
- The `relations` warning now explains OSS has nothing to populate the field with, and offers Platform as the way to keep that data.

One judgment call worth reviewing: the page also documents the `{collection}_entities` collection, the spaCy `[nlp]` install, and entity scoring in hybrid search. That is live OSS code (`mem0/utils/entity_extraction.py`, the `entity_store` in `mem0/memory/main.py`), and section 6 exists because it needs vector-store create permissions, so deleting it would break the upgrade path. It is kept but renamed "Entity Matching Store" and scoped to a hybrid-search ranking signal, with an explicit line that it is unrelated to graph memory. No sentence on the page now claims OSS has graph memory.

### `docs/open-source/configuration.mdx`

- Dropped the graph memory mention from the intro.
- Corrected "Reranker and graph memory are Python-only today". The TypeScript OSS SDK ships rerankers (`cohere`, `cross_encoder`, `llm`, `zeroentropy` under `mem0-ts/src/oss/src/rerankers/`, wired in `config/manager.ts`), so only the graph memory half of that sentence was about a missing feature, and that feature is Platform-only rather than Python-only.

### `docs/core-concepts/how-it-works.mdx`

- "OSS retrieval depends on your configured vector store, optional reranker, and graph store" no longer mentions a graph store.
- The stores table row "Entity or graph store ... when graph memory is enabled" reworded: there is no enable flag anymore.
- Extraction step 4 "Entity linking. When configured, ..." reworded, since it is not gated behind config.

### `docs/llms.txt`

- OSS Configuration description listed "graph store"; now "reranker".
- How Mem0 Works description said "vector/graph/history stores"; now "vector/entity/history stores".

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Docs-only change, no code touched. Verified:

- `python scripts/check-llms-txt-coverage.py` reports `docs/llms.txt is in sync with docs/**/*.mdx.`
- No em-dashes in any of the four changed files.
- The `oss-v2-to-v3.mdx` frontmatter description is 140 chars, under the 160 SEO limit.
- Swept every `graph` and `entity` occurrence in the changed files; remaining `graph` hits are historical "Before" code samples and the client-SDK removed-parameter lists, both correct.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
