### PR TITLE
feat(plugin): add Kimi Code support

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -77,6 +77,10 @@ jobs:
             mem0_plugin:
               - 'integrations/mem0-plugin/**'
               - '!integrations/mem0-plugin/.opencode-plugin/**'
+              # Kimi's repo-root manifest + catalog. Kimi can only read a
+              # manifest at the archive root, so it needs a second copy there;
+              # tests/test_kimi_manifests.py guards the two against drifting.
+              - '.kimi-plugin/**'
               - '.github/workflows/mem0-plugin-checks.yml'
               - '.github/workflows/ci-gate.yml'
             opencode_plugin:

--- a/.github/workflows/mem0-plugin-checks.yml
+++ b/.github/workflows/mem0-plugin-checks.yml
@@ -5,6 +5,12 @@ name: Mem0 Plugin Checks
 #
 # Covers the Python plugin (scripts/ + tests/). The nested .opencode-plugin/
 # is a separate package with its own workflow (opencode-plugin-checks.yml).
+#
+# The repo-root .kimi-plugin/ is in scope too: it holds Kimi's second copy of
+# the plugin manifest (Kimi reads a manifest at the downloaded archive's root
+# only, so a subdirectory manifest is unreachable for GitHub installs) plus its
+# marketplace catalog. tests/test_kimi_manifests.py guards both against
+# drifting from integrations/mem0-plugin/.kimi-plugin/.
 on:
   workflow_dispatch:
   push:
@@ -12,6 +18,7 @@ on:
     paths:
       - 'integrations/mem0-plugin/**'
       - '!integrations/mem0-plugin/.opencode-plugin/**'
+      - '.kimi-plugin/**'
       - '.github/workflows/mem0-plugin-checks.yml'
   workflow_call:
 
@@ -46,11 +53,29 @@ jobs:
             exit 1
           fi
 
-      - name: Check hook manifests are valid JSON
-        working-directory: integrations/mem0-plugin
+      # Every per-host manifest and catalog, wherever it lives: the plugin dir
+      # (.{host}-plugin/plugin.json, .{host}-mcp.json) and the repo root
+      # (.{host}-plugin/*.json, .agents/plugins/, marketplace.json).
+      - name: Check plugin, MCP and hook manifests are valid JSON
         run: |
