### PR TITLE
fix(server): stop leaking internal payload keys in admin GET /memories

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -52,6 +52,8 @@ from mem0.memory.setup import mem0_dir, setup_config
 from mem0.memory.storage import SQLiteManager
 from mem0.memory.telemetry import MEM0_TELEMETRY, capture_event
 from mem0.memory.utils import (
+    NON_METADATA_PAYLOAD_KEYS,
+    PROMOTED_PAYLOAD_KEYS,
     extract_json,
     parse_messages,
     parse_vision_messages,
@@ -1211,18 +1213,6 @@ class Memory(MemoryBase):
             display_first_run_notice(self, "sync", "get")
             return None
 
-        promoted_payload_keys = [
-            "user_id",
-            "agent_id",
-            "run_id",
-            "actor_id",
-            "role",
-            "attributed_to",
-            "expiration_date",
-        ]
-
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
-
         result_item = MemoryItem(
             id=memory.id,
             memory=memory.payload.get("data", ""),
@@ -1231,11 +1221,11 @@ class Memory(MemoryBase):
             updated_at=memory.payload.get("updated_at"),
         ).model_dump()
 
-        for key in promoted_payload_keys:
+        for key in PROMOTED_PAYLOAD_KEYS:
             if key in memory.payload:
                 result_item[key] = memory.payload[key]
 
-        additional_metadata = {k: v for k, v in memory.payload.items() if k not in core_and_promoted_keys}
+        additional_metadata = {k: v for k, v in memory.payload.items() if k not in NON_METADATA_PAYLOAD_KEYS}
         if additional_metadata:
             result_item["metadata"] = additional_metadata
 
@@ -1329,17 +1319,6 @@ class Memory(MemoryBase):
         else:
             actual_memories = memories_result
 
-        promoted_payload_keys = [
-            "user_id",
-            "agent_id",
-            "run_id",
-            "actor_id",
-            "role",
-            "attributed_to",
-            "expiration_date",
-        ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
-
         formatted_memories = []
         for mem in actual_memories:
             if not show_expired and _payload_is_expired(mem.payload):
@@ -1352,11 +1331,11 @@ class Memory(MemoryBase):
                 updated_at=mem.payload.get("updated_at"),
             ).model_dump(exclude={"score"})
 
-            for key in promoted_payload_keys:
+            for key in PROMOTED_PAYLOAD_KEYS:
                 if key in mem.payload:
                     memory_item_dict[key] = mem.payload[key]
 
-            additional_metadata = {k: v for k, v in mem.payload.items() if k not in core_and_promoted_keys}
+            additional_metadata = {k: v for k, v in mem.payload.items() if k not in NON_METADATA_PAYLOAD_KEYS}
             if additional_metadata:
                 memory_item_dict["metadata"] = additional_metadata
 
@@ -1677,17 +1656,6 @@ class Memory(MemoryBase):
         )
 
         # Step 9: Format results
-        promoted_payload_keys = [
-            "user_id",
-            "agent_id",
-            "run_id",
-            "actor_id",
-            "role",
-            "attributed_to",
-            "expiration_date",
-        ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
-
         original_memories = []
         for scored in scored_results:
             payload = scored.get("payload") or {}
@@ -1704,11 +1672,11 @@ class Memory(MemoryBase):
                 score=scored["score"],
             ).model_dump()
 
-            for key in promoted_payload_keys:
+            for key in PROMOTED_PAYLOAD_KEYS:
                 if key in payload:
                     memory_item_dict[key] = payload[key]
 
-            additional_metadata = {k: v for k, v in payload.items() if k not in core_and_promoted_keys}
+            additional_metadata = {k: v for k, v in payload.items() if k not in NON_METADATA_PAYLOAD_KEYS}
             if additional_metadata:
                 if not memory_item_dict.get("metadata"):
                     memory_item_dict["metadata"] = {}
@@ -2857,18 +2825,6 @@ class AsyncMemory(MemoryBase):
             await display_first_run_notice_async(self, "async", "get")
             return None
 
-        promoted_payload_keys = [
-            "user_id",
-            "agent_id",
-            "run_id",
-            "actor_id",
-            "role",
-            "attributed_to",
-            "expiration_date",
-        ]
-
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
-
         result_item = MemoryItem(
             id=memory.id,
             memory=memory.payload.get("data", ""),
@@ -2877,11 +2833,11 @@ class AsyncMemory(MemoryBase):
             updated_at=memory.payload.get("updated_at"),
         ).model_dump()
 
-        for key in promoted_payload_keys:
+        for key in PROMOTED_PAYLOAD_KEYS:
             if key in memory.payload:
                 result_item[key] = memory.payload[key]
 
