### PR TITLE
fix(plugin): converge plugin.json manifests on 0.2.14 and guard against drift

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -77,6 +77,10 @@ jobs:
             mem0_plugin:
               - 'integrations/mem0-plugin/**'
               - '!integrations/mem0-plugin/.opencode-plugin/**'
+              # Marketplace manifests duplicate the plugin version; a release PR
+              # that bumps only these must still run the version-parity test.
+              - '.claude-plugin/marketplace.json'
+              - '.cursor-plugin/marketplace.json'
               - '.github/workflows/mem0-plugin-checks.yml'
               - '.github/workflows/ci-gate.yml'
             opencode_plugin:

--- a/.github/workflows/mem0-plugin-checks.yml
+++ b/.github/workflows/mem0-plugin-checks.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'integrations/mem0-plugin/**'
       - '!integrations/mem0-plugin/.opencode-plugin/**'
+      - '.claude-plugin/marketplace.json'
+      - '.cursor-plugin/marketplace.json'
       - '.github/workflows/mem0-plugin-checks.yml'
   workflow_call:
 

--- a/integrations/mem0-plugin/.claude-plugin/plugin.json
+++ b/integrations/mem0-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Persistent memory for Claude Code. Remembers decisions, patterns, and preferences across sessions.",
   "author": {
     "name": "Mem0",

--- a/integrations/mem0-plugin/.codex-plugin/plugin.json
+++ b/integrations/mem0-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Persistent memory for Codex. Remembers decisions, patterns, and preferences across sessions.",
   "author": {
     "name": "Mem0",

--- a/integrations/mem0-plugin/.cursor-plugin/plugin.json
+++ b/integrations/mem0-plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem0",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Mem0 memory layer for AI applications. Add persistent memory, personalization, and semantic search using the Mem0 Platform MCP server.",
   "author": {
     "name": "Mem0",

--- a/integrations/mem0-plugin/tests/test_manifest_versions.py
+++ b/integrations/mem0-plugin/tests/test_manifest_versions.py
@@ -1,0 +1,46 @@
+"""The mem0 plugin's version is duplicated across five manifests; they must agree.
+
+Regression guard: release 0.2.14 bumped the two marketplace manifests but left the
+three per-host plugin.json files at 0.2.13, so a host that advertised 0.2.14 installed
+a plugin whose own manifest reported 0.2.13 and never converged.
+
+The Antigravity manifest (integrations/mem0-plugin/plugin.json) tracks its own version
+line and is deliberately not part of this set.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_SOURCE = "./integrations/mem0-plugin"
+
+PLUGIN_MANIFESTS = [
+    REPO_ROOT / "integrations" / "mem0-plugin" / host / "plugin.json"
+    for host in (".claude-plugin", ".cursor-plugin", ".codex-plugin")
+]
+MARKETPLACE_MANIFESTS = [
+    REPO_ROOT / ".claude-plugin" / "marketplace.json",
+    REPO_ROOT / ".cursor-plugin" / "marketplace.json",
+]
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _declared_version(path: Path) -> str:
+    manifest = _load(path)
+    if "plugins" not in manifest:
+        return manifest["version"]
+    entry = next(p for p in manifest["plugins"] if p["source"] == PLUGIN_SOURCE)
+    return entry["version"]
+
+
+def test_all_manifests_declare_the_same_version():
+    versions = {
+        path.relative_to(REPO_ROOT).as_posix(): _declared_version(path)
+        for path in PLUGIN_MANIFESTS + MARKETPLACE_MANIFESTS
+    }
+    assert len(set(versions.values())) == 1, f"plugin version drift: {versions}"


### PR DESCRIPTION
Fixes #6828

## Problem

The 0.2.14 release (#6800, 1112be3e) bumped the two marketplace manifests but not the
three per-host plugin manifests they point at:

```
.claude-plugin/marketplace.json                        0.2.14
.cursor-plugin/marketplace.json                        0.2.14
integrations/mem0-plugin/.claude-plugin/plugin.json    0.2.13
integrations/mem0-plugin/.cursor-plugin/plugin.json    0.2.13
integrations/mem0-plugin/.codex-plugin/plugin.json     0.2.13
```

Both marketplace entries use `"source": "./integrations/mem0-plugin"`, so a host that
advertises 0.2.14 installs a plugin whose own manifest reports 0.2.13: the version never
converges, "update available" never clears, and support triage gets an installed version
that doesn't exist in the marketplace. These five files moved in lockstep through 0.2.9 →
0.2.13; 0.2.14 is the first divergence.

## Changes

- Bumped the three `plugin.json` manifests to **0.2.14**. The Antigravity manifest
  (`integrations/mem0-plugin/plugin.json`, 0.1.6) tracks its own version line and is
  deliberately left alone.
- Added `integrations/mem0-plugin/tests/test_manifest_versions.py` — one test that loads
  all five manifests and asserts a single version, printing the offender on failure:

  ```
  AssertionError: plugin version drift: {'integrations/mem0-plugin/.claude-plugin/plugin.json': '0.2.13',
  '.claude-plugin/marketplace.json': '0.2.14', ...}
  ```

  It runs inside the existing `pytest -q` step of `mem0-plugin-checks.yml`, so no new CI
  job is needed.
- Added `.claude-plugin/marketplace.json` and `.cursor-plugin/marketplace.json` to the
  `mem0_plugin` path filter in `ci-gate.yml` and to the push paths in
  `mem0-plugin-checks.yml`. **Without this the guard is decorative:** a release PR shaped
  like 1112be3e touches only the root marketplace manifests, which don't match
  `integrations/mem0-plugin/**`, so the plugin pipeline would be skipped and the new test
  would never run — exactly the change that needs checking.

## Test plan

```
pytest integrations/mem0-plugin/tests/test_manifest_versions.py   -> 1 passed
```

Verified the guard actually bites by reverting one manifest to 0.2.13 — the test fails and
names the file. Full plugin suite: 167 passed, 1 failed
(`test_rubric_dedup.py::test_first_prompt_gets_full_rubric`, which fails identically on a
clean `main` and is unrelated to this change).

## Not included

No `version` field added to `marketplace.json` / `.codex-plugin/marketplace.json` (they
carry none by design), and no release-script automation — the parity test is the cheap
enforcement. Worth a bump script when releases stop being hand-edited.