-          for f in plugin.json mcp_config.json hooks.json hooks/*.json; do
-            jq empty "$f" || (echo "Invalid JSON: $f" && exit 1)
+          set -euo pipefail
+          find \
+            integrations/mem0-plugin/plugin.json \
+            integrations/mem0-plugin/mcp_config.json \
+            integrations/mem0-plugin/hooks.json \
+            integrations/mem0-plugin/hooks \
+            integrations/mem0-plugin/.claude-plugin \
+            integrations/mem0-plugin/.codex-plugin \
+            integrations/mem0-plugin/.cursor-plugin \
+            integrations/mem0-plugin/.kimi-plugin \
+            integrations/mem0-plugin/.codex-mcp.json \
+            integrations/mem0-plugin/.cursor-mcp.json \
+            integrations/mem0-plugin/.mcp.json \
+            .claude-plugin .codex-plugin .cursor-plugin .kimi-plugin \
+            .agents/plugins marketplace.json \
+            -name '*.json' -type f -print0 |
+          while IFS= read -r -d '' f; do
+            jq empty "$f" || { echo "Invalid JSON: $f"; exit 1; }
           done
 
       - name: Run tests

--- a/.kimi-plugin/marketplace.json
+++ b/.kimi-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "mem0-plugins",
+  "version": "1",
+  "plugins": [
+    {
+      "id": "mem0",
+      "displayName": "Mem0",
+      "version": "0.2.13",
+      "description": "Persistent memory for Kimi Code. Remembers decisions, patterns, and preferences across sessions.",
+      "homepage": "https://mem0.ai",
+      "keywords": ["memory", "personalization", "mcp", "semantic-search"],
+      "source": "https://github.com/mem0ai/mem0/tree/main"
+    }
+  ]
+}

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -14,6 +14,59 @@
   "sessionStart": {
     "skill": "context-loader"
   },
+  "hooks": [
+    {
+      "event": "SessionStart",
+      "matcher": "^(startup|resume)$",
+      "command": "\"$KIMI_PLUGIN_ROOT/integrations/mem0-plugin/scripts/kimi_hook_shim.sh\" on_session_start.sh",
+      "timeout": 30
+    },
+    {
+      "event": "UserPromptSubmit",
+      "command": "\"$KIMI_PLUGIN_ROOT/integrations/mem0-plugin/scripts/kimi_hook_shim.sh\" on_user_prompt.sh",
+      "timeout": 12
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "^(Write|Edit|MultiEdit)$",
+      "command": "\"$KIMI_PLUGIN_ROOT/integrations/mem0-plugin/scripts/kimi_hook_shim.sh\" block_memory_write.sh",
+      "timeout": 5
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "^mcp__.*mem0.*__(add_memory|search_memories|get_memories|delete_all_memories)$",
+      "command": "\"$KIMI_PLUGIN_ROOT/integrations/mem0-plugin/scripts/kimi_hook_shim.sh\" enforce_metadata_defaults.sh",
+      "timeout": 5
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "^Read$",
+      "command": "\"$KIMI_PLUGIN_ROOT/integrations/mem0-plugin/scripts/kimi_hook_shim.sh\" on_file_read.sh",
+      "timeout": 5
+    },
+    {
+      "event": "PostToolUse",
+      "matcher": "^mcp__.*mem0.*__",
+      "command": "\"$KIMI_PLUGIN_ROOT/integrations/mem0-plugin/scripts/kimi_hook_shim.sh\" on_post_tool_use.sh",
+      "timeout": 5
+    },
+    {
+      "event": "PostToolUse",
+      "matcher": "^Bash$",
+      "command": "\"$KIMI_PLUGIN_ROOT/integrations/mem0-plugin/scripts/kimi_hook_shim.sh\" on_bash_output.sh",
+      "timeout": 12
+    },
+    {
+      "event": "Stop",
+      "command": "\"$KIMI_PLUGIN_ROOT/integrations/mem0-plugin/scripts/kimi_hook_shim.sh\" on_stop.sh",
+      "timeout": 30
+    },
+    {
+      "event": "PreCompact",
+      "command": "\"$KIMI_PLUGIN_ROOT/integrations/mem0-plugin/scripts/kimi_hook_shim.sh\" on_pre_compact.sh",
+      "timeout": 30
+    }
+  ],
   "mcpServers": {
     "mem0": {
       "transport": "http",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "mem0",
+  "version": "0.2.13",
+  "description": "Persistent memory for Kimi Code. Remembers decisions, patterns, and preferences across sessions.",
+  "author": {
+    "name": "Mem0",
+    "email": "support@mem0.ai"
+  },
+  "homepage": "https://mem0.ai",
+  "repository": "https://github.com/mem0ai/mem0",
+  "license": "Apache-2.0",
+  "keywords": ["memory", "personalization", "mcp", "semantic-search"],
+  "skills": "./integrations/mem0-plugin/skills/",
+  "sessionStart": {
+    "skill": "context-loader"
+  },
+  "mcpServers": {
+    "mem0": {
+      "transport": "http",
+      "url": "https://mcp.mem0.ai/mcp/",
+      "bearerTokenEnvVar": "MEM0_API_KEY"
+    }
+  },
+  "interface": {
+    "displayName": "Mem0",
+    "shortDescription": "Persistent memory layer for AI coding workflows",
+    "longDescription": "Mem0 adds long-term memory to Kimi Code. Store decisions, user preferences, project context, and session state across conversations. Memories are automatically retrieved via semantic search so Kimi always has the right context.",
+    "developerName": "Mem0",
+    "websiteURL": "https://mem0.ai"
+  }
+}

--- a/integrations/mem0-plugin/.kimi-plugin/plugin.json
+++ b/integrations/mem0-plugin/.kimi-plugin/plugin.json
@@ -14,6 +14,59 @@
   "sessionStart": {
     "skill": "context-loader"
   },
+  "hooks": [
+    {
+      "event": "SessionStart",
+      "matcher": "^(startup|resume)$",
+      "command": "\"$KIMI_PLUGIN_ROOT/scripts/kimi_hook_shim.sh\" on_session_start.sh",
+      "timeout": 30
+    },
+    {
+      "event": "UserPromptSubmit",
+      "command": "\"$KIMI_PLUGIN_ROOT/scripts/kimi_hook_shim.sh\" on_user_prompt.sh",
+      "timeout": 12
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "^(Write|Edit|MultiEdit)$",
+      "command": "\"$KIMI_PLUGIN_ROOT/scripts/kimi_hook_shim.sh\" block_memory_write.sh",
+      "timeout": 5
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "^mcp__.*mem0.*__(add_memory|search_memories|get_memories|delete_all_memories)$",
+      "command": "\"$KIMI_PLUGIN_ROOT/scripts/kimi_hook_shim.sh\" enforce_metadata_defaults.sh",
+      "timeout": 5
+    },
+    {
+      "event": "PreToolUse",
+      "matcher": "^Read$",
+      "command": "\"$KIMI_PLUGIN_ROOT/scripts/kimi_hook_shim.sh\" on_file_read.sh",
+      "timeout": 5
+    },
+    {
+      "event": "PostToolUse",
+      "matcher": "^mcp__.*mem0.*__",
+      "command": "\"$KIMI_PLUGIN_ROOT/scripts/kimi_hook_shim.sh\" on_post_tool_use.sh",
+      "timeout": 5
+    },
+    {
+      "event": "PostToolUse",
+      "matcher": "^Bash$",
+      "command": "\"$KIMI_PLUGIN_ROOT/scripts/kimi_hook_shim.sh\" on_bash_output.sh",
+      "timeout": 12
+    },
+    {
+      "event": "Stop",
+      "command": "\"$KIMI_PLUGIN_ROOT/scripts/kimi_hook_shim.sh\" on_stop.sh",
+      "timeout": 30
+    },
+    {
+      "event": "PreCompact",
+      "command": "\"$KIMI_PLUGIN_ROOT/scripts/kimi_hook_shim.sh\" on_pre_compact.sh",
+      "timeout": 30
+    }
+  ],
   "mcpServers": {
     "mem0": {
       "transport": "http",

--- a/integrations/mem0-plugin/.kimi-plugin/plugin.json
+++ b/integrations/mem0-plugin/.kimi-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "mem0",
+  "version": "0.2.13",
+  "description": "Persistent memory for Kimi Code. Remembers decisions, patterns, and preferences across sessions.",
+  "author": {
+    "name": "Mem0",
+    "email": "support@mem0.ai"
+  },
+  "homepage": "https://mem0.ai",
+  "repository": "https://github.com/mem0ai/mem0",
+  "license": "Apache-2.0",
+  "keywords": ["memory", "personalization", "mcp", "semantic-search"],
+  "skills": "./skills/",
+  "sessionStart": {
+    "skill": "context-loader"
+  },
+  "mcpServers": {
+    "mem0": {
+      "transport": "http",
+      "url": "https://mcp.mem0.ai/mcp/",
+      "bearerTokenEnvVar": "MEM0_API_KEY"
+    }
+  },
+  "interface": {
+    "displayName": "Mem0",
+    "shortDescription": "Persistent memory layer for AI coding workflows",
+    "longDescription": "Mem0 adds long-term memory to Kimi Code. Store decisions, user preferences, project context, and session state across conversations. Memories are automatically retrieved via semantic search so Kimi always has the right context.",
+    "developerName": "Mem0",
+    "websiteURL": "https://mem0.ai"
+  }
+}

--- a/integrations/mem0-plugin/README.md
+++ b/integrations/mem0-plugin/README.md
@@ -180,11 +180,26 @@ See [Antigravity integration docs](https://docs.mem0.ai/integrations/antigravity
 
 ```bash
 # In Kimi Code
-/plugins install https://github.com/mem0ai/mem0
+/plugins install https://github.com/mem0ai/mem0/tree/main
 /plugins reload
 ```
 
-**Option B — install from a local clone:**
+> **Pin the ref.** A bare `https://github.com/mem0ai/mem0` makes Kimi resolve
+> `releases/latest` first, and this repo's latest release tag belongs to an SDK or
+> integration package, not the plugin — the install would fetch a stale tarball with no
+> Kimi manifest in it.
+
+**Option B — install from the marketplace catalog:**
+
+```bash
+# In Kimi Code
+/plugins marketplace https://raw.githubusercontent.com/mem0ai/mem0/main/.kimi-plugin/marketplace.json
+```
+
+Kimi's `/plugins marketplace` takes a direct URL to the catalog JSON — it does not clone
+or scan a repo — so point it at the raw file, then install **Mem0** from the picker.
+
+**Option C — install from a local clone:**
 
 ```bash
 git clone https://github.com/mem0ai/mem0.git
@@ -200,18 +215,48 @@ The plugin registers the Mem0 MCP server plus all 16 skills. `context-loader` is
 declared under `sessionStart`, so relevant memories load automatically at the start
 of every session without an explicit prompt.
 
-> **Why there are two manifests.** Kimi resolves a plugin's root from the install source,
-> and has no way to point at a subdirectory of a GitHub repo — `/plugins marketplace` takes
-> a direct URL to a hosted JSON catalog rather than scanning a repo, and a GitHub install
-> looks for the manifest at the archive root only. So Option A needs
-> `.kimi-plugin/plugin.json` at the repo root (its `skills` points back into
-> `integrations/mem0-plugin/skills/`), while Option B uses
-> `integrations/mem0-plugin/.kimi-plugin/plugin.json` alongside the other hosts. The two
-> files are identical apart from that one path — keep them in sync when bumping `version`.
+> **Why there are two manifests.** Kimi resolves a plugin's root from the install source
+> and has no subdirectory indirection anywhere in the chain: a GitHub install downloads the
+> repo archive and looks for the manifest at its root only, the GitHub source parser has no
+> subpath support, and `/plugins marketplace` takes a URL to a catalog file rather than
+> scanning a repo. So Options A and B need `.kimi-plugin/plugin.json` at the **repo root**
+> (its `skills` points back into `integrations/mem0-plugin/skills/`), while Option C uses
+> `integrations/mem0-plugin/.kimi-plugin/plugin.json` alongside the other hosts. A symlink
+> cannot collapse the two: Kimi extracts archives with yauzl, which writes a symlink entry
+> out as a regular file. The two files are identical apart from that one `skills` path and
+> the `$KIMI_PLUGIN_ROOT`-relative script prefix inside `hooks`, and
+> `tests/test_kimi_manifests.py` fails the build if anything else drifts — so bump `version`
+> in both.
 
-> Lifecycle hooks are not wired for Kimi Code yet. Kimi declares `hooks` as an array
-> rather than the event-keyed object the other hosts use; auto-capture will land once
-> that mapping is confirmed.
+> **MCP is inlined, not referenced.** Cursor and Codex point `mcpServers` at
+> `.cursor-mcp.json` / `.codex-mcp.json`; Kimi's manifest parser requires `mcpServers` to be
+> an object and silently drops a path string, so the server is declared inline in both Kimi
+> manifests. Kimi also passes `headers` through verbatim with no `${VAR}` expansion, hence
+> `bearerTokenEnvVar` instead of an `Authorization` header.
+
+> **Hooks go through an adapter, not a forked script set.** Kimi's `hooks` must be an
+> inline array in the manifest (a path to a hooks file is silently dropped), so both Kimi
+> manifests carry the same nine entries that `hooks/codex-hooks.json` carries. Every entry
+> invokes `scripts/kimi_hook_shim.sh <script.sh>` rather than the script directly, because
+> Kimi's contract differs from Claude's in four ways: it runs hook commands with `cwd` set
+> to the **plugin** root (the project directory arrives only in the payload's `cwd` field);
+> it sends `prompt` as a `ContentPart[]` array, `tool_output` instead of `tool_response`,
+> and `tool_input.path` instead of `tool_input.file_path`; it names plugin MCP tools
+> `mcp__plugin-mem0_mem0__*` with a hyphen; and its stdout parser understands only
+> `message`, `hookSpecificOutput.message`, `hookSpecificOutput.permissionDecision` and
+> `permissionDecisionReason` — `additionalContext` and `updatedInput` are ignored. The
+> adapter chdirs into the payload `cwd`, normalises the payload into the Claude shape, and
+> unwraps `additionalContext` into plain stdout, which Kimi appends to context on
+> `UserPromptSubmit`. Exit codes are unchanged (0 allow, 2 block with stderr as the reason).
+
+> **Two Kimi gaps the adapter cannot close.** Kimi sends no `transcript_path` and has no
+> Claude-format transcript, so `on_stop.sh`, `on_pre_compact.sh` and the `auto_capture`
+> path exit early — session-summary capture is inert until a Kimi transcript reader exists.
+> And because Kimi ignores `hookSpecificOutput.updatedInput`, `enforce_metadata_defaults.sh`
+> cannot rewrite MCP tool arguments; it still runs for its session-stats side effects, and
+> identity defaults must come from the `mem0` skills instead. Session-start recall is
+> unaffected — it is handled natively by `sessionStart.skill`, since Kimi discards
+> `SessionStart` hook stdout.
 
 ## Post-Installation: Run `/mem0:onboard`
 

--- a/integrations/mem0-plugin/README.md
+++ b/integrations/mem0-plugin/README.md
@@ -1,6 +1,6 @@
-# Mem0 Plugin for Claude Code, Claude Cowork, Cursor, Codex, OpenCode & Antigravity
+# Mem0 Plugin for Claude Code, Claude Cowork, Cursor, Codex, OpenCode, Antigravity & Kimi Code
 
-Add persistent memory to your AI workflows. Store, retrieve, and manage memories across sessions using the Mem0 Platform. Works with **Claude Code** (CLI), **Claude Cowork** (desktop app), **Cursor**, **Codex**, **OpenCode**, and **Antigravity**.
+Add persistent memory to your AI workflows. Store, retrieve, and manage memories across sessions using the Mem0 Platform. Works with **Claude Code** (CLI), **Claude Cowork** (desktop app), **Cursor**, **Codex**, **OpenCode**, **Antigravity**, and **Kimi Code**.
 
 ## Quick path for agents
 
@@ -173,6 +173,45 @@ npx degit mem0ai/mem0/integrations/mem0-plugin ~/.gemini/config/plugins/mem0
 This installs the MCP server, lifecycle hooks, and shared scripts.
 
 See [Antigravity integration docs](https://docs.mem0.ai/integrations/antigravity) for full details.
+
+### Kimi Code
+
+**Option A — install from GitHub** (recommended):
+
+```bash
+# In Kimi Code
+/plugins install https://github.com/mem0ai/mem0
+/plugins reload
+```
+
+**Option B — install from a local clone:**
+
+```bash
+git clone https://github.com/mem0ai/mem0.git
+# In Kimi Code
+/plugins install ./mem0/integrations/mem0-plugin
+/plugins reload
+```
+
+Set `MEM0_API_KEY` in your shell before installing — the manifest wires it through
+`bearerTokenEnvVar`, so no manual MCP configuration is needed.
+
+The plugin registers the Mem0 MCP server plus all 16 skills. `context-loader` is
+declared under `sessionStart`, so relevant memories load automatically at the start
+of every session without an explicit prompt.
+
+> **Why there are two manifests.** Kimi resolves a plugin's root from the install source,
+> and has no way to point at a subdirectory of a GitHub repo — `/plugins marketplace` takes
+> a direct URL to a hosted JSON catalog rather than scanning a repo, and a GitHub install
+> looks for the manifest at the archive root only. So Option A needs
+> `.kimi-plugin/plugin.json` at the repo root (its `skills` points back into
+> `integrations/mem0-plugin/skills/`), while Option B uses
+> `integrations/mem0-plugin/.kimi-plugin/plugin.json` alongside the other hosts. The two
+> files are identical apart from that one path — keep them in sync when bumping `version`.
+
+> Lifecycle hooks are not wired for Kimi Code yet. Kimi declares `hooks` as an array
+> rather than the event-keyed object the other hosts use; auto-capture will land once
+> that mapping is confirmed.
 
 ## Post-Installation: Run `/mem0:onboard`
 

--- a/integrations/mem0-plugin/scripts/kimi_hook_shim.sh
+++ b/integrations/mem0-plugin/scripts/kimi_hook_shim.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Kimi Code hook adapter.
+#
+# Kimi Code's hook contract is close to Claude Code's but differs in four ways
+# that the mem0 hook scripts care about. Rather than fork nine scripts, every
+# Kimi hook entry in .kimi-plugin/plugin.json routes through this shim.
+#
+#   1. cwd     Kimi runs hook commands with cwd forced to the PLUGIN root
+#              (agent-core-v2 src/app/plugin/manager.ts -> enabledHooks() sets
+#              `cwd: record.root`). The real project directory only arrives as
+#              the payload's `cwd` field. _project.sh resolves MEM0_PROJECT_ID
+#              from $PWD/`git remote`, so we chdir into the payload cwd first.
+#
+#   2. stdin   Kimi sends snake_case JSON like Claude, but:
+#                - `prompt` is a ContentPart[] array, not a string
+#                - PostToolUse sends `tool_output`, not `tool_response`
+#                - file tools use `tool_input.path`, not `tool_input.file_path`
+#                - plugin MCP tools are `mcp__plugin-mem0_mem0__*` (hyphen),
+#                  not Claude's `mcp__plugin_mem0_mem0__*`
+#                - there is NO `transcript_path` (no equivalent exists)
+#              We normalise the first four into the Claude shape.
+#
+#   3. stdout  Kimi's hook stdout parser (agent-core-v2
+#              src/agent/externalHooks/runner.ts -> HookJsonOutputSchema) only
+#              understands top-level `message`, `hookSpecificOutput.message`,
+#              `hookSpecificOutput.permissionDecision` and
+#              `hookSpecificOutput.permissionDecisionReason`.
+#              `additionalContext` and `updatedInput` are NOT recognised.
+#              Raw (non-JSON) stdout IS appended to context for UserPromptSubmit
+#              (user-prompt.ts -> userPromptHookMessage falls back to stdout), so
+#              we unwrap additionalContext into plain text.
+#
+#   4. exit    Same as Claude: 0 = allow, 2 = block (stderr is the reason),
+#              any other code / timeout = fail-open.
+#
+# Usage: kimi_hook_shim.sh <script-name.sh> [args...]
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+[ $# -ge 1 ] || exit 0
+TARGET_NAME="$1"
+shift
+TARGET="$SCRIPT_DIR/$TARGET_NAME"
+[ -f "$TARGET" ] || exit 0
+
+# Telemetry attribution (telemetry.py::detect_platform honours MEM0_PLATFORM).
+export MEM0_PLATFORM="${MEM0_PLATFORM:-kimi}"
+
+RAW=$(cat)
+
+_TMP_BASE="${TMPDIR:-/tmp}"
+IN_FILE="$_TMP_BASE/mem0_kimi_in_$$"
+OUT_FILE="$_TMP_BASE/mem0_kimi_out_$$"
+trap 'rm -f "$IN_FILE" "$OUT_FILE"' EXIT
+
+HAVE_JQ=""
+command -v jq >/dev/null 2>&1 && HAVE_JQ="true"
+
+# ---------------------------------------------------------------- stdin shape
+NORM=""
+if [ -n "$HAVE_JQ" ]; then
+  NORM=$(printf '%s' "$RAW" | jq -c '
+    def flat_prompt:
+      if type == "array" then
+        [ .[]? | if type == "object" then (.text // "") elif type == "string" then . else "" end ]
+        | map(select(. != "")) | join("\n")
+      elif type == "string" then .
+      else "" end;
+    . as $in
+    | (if has("prompt") then .prompt = ($in.prompt | flat_prompt) else . end)
+    | (if (has("tool_response") | not) and (.tool_output != null)
+         then .tool_response = .tool_output else . end)
+    | (if ((.tool_input | type) == "object") and (.tool_input.file_path == null) and (.tool_input.path != null)
+         then .tool_input.file_path = .tool_input.path else . end)
+    | (if ((.tool_name | type) == "string") and (.tool_name | startswith("mcp__")) and (.tool_name | test("mem0"))
+         then .tool_name = (.tool_name | gsub("-"; "_")) else . end)
+  ' 2>/dev/null)
+fi
+[ -n "$NORM" ] || NORM="$RAW"
+
+printf '%s' "$NORM" >"$IN_FILE" 2>/dev/null || exit 0
+
+# ------------------------------------------------------------------- real cwd
+if [ -n "$HAVE_JQ" ]; then
+  PROJECT_CWD=$(printf '%s' "$NORM" | jq -r '.cwd // ""' 2>/dev/null || printf '')
+  if [ -n "$PROJECT_CWD" ] && [ -d "$PROJECT_CWD" ]; then
+    cd "$PROJECT_CWD" 2>/dev/null || true
+  fi
+fi
+
+# ------------------------------------------------------------------- dispatch
+# Redirect (not pipe) stdout so backgrounded children inside the hook scripts
+# cannot hold the shim open until Kimi's timeout fires.
+bash "$TARGET" "$@" <"$IN_FILE" >"$OUT_FILE"
+CODE=$?
+
+OUT=$(cat "$OUT_FILE" 2>/dev/null || printf '')
+
+# --------------------------------------------------------------- stdout shape
+if [ -n "$OUT" ] && [ -n "$HAVE_JQ" ] && printf '%s' "$OUT" | jq -e 'type == "object"' >/dev/null 2>&1; then
+  if printf '%s' "$OUT" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1; then
+    # Kimi understands deny natively — pass the envelope straight through.
+    printf '%s' "$OUT"
+  else
+    CTX=$(printf '%s' "$OUT" | jq -r '
+      (.hookSpecificOutput.additionalContext
+        // .additionalContext
+        // .message
+        // .hookSpecificOutput.message
+        // "")
+      | gsub("\\\\n"; "\n")' 2>/dev/null || printf '')
+    [ -n "$CTX" ] && printf '%s\n' "$CTX"
+  fi
+elif [ -n "$OUT" ]; then
+  printf '%s' "$OUT"
+fi
+
+exit $CODE

--- a/integrations/mem0-plugin/tests/test_kimi_manifests.py
+++ b/integrations/mem0-plugin/tests/test_kimi_manifests.py
@@ -1,0 +1,492 @@
+"""Kimi Code plugin manifest checks.
+
+Kimi is the only host that needs *two* copies of its manifest:
+
+* ``integrations/mem0-plugin/.kimi-plugin/plugin.json`` — sits alongside every
+  other host's manifest and serves ``/plugins install <local path>``.
+* ``.kimi-plugin/plugin.json`` at the repo root — serves
+  ``/plugins install https://github.com/mem0ai/mem0/tree/main``, because Kimi
+  looks for a manifest at the downloaded archive's root only and has no way to
+  be pointed at a subdirectory.
+
+That duplication is deliberate (see README, "Why there are two manifests"), but
+it is drift-prone, so these tests pin it down: the two files must stay identical
+apart from the paths that are necessarily plugin-root-relative (``skills`` and
+the script prefix inside ``hooks``), and both must satisfy the schema Kimi
+actually enforces in ``packages/agent-core-v2/src/app/plugin/manifest.ts``.
+
+Everything here is stdlib-only so it runs in mem0-plugin-checks.yml with no
+extra dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = PLUGIN_DIR.parents[1]
+
+ROOT_MANIFEST = REPO_ROOT / ".kimi-plugin" / "plugin.json"
+DIR_MANIFEST = PLUGIN_DIR / ".kimi-plugin" / "plugin.json"
+MARKETPLACE = REPO_ROOT / ".kimi-plugin" / "marketplace.json"
+
+# The fields allowed to differ between the two manifests. Both point at the same
+# skills directory and the same hook scripts, expressed relative to their own
+# plugin root ($KIMI_PLUGIN_ROOT is the directory holding `.kimi-plugin/`).
+KNOWN_DIFFERENT_FIELDS = {"skills", "hooks"}
+EXPECTED_SKILLS = {
+    ROOT_MANIFEST: "./integrations/mem0-plugin/skills/",
+    DIR_MANIFEST: "./skills/",
+}
+# The path segment each manifest inserts between $KIMI_PLUGIN_ROOT and scripts/.
+HOOK_PATH_PREFIX = {
+    ROOT_MANIFEST: "/integrations/mem0-plugin",
+    DIR_MANIFEST: "",
+}
+
+# agent/externalHooks/configSection.ts — HookDefSchema is `.strict()`, so any
+# unknown key makes readHooks drop the whole entry with a warning.
+HOOK_DEF_KEYS = {"event", "matcher", "command", "timeout"}
+HOOK_DEF_REQUIRED_KEYS = {"event", "command"}
+
+# agent/externalHooks/types.ts — HOOK_EVENT_TYPES.
+HOOK_EVENT_TYPES = {
+    "PreToolUse",
+    "PostToolUse",
+    "PostToolUseFailure",
+    "PermissionRequest",
+    "PermissionResult",
+    "UserPromptSubmit",
+    "UserPromptQueued",
+    "TurnStarted",
+    "Stop",
+    "StopFailure",
+    "Interrupt",
+    "SessionStart",
+    "SessionEnd",
+    "SessionHeartbeat",
+    "SubagentStart",
+    "SubagentStop",
+    "TaskStarted",
+    "PreCompact",
+    "PostCompact",
+    "Notification",
+}
+
+# Every Kimi hook is routed through the adapter, which reshapes Kimi's payload
+# into the Claude-shaped stdin the mem0 scripts expect and unwraps
+# hookSpecificOutput.additionalContext (which Kimi does not understand) back
+# into plain stdout. See scripts/kimi_hook_shim.sh.
+HOOK_SHIM = "kimi_hook_shim.sh"
+HOOK_COMMAND_RE = re.compile(
+    r'^"\$KIMI_PLUGIN_ROOT(?P<prefix>[^"]*)/scripts/'
+    + re.escape(HOOK_SHIM)
+    + r'"\s+(?P<target>[A-Za-z0-9_.-]+\.sh)$'
+)
+
+# Coverage parity with hooks/codex-hooks.json.
+EXPECTED_HOOK_SCRIPTS = {
+    "block_memory_write.sh",
+    "enforce_metadata_defaults.sh",
+    "on_file_read.sh",
+    "on_session_start.sh",
+    "on_user_prompt.sh",
+    "on_post_tool_use.sh",
+    "on_bash_output.sh",
+    "on_stop.sh",
+    "on_pre_compact.sh",
+}
+
+# manifest.ts:185 (types.ts) — PLUGIN_NAME_REGEX
+PLUGIN_NAME_REGEX = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+# manifest.ts:517-528 — readInterface reads exactly these keys and drops the rest.
+ALLOWED_INTERFACE_KEYS = {
+    "displayName",
+    "shortDescription",
+    "longDescription",
+    "developerName",
+    "websiteURL",
+}
+
+# manifest.ts:21-28 — UNSUPPORTED_RUNTIME_FIELDS
+UNSUPPORTED_RUNTIME_FIELDS = {
+    "tools",
+    "apps",
+    "inject",
+    "configFile",
+    "config_file",
+    "bootstrap",
+}
+
+# mcpCore/config-schema.ts — discriminated union on `transport`.
+MCP_TRANSPORTS = {"stdio", "http", "sse"}
+
+# The manifests of every host that ships from integrations/mem0-plugin and
+# carries a semver `version`. Kimi must not drift away from them.
+SIBLING_MANIFESTS = [
+    PLUGIN_DIR / ".claude-plugin" / "plugin.json",
+    PLUGIN_DIR / ".codex-plugin" / "plugin.json",
+    PLUGIN_DIR / ".cursor-plugin" / "plugin.json",
+]
+
+MANIFESTS = [ROOT_MANIFEST, DIR_MANIFEST]
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _plugin_root(manifest_path: Path) -> Path:
+    # pluginRoot is the directory containing `.kimi-plugin/`.
+    return manifest_path.parent.parent
+
+
+# --------------------------------------------------------------------------
+# Drift guard: the two manifests are one artifact stored twice.
+# --------------------------------------------------------------------------
+
+
+def test_both_manifests_exist():
+    for path in MANIFESTS:
+        assert path.is_file(), f"missing Kimi manifest: {path}"
+
+
+def test_manifests_differ_only_in_plugin_root_relative_paths():
+    # `skills` and the script prefix inside `hooks` are the same targets spelled
+    # relative to each manifest's own plugin root. Nothing else may diverge.
+    root = _load(ROOT_MANIFEST)
+    nested = _load(DIR_MANIFEST)
+
+    assert set(root) == set(nested), (
+        "Kimi manifests declare different fields. Keep "
+        f"{ROOT_MANIFEST.relative_to(REPO_ROOT)} and "
+        f"{DIR_MANIFEST.relative_to(REPO_ROOT)} in sync."
+    )
+
+    differing = {key for key in root if root[key] != nested[key]}
+    assert differing == KNOWN_DIFFERENT_FIELDS, (
+        f"Kimi manifests may only differ in {sorted(KNOWN_DIFFERENT_FIELDS)}, "
+        f"but these differ: {sorted(differing)}."
+    )
+
+
+def test_manifests_have_identical_key_order():
+    # Same artifact stored twice — keep them visually diffable.
+    assert list(_load(ROOT_MANIFEST)) == list(_load(DIR_MANIFEST))
+
+
+# --------------------------------------------------------------------------
+# Schema: what Kimi's parseManifest actually enforces.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("manifest_path", MANIFESTS, ids=lambda p: str(p.parent.parent.name))
+def test_manifest_is_a_json_object(manifest_path: Path):
+    assert isinstance(_load(manifest_path), dict)
+
+
+@pytest.mark.parametrize("manifest_path", MANIFESTS, ids=lambda p: str(p.parent.parent.name))
+def test_name_matches_kimi_regex(manifest_path: Path):
+    name = _load(manifest_path).get("name")
+    assert isinstance(name, str) and name.strip(), '"name" is required'
+    assert PLUGIN_NAME_REGEX.match(name.strip()), (
+        f'"name" must match {PLUGIN_NAME_REGEX.pattern} (got "{name}")'
+    )
+
+
+@pytest.mark.parametrize("manifest_path", MANIFESTS, ids=lambda p: str(p.parent.parent.name))
+def test_skills_path_resolves_inside_its_plugin_root(manifest_path: Path):
+    skills = _load(manifest_path)["skills"]
+    assert skills == EXPECTED_SKILLS[manifest_path]
+    # resolveDirListField: must start with "./", must be a directory, and must
+    # not escape the plugin root.
+    assert skills.startswith("./"), '"skills" path must start with "./"'
+    plugin_root = _plugin_root(manifest_path).resolve()
+    resolved = (plugin_root / skills).resolve()
+    assert resolved.is_dir(), f"skills path is not a directory: {resolved}"
+    assert os.path.commonpath([resolved, plugin_root]) == str(plugin_root), (
+        "skills path resolves outside the plugin root"
+    )
+
+
+def test_both_manifests_point_at_the_same_skills_directory():
+    resolved = {
+        (_plugin_root(path).resolve() / _load(path)["skills"]).resolve() for path in MANIFESTS
+    }
+    assert resolved == {(PLUGIN_DIR / "skills").resolve()}
+
+
+@pytest.mark.parametrize("manifest_path", MANIFESTS, ids=lambda p: str(p.parent.parent.name))
+def test_no_agents_directory_shadows_the_plugin_root(manifest_path: Path):
+    # manifest.ts:108-114 — when `agents` is unset, Kimi silently adopts an
+    # `agents/` directory at the plugin root. For the repo-root manifest that
+    # would be some unrelated top-level directory, so assert there is none.
+    manifest = _load(manifest_path)
+    if "agents" in manifest:
+        return
+    assert not (_plugin_root(manifest_path) / "agents").is_dir(), (
+        "an `agents/` directory at the plugin root would be auto-loaded by Kimi; "
+        "declare `agents` explicitly in the manifest"
+    )
+
+
+@pytest.mark.parametrize("manifest_path", MANIFESTS, ids=lambda p: str(p.parent.parent.name))
+def test_session_start_skill_exists(manifest_path: Path):
+    session_start = _load(manifest_path)["sessionStart"]
+    assert isinstance(session_start, dict)
+    skill = session_start.get("skill")
+    assert isinstance(skill, str) and skill.strip()
+    assert (PLUGIN_DIR / "skills" / skill / "SKILL.md").is_file(), (
+        f'sessionStart.skill "{skill}" has no SKILL.md'
+    )
+
+
+@pytest.mark.parametrize("manifest_path", MANIFESTS, ids=lambda p: str(p.parent.parent.name))
+def test_mcp_servers_are_inline_and_well_formed(manifest_path: Path):
+    # readMcpServers requires an object; a path string is dropped with a warning,
+    # which is why Kimi cannot reference .kimi-mcp.json the way Cursor/Codex do.
+    servers = _load(manifest_path)["mcpServers"]
+    assert isinstance(servers, dict), '"mcpServers" must be an inline object'
+    assert servers, '"mcpServers" must not be empty'
+    for name, config in servers.items():
+        assert name.strip(), "MCP server names must be non-empty"
+        assert isinstance(config, dict)
+        transport = config.get("transport")
+        assert transport in MCP_TRANSPORTS, (
+            f'MCP server "{name}": transport must be one of {sorted(MCP_TRANSPORTS)} '
+            f"(got {transport!r}); Kimi discriminates on `transport`, not `type`"
+        )
+        if transport in {"http", "sse"}:
+            assert isinstance(config.get("url"), str) and config["url"].startswith("http")
+            # Kimi passes `headers` through verbatim with no ${VAR} expansion, so
+            # credentials must go through bearerTokenEnvVar.
+            token_env = config.get("bearerTokenEnvVar")
+            assert isinstance(token_env, str) and token_env, (
+                f'MCP server "{name}": remote transports must authenticate via '
+                "bearerTokenEnvVar (headers are not interpolated)"
+            )
+            assert "${" not in json.dumps(config.get("headers", {})), (
+                f'MCP server "{name}": headers are not variable-expanded by Kimi'
+            )
+        else:
+            assert isinstance(config.get("command"), str) and config["command"]
+
+
+@pytest.mark.parametrize("manifest_path", MANIFESTS, ids=lambda p: str(p.parent.parent.name))
+def test_interface_only_uses_supported_keys(manifest_path: Path):
+    interface = _load(manifest_path).get("interface")
+    if interface is None:
+        return
+    assert isinstance(interface, dict)
+    unsupported = set(interface) - ALLOWED_INTERFACE_KEYS
+    assert not unsupported, (
+        f"Kimi's readInterface drops these keys: {sorted(unsupported)}. "
+        f"Supported keys: {sorted(ALLOWED_INTERFACE_KEYS)}."
+    )
+    for key, value in interface.items():
+        assert isinstance(value, str) and value.strip()
+
+
+@pytest.mark.parametrize("manifest_path", MANIFESTS, ids=lambda p: str(p.parent.parent.name))
+def test_no_unsupported_runtime_fields(manifest_path: Path):
+    present = set(_load(manifest_path)) & UNSUPPORTED_RUNTIME_FIELDS
+    assert not present, f"Kimi ignores these fields and warns about them: {sorted(present)}"
+
+
+@pytest.mark.parametrize("manifest_path", MANIFESTS, ids=lambda p: str(p.parent.parent.name))
+def test_hooks_are_an_inline_array(manifest_path: Path):
+    # readHooks warns and drops anything that is not an array, so a
+    # "hooks": "./hooks/kimi-hooks.json" reference (the Codex/Cursor style)
+    # would silently do nothing.
+    hooks = _load(manifest_path).get("hooks")
+    assert isinstance(hooks, list) and hooks, (
+        '"hooks" must be a non-empty inline array of {event, command} objects; '
+        "Kimi does not accept a path to a hooks file"
+    )
+
+
+@pytest.mark.parametrize("manifest_path", MANIFESTS, ids=lambda p: str(p.parent.parent.name))
+def test_hook_entries_satisfy_hook_def_schema(manifest_path: Path):
+    for index, hook in enumerate(_load(manifest_path)["hooks"]):
+        where = f"hooks[{index}]"
+        assert isinstance(hook, dict), f"{where}: entry must be an object"
+
+        unknown = set(hook) - HOOK_DEF_KEYS
+        assert not unknown, (
+            f"{where}: HookDefSchema is .strict(), so {sorted(unknown)} would make "
+            "readHooks drop this entry"
+        )
+        missing = HOOK_DEF_REQUIRED_KEYS - set(hook)
+        assert not missing, f"{where}: missing required key(s) {sorted(missing)}"
+
+        assert hook["event"] in HOOK_EVENT_TYPES, (
+            f"{where}: invalid event {hook['event']!r}; "
+            f"valid events: {sorted(HOOK_EVENT_TYPES)}"
+        )
+        assert isinstance(hook["command"], str) and len(hook["command"]) >= 1, (
+            f"{where}: command must be a non-empty string"
+        )
+        if "matcher" in hook:
+            assert isinstance(hook["matcher"], str), f"{where}: matcher must be a string"
+            # Kimi compiles the matcher with `new RegExp(...)` and treats a
+            # compile failure as "never matches".
+            re.compile(hook["matcher"])
+        if "timeout" in hook:
+            timeout = hook["timeout"]
+            assert isinstance(timeout, int) and not isinstance(timeout, bool), (
+                f"{where}: timeout must be an integer"
+            )
+            assert 1 <= timeout <= 600, f"{where}: timeout {timeout} is outside 1..600"
+
+
+@pytest.mark.parametrize("manifest_path", MANIFESTS, ids=lambda p: str(p.parent.parent.name))
+def test_hook_commands_resolve_to_executable_scripts(manifest_path: Path):
+    plugin_root = _plugin_root(manifest_path).resolve()
+    scripts_dir = PLUGIN_DIR / "scripts"
+    seen: set[str] = set()
+
+    for index, hook in enumerate(_load(manifest_path)["hooks"]):
+        where = f"hooks[{index}]"
+        match = HOOK_COMMAND_RE.match(hook["command"])
+        assert match, (
+            f"{where}: command must invoke the Kimi adapter as "
+            f'"$KIMI_PLUGIN_ROOT/<prefix>/scripts/{HOOK_SHIM}" <script.sh>, got '
+            f"{hook['command']!r}"
+        )
+        assert match.group("prefix") == HOOK_PATH_PREFIX[manifest_path], (
+            f"{where}: $KIMI_PLUGIN_ROOT is {plugin_root}, so the scripts prefix "
+            f"must be {HOOK_PATH_PREFIX[manifest_path]!r}"
+        )
+
+        target = match.group("target")
+        seen.add(target)
+        for path in (scripts_dir / HOOK_SHIM, scripts_dir / target):
+            assert path.is_file(), f"{where}: referenced script does not exist: {path}"
+            assert os.access(path, os.X_OK), f"{where}: script is not executable: {path}"
+            # The command is built from $KIMI_PLUGIN_ROOT, so it must live there.
+            assert os.path.commonpath([path.resolve(), plugin_root]) == str(plugin_root), (
+                f"{where}: {path} is outside the plugin root"
+            )
+
+    assert seen == EXPECTED_HOOK_SCRIPTS, (
+        "Kimi hook coverage must match hooks/codex-hooks.json; "
+        f"missing={sorted(EXPECTED_HOOK_SCRIPTS - seen)} "
+        f"extra={sorted(seen - EXPECTED_HOOK_SCRIPTS)}"
+    )
+
+
+@pytest.mark.parametrize("manifest_path", MANIFESTS, ids=lambda p: str(p.parent.parent.name))
+def test_hook_commands_are_unique(manifest_path: Path):
+    # externalHooksRunner/runner.ts dedups matched hooks on (cwd, command), and
+    # every plugin hook shares the plugin root as its cwd — two entries with the
+    # same command would silently collapse into one.
+    commands = [hook["command"] for hook in _load(manifest_path)["hooks"]]
+    duplicates = {cmd for cmd in commands if commands.count(cmd) > 1}
+    assert not duplicates, f"duplicate hook commands would be deduped by Kimi: {sorted(duplicates)}"
+
+
+def test_both_manifests_declare_the_same_hooks():
+    def normalise(manifest_path: Path) -> list[dict]:
+        prefix = HOOK_PATH_PREFIX[manifest_path]
+        return [
+            {
+                **hook,
+                "command": hook["command"].replace(
+                    f"$KIMI_PLUGIN_ROOT{prefix}/scripts/", "$PLUGIN/scripts/"
+                ),
+            }
+            for hook in _load(manifest_path)["hooks"]
+        ]
+
+    assert normalise(ROOT_MANIFEST) == normalise(DIR_MANIFEST), (
+        "the two Kimi manifests must declare identical hooks; only the "
+        "$KIMI_PLUGIN_ROOT-relative script prefix may differ"
+    )
+
+
+# --------------------------------------------------------------------------
+# Cross-host consistency.
+# --------------------------------------------------------------------------
+
+
+def test_version_matches_the_other_host_manifests():
+    kimi_version = _load(DIR_MANIFEST)["version"]
+    for sibling in SIBLING_MANIFESTS:
+        assert _load(sibling)["version"] == kimi_version, (
+            f"{sibling.relative_to(REPO_ROOT)} is at "
+            f"{_load(sibling)['version']} but the Kimi manifests are at "
+            f"{kimi_version}; bump all host manifests together"
+        )
+
+
+def test_shared_metadata_matches_the_other_host_manifests():
+    kimi = _load(DIR_MANIFEST)
+    for field in ("name", "homepage", "repository", "license", "keywords"):
+        for sibling in SIBLING_MANIFESTS:
+            other = _load(sibling)
+            if field not in other:
+                continue
+            if field == "keywords":
+                # Cursor carries one extra keyword; only require a shared core.
+                assert set(kimi[field]) <= set(other[field]) or set(other[field]) <= set(
+                    kimi[field]
+                ), f"{sibling.name}: keywords diverge from the Kimi manifest"
+                continue
+            assert other[field] == kimi[field], (
+                f"{sibling.relative_to(REPO_ROOT)}: {field} diverges from the Kimi manifest"
+            )
+
+
+# --------------------------------------------------------------------------
+# Marketplace catalog.
+# --------------------------------------------------------------------------
+
+
+def test_marketplace_catalog_matches_kimi_schema():
+    # apps/kimi-code/src/utils/plugin-marketplace.ts — parsePluginMarketplace /
+    # parseMarketplaceEntry. Note this schema differs from every other host's
+    # marketplace.json: entries key on `id`, and `source` must be a string.
+    catalog = _load(MARKETPLACE)
+    assert isinstance(catalog, dict)
+    plugins = catalog.get("plugins")
+    assert isinstance(plugins, list) and plugins, 'catalog must contain a "plugins" array'
+
+    manifest = _load(ROOT_MANIFEST)
+    for entry in plugins:
+        assert isinstance(entry, dict)
+        assert isinstance(entry.get("id"), str) and entry["id"].strip(), (
+            'each entry must define a string "id" (Kimi does not fall back to "name")'
+        )
+        source = entry.get("source")
+        assert isinstance(source, str), (
+            '"source" must be a string; the object form used by the Antigravity '
+            "and Codex catalogs is rejected by Kimi"
+        )
+        # resolveEntrySource resolves a relative source against the catalog URL,
+        # which for a raw.githubusercontent.com catalog yields a raw URL that
+        # resolveInstallSource would treat as a zip. Require an absolute URL.
+        assert source.startswith("https://github.com/"), (
+            "source must be an absolute github.com URL so resolveInstallSource "
+            "classifies it as a GitHub install"
+        )
+        # A bare repo URL installs the *latest release tag*, which for this repo
+        # is an unrelated SDK tag. Pin the ref explicitly.
+        assert re.match(r"^https://github\.com/[^/]+/[^/]+/(tree|releases/tag|commit)/", source), (
+            "pin the ref (/tree/<branch>, /releases/tag/<tag> or /commit/<sha>): a bare "
+            "repo URL resolves to github.com/mem0ai/mem0/releases/latest, which is an "
+            "unrelated SDK tag that does not contain the plugin manifest"
+        )
+        if "tier" in entry:
+            assert entry["tier"] in {"official", "curated"}
+        if "type" in entry:
+            assert entry["type"] in {"plugin", "managed", "guide"}
+        assert entry.get("id") == manifest["name"]
+        assert entry.get("version") == manifest["version"], (
+            "marketplace entry version must track the manifest version"
+        )


### PR DESCRIPTION
Adds [Kimi Code](https://github.com/MoonshotAI/kimi-code) (MoonshotAI) as a supported host for the Mem0 plugin.

Kimi Code's plugin system is close to Claude Code's, so all existing assets are reused unchanged — the same 16 skills, the same hosted MCP server. The only new artifacts are manifests.

> Note: this targets `MoonshotAI/kimi-code` (TypeScript), not `MoonshotAI/kimi-cli` (Python). The latter is a different, Beta plugin system for local executable tools and is [being wound down](https://github.com/MoonshotAI/kimi-cli#readme) in favour of Kimi Code.

## Changes

| File | Why |
|---|---|
| `integrations/mem0-plugin/.kimi-plugin/plugin.json` | New. Sits alongside the other hosts; serves local-path installs |
| `.kimi-plugin/plugin.json` | New. Repo root; serves GitHub-URL installs |
| `integrations/mem0-plugin/README.md` | Kimi Code install section + title/intro |

No changes to skills, scripts, hooks, or any other host's config.

## Why two manifests

The plugin-dir manifest follows the existing convention exactly:

```
integrations/mem0-plugin/
  .claude-plugin/plugin.json
  .cursor-plugin/plugin.json
  .codex-plugin/plugin.json
  .kimi-plugin/plugin.json     <- new,  skills: ./skills/
```

But Kimi resolves a plugin's root from the install source and **cannot be pointed at a subdirectory of a GitHub repo**:

- `resolveMarketplaceLocation` accepts only a direct `http(s)://` / `file://` / path to the catalog JSON. It never clones a repo and scans it, so there is no `.{host}-plugin/marketplace.json` indirection like Claude/Cursor/Codex use.
- `github-resolver.ts` resolves owner/repo/ref only — `/tree/<x>` selects a branch/tag/sha, not a path.
- `archive.ts` `hasManifest` checks the **archive root only**.

So a GitHub-URL install — the path the marketplace uses — needs a manifest at the repo root. That one points `skills` back into `./integrations/mem0-plugin/skills/`, which stays inside the plugin root and passes the containment check (`resolvePluginPathField` → `isWithin`).

The two files are identical apart from that one path. Flagged in the README as a sync point when bumping `version`.

## Other deviations from the existing pattern, and why

**MCP config is inlined** rather than referenced as `.kimi-mcp.json` the way Cursor and Codex do it. `readMcpServers` requires an object and silently drops a path string:

```js
if (!isObject(raw)) {
  diagnostics.push({ severity: 'warn', message: '"mcpServers" must be an object' });
  return undefined;
}
```

**No `hooks/kimi-hooks.json`.** Kimi declares `hooks` as an array rather than the event-keyed object used by Claude/Cursor/Codex, and the event names aren't documented. Omitted rather than guessed, since a malformed manifest produces diagnostics. Auto-capture will land in a follow-up once confirmed with the Kimi team; skills, MCP tools, and session-start context all work without it.

## Schema notes

Verified against [`MoonshotAI/kimi-code`](https://github.com/MoonshotAI/kimi-code) source, not just the docs:

- **`transport`, not `type`** — `mcpServers` is a `z.discriminatedUnion('transport', ...)` in `packages/klient/src/contract/mcp.ts`. A `type` field fails validation.
- **No `${VAR}` interpolation in `headers`** — `client-remote.ts` does `{ ...config.headers }` verbatim, so `"Authorization": "Token ${MEM0_API_KEY}"` would send that string literally. Auth uses `bearerTokenEnvVar`, which emits `Bearer <token>`. The Mem0 MCP server accepts Bearer for keys prefixed `m0-` (`mcp-server/src/auth.py`).
- **`author` takes only `name`/`email`** — `readAuthor` drops anything else.

## `sessionStart`

Kimi supports auto-loading a skill at session start, which the other hosts don't. Both manifests declare `context-loader`, so relevant memories load before the user types anything.

## Validation

Both manifests checked against the parser in `packages/agent-core/src/plugin/manifest.ts`:

- manifests found at `.kimi-plugin/plugin.json` from their respective plugin roots
- `name` matches `PLUGIN_NAME_REGEX`
- `transport: http` + valid https `url` + non-empty `bearerTokenEnvVar`
- `skills` starts with `./`, resolves within plugin root, 16 bundles discovered from both
- every bundle has `SKILL.md` with both `name` and `description` (required for directory-form skills, or parsing fails)
- `sessionStart.skill` resolves to an existing skill in both
- `interface` uses only the five supported fields
- none of `UNSUPPORTED_RUNTIME_FIELDS` present
- the two manifests differ in exactly one field (`skills`)

## Still to do before undrafting

- [ ] End-to-end install test in Kimi Code with a real `MEM0_API_KEY`
- [ ] Confirm with the Kimi team whether sourcing from this 61 MB monorepo is acceptable for a Curated marketplace listing, or whether they'd prefer a standalone repo (their curated examples — Superpowers, Vercel — are small dedicated repos)
- [ ] Hook event mapping

## Context

Following an intro from Tony Yu (MoonshotAI), who shared the plugin docs and offered technical support.