-        additional_metadata = {k: v for k, v in memory.payload.items() if k not in core_and_promoted_keys}
+        additional_metadata = {k: v for k, v in memory.payload.items() if k not in NON_METADATA_PAYLOAD_KEYS}
         if additional_metadata:
             result_item["metadata"] = additional_metadata
 
@@ -2975,17 +2931,6 @@ class AsyncMemory(MemoryBase):
         else:
             actual_memories = memories_result
 
-        promoted_payload_keys = [
-            "user_id",
-            "agent_id",
-            "run_id",
-            "actor_id",
-            "role",
-            "attributed_to",
-            "expiration_date",
-        ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
-
         formatted_memories = []
         for mem in actual_memories:
             if not show_expired and _payload_is_expired(mem.payload):
@@ -2998,11 +2943,11 @@ class AsyncMemory(MemoryBase):
                 updated_at=mem.payload.get("updated_at"),
             ).model_dump(exclude={"score"})
 
-            for key in promoted_payload_keys:
+            for key in PROMOTED_PAYLOAD_KEYS:
                 if key in mem.payload:
                     memory_item_dict[key] = mem.payload[key]
 
-            additional_metadata = {k: v for k, v in mem.payload.items() if k not in core_and_promoted_keys}
+            additional_metadata = {k: v for k, v in mem.payload.items() if k not in NON_METADATA_PAYLOAD_KEYS}
             if additional_metadata:
                 memory_item_dict["metadata"] = additional_metadata
 
@@ -3329,17 +3274,6 @@ class AsyncMemory(MemoryBase):
         )
 
         # Step 9: Format results
-        promoted_payload_keys = [
-            "user_id",
-            "agent_id",
-            "run_id",
-            "actor_id",
-            "role",
-            "attributed_to",
-            "expiration_date",
-        ]
-        core_and_promoted_keys = {"data", "hash", "created_at", "updated_at", "id", "text_lemmatized", "attributed_to", *promoted_payload_keys}
-
         original_memories = []
         for scored in scored_results:
             payload = scored.get("payload") or {}
@@ -3355,11 +3289,11 @@ class AsyncMemory(MemoryBase):
                 score=scored["score"],
             ).model_dump()
 
-            for key in promoted_payload_keys:
+            for key in PROMOTED_PAYLOAD_KEYS:
                 if key in payload:
                     memory_item_dict[key] = payload[key]
 
