### PR TITLE
feat(memory): redact secret-shaped strings from recalled memory text

### DIFF
--- a/docs/open-source/configuration.mdx
+++ b/docs/open-source/configuration.mdx
@@ -125,6 +125,25 @@ Change the `provider` string to switch backends. The most common options:
 
 See the full catalog in <Link href="/components/llms/overview">Components</Link>.
 
+## Redact secrets from recalled memories
+
+`search()` returns stored memory text verbatim, and the LLM proxy splices that text into the next model turn. If a credential ever reaches storage, it rides back into fresh model context on every recall. Python's `redact_recalled_secrets` strips secret-shaped strings at that boundary and is **on by default**:
+
+```python
+from mem0 import Memory
+
+memory = Memory.from_config({
+    "vector_store": {"provider": "qdrant", "config": {"host": "localhost", "port": 6333}},
+    "redact_recalled_secrets": False,   # default: True
+})
+```
+
+Redacted shapes are high-confidence only: PEM private-key blocks, JWTs, `sk-` keys (OpenAI, Anthropic), AWS access key IDs, GitHub tokens, Stripe secret and restricted keys, Slack tokens, Google API keys, and the password inside a credentialed URI (`postgres://admin:[REDACTED]@host`). Bare 40-character hex strings are left alone on purpose, because they are indistinguishable from git SHAs.
+
+<Note>
+  This is defense-in-depth, not a PII or governance layer. It filters on read, so storage is untouched and setting `redact_recalled_secrets: False` recovers the original text. Turn it off if you deliberately store technical content or credentials you need back verbatim. `get()` and `get_all()` are management APIs and always return unredacted text.
+</Note>
+
 ## Tune component settings
 
 <AccordionGroup>

--- a/mem0/__init__.py
+++ b/mem0/__init__.py
@@ -1,6 +1,11 @@
 import importlib.metadata
 
-__version__ = importlib.metadata.version("mem0ai")
+try:
+    __version__ = importlib.metadata.version("mem0ai")
+except importlib.metadata.PackageNotFoundError:
+    # Running from a source checkout (pytest uses pythonpath = ["."]), a vendored
+    # copy, or a container that copied mem0/ in without installing the dist.
+    __version__ = "0.0.0+unknown"
 
 from mem0.client.main import AsyncMemoryClient, MemoryClient  # noqa
 from mem0.memory.main import AsyncMemory, Memory  # noqa

--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -55,6 +55,15 @@ class MemoryConfig(BaseModel):
         description="Custom instructions for fact extraction",
         default=None,
     )
+    redact_recalled_secrets: bool = Field(
+        description=(
+            "Redact secret-shaped strings (API keys, JWTs, PEM private keys, credentialed "
+            "URIs) from memory text returned by search(). On by default: an unredacted "
+            "secret silently re-enters model context, while an over-eager redaction is "
+            "visible and fixed by turning this off. Set False to recall text verbatim."
+        ),
+        default=True,
+    )
 
 
 class AzureConfig(BaseModel):

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -48,6 +48,7 @@ from mem0.memory.notices import (
     get_temporal_feature_error_message,
     get_temporal_feature_error_message_async,
 )
+from mem0.memory.redaction import redact_secrets
 from mem0.memory.setup import _ensure_dir, mem0_dir, setup_config
 from mem0.memory.storage import SQLiteManager
 from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
@@ -249,6 +250,11 @@ def _validate_and_trim_search_query(query: str) -> str:
     if not trimmed:
         raise ValueError("Invalid query: cannot be empty or whitespace-only.")
     return trimmed
+
+
+def _identity(value):
+    """No-op stand-in for redact_secrets when redaction is turned off."""
+    return value
 
 
 def _is_sensitive_field(field_name: str) -> bool:
@@ -1692,6 +1698,10 @@ class Memory(MemoryBase):
         ]
         core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
+        # Recall boundary: search() results are what the proxy splices into the next
+        # model turn, so secret-shaped strings are stripped here unless opted out.
+        redact = redact_secrets if self.config.redact_recalled_secrets else _identity
+
         original_memories = []
         for scored in scored_results:
             payload = scored.get("payload") or {}
