### PR TITLE
fix(sdk): fall back to a sentinel __version__ when mem0ai dist metadata is absent

### DIFF
--- a/mem0/__init__.py
+++ b/mem0/__init__.py
@@ -1,6 +1,11 @@
 import importlib.metadata
 
-__version__ = importlib.metadata.version("mem0ai")
+try:
+    __version__ = importlib.metadata.version("mem0ai")
+except importlib.metadata.PackageNotFoundError:
+    # Running from a source checkout (pytest uses pythonpath = ["."]), a vendored
+    # copy, or a container that copied mem0/ in without installing the dist.
+    __version__ = "0.0.0+unknown"
 
 from mem0.client.main import AsyncMemoryClient, MemoryClient  # noqa
 from mem0.memory.main import AsyncMemory, Memory  # noqa


### PR DESCRIPTION

## Linked Issue

Closes #6810

##  Description

`mem0/__init__.py` read the package version from installed distribution metadata with
no fallback:

```python
__version__ = importlib.metadata.version("mem0ai")
```

That makes the package unimportable from a source tree unless the mem0ai distribution
itself is installed — which contradicts pyproject.toml's [tool.pytest.ini_options] pythonpath = ["."], whose whole purpose is to let tests/ import mem0 straight out of
the repo. Because every test module imports mem0 directly or transitively, all of them
errored at collection with PackageNotFoundError and the suite collected zero tests.
make install_all lands you in exactly this state: it installs every optional dependency
but never mem0ai itself. The same failure hits vendored copies and container images that
copy mem0/ in without a pip install.

This wraps the lookup and falls back to "0.0.0+unknown" when the distribution is not
installed. Installed usage is unchanged — __version__ still reports the real version from
package metadata.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Verified in a venv holding the runtime dependencies with the mem0ai distribution
uninstalled — the exact state described in the issue.

## Before:

E   importlib.metadata.PackageNotFoundError: No package metadata was found for mem0ai
ERROR tests/configs/test_prompts.py
no tests collected, 1 error in 0.14s

## After:

$ python -c "import mem0; print(mem0.__version__)"
0.0.0+unknown

$ python -m pytest tests/ -q --co
1022 tests collected

$ python -m pytest tests/ -q   # core suite, optional-dep dirs excluded
745 passed, 22 skipped

The collection errors and failures that remain in that venv are all missing optional
dependencies (weaviate, chromadb, transformers, langchain-core, …) and are
unrelated to this change; a hatch dev_py_3_11 environment installs them.

No unit test added: the suite's own collection is the regression check for this, and
simulating absent distribution metadata in-process requires patching importlib.metadata
plus a module reload. Happy to add one if you'd prefer it enforced explicitly in CI.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed