### PR TITLE
docs(skill): migrate remaining Python search() snippets to the v3 filters form

### DIFF
--- a/integrations/mem0-plugin/skills/mem0/references/use-cases.md
+++ b/integrations/mem0-plugin/skills/mem0/references/use-cases.md
@@ -30,7 +30,7 @@ openai_client = OpenAI()
 
 def chat(user_input: str, user_id: str) -> str:
     # 1. Retrieve relevant memories
-    memories = mem0.search(user_input, user_id=user_id)
+    memories = mem0.search(user_input, filters={"user_id": user_id})
     context = "\n".join([f"- {m['memory']}" for m in memories.get("results", [])])
 
     # 2. Generate response with memory context
@@ -226,7 +226,7 @@ def save_patient_info(user_id: str, information: str):
 
 def consult(user_id: str, question: str) -> str:
     # High threshold for medical accuracy
-    memories = mem0.search(question, user_id=user_id, top_k=5, threshold=0.7)
+    memories = mem0.search(question, filters={"user_id": user_id}, top_k=5, threshold=0.7)
     context = "\n".join([f"- {m['memory']}" for m in memories.get("results", [])])
 
     response = openai_client.chat.completions.create(
@@ -516,7 +516,7 @@ Extract dietary preferences, location, interests, and purchase history."""
 
 def personalized_search(user_id: str, query: str, search_results: list) -> str:
     # Get user context from memory
-    memories = mem0.search(query, user_id=user_id, top_k=5)
+    memories = mem0.search(query, filters={"user_id": user_id}, top_k=5)
     user_context = "\n".join([f"- {m['memory']}" for m in memories.get("results", [])])
 
     response = openai_client.chat.completions.create(
@@ -661,7 +661,7 @@ Every use case follows the same 3-step loop:
 
 ```python
 # 1. Retrieve relevant context
-memories = mem0.search(user_input, user_id=user_id)
+memories = mem0.search(user_input, filters={"user_id": user_id})
 context = "\n".join([m["memory"] for m in memories.get("results", [])])
 
 # 2. Generate with context

--- a/skills/mem0/references/integration-patterns.md
+++ b/skills/mem0/references/integration-patterns.md
@@ -38,7 +38,7 @@ prompt = ChatPromptTemplate.from_messages([
 
 def retrieve_context(query: str, user_id: str):
     """Retrieve relevant memories from Mem0"""
-    memories = mem0.search(query, user_id=user_id)
+    memories = mem0.search(query, filters={"user_id": user_id})
     memory_list = memories['results']
     serialized = ' '.join([m["memory"] for m in memory_list])
     return [
@@ -150,7 +150,7 @@ mem0 = MemoryClient()
 @function_tool
 def search_memory(query: str, user_id: str) -> str:
     """Search through past conversations and memories"""
-    memories = mem0.search(query, user_id=user_id, top_k=3)
+    memories = mem0.search(query, filters={"user_id": user_id}, top_k=3)
     if memories and memories.get('results'):
         return "\n".join([f"- {mem['memory']}" for mem in memories['results']])
     return "No relevant memories found."
@@ -266,7 +266,7 @@ def chatbot(state: State):
     user_id = state["mem0_user_id"]
 
     # Retrieve relevant memories
-    memories = mem0.search(messages[-1].content, user_id=user_id)
+    memories = mem0.search(messages[-1].content, filters={"user_id": user_id})
     context = "Relevant context:\n"
     for memory in memories["results"]:
         context += f"- {memory['memory']}\n"
@@ -359,7 +359,7 @@ agent = ConversableAgent(
 
 def get_context_aware_response(question: str) -> str:
     # Retrieve memories for context
-    relevant_memories = memory_client.search(question, user_id=USER_ID)
+    relevant_memories = memory_client.search(question, filters={"user_id": USER_ID})
     context = "\n".join([m["memory"] for m in relevant_memories.get("results", [])])
 
     prompt = f"""Answer considering previous interactions:

--- a/skills/mem0/references/quickstart.md
+++ b/skills/mem0/references/quickstart.md
@@ -27,7 +27,7 @@ messages = [
 client.add(messages, user_id="user123")
 
 # Search memories
-results = client.search("What are my dietary restrictions?", user_id="user123")
+results = client.search("What are my dietary restrictions?", filters={"user_id": "user123"})
 print(results)
 ```
 
@@ -39,7 +39,7 @@ from mem0 import AsyncMemoryClient
 client = AsyncMemoryClient(api_key="your-api-key")
 
 await client.add(messages, user_id="user123")
-results = await client.search("query", user_id="user123")
+results = await client.search("query", filters={"user_id": "user123"})
 ```
 
 ## TypeScript / JavaScript Setup
@@ -74,7 +74,7 @@ console.log(results);
 export MEM0_API_KEY="m0-your-api-key"
 
 # Add memory
-curl -X POST https://api.mem0.ai/v1/memories/ \
+curl -X POST https://api.mem0.ai/v3/memories/add/ \
   -H "Authorization: Token $MEM0_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -86,7 +86,7 @@ curl -X POST https://api.mem0.ai/v1/memories/ \
   }'
 
 # Search memories
-curl -X POST https://api.mem0.ai/v2/memories/search/ \
+curl -X POST https://api.mem0.ai/v3/memories/search/ \
   -H "Authorization: Token $MEM0_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/skills/mem0/references/use-cases.md
+++ b/skills/mem0/references/use-cases.md
@@ -30,7 +30,7 @@ openai_client = OpenAI()
 
 def chat(user_input: str, user_id: str) -> str:
     # 1. Retrieve relevant memories
-    memories = mem0.search(user_input, user_id=user_id)
+    memories = mem0.search(user_input, filters={"user_id": user_id})
     context = "\n".join([f"- {m['memory']}" for m in memories.get("results", [])])
 
     # 2. Generate response with memory context
@@ -226,7 +226,7 @@ def save_patient_info(user_id: str, information: str):
 
 def consult(user_id: str, question: str) -> str:
     # High threshold for medical accuracy
-    memories = mem0.search(question, user_id=user_id, top_k=5, threshold=0.7)
+    memories = mem0.search(question, filters={"user_id": user_id}, top_k=5, threshold=0.7)
     context = "\n".join([f"- {m['memory']}" for m in memories.get("results", [])])
 
     response = openai_client.chat.completions.create(
@@ -516,7 +516,7 @@ Extract dietary preferences, location, interests, and purchase history."""
 
 def personalized_search(user_id: str, query: str, search_results: list) -> str:
     # Get user context from memory
-    memories = mem0.search(query, user_id=user_id, top_k=5)
+    memories = mem0.search(query, filters={"user_id": user_id}, top_k=5)
     user_context = "\n".join([f"- {m['memory']}" for m in memories.get("results", [])])
 
     response = openai_client.chat.completions.create(
@@ -661,7 +661,7 @@ Every use case follows the same 3-step loop:
 
 ```python
 # 1. Retrieve relevant context
-memories = mem0.search(user_input, user_id=user_id)
+memories = mem0.search(user_input, filters={"user_id": user_id})
 context = "\n".join([m["memory"] for m in memories.get("results", [])])
 
 # 2. Generate with context


### PR DESCRIPTION
Fixes #6831

## Problem

`skills/mem0/` is loaded straight into an AI coding assistant's context, so its snippets
become generated code. Its Python quickstart still taught the call shape v3 removed:

```python
results = client.search("What are my dietary restrictions?", user_id="user123")
```

`MemoryClient.search()` rejects this before any request goes out
(`mem0/client/main.py:319-325`):

```
ValueError: Top-level entity parameters {'user_id'} are not supported in search().
Use filters={'user_id': '...'} instead.
```

The skill contradicted itself: `references/sdk-guide.md:303` documents that exact call as
"v2 (deprecated)", while the quickstart — the first page an assistant reads — handed it out.

## Changes

14 snippets moved to `filters={"user_id": ...}`:

- `skills/mem0/references/quickstart.md` — :30, :42
- `skills/mem0/references/integration-patterns.md` — :41, :153, :269, :362
- `skills/mem0/references/use-cases.md` — :33, :229, :519, :664
- `integrations/mem0-plugin/skills/mem0/references/use-cases.md` — same four

The skill ships in two copies. The plugin copy was already migrated for `quickstart.md` and
`integration-patterns.md`; `use-cases.md` was stale in **both**, so both are fixed. All
three files now emit identical `search(...)` calls across the two copies.

Also bumped two cURL endpoints in the root quickstart: `POST /v1/memories/` →
`/v3/memories/add/` and `POST /v2/memories/search/` → `/v3/memories/search/`, matching the
client (`mem0/client/main.py:217,332`) and the already-migrated plugin copy. The issue lists
this cURL block as correct — its *body* uses `filters`, but the URLs were still v1/v2, the
same missed migration.

## Left unchanged

`client/python.md:468` and `references/sdk-guide.md:303` in both copies keep
`client.search("query", user_id="alice")` — they are labelled `# v2` / `# v2 (deprecated)`
counter-examples in migration tables, correct as-is.

## Test plan

Documentation only, no code paths touched.

```
grep -rn '\.search(' skills/mem0 integrations/mem0-plugin/skills/mem0 --include=*.md \
  | grep -E 'user_id=|agent_id=|run_id=' | grep -v filters
```

returns only the four labelled v2 counter-examples above.

No regression test added: a grep guard would have to carve out those intentional
counter-examples, making it more fragile than what it protects. The durable fix is
de-duplicating the two skill trees, which is a separate change.