### PR TITLE
fix(sdk-python): fallback __version__ when distribution metadata is absent

### DIFF
--- a/mem0/__init__.py
+++ b/mem0/__init__.py
@@ -1,6 +1,9 @@
 import importlib.metadata
 
-__version__ = importlib.metadata.version("mem0ai")
+try:
+    __version__ = importlib.metadata.version("mem0ai")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
 
 from mem0.client.main import AsyncMemoryClient, MemoryClient  # noqa
 from mem0.memory.main import AsyncMemory, Memory  # noqa

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,26 @@
+"""Regression tests for mem0 package initialization."""
+
+import importlib
+import importlib.metadata
+import sys
+
+
+def test_version_fallback_when_distribution_metadata_missing(monkeypatch):
+    """mem0 falls back to a sentinel version without installed dist metadata."""
+    real_version = importlib.metadata.version
+
+    def fake_version(distribution_name):
+        if distribution_name == "mem0ai":
+            raise importlib.metadata.PackageNotFoundError(distribution_name)
+        return real_version(distribution_name)
+
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+
+    cached_mem0 = sys.modules.pop("mem0", None)
+    try:
+        imported = importlib.import_module("mem0")
+        assert imported.__version__ == "0.0.0+unknown"
+    finally:
+        sys.modules.pop("mem0", None)
+        if cached_mem0 is not None:
+            sys.modules["mem0"] = cached_mem0


### PR DESCRIPTION
Resolves #6810.

## Problem

`mem0/__init__.py` reads the package version from installed distribution metadata with no fallback:

```python
import importlib.metadata

__version__ = importlib.metadata.version("mem0ai")
```

When the package is imported from a source checkout (without `pip install mem0ai`), this raises `PackageNotFoundError` at the very first import. The result is that:

- `pytest tests/` cannot collect a single test, even though `pyproject.toml` explicitly configures `pythonpath = ["."]` for this workflow.
- `make install_all` installs every optional dependency but not `mem0ai` itself, so the documented "clone → install deps → run tests" path lands in a broken state.
- Any vendored or zip-imported copy of the source fails identically.

## Fix

Wrap the metadata lookup in a `try/except` and fall back to the sentinel `"0.0.0+unknown"` when the distribution is not installed. The rest of `__init__.py` (and every downstream consumer) continues to see a valid `__version__` string.

```python
try:
    __version__ = importlib.metadata.version("mem0ai")
except importlib.metadata.PackageNotFoundError:
    __version__ = "0.0.0+unknown"
```

This is the standard pattern used across mature Python packages for source-tree imports.

## Test

Adds `tests/test_init.py::test_version_fallback_when_distribution_metadata_missing` — monkeypatches `importlib.metadata.version` to raise for `mem0ai`, evicts `mem0` from `sys.modules`, re-imports, and asserts `__version__ == "0.0.0+unknown"`. The test does not depend on the rest of the package, so it runs under the exact source-tree configuration the bug report describes.