@@ -1701,7 +1711,7 @@ class Memory(MemoryBase):
 
             memory_item_dict = MemoryItem(
                 id=scored["id"],
-                memory=payload.get("data", ""),
+                memory=redact(payload.get("data", "")),
                 hash=payload.get("hash"),
                 created_at=payload.get("created_at"),
                 updated_at=payload.get("updated_at"),
@@ -3346,6 +3356,10 @@ class AsyncMemory(MemoryBase):
         ]
         core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
 
+        # Recall boundary: search() results are what the proxy splices into the next
+        # model turn, so secret-shaped strings are stripped here unless opted out.
+        redact = redact_secrets if self.config.redact_recalled_secrets else _identity
+
         original_memories = []
         for scored in scored_results:
             payload = scored.get("payload") or {}
@@ -3354,7 +3368,7 @@ class AsyncMemory(MemoryBase):
 
             memory_item_dict = MemoryItem(
                 id=scored["id"],
-                memory=payload.get("data", ""),
+                memory=redact(payload.get("data", "")),
                 hash=payload.get("hash"),
                 created_at=payload.get("created_at"),
                 updated_at=payload.get("updated_at"),

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -48,7 +48,7 @@ from mem0.memory.notices import (
     get_temporal_feature_error_message,
     get_temporal_feature_error_message_async,
 )
-from mem0.memory.setup import mem0_dir, setup_config
+from mem0.memory.setup import _ensure_dir, mem0_dir, setup_config
 from mem0.memory.storage import SQLiteManager
 from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
 from mem0.memory.utils import (
@@ -523,18 +523,22 @@ class Memory(MemoryBase):
             # Override collection name for telemetry
             telemetry_config_dict['collection_name'] = "mem0migrations"
 
-            # Set path for file-based vector stores
+            # Set path for file-based vector stores. An uncreatable mem0_dir
+            # costs local telemetry state only, so skip it rather than failing
+            # Memory() construction.
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
+            telemetry_dir_ok = True
             if self.config.vector_store.provider in ["faiss", "qdrant"]:
                 provider_path = f"migrations_{self.config.vector_store.provider}"
                 telemetry_config_dict['path'] = os.path.join(mem0_dir, provider_path)
-                os.makedirs(telemetry_config_dict['path'], exist_ok=True)
+                telemetry_dir_ok = _ensure_dir(telemetry_config_dict['path'])
 
-            # Create the config object using the same class as the original
-            telemetry_config = self.config.vector_store.config.__class__(**telemetry_config_dict)
-            self._telemetry_vector_store = VectorStoreFactory.create(
-                self.config.vector_store.provider, telemetry_config
-            )
+            if telemetry_dir_ok:
+                # Create the config object using the same class as the original
+                telemetry_config = self.config.vector_store.config.__class__(**telemetry_config_dict)
+                self._telemetry_vector_store = VectorStoreFactory.create(
+                    self.config.vector_store.provider, telemetry_config
+                )
         if getattr(type(self.vector_store), "keyword_search", None) is VectorStoreBase.keyword_search:
             logger.warning(
                 "The '%s' vector store does not support keyword search. "
@@ -2183,11 +2187,13 @@ class AsyncMemory(MemoryBase):
         if MEM0_TELEMETRY:
             telemetry_config = _safe_deepcopy_config(self.config.vector_store.config)
             telemetry_config.collection_name = "mem0migrations"
+            telemetry_dir_ok = True
             if self.config.vector_store.provider in ["faiss", "qdrant"]:
                 provider_path = f"migrations_{self.config.vector_store.provider}"
                 telemetry_config.path = os.path.join(mem0_dir, provider_path)
-                os.makedirs(telemetry_config.path, exist_ok=True)
-            self._telemetry_vector_store = VectorStoreFactory.create(self.config.vector_store.provider, telemetry_config)
+                telemetry_dir_ok = _ensure_dir(telemetry_config.path)
+            if telemetry_dir_ok:
+                self._telemetry_vector_store = VectorStoreFactory.create(self.config.vector_store.provider, telemetry_config)
 
         if getattr(type(self.vector_store), "keyword_search", None) is VectorStoreBase.keyword_search:
             logger.warning(

--- a/mem0/memory/redaction.py
+++ b/mem0/memory/redaction.py
@@ -1,0 +1,70 @@
+"""Secret redaction for recalled memory text.
+
+Defense-in-depth for the recall boundary. When a memory is recalled it is handed
+back verbatim, and the LLM proxy splices that text straight into the next model
+turn -- so a credential that ever reached storage rides back into fresh model
+context on every recall. With the default ``infer=True`` an extracted fact rarely
+carries a secret verbatim, but ``infer=False``, entity text, and any database
+written before this landed all can.
+
+Deliberately shape-based and high-confidence only. This is not a PII or governance
+layer: it matches credentials whose *shape* is unambiguous (known key prefixes,
+JWTs, PEM private-key blocks, credentialed URIs) and nothing else. In particular
+bare 40-hex strings are left alone -- they are indistinguishable from git SHAs, and
+redacting every SHA in recalled text would be worse than the problem.
+"""
+
+from __future__ import annotations
+
+import re
+
+REDACTED = "[REDACTED]"
+
+# Guard against matching inside a longer word ("risk-averse" contains "sk-").
+_NOT_WORD_BEFORE = r"(?<![A-Za-z0-9])"
+
+_PATTERNS: tuple[tuple[re.Pattern, str], ...] = (
+    # PEM private key blocks (any type: RSA, EC, OPENSSH, PGP, plain).
+    (
+        re.compile(
+            r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+            re.DOTALL,
+        ),
+        REDACTED,
+    ),
+    # JSON Web Tokens. A JWT header is base64url of '{"', which always yields "eyJ".
+    (
+        re.compile(_NOT_WORD_BEFORE + r"eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}"),
+        REDACTED,
+    ),
+    # OpenAI / Anthropic and anything else using the "sk-" convention
+    # (sk-, sk-ant-, sk-proj-, sk-svcacct-).
+    (re.compile(_NOT_WORD_BEFORE + r"sk-[A-Za-z0-9_-]{20,}"), REDACTED),
+    # AWS access key IDs.
+    (re.compile(_NOT_WORD_BEFORE + r"(?:AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}"), REDACTED),
+    # GitHub tokens: ghp_/gho_/ghu_/ghs_/ghr_ and fine-grained PATs.
+    (re.compile(_NOT_WORD_BEFORE + r"gh[pousr]_[A-Za-z0-9]{36,}"), REDACTED),
+    (re.compile(_NOT_WORD_BEFORE + r"github_pat_[A-Za-z0-9_]{22,}"), REDACTED),
+    # Stripe secret and restricted keys (publishable pk_ keys are not secrets).
+    (re.compile(_NOT_WORD_BEFORE + r"[sr]k_(?:live|test)_[A-Za-z0-9]{10,}"), REDACTED),
+    # Slack tokens.
+    (re.compile(_NOT_WORD_BEFORE + r"xox[abposr]-[A-Za-z0-9-]{10,}"), REDACTED),
+    # Google API keys.
+    (re.compile(_NOT_WORD_BEFORE + r"AIza[0-9A-Za-z_-]{35}"), REDACTED),
+    # Credentialed URIs (postgres://user:pw@host, mongodb+srv://..., redis://...).
+    # Only the password is replaced, so the rest of the URI stays readable.
+    (
+        re.compile(r"\b([a-z][a-z0-9+.\-]*://[^\s:/@]+:)[^\s/@]+(@)"),
+        r"\1" + REDACTED + r"\2",
+    ),
+)
+
+
+def redact_secrets(text):
+    """Replace secret-shaped substrings in ``text``. Returns ``text`` unchanged
+    when it is empty or not a string."""
+    if not text or not isinstance(text, str):
+        return text
+    for pattern, replacement in _PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text

--- a/mem0/memory/setup.py
+++ b/mem0/memory/setup.py
@@ -9,9 +9,26 @@ from hashlib import sha256
 VECTOR_ID = str(uuid.uuid4())
 home_dir = os.path.expanduser("~")
 mem0_dir = os.environ.get("MEM0_DIR") or os.path.join(home_dir, ".mem0")
-os.makedirs(mem0_dir, exist_ok=True)
 
 _logger = logging.getLogger(__name__)
+
+
+def _ensure_dir(path):
+    """Best-effort mkdir. Returns False instead of raising when the directory
+    cannot be created (read-only or missing $HOME: Lambda, distroless images,
+    build sandboxes). This directory only holds local telemetry/notice state,
+    so losing it must never be fatal."""
+    try:
+        os.makedirs(path, exist_ok=True)
+        return True
+    except OSError as e:
+        _logger.debug("Failed to create mem0 directory %s: %s", path, e)
+        return False
+
+
+# Created at import so the default history_db_path (~/.mem0/history.db) works
+# out of the box, but never at the cost of `import mem0` itself.
+_ensure_dir(mem0_dir)
 
 
 def _config_path():

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -166,7 +166,10 @@ class EmbedderFactory:
 
     @classmethod
     def create(cls, provider_name, config, vector_config: Optional[dict]):
-        if provider_name == "upstash_vector" and vector_config and vector_config.enable_embeddings:
+        # Vector stores that embed server-side (Upstash `enable_embeddings`) need no
+        # external embedder. Keyed off the vector store config alone: provider_name is
+        # the *embedder* provider and can never equal a vector store provider name.
+        if getattr(vector_config, "enable_embeddings", False):
             return MockEmbeddings()
         class_type = cls.provider_to_class.get(provider_name)
         if class_type:

--- a/tests/memory/test_redaction.py
+++ b/tests/memory/test_redaction.py
@@ -1,0 +1,122 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mem0.memory.main import AsyncMemory, Memory
+from mem0.memory.redaction import REDACTED, redact_secrets
+
+SECRETS = [
+    # OpenAI / Anthropic "sk-" convention
+    "sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKL",
+    "sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789",
+    "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+    # AWS access key IDs
+    "AKIAIOSFODNN7EXAMPLE",
+    "ASIAIOSFODNN7EXAMPLE",
+    # GitHub
+    "ghp_" + "a" * 36,
+    "github_pat_" + "A1b2C3d4E5f6G7h8I9j0K1",
+    # Stripe
+    "sk_live_abcdefghij1234567890",
+    "rk_test_abcdefghij1234567890",
+    # Slack
+    "xoxb-123456789012-abcdefghijkl",
+    # Google
+    "AIza" + "B" * 35,
+    # JWT
+    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+]
+
+# Shapes that must survive: redacting these would be worse than the problem.
+KEEP = [
+    "da39a3ee5e6b4b0d3255bfef95601890afd80709",  # git SHA-1
+    "I use a risk-based approach to prioritisation",  # contains "sk-"
+    "https://api.example.com/v1/users?page=2",  # URI without credentials
+    "pk_live_abcdefghij1234567890",  # Stripe publishable key, not a secret
+    "AKIAIOSFODNN7",  # too short to be an AWS key id
+    "The meeting is at 3pm on Tuesday",
+]
+
+
+@pytest.mark.parametrize("secret", SECRETS)
+def test_secret_shapes_are_redacted(secret):
+    out = redact_secrets(f"my key is {secret} keep this")
+    assert secret not in out
+    assert REDACTED in out
+    assert out.startswith("my key is ") and out.endswith(" keep this")
+
+
+@pytest.mark.parametrize("text", KEEP)
+def test_non_secrets_are_left_alone(text):
+    assert redact_secrets(text) == text
+
+
+def test_pem_private_key_block_is_redacted():
+    text = (
+        "here it is\n"
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEA1234\nabcd\n"
+        "-----END RSA PRIVATE KEY-----\n"
+        "that was it"
+    )
+    out = redact_secrets(text)
+    assert "MIIEowIBAAKCAQEA1234" not in out
+    assert "BEGIN RSA PRIVATE KEY" not in out
+    assert out == f"here it is\n{REDACTED}\nthat was it"
+
+
+def test_credentialed_uri_keeps_everything_but_the_password():
+    out = redact_secrets("postgres://admin:hunter2@db.internal:5432/prod")
+    assert out == f"postgres://admin:{REDACTED}@db.internal:5432/prod"
+
+
+def test_multiple_secrets_in_one_memory():
+    out = redact_secrets("AKIAIOSFODNN7EXAMPLE and " + "ghp_" + "b" * 36)
+    assert out == f"{REDACTED} and {REDACTED}"
+
+
+@pytest.mark.parametrize("value", ["", None, 0, [], {"a": 1}])
+def test_empty_and_non_string_inputs_pass_through(value):
+    assert redact_secrets(value) == value
+
+
+# --- recall boundary wiring -------------------------------------------------
+
+STORED = "deploy key AKIAIOSFODNN7EXAMPLE for prod"
+
+
+def _stub_self(redact_recalled_secrets, is_async=False):
+    """Minimal stand-in for Memory/AsyncMemory covering what _search_vector_store
+    touches, so the wiring is tested without a live store, embedder, or LLM."""
+    stub = MagicMock()
+    stub.config.redact_recalled_secrets = redact_recalled_secrets
+    stub.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+    stub.vector_store.keyword_search.return_value = None
+    stub.vector_store.search.return_value = [SimpleNamespace(id="m1", score=0.9, payload={"data": STORED, "hash": "h"})]
+    if is_async:
+        stub._compute_entity_boosts_async = AsyncMock(return_value={})
+    else:
+        stub._compute_entity_boosts.return_value = {}
+    return stub
+
+
+def test_search_redacts_recalled_memory_by_default():
+    results = Memory._search_vector_store(_stub_self(True), "deploy key", {"user_id": "alice"}, 10)
+
+    assert results[0]["memory"] == f"deploy key {REDACTED} for prod"
+
+
+def test_search_returns_verbatim_when_redaction_is_disabled():
+    results = Memory._search_vector_store(_stub_self(False), "deploy key", {"user_id": "alice"}, 10)
+
+    assert results[0]["memory"] == STORED
+
+
+@pytest.mark.asyncio
+async def test_async_search_redacts_recalled_memory_by_default():
+    stub = _stub_self(True, is_async=True)
+
+    results = await AsyncMemory._search_vector_store(stub, "deploy key", {"user_id": "alice"}, 10)
+
+    assert results[0]["memory"] == f"deploy key {REDACTED} for prod"

--- a/tests/vector_stores/test_upstash_vector.py
+++ b/tests/vector_stores/test_upstash_vector.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from mem0.configs.vector_stores.upstash_vector import UpstashVectorConfig
+from mem0.embeddings.mock import MockEmbeddings
+from mem0.utils.factory import EmbedderFactory
 from mem0.vector_stores.upstash_vector import UpstashVector, _validate_filter
 
 
@@ -469,3 +471,29 @@ def test_env_var_only_config_builds_provider(monkeypatch):
         UpstashVector(**dumped)
 
     mock_index.assert_called_once_with("https://example.upstash.io", "tok_123")
+
+
+def test_enable_embeddings_bypasses_the_external_embedder(monkeypatch):
+    """Regression: `enable_embeddings=True` must skip the external embedder.
+
+    EmbedderFactory.create() gated the MockEmbeddings bypass on
+    ``provider_name == "upstash_vector"``, but provider_name is the *embedder*
+    provider (default "openai") — never a vector store name — so the branch was
+    dead. The documented config (enable_embeddings on the vector store, no
+    embedder section) built an OpenAI embedder and failed on a missing
+    OPENAI_API_KEY, or silently billed OpenAI when one was present.
+    """
+    monkeypatch.setenv("UPSTASH_VECTOR_REST_URL", "https://example.upstash.io")
+    monkeypatch.setenv("UPSTASH_VECTOR_REST_TOKEN", "tok_123")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    # Mirrors Memory.__init__: EmbedderFactory.create(embedder.provider,
+    # embedder.config, vector_store.config), with the default embedder provider.
+    on = UpstashVectorConfig(enable_embeddings=True)
+    assert isinstance(EmbedderFactory.create("openai", {}, on), MockEmbeddings)
+
+    # Off (the default) still builds the configured embedder.
+    off = UpstashVectorConfig(enable_embeddings=False)
+    with patch("mem0.utils.factory.load_class") as load_class:
+        assert not isinstance(EmbedderFactory.create("openai", {}, off), MockEmbeddings)
+    load_class.assert_called_once()


### PR DESCRIPTION
## Linked Issue

Closes #6817

## Description

`search()` hands stored memory text back verbatim, and `Mem0._format_query_with_memories`
splices it straight into the outgoing user message. Nothing on that path strips
secret-shaped strings, so a credential that ever reached storage rides back into fresh
model context on every recall.

This adds the redaction boundary the issue proposes: one self-contained function plus the
two call sites it names.

**`mem0/memory/redaction.py`** (new) — `redact_secrets()` over a tuple of compiled patterns.
High-confidence shapes only: PEM private-key blocks, JWTs, `sk-` keys (OpenAI, Anthropic,
`sk-proj-`, `sk-svcacct-`), AWS access key IDs, GitHub `gh?_`/`github_pat_`, Stripe `sk_`/`rk_`,
Slack `xox?-`, Google `AIza`, and the password inside a credentialed URI. Bare 40-hex is
deliberately left alone — indistinguishable from a git SHA, and redacting every SHA in
recalled text would be worse than the problem.

Two details worth a reviewer's eye:

- Every prefix rule carries a `(?<![A-Za-z0-9])` guard. Without it `"risk-based"` contains
  `sk-`, and a long enough hyphenated word would be eaten.
- The URI rule replaces only the password capture group, so the result stays readable:
  `postgres://admin:[REDACTED]@db.internal:5432/prod`.

**`mem0/configs/base.py`** — `redact_recalled_secrets: bool = True`. On by default, per the
reasoning in the issue: an unredacted secret silently re-enters model context and nobody
finds out until it is in a log or a training pipeline, whereas an over-eager redaction is
visible and self-correcting via a documented flag.

**`mem0/memory/main.py`** — `Memory._search_vector_store` and
`AsyncMemory._search_vector_store`. The flag is resolved once outside the result loop rather
than per-result:

```python
redact = redact_secrets if self.config.redact_recalled_secrets else _identity
...
memory=redact(payload.get("data", "")),
```

Scope, matching the issue: `search()` only. `get()` and `get_all()` still return verbatim
text — they are management/list APIs, not the path that feeds model context, and redacting
there would break "show me what you stored about me". Storage is untouched, so this is a
read-boundary filter, not a migration: setting the flag to `False` recovers the original
text, including for databases written before this lands.

This is defense-in-depth, not a PII or governance layer (cf. #5507, #5331) — it matches
credentials whose shape is unambiguous and nothing else.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

Not breaking in the API sense — no signature or response-shape change. It is a behaviour
change on by default: `search()` results containing a secret-shaped string now come back with
`[REDACTED]` in place of it. Anyone who stores technical content or credentials on purpose
sets `redact_recalled_secrets: False` to restore the previous behaviour. Nothing is rewritten
at rest, so the switch is reversible at any time.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

`tests/memory/test_redaction.py` (new), 29 tests:

- Every listed shape is redacted, with the surrounding text left intact.
- A keep-list asserts the false-positive cases survive untouched: git SHA-1s,
  `"risk-based approach"`, credential-free URIs, Stripe publishable (`pk_`) keys, and
  AWS-lookalikes that are too short.
- PEM blocks, credentialed URIs, multiple secrets in one memory, and empty/non-string inputs.
- Three wiring tests driving `Memory._search_vector_store` and
  `AsyncMemory._search_vector_store` directly, covering flag on (sync + async) and flag off.

End-to-end through `search()` against a local Qdrant:

```text
sync  default (on) : The deploy key is [REDACTED] for prod
sync  off          : The deploy key is sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKL for prod
async default (on) : The deploy key is [REDACTED] for prod
```

Existing suite, optional-dependency directories excluded: **774 passed, 22 skipped, 3 failed**
— the same 3 failures as on the base commit, all from optional dependencies absent in my venv
(`transformers`, `sentence-transformers`, `langchain-core`).

`make lint` (`ruff check`) and `isort --profile black --check-only` are clean on every touched
file. `ruff format` was applied to the two new files only — `mem0/memory/main.py` is already
unformatted on main, and running the formatter over it would bury a three-line change in
hundreds of lines of unrelated reflow. The mem0 CI gate runs `make lint`, not
`ruff format --check`.

## Checklist

- [x] An issue exists and is linked with `Closes #<number>`
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

Docs: new "Redact secrets from recalled memories" section in
`docs/open-source/configuration.mdx` — what it does, the default, the off switch, the exact
shapes covered, why 40-hex is excluded, and the scope note. No new `.mdx` page, so no
`docs/llms.txt` entry is required; confirmed with
`python scripts/check-llms-txt-coverage.py` (`docs/llms.txt` is in sync with `docs/**/*.mdx`).

---

Two follow-ups I left out on purpose rather than widening this PR:

- TypeScript parity. `mem0-ts` has the same recall boundary and the same gap. Happy to
  open a sibling issue and port this once the shape list is agreed here.
- `get()` / `get_all()`. Left verbatim by design, as described above — say the word if
  you would rather they were filtered too.