### PR TITLE
fix(vector-stores/pgvector): use bare raise in psycopg2 path

### DIFF
--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -246,7 +246,7 @@ class PGVector(VectorStoreBase):
             except Exception as exc:
                 conn.rollback()
                 logger.error(f"Error occurred: {exc}")
-                raise exc
+                raise
             finally:
                 cur.close()
                 self.connection_pool.putconn(conn)


### PR DESCRIPTION
## Linked Issue

Closes #6731 

## Description

The psycopg2 code path in `PGVector._get_cursor()` re-raised the caught exception
with `raise exc` instead of a bare `raise`.

Both forms preserve the original traceback — the exception object carries its own
`__traceback__`, so the origin frame survives either way. The actual defect is that
`raise exc` inserts an extra frame at the re-raise site, adding noise between the
caller and the DB call that actually failed:

```
raise exc    frames=4 -> [('<module>', 20), ('wrapper', 10), ('wrapper', 8), ('origin', 4)]
bare raise   frames=3 -> [('<module>', 20), ('wrapper', 14), ('origin', 4)]
```

This changes it to a bare `raise`, which matches the psycopg3 branch directly above
it (`mem0/vector_stores/pgvector.py:237`) and is the form Ruff enforces via `TRY201`.

One line changed; the `except Exception as exc:` binding is retained because the
`logger.error(f"Error occurred: {exc}")` call above still uses it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [x] No tests needed (explain why)

Verified the semantics with a standalone stdlib reproduction of the same
try/except/re-raise shape, confirming that bare `raise` drops the redundant
re-raise frame while keeping the origin frame (`origin:4`) intact in both cases.

No new tests are included because there is no behavioral change to assert on: the
same exception instance propagates to the caller with the same type, message, and
origin frame. Only the intermediate frame count differs, which no existing test
depends on. Existing `tests/vector_stores/test_pgvector.py` continues to pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works — N/A, no behavioral change
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed — N/A, internal error-handling only