-            additional_metadata = {k: v for k, v in payload.items() if k not in core_and_promoted_keys}
+            additional_metadata = {k: v for k, v in payload.items() if k not in NON_METADATA_PAYLOAD_KEYS}
             if additional_metadata:
                 if not memory_item_dict.get("metadata"):
                     memory_item_dict["metadata"] = {}

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -11,6 +11,30 @@ from mem0.configs.prompts import (
 
 logger = logging.getLogger(__name__)
 
+# Payload keys the public memory shape exposes at the top level instead of inside `metadata`.
+PROMOTED_PAYLOAD_KEYS = [
+    "user_id",
+    "agent_id",
+    "run_id",
+    "actor_id",
+    "role",
+    "attributed_to",
+    "expiration_date",
+]
+
+# Payload keys that must never surface as user metadata: the promoted ones above plus the
+# internal fields (`data`/`hash`/timestamps live at the top level, `text_lemmatized` is the
+# BM25 search index). Every read path -- SDK and REST server -- filters `metadata` with this.
+NON_METADATA_PAYLOAD_KEYS = {
+    "data",
+    "hash",
+    "created_at",
+    "updated_at",
+    "id",
+    "text_lemmatized",
+    *PROMOTED_PAYLOAD_KEYS,
+}
+
 
 def get_fact_retrieval_messages(message, is_agent_memory=False):
     """Get fact retrieval messages based on the memory type.

--- a/server/main.py
+++ b/server/main.py
@@ -39,6 +39,7 @@ from slowapi.errors import RateLimitExceeded
 from sqlalchemy import func, select
 
 from mem0.exceptions import ValidationError as Mem0ValidationError
+from mem0.memory.utils import NON_METADATA_PAYLOAD_KEYS, PROMOTED_PAYLOAD_KEYS
 
 load_dotenv()
 
@@ -383,23 +384,25 @@ def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
 
 
 ALL_MEMORIES_LIMIT = 1000
-_RESERVED_PAYLOAD_KEYS = {"data", "user_id", "agent_id", "run_id", "hash", "created_at", "updated_at", "expiration_date"}
 
 
 def _serialize_memory(row: Any) -> Dict[str, Any]:
+    """Shape a raw vector-store row like Memory.get_all() does, so the admin list-all
+    branch never leaks internal payload keys (e.g. the BM25 `text_lemmatized` index)."""
     payload = getattr(row, "payload", None) or {}
-    return {
+    metadata = {k: v for k, v in payload.items() if k not in NON_METADATA_PAYLOAD_KEYS}
+    item = {
         "id": getattr(row, "id", None),
         "memory": payload.get("data"),
-        "user_id": payload.get("user_id"),
-        "agent_id": payload.get("agent_id"),
-        "run_id": payload.get("run_id"),
         "hash": payload.get("hash"),
-        "expiration_date": payload.get("expiration_date"),
-        "metadata": {k: v for k, v in payload.items() if k not in _RESERVED_PAYLOAD_KEYS},
+        "metadata": metadata or None,
         "created_at": payload.get("created_at"),
         "updated_at": payload.get("updated_at"),
     }
+    for key in PROMOTED_PAYLOAD_KEYS:
+        if key in payload:
+            item[key] = payload[key]
+    return item
 
 
 def _list_all_memories(limit: int = ALL_MEMORIES_LIMIT) -> Dict[str, Any]:

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -646,6 +646,38 @@ class TestGetMemories:
         _, kwargs = mock_memory.vector_store.list.call_args
         assert kwargs["top_k"] == 0
 
+    def test_get_memories_admin_list_all_hides_internal_payload_keys(self, client, mock_memory):
+        """Admin list-all must expose the same shape as the scoped get_all() path:
+        no internal `text_lemmatized`, and actor/role promoted out of metadata."""
+        row = MagicMock()
+        row.id = "mem-1"
+        row.payload = {
+            "data": "I love hiking on weekends",
+            "hash": "h1",
+            "user_id": "alice",
+            "actor_id": "a1",
+            "role": "user",
+            "text_lemmatized": "love hike weekend",
+            "category": "hobbies",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+        mock_memory.vector_store.list.return_value = [[row]]
+
+        result = client.get("/memories").json()["results"][0]
+
+        assert result["metadata"] == {"category": "hobbies"}
+        assert result["user_id"] == "alice"
+        assert result["actor_id"] == "a1"
+        assert result["role"] == "user"
+
+    def test_get_memories_admin_list_all_metadata_none_when_empty(self, client, mock_memory):
+        row = MagicMock()
+        row.id = "mem-1"
+        row.payload = {"data": "hi", "user_id": "alice", "text_lemmatized": "hi"}
+        mock_memory.vector_store.list.return_value = [[row]]
+
+        assert client.get("/memories").json()["results"][0]["metadata"] is None
+
     def test_get_memories_rejects_top_k_above_limit(self, client, mock_memory):
         response = client.get("/memories?user_id=test_routing_user&top_k=1001")
 


### PR DESCRIPTION
Fixes #6825

## Problem

`GET /memories` with no `user_id`/`agent_id`/`run_id` (the admin list-all branch) goes
through `server/main.py::_serialize_memory()` instead of `Memory.get_all()`. That
serializer had its own hand-written reserved-key set which never included
`text_lemmatized`, so every listed memory returned the internal BM25 index field — plus
`actor_id`, `role`, and `attributed_to` — inside `metadata`, as if it were user metadata.

The same server therefore returned two shapes for the same memory:

```text
GET /memories?user_id=alice  -> metadata: None
GET /memories                -> metadata: {'text_lemmatized': 'love hike weekend', 'role': 'user'}
```

## Root cause

The payload → public-shape key set was written out by hand in **7 places**: six inline
copies inside `mem0/memory/main.py` (`get`, `get_all`, `_search_vector_store`, sync and
async) and one in the REST server. The server's copy drifted.

## Changes

- `mem0/memory/utils.py`: single source of truth — `PROMOTED_PAYLOAD_KEYS` and
  `NON_METADATA_PAYLOAD_KEYS` (which includes `text_lemmatized`).
- `mem0/memory/main.py`: dropped the 6 duplicated local copies in favour of the shared
  constants (−80/+14 lines, no behaviour change).
- `server/main.py`: `_serialize_memory()` now filters `metadata` with
  `NON_METADATA_PAYLOAD_KEYS` and promotes `PROMOTED_PAYLOAD_KEYS` to the top level, so
  the admin branch returns the same shape as `Memory.get_all()`.

## Note on the response shape

To match `get_all()`, `user_id` / `agent_id` / `run_id` / `expiration_date` are now
omitted when absent from the payload rather than emitted as `null`, and `metadata` is
`None` rather than `{}` when there is no user metadata.

## Test plan

Added to `tests/test_server_params.py::TestGetMemories`:

- `test_get_memories_admin_list_all_hides_internal_payload_keys` — `text_lemmatized` is
  gone, `actor_id`/`role`/`user_id` are promoted, only user metadata remains.
- `test_get_memories_admin_list_all_metadata_none_when_empty`

```text
pytest tests/test_server_params.py    ->  70 passed
pytest tests/memory                   -> 309 passed
pytest tests/test_memory.py           ->  58 passed
ruff check                            -> clean
```