### PR TITLE
fix(ts-oss, py): release Oracle client on init failure, validate insert batches

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/oracledb.ts
+++ b/mem0-ts/src/oss/src/vector_stores/oracledb.ts
@@ -401,7 +401,15 @@ export class OracleAIVectorSearch implements VectorStore {
 
   async initialize(): Promise<void> {
     if (!this._initPromise) {
-      this._initPromise = this._doInitialize();
+      this._initPromise = this._doInitialize().catch(async (error) => {
+        if (this.ownsClient && this.client) {
+          await Promise.resolve(this.client.close()).catch(() => {});
+          this.client = undefined;
+          this.ownsClient = false;
+        }
+        this._initPromise = undefined;
+        throw error;
+      });
     }
     return this._initPromise;
   }
@@ -565,9 +573,16 @@ export class OracleAIVectorSearch implements VectorStore {
     ids: string[],
     payloads: Record<string, any>[],
   ): Promise<void> {
-    await this.initialize();
+    if (ids.length !== vectors.length) {
+      throw new Error("ids and vectors must have the same length");
+    }
+    if (payloads.length !== vectors.length) {
+      throw new Error("payloads and vectors must have the same length");
+    }
 
     if (vectors.length === 0) return;
+
+    await this.initialize();
 
     await this.withConnection(async (connection) => {
       await connection.executeMany(

--- a/mem0-ts/src/oss/tests/oracledb.unit.test.ts
+++ b/mem0-ts/src/oss/tests/oracledb.unit.test.ts
@@ -4,9 +4,17 @@ const DB_TYPE_VECTOR = { name: "DB_TYPE_VECTOR" };
 const DB_TYPE_JSON = { name: "DB_TYPE_JSON" };
 const DB_TYPE_VARCHAR = { name: "DB_TYPE_VARCHAR" };
 
+const mockCreatePool = jest.fn();
+
 jest.mock(
   "oracledb",
-  () => ({ thin: true, DB_TYPE_VECTOR, DB_TYPE_JSON, DB_TYPE_VARCHAR }),
+  () => ({
+    thin: true,
+    DB_TYPE_VECTOR,
+    DB_TYPE_JSON,
+    DB_TYPE_VARCHAR,
+    createPool: mockCreatePool,
+  }),
   { virtual: true },
 );
 
@@ -297,6 +305,17 @@ describe("OracleAIVectorSearch SQL", () => {
     );
   });
 
+  it("rejects insert batches whose IDs or payloads do not match vectors", async () => {
+    const store = makeStore([]);
+
+    await expect(store.insert([[1, 2, 3]], [], [{}])).rejects.toThrow(
+      "ids and vectors must have the same length",
+    );
+    await expect(store.insert([[1, 2, 3]], ["id-1"], [])).rejects.toThrow(
+      "payloads and vectors must have the same length",
+    );
+  });
+
   it("converts cosine distance to a similarity score", async () => {
     const calls: Call[] = [];
     const store = makeStore(calls, [[["id-1", { data: "hello" }, 0.25]]]);
@@ -391,5 +410,66 @@ describe("OracleAIVectorSearch SQL", () => {
     const [results, count] = await store.list();
     expect(results).toEqual([]);
     expect(count).toBe(0);
+  });
+});
+
+describe("OracleAIVectorSearch initialization failure", () => {
+  beforeEach(() => mockCreatePool.mockReset());
+
+  function fakePool(serverVersion: string) {
+    const connection = {
+      ...fakeConnection([], []),
+      oracleServerVersionString: serverVersion,
+    };
+    return {
+      close: jest.fn(async () => {}),
+      getConnection: jest.fn(async () => connection),
+    };
+  }
+
+  function makePoolStore() {
+    return new OracleAIVectorSearch({
+      connectionParams: { user: "u", password: "p", connectString: "d" },
+      collectionName: "mem0",
+      embeddingModelDims: 3,
+    } as any);
+  }
+
+  it("closes the pool it owns when initialization fails", async () => {
+    const pool = fakePool("23.3.0.24.05");
+    mockCreatePool.mockResolvedValue(pool);
+
+    await expect(makePoolStore().initialize()).rejects.toThrow(
+      "Oracle DB version 23.3.0.24.05 not supported",
+    );
+    expect(pool.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache the rejection, so a later attempt can succeed", async () => {
+    const failing = fakePool("23.3.0.24.05");
+    const working = fakePool("23.4.0.24.05");
+    mockCreatePool
+      .mockResolvedValueOnce(failing)
+      .mockResolvedValueOnce(working);
+
+    const store = makePoolStore();
+    await expect(store.initialize()).rejects.toThrow("not supported");
+    await expect(store.initialize()).resolves.toBeUndefined();
+    expect(mockCreatePool).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves a caller-supplied client open when initialization fails", async () => {
+    const client = fakeConnection([], []);
+    client.oracleServerVersionString = "23.3.0.24.05";
+    const close = jest.spyOn(client, "close");
+
+    const store = new OracleAIVectorSearch({
+      client: client as any,
+      collectionName: "mem0",
+      embeddingModelDims: 3,
+    } as any);
+
+    await expect(store.initialize()).rejects.toThrow("not supported");
+    expect(close).not.toHaveBeenCalled();
   });
 });

--- a/mem0/vector_stores/oracledb.py
+++ b/mem0/vector_stores/oracledb.py
@@ -245,25 +245,34 @@ class OracleAIVectorSearch(VectorStoreBase):
             self.client = oracledb.connect(**self.config.connection_params)
             self._owns_client = True
 
-        if not (hasattr(self.client, "thin") and self.client.thin):
-            if oracledb.clientversion()[:2] < (23, 4):
-                raise RuntimeError(
-                    f"Oracle DB client driver version {'.'.join(map(str, oracledb.clientversion()))} "
-                    "not supported, must be >=23.4 for vector support"
+        try:
+            if not (hasattr(self.client, "thin") and self.client.thin):
+                if oracledb.clientversion()[:2] < (23, 4):
+                    raise RuntimeError(
+                        f"Oracle DB client driver version {'.'.join(map(str, oracledb.clientversion()))} "
+                        "not supported, must be >=23.4 for vector support"
+                    )
+
+            if isinstance(self.client, oracledb.Connection):
+                db_version = tuple([int(v) for v in self.client.version.split(".")])
+            else:
+                with self.client.acquire() as conn:
+                    db_version = tuple([int(v) for v in conn.version.split(".")])
+
+            if db_version < (23, 4):
+                raise ValueError(
+                    f"Oracle DB version {'.'.join(map(str, db_version))} not supported, "
+                    "must be >=23.4 for vector support"
                 )
 
-        if isinstance(self.client, oracledb.Connection):
-            db_version = tuple([int(v) for v in self.client.version.split(".")])
-        else:
-            with self.client.acquire() as conn:
-                db_version = tuple([int(v) for v in conn.version.split(".")])
-
-        if db_version < (23, 4):
-            raise ValueError(
-                f"Oracle DB version {'.'.join(map(str, db_version))} not supported, must be >=23.4 for vector support"
-            )
-
-        self.create_col()
+            self.create_col()
+        except Exception:
+            if self._owns_client:
+                try:
+                    self.client.close()
+                except Exception:
+                    pass
+            raise
 
     @contextmanager
     def _get_cursor(self, commit: bool = False):

--- a/tests/vector_stores/test_oracledb.py
+++ b/tests/vector_stores/test_oracledb.py
@@ -331,6 +331,27 @@ def test_config_rejects_none_for_non_optional_fields(field, value):
         OracleAIVectorSearchConfig(client=object(), **{field: value})
 
 
+def test_init_closes_owned_client_when_post_connect_setup_fails(monkeypatch):
+    fake_connection = MagicMock(spec=oracledb.Connection)
+    fake_connection.thin = True
+    fake_connection.version = "23.4.0.0"
+
+    monkeypatch.setattr(oracledb, "connect", MagicMock(return_value=fake_connection))
+    monkeypatch.setattr(OracleAIVectorSearch, "create_col", MagicMock(side_effect=RuntimeError("boom")))
+    monkeypatch.setattr(OracleAIVectorSearch, "__del__", lambda self: None)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        OracleAIVectorSearch(
+            collection_name=_unique_collection_name(),
+            embedding_model_dims=DIM,
+            connection_params={"user": "u", "password": "p", "dsn": "d"},
+            use_connection_pool=False,
+            do_create_index=False,
+        )
+
+    fake_connection.close.assert_called_once()
+
+
 @pytest.mark.parametrize(
     ("metric", "distance", "expected_score"),
     [


### PR DESCRIPTION
## Linked Issue

Follow-up to review feedback on #6835 (no separate issue — these are review comments from @sudarshan-oracle on the merged Oracle vector store PR).

## Description

Two failure-handling gaps raised in review of #6835, plus the Python parity fix for the same class of bug.

### TypeScript (`mem0-ts/src/oss/src/vector_stores/oracledb.ts`)

**1. Initialization failure leaked the client and was permanently cached.**

`initialize()` memoizes `_initPromise`. If `_doInitialize()` failed after creating the pool/connection but before finishing (e.g. `assertVectorSupport()` rejects an older server, or `createCol()` hits a DDL error), two things went wrong:

- the owned pool/connection was never closed, leaking sockets and pool slots;
- the rejected promise stayed cached, so every subsequent call re-threw the original error and the store could never recover.

Now the failure path closes the client we own, resets `client`/`ownsClient`, clears `_initPromise` so a retry can re-initialize, and rethrows the original error. A failure from `close()` is swallowed so it can't mask the real cause. A caller-supplied client is left open, since we don't own its lifecycle.

**2. `insert()` did not validate batch lengths.**

Mismatched `ids`/`payloads` silently inserted `undefined` ids and `{}` payloads rather than failing. Lengths are now checked up front. An empty batch also short-circuits before `initialize()`, so a no-op insert no longer forces a connection.

### Python (`mem0/vector_stores/oracledb.py`)

Same class of bug on the init path. `__init__` is eager: it creates the pool/connection (setting `_owns_client = True`), then runs the client-version check, the DB-version check, and `create_col()`. A failure in any of those left cleanup to `__del__`, which depends on GC timing and is unreliable at interpreter shutdown. Those steps are now wrapped so an owned client is closed deterministically before the original exception propagates. `__del__` is unchanged and still covers the normal object-lifetime case.

Python's `insert()` already validated id/payload counts against vector count, so item 2 needed no Python change — the TS fix brings TypeScript to parity.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. `insert()` now raises on mismatched batch lengths instead of silently writing bad rows — that path was already corrupt data, and it matches the Python SDK's long-standing behaviour.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

**TypeScript** — `mem0-ts/src/oss/tests/oracledb.unit.test.ts`, 4 new tests:

- rejects insert batches whose IDs or payloads do not match vectors
- closes the pool it owns when initialization fails
- does not cache the rejection, so a later attempt can succeed
- leaves a caller-supplied client open when initialization fails

**Python** — `tests/vector_stores/test_oracledb.py`: `test_init_closes_owned_client_when_post_connect_setup_fails` asserts the owned connection is closed and the original exception propagates when `create_col()` raises.

### Verification

```
# TypeScript
npx jest src/oss/tests/oracledb.unit.test.ts   → 45 passed, 45 total
npx prettier --check <changed files>           → All matched files use Prettier code style!
npx tsc --noEmit                               → no errors in oracledb files
pnpm run build                                 → DTS build success

# Python
pytest tests/vector_stores/test_oracledb.py -q → 55 passed, 27 skipped
ruff check / ruff format --check               → All checks passed / already formatted
```

Both new test groups were confirmed to fail against the unfixed source: reverting only `oracledb.ts` drops the TS suite to `3 failed, 42 passed`, and reverting only `oracledb.py` fails the Python test with `Expected 'close' to have been called once. Called 0 times.`

The 27 Python skips are `@requires_oracle_credentials` tests that need a live Oracle DB.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (no public API surface changed)
