### PR TITLE
docs: update Python search examples for v3 filters API

### DIFF
--- a/skills/mem0/references/integration-patterns.md
+++ b/skills/mem0/references/integration-patterns.md
@@ -38,7 +38,7 @@ prompt = ChatPromptTemplate.from_messages([
 
 def retrieve_context(query: str, user_id: str):
     """Retrieve relevant memories from Mem0"""
-    memories = mem0.search(query, user_id=user_id)
+    memories = mem0.search(query, filters={"user_id": user_id})
     memory_list = memories['results']
     serialized = ' '.join([m["memory"] for m in memory_list])
     return [
@@ -150,7 +150,7 @@ mem0 = MemoryClient()
 @function_tool
 def search_memory(query: str, user_id: str) -> str:
     """Search through past conversations and memories"""
-    memories = mem0.search(query, user_id=user_id, top_k=3)
+    memories = mem0.search(query, filters={"user_id": user_id}, top_k=3)
     if memories and memories.get('results'):
         return "\n".join([f"- {mem['memory']}" for mem in memories['results']])
     return "No relevant memories found."
@@ -266,7 +266,7 @@ def chatbot(state: State):
     user_id = state["mem0_user_id"]
 
     # Retrieve relevant memories
-    memories = mem0.search(messages[-1].content, user_id=user_id)
+    memories = mem0.search(messages[-1].content, filters={"user_id": user_id})
     context = "Relevant context:\n"
     for memory in memories["results"]:
         context += f"- {memory['memory']}\n"
@@ -359,7 +359,7 @@ agent = ConversableAgent(
 
 def get_context_aware_response(question: str) -> str:
     # Retrieve memories for context
-    relevant_memories = memory_client.search(question, user_id=USER_ID)
+    relevant_memories = memory_client.search(question, filters={"user_id": USER_ID})
     context = "\n".join([m["memory"] for m in relevant_memories.get("results", [])])
 
     prompt = f"""Answer considering previous interactions:

--- a/skills/mem0/references/quickstart.md
+++ b/skills/mem0/references/quickstart.md
@@ -27,7 +27,7 @@ messages = [
 client.add(messages, user_id="user123")
 
 # Search memories
-results = client.search("What are my dietary restrictions?", user_id="user123")
+results = client.search("What are my dietary restrictions?", filters={"user_id": "user123"})
 print(results)
 ```
 
@@ -39,7 +39,10 @@ from mem0 import AsyncMemoryClient
 client = AsyncMemoryClient(api_key="your-api-key")
 
 await client.add(messages, user_id="user123")
-results = await client.search("query", user_id="user123")
+results = await client.search(
+    "query",
+    filters={"user_id": "user123"},
+)
 ```
 
 ## TypeScript / JavaScript Setup

--- a/skills/mem0/references/use-cases.md
+++ b/skills/mem0/references/use-cases.md
@@ -30,7 +30,7 @@ openai_client = OpenAI()
 
 def chat(user_input: str, user_id: str) -> str:
     # 1. Retrieve relevant memories
-    memories = mem0.search(user_input, user_id=user_id)
+    memories = mem0.search(user_input, filters={"user_id": user_id})
     context = "\n".join([f"- {m['memory']}" for m in memories.get("results", [])])
 
     # 2. Generate response with memory context
@@ -226,7 +226,7 @@ def save_patient_info(user_id: str, information: str):
 
 def consult(user_id: str, question: str) -> str:
     # High threshold for medical accuracy
-    memories = mem0.search(question, user_id=user_id, top_k=5, threshold=0.7)
+    memories = mem0.search(question, filters={"user_id": user_id}, top_k=5, threshold=0.7)
     context = "\n".join([f"- {m['memory']}" for m in memories.get("results", [])])
 
     response = openai_client.chat.completions.create(
@@ -516,7 +516,7 @@ Extract dietary preferences, location, interests, and purchase history."""
 
 def personalized_search(user_id: str, query: str, search_results: list) -> str:
     # Get user context from memory
-    memories = mem0.search(query, user_id=user_id, top_k=5)
+    memories = mem0.search(query, filters={"user_id": user_id}, top_k=5)
     user_context = "\n".join([f"- {m['memory']}" for m in memories.get("results", [])])
 
     response = openai_client.chat.completions.create(
@@ -661,7 +661,7 @@ Every use case follows the same 3-step loop:
 
 ```python
 # 1. Retrieve relevant context
-memories = mem0.search(user_input, user_id=user_id)
+memories = mem0.search(user_input, filters={"user_id": user_id})
 context = "\n".join([m["memory"] for m in memories.get("results", [])])
 
 # 2. Generate with context


### PR DESCRIPTION
## Linked Issue

Closes #<!-- Add issue number here if applicable -->

## Description

This PR updates the Python SDK reference snippets within the `skills/mem0/` documentation to use the correct v3-compatible `filters` dictionary parameter for `client.search()` calls. 

Previously, several code examples were still using the deprecated v2 syntax where `user_id` was passed as a top-level kwarg (e.g., `client.search("query", user_id="user123")`). This outdated syntax throws a `ValueError` in SDK v3. These calls have been migrated to use `filters={"user_id": "user123"}` for consistency with the rest of the updated v3 documentation and to ensure that an AI assistant loading this skill generates working code.

Files updated:
- `skills/mem0/references/quickstart.md`
- `skills/mem0/references/integration-patterns.md`
- `skills/mem0/references/use-cases.md`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

**Explanation:** This is purely a documentation and AI skill reference update to ensure code snippets are correct. No library source code or logic was changed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
