### PR TITLE
fix(sdk): never fail import or Memory() when the mem0 config dir can't be created

### DIFF
--- a/mem0/__init__.py
+++ b/mem0/__init__.py
@@ -1,6 +1,11 @@
 import importlib.metadata
 
-__version__ = importlib.metadata.version("mem0ai")
+try:
+    __version__ = importlib.metadata.version("mem0ai")
+except importlib.metadata.PackageNotFoundError:
+    # Running from a source checkout (pytest uses pythonpath = ["."]), a vendored
+    # copy, or a container that copied mem0/ in without installing the dist.
+    __version__ = "0.0.0+unknown"
 
 from mem0.client.main import AsyncMemoryClient, MemoryClient  # noqa
 from mem0.memory.main import AsyncMemory, Memory  # noqa

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -48,7 +48,7 @@ from mem0.memory.notices import (
     get_temporal_feature_error_message,
     get_temporal_feature_error_message_async,
 )
-from mem0.memory.setup import mem0_dir, setup_config
+from mem0.memory.setup import _ensure_dir, mem0_dir, setup_config
 from mem0.memory.storage import SQLiteManager
 from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
 from mem0.memory.utils import (
@@ -523,18 +523,22 @@ class Memory(MemoryBase):
             # Override collection name for telemetry
             telemetry_config_dict['collection_name'] = "mem0migrations"
 
-            # Set path for file-based vector stores
+            # Set path for file-based vector stores. An uncreatable mem0_dir
+            # costs local telemetry state only, so skip it rather than failing
+            # Memory() construction.
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
+            telemetry_dir_ok = True
             if self.config.vector_store.provider in ["faiss", "qdrant"]:
                 provider_path = f"migrations_{self.config.vector_store.provider}"
                 telemetry_config_dict['path'] = os.path.join(mem0_dir, provider_path)
-                os.makedirs(telemetry_config_dict['path'], exist_ok=True)
+                telemetry_dir_ok = _ensure_dir(telemetry_config_dict['path'])
 
-            # Create the config object using the same class as the original
-            telemetry_config = self.config.vector_store.config.__class__(**telemetry_config_dict)
-            self._telemetry_vector_store = VectorStoreFactory.create(
-                self.config.vector_store.provider, telemetry_config
-            )
+            if telemetry_dir_ok:
+                # Create the config object using the same class as the original
+                telemetry_config = self.config.vector_store.config.__class__(**telemetry_config_dict)
+                self._telemetry_vector_store = VectorStoreFactory.create(
+                    self.config.vector_store.provider, telemetry_config
+                )
         if getattr(type(self.vector_store), "keyword_search", None) is VectorStoreBase.keyword_search:
             logger.warning(
                 "The '%s' vector store does not support keyword search. "
@@ -2183,11 +2187,13 @@ class AsyncMemory(MemoryBase):
         if MEM0_TELEMETRY:
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
             telemetry_config.collection_name = "mem0migrations"
+            telemetry_dir_ok = True
             if self.config.vector_store.provider in ["faiss", "qdrant"]:
                 provider_path = f"migrations_{self.config.vector_store.provider}"
                 telemetry_config.path = os.path.join(mem0_dir, provider_path)
-                os.makedirs(telemetry_config.path, exist_ok=True)
-            self._telemetry_vector_store = VectorStoreFactory.create(self.config.vector_store.provider, telemetry_config)
+                telemetry_dir_ok = _ensure_dir(telemetry_config.path)
+            if telemetry_dir_ok:
+                self._telemetry_vector_store = VectorStoreFactory.create(self.config.vector_store.provider, telemetry_config)
 
         if getattr(type(self.vector_store), "keyword_search", None) is VectorStoreBase.keyword_search:
             logger.warning(

--- a/mem0/memory/setup.py
+++ b/mem0/memory/setup.py
@@ -9,9 +9,26 @@ from hashlib import sha256
 VECTOR_ID = str(uuid.uuid4())
 home_dir = os.path.expanduser("~")
 mem0_dir = os.environ.get("MEM0_DIR") or os.path.join(home_dir, ".mem0")
-os.makedirs(mem0_dir, exist_ok=True)
 
 _logger = logging.getLogger(__name__)
+
+
+def _ensure_dir(path):
+    """Best-effort mkdir. Returns False instead of raising when the directory
+    cannot be created (read-only or missing $HOME: Lambda, distroless images,
+    build sandboxes). This directory only holds local telemetry/notice state,
+    so losing it must never be fatal."""
+    try:
+        os.makedirs(path, exist_ok=True)
+        return True
+    except OSError as e:
+        _logger.debug("Failed to create mem0 directory %s: %s", path, e)
+        return False
+
+
+# Created at import so the default history_db_path (~/.mem0/history.db) works
+# out of the box, but never at the cost of `import mem0` itself.
+_ensure_dir(mem0_dir)
 
 
 def _config_path():


### PR DESCRIPTION
## Linked Issue

Closes #6812

## Description

`mem0/memory/setup.py` created `~/.mem0` as a side effect of importing the module:

```python
mem0_dir = os.environ.get("MEM0_DIR") or os.path.join(home_dir, ".mem0")
os.makedirs(mem0_dir, exist_ok=True)   # unguarded, at import time
```

`telemetry.py` imports `setup.py` at module scope, `client/project.py` imports `telemetry`,
and `mem0/__init__.py` imports the client — so this ran on plain `import mem0`, before any
user code. On a read-only or missing `$HOME` (Lambda, distroless images, Nix/Bazel
sandboxes, hardened CI) the import raised `PermissionError`/`FileNotFoundError` and there
was no way to catch it short of wrapping the import statement. `MEM0_TELEMETRY=false`
did not help — the opt-out is read later, in `telemetry.py`, long after `setup.py` has
already run the `makedirs`.

This is the only unguarded filesystem call in that module. `_load_config` returns `{}` on a
missing or malformed file and `_write_config` is documented "Best-effort write ... Never
raises"; the directory those two operate on is now held to the same contract via a
`_ensure_dir()` helper that returns `False` instead of raising.

Two sibling calls hit the same directory unguarded in `Memory.__init__` and
`AsyncMemory.__init__`, when building the telemetry migrations store for the `faiss`/`qdrant`
providers:

```python
telemetry_config.path = os.path.join(mem0_dir, provider_path)
os.makedirs(telemetry_config.path, exist_ok=True)
```

Guarding only the import would have moved the crash from `import mem0` to `Memory()` on the
same host, so both now route through `_ensure_dir` and skip `_telemetry_vector_store` when
the directory is unavailable. Nothing reads that attribute, and it is already absent
whenever `MEM0_TELEMETRY=false`, so callers already tolerate it being unset.

`_ensure_dir(mem0_dir)` is deliberately still called at import rather than deleted:
`MemoryConfig.history_db_path` defaults to `~/.mem0/history.db` and `SQLiteManager` opens it
with `sqlite3.connect`, which will not create the parent directory. Removing the call
outright would break first-run `Memory()` on every ordinary machine. The behaviour on a
writable host is therefore unchanged — the directory is created at import exactly as before,
just no longer at the cost of the import itself.

Scope note: on a genuinely read-only `$HOME`, a default `Memory()` still fails inside
`SQLiteManager`, because it is being asked to open a real database in an unwritable
location — callers need to point `history_db_path` somewhere writable. What this PR fixes is
that `import mem0` and `MemoryClient` no longer require a writable home at all, and that
losing the local telemetry directory degrades to "no local telemetry state" instead of
taking down construction.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

`MEM0_DIR` pointed at an uncreatable path stands in for a read-only `$HOME`, since both reach
the same `makedirs`:

| Check | Before | After |
|---|---|---|
| `MEM0_DIR=Z:/nope python -c "import mem0"` | `FileNotFoundError` | imports |
| same, with `MEM0_TELEMETRY=false` | `FileNotFoundError` | imports |
| `Memory()` with uncreatable `mem0_dir`, writable history/vector paths | raised at `main.py:531` | constructs; `_telemetry_vector_store` absent |
| fresh writable `MEM0_DIR` | dir created at import | dir created at import (unchanged) |

Existing suite, optional-dependency directories excluded: **745 passed, 22 skipped, 3 failed** — the same 3 failures as on the base commit, all from optional dependencies absent in my venv (`transformers`, `sentence-transformers`, `langchain-core`). `tests/test_main.py`, `tests/test_telemetry.py` and `tests/test_memory.py` were run specifically for the telemetry paths touched here: **145 passed**.

No unit test added: simulating an unwritable directory portably means patching `os.makedirs`,
which tests the mock rather than the behaviour, and the `MEM0_DIR` invocations above cover it
directly. Happy to add one if you'd like it pinned in CI.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed