### PR TITLE
fix(memory): honour top_k=0 in get_all() — return nothing instead of one result or a crash

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1314,6 +1314,13 @@ class Memory(MemoryBase):
         return {"results": all_memories_result}
 
     def _get_all_from_vector_store(self, filters, limit, show_expired=False, output_limit=None):
+        # top_k=0 means "return nothing" and is a documented-valid input. Skip the
+        # store round trip entirely: with show_expired=True the caller's 0 is passed
+        # straight through as the fetch limit, and stores reject it (Qdrant raises
+        # "limit value 0 is invalid. Must be 1 or larger.").
+        if output_limit == 0:
+            return []
+
         memories_result = self.vector_store.list(filters=filters, top_k=limit)
 
         # Handle different vector store return formats by inspecting first element
@@ -1342,6 +1349,11 @@ class Memory(MemoryBase):
 
         formatted_memories = []
         for mem in actual_memories:
+            # Checked before formatting, not after appending: the old
+            # append-then-`>=` order let one memory through for output_limit=0,
+            # which is a documented-valid top_k ("non-negative integer").
+            if output_limit is not None and len(formatted_memories) >= output_limit:
+                break
             if not show_expired and _payload_is_expired(mem.payload):
                 continue
             memory_item_dict = MemoryItem(
@@ -1361,8 +1373,6 @@ class Memory(MemoryBase):
                 memory_item_dict["metadata"] = additional_metadata
 
             formatted_memories.append(memory_item_dict)
-            if output_limit is not None and len(formatted_memories) >= output_limit:
-                break
 
         return formatted_memories
 
@@ -2960,6 +2970,11 @@ class AsyncMemory(MemoryBase):
         return {"results": all_memories_result}
 
     async def _get_all_from_vector_store(self, filters, limit, show_expired=False, output_limit=None):
+        # See the sync version: top_k=0 must not reach the store, which rejects a
+        # zero fetch limit when show_expired=True passes it straight through.
+        if output_limit == 0:
+            return []
+
         memories_result = await asyncio.to_thread(self.vector_store.list, filters=filters, top_k=limit)
 
         # Handle different vector store return formats by inspecting first element
@@ -2988,6 +3003,11 @@ class AsyncMemory(MemoryBase):
 
         formatted_memories = []
         for mem in actual_memories:
+            # Checked before formatting, not after appending: the old
+            # append-then-`>=` order let one memory through for output_limit=0,
+            # which is a documented-valid top_k ("non-negative integer").
+            if output_limit is not None and len(formatted_memories) >= output_limit:
+                break
             if not show_expired and _payload_is_expired(mem.payload):
                 continue
             memory_item_dict = MemoryItem(
@@ -3007,8 +3027,6 @@ class AsyncMemory(MemoryBase):
                 memory_item_dict["metadata"] = additional_metadata
 
             formatted_memories.append(memory_item_dict)
-            if output_limit is not None and len(formatted_memories) >= output_limit:
-                break
 
         return formatted_memories
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1574,3 +1574,99 @@ async def test_async_procedural_memory_default_path_without_langchain(mock_llm_f
 
     assert result["results"][0]["event"] == "ADD"
     memory.llm.generate_response.assert_called_once()
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+@pytest.mark.parametrize("output_limit,expected", [(0, 0), (1, 1), (2, 2), (5, 3), (None, 3)])
+def test_get_all_honours_output_limit_including_zero(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory, output_limit, expected
+):
+    """`top_k=0` is a documented-valid input (_validate_search_params only rejects
+    negatives, and the REST layer declares `ge=0`), and it means "return nothing".
+
+    The limit used to be applied after appending with `>=`, so for output_limit=0
+    the first memory was appended, `1 >= 0` tripped, and exactly one memory leaked
+    past a limit of zero — while `search(top_k=0)` correctly returned none.
+    """
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    memory = MemoryClass(MemoryConfig())
+    mock_vector_store.list.return_value = [
+        MockVectorMemory(f"mem_{i}", {"data": f"fact {i}", "user_id": "alice"}) for i in range(3)
+    ]
+
+    result = memory._get_all_from_vector_store(
+        {"user_id": "alice"}, 100, show_expired=False, output_limit=output_limit
+    )
+
+    assert len(result) == expected
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_get_all_limit_counts_only_unexpired_memories(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Moving the check to the top of the loop must not start counting skipped
+    (expired) memories against the limit."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    memory = MemoryClass(MemoryConfig())
+    mock_vector_store.list.return_value = [
+        MockVectorMemory("expired_1", {"data": "old", "user_id": "alice", "expiration_date": "2020-01-01"}),
+        MockVectorMemory("live_1", {"data": "fact 1", "user_id": "alice"}),
+        MockVectorMemory("expired_2", {"data": "old", "user_id": "alice", "expiration_date": "2020-01-01"}),
+        MockVectorMemory("live_2", {"data": "fact 2", "user_id": "alice"}),
+    ]
+
+    result = memory._get_all_from_vector_store(
+        {"user_id": "alice"}, 100, show_expired=False, output_limit=2
+    )
+
+    assert [m["memory"] for m in result] == ["fact 1", "fact 2"]
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_get_all_top_k_zero_does_not_query_the_vector_store(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """With show_expired=True the fetch limit is the caller's top_k verbatim, so
+    top_k=0 used to reach the store as limit=0 — which Qdrant rejects outright
+    ("limit value 0 is invalid. Must be 1 or larger."). Asking for nothing must
+    not hit the store at all."""
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    memory = MemoryClass(MemoryConfig())
+
+    result = memory._get_all_from_vector_store(
+        {"user_id": "alice"}, 0, show_expired=True, output_limit=0
+    )
+
+    assert result == []
+    mock_vector_store.list.assert_not_called()


### PR DESCRIPTION
## Linked Issue

Closes #6823

## Description

`top_k=0` is a documented-valid input: `_validate_search_params` enforces "non-negative
integer" and only rejects `< 0`, and the REST layer declares `Query(None, ge=0, le=...)`.
`search(top_k=0)` honours it correctly by slicing (`scored[:top_k]` in
`mem0/utils/scoring.py`). `get_all(top_k=0)` did not.

**Bug 1 — one memory leaks past a limit of zero.** The limit was applied *after* appending,
with `>=`:

```python
formatted_memories.append(memory_item_dict)
if output_limit is not None and len(formatted_memories) >= output_limit:
    break
```

With `output_limit == 0` the first memory is appended, `1 >= 0` trips, the loop breaks, and one
result is left in the list. So `get_all` and `search` disagreed on what the same documented
argument means.

Bug 2 — `show_expired=True` crashes outright. I hit this while checking edge cases and it
is not in the issue text:

```text
ValueError: limit value 0 is invalid. Must be 1 or larger.
  at qdrant_client/local/qdrant_local.py:543
  from mem0/memory/main.py:1279  self.vector_store.list(filters=filters, top_k=limit)
```

`fetch_limit = limit if show_expired else max(limit * 4, 60)`. On the default path the
`max(..., 60)` over-fetch masks the zero, but with `show_expired=True` the caller's 0 reaches the store
verbatim and Qdrant rejects a zero limit. So `top_k=0` had two failure modes on the same
contract, not one.

The fix, applied to both `Memory._get_all_from_vector_store` and the `AsyncMemory` twin:

```python
if output_limit == 0:
    return []
```

plus the limit check moved from after the append to the top of the loop.

The early return is what actually fixes both bugs — reordering the loop alone would have fixed
the leak and shipped the crash. It also skips a store round trip that could only ever return
rows we discard. The loop reorder stays because it costs zero net lines (a moved check, not an
added one) and keeps the counting invariant local, rather than leaving a `>=`-after-append that
is only correct because of a guard twenty lines above it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A for every value that previously worked. `top_k >= 1` and `top_k=None` are unchanged —
verified across the matrix below. Only `top_k=0` changes, from "one memory" or `ValueError` to
the documented empty result.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Three tests added to `tests/test_memory.py`, in the style of the existing
`test_get_all_handles_*` cases:

| test | pins |
|---|---|
| `test_get_all_honours_output_limit_including_zero` | parametrized `0, 1, 2, 5, None` → `0, 1, 2, 3, 3` |
| `test_get_all_top_k_zero_does_not_query_the_vector_store` | `vector_store.list` is not called — guards the Qdrant crash |
| `test_get_all_limit_counts_only_unexpired_memories` | the relocated check must not count skipped expired rows against the limit |

The third exists because the reorder had a plausible way to go wrong: had the pre-check counted
iterations rather than appended results, expired memories would have eaten into the limit.

Manual verification against a local Qdrant, sync and async, full matrix:

```text
sync  show_expired=False top_k=0 -> 0      async show_expired=False top_k=0 -> 0
sync  show_expired=False top_k=2 -> 2      async show_expired=False top_k=2 -> 2
sync  show_expired=False top_k=5 -> 3      async show_expired=True  top_k=0 -> 0
sync  show_expired=True  top_k=0 -> 0      async show_expired=True  top_k=2 -> 2
sync  show_expired=True  top_k=2 -> 2
sync  show_expired=True  top_k=5 -> 3
```

This matches the issue's expected output, and the `show_expired=True` column no longer raises.

Results:

- New tests against the pre-fix `mem0/memory/main.py`: **2 failed, 5 passed** — the two
  failures are exactly the two bugs above. After the fix: all pass.
- Existing suite, optional-dependency directories excluded: **731 passed, 22 skipped, 1 failed**
  — the same pre-existing failure as on the base commit
  (`test_async_procedural_memory_langchain_strips_code_blocks`, missing optional
  `langchain-core` in my venv).
- `ruff check --select E4,E7,E9,F` (the selection configured in `pyproject.toml`): clean.

## Checklist

- [x] An issue exists and is linked with `Closes #<number>`
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

Docs box unticked: no documented behaviour changes. `top_k` is already documented as a
non-negative integer meaning "maximum number of memories to return" — this makes the code match
that, and match `search()`.