### PR TITLE
fix(vector_stores/azure_ai_search): raise on failed IndexingResult

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -169,6 +169,35 @@ class AzureAISearch(VectorStoreBase):
                 document[field] = payload[field]
         return document
 
+    @staticmethod
+    def _assert_indexing_succeeded(
+        doc, operation: str, expected_status: Optional[int] = None, fallback_id: Optional[str] = None
+    ):
+        """Raise if an Azure IndexingResult (object or dict) did not succeed.
+
+        Prefers the SDK ``succeeded`` attribute (matching the TypeScript client),
+        then falls back to ``status_code`` when ``succeeded`` is absent.
+        """
+        if isinstance(doc, dict):
+            succeeded = doc.get("succeeded")
+            status_code = doc.get("status_code")
+            key = doc.get("key") or doc.get("id") or fallback_id
+            error_message = doc.get("error_message") or doc.get("errorMessage") or doc
+        else:
+            succeeded = getattr(doc, "succeeded", None)
+            status_code = getattr(doc, "status_code", None)
+            key = getattr(doc, "key", None) or getattr(doc, "id", None) or fallback_id
+            error_message = getattr(doc, "error_message", None) or getattr(doc, "errorMessage", None) or doc
+
+        if succeeded is None and status_code is not None:
+            if expected_status is not None:
+                succeeded = status_code == expected_status
+            else:
+                succeeded = 200 <= int(status_code) < 300
+
+        if not succeeded:
+            raise Exception(f"{operation} failed for document {key}: {error_message}")
+
     # Note: Explicit "insert" calls may later be decoupled from memory management decisions.
     def insert(self, vectors, payloads=None, ids=None):
         """
@@ -185,8 +214,7 @@ class AzureAISearch(VectorStoreBase):
         ]
         response = self.search_client.upload_documents(documents)
         for doc in response:
-            if not hasattr(doc, "status_code") and doc.get("status_code") != 201:
-                raise Exception(f"Insert failed for document {doc.get('id')}: {doc}")
+            self._assert_indexing_succeeded(doc, "Insert", expected_status=201)
         return response
 
     def _sanitize_key(self, key: str) -> str:
@@ -205,8 +233,7 @@ class AzureAISearch(VectorStoreBase):
                 condition = f"{safe_key} eq {value}"
             else:
                 raise ValueError(
-                    f"Filter value for {key!r} must be str, int, float, or bool, "
-                    f"got {type(value).__name__}"
+                    f"Filter value for {key!r} must be str, int, float, or bool, got {type(value).__name__}"
                 )
             filter_conditions.append(condition)
         filter_expression = " and ".join(filter_conditions)
@@ -290,8 +317,7 @@ class AzureAISearch(VectorStoreBase):
         """
         response = self.search_client.delete_documents(documents=[{"id": vector_id}])
         for doc in response:
-            if not hasattr(doc, "status_code") and doc.get("status_code") != 200:
-                raise Exception(f"Delete failed for document {vector_id}: {doc}")
+            self._assert_indexing_succeeded(doc, "Delete", expected_status=200, fallback_id=vector_id)
         logger.info(f"Deleted document with ID '{vector_id}' from index '{self.index_name}'.")
         return response
 
@@ -314,8 +340,7 @@ class AzureAISearch(VectorStoreBase):
                 document[field] = payload.get(field)
         response = self.search_client.merge_or_upload_documents(documents=[document])
         for doc in response:
-            if not hasattr(doc, "status_code") and doc.get("status_code") != 200:
-                raise Exception(f"Update failed for document {vector_id}: {doc}")
+            self._assert_indexing_succeeded(doc, "Update", expected_status=200, fallback_id=vector_id)
         return response
 
     def get(self, vector_id) -> OutputData:

--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -170,6 +170,20 @@ class AzureAISearch(VectorStoreBase):
         return document
 
     @staticmethod
+    def _indexing_result_field(doc, *names, default=None):
+        """Read the first present field from an IndexingResult dict or SDK object."""
+        if isinstance(doc, dict):
+            for name in names:
+                if name in doc and doc[name] is not None:
+                    return doc[name]
+            return default
+        for name in names:
+            value = getattr(doc, name, None)
+            if value is not None:
+                return value
+        return default
+
+    @staticmethod
     def _assert_indexing_succeeded(
         doc, operation: str, expected_status: Optional[int] = None, fallback_id: Optional[str] = None
     ):
@@ -178,25 +192,25 @@ class AzureAISearch(VectorStoreBase):
         Prefers the SDK ``succeeded`` attribute (matching the TypeScript client),
         then falls back to ``status_code`` when ``succeeded`` is absent.
         """
-        if isinstance(doc, dict):
-            succeeded = doc.get("succeeded")
-            status_code = doc.get("status_code")
-            key = doc.get("key") or doc.get("id") or fallback_id
-            error_message = doc.get("error_message") or doc.get("errorMessage") or doc
-        else:
-            succeeded = getattr(doc, "succeeded", None)
-            status_code = getattr(doc, "status_code", None)
-            key = getattr(doc, "key", None) or getattr(doc, "id", None) or fallback_id
-            error_message = getattr(doc, "error_message", None) or getattr(doc, "errorMessage", None) or doc
+        succeeded = AzureAISearch._indexing_result_field(doc, "succeeded")
+        status_code = AzureAISearch._indexing_result_field(doc, "status_code")
+        key = AzureAISearch._indexing_result_field(doc, "key", "id", default=fallback_id)
+        error_message = AzureAISearch._indexing_result_field(doc, "error_message", "errorMessage", default=doc)
 
         if succeeded is None and status_code is not None:
+            try:
+                code = int(status_code)
+            except (TypeError, ValueError):
+                raise RuntimeError(
+                    f"{operation} failed for document {key}: invalid status_code {status_code!r}; {error_message}"
+                ) from None
             if expected_status is not None:
-                succeeded = status_code == expected_status
+                succeeded = code == expected_status
             else:
-                succeeded = 200 <= int(status_code) < 300
+                succeeded = 200 <= code < 300
 
         if not succeeded:
-            raise Exception(f"{operation} failed for document {key}: {error_message}")
+            raise RuntimeError(f"{operation} failed for document {key}: {error_message}")
 
     # Note: Explicit "insert" calls may later be decoupled from memory management decisions.
     def insert(self, vectors, payloads=None, ids=None):

--- a/tests/vector_stores/test_azure_ai_search.py
+++ b/tests/vector_stores/test_azure_ai_search.py
@@ -449,7 +449,7 @@ def test_insert_with_error(azure_ai_search_instance):
     payloads = [{"user_id": "user1"}]
     ids = ["doc1"]
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(RuntimeError) as exc_info:
         instance.insert(vectors, payloads, ids)
 
     assert "Insert failed for document doc1" in str(exc_info.value)
@@ -465,7 +465,7 @@ def test_insert_with_error(azure_ai_search_instance):
     payloads = [{"user_id": "user1"}, {"user_id": "user2"}]
     ids = ["doc1", "doc2"]
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(RuntimeError) as exc_info:
         instance.insert(vectors, payloads, ids)
 
     assert "Insert failed for document doc2" in str(exc_info.value)
@@ -486,10 +486,22 @@ def test_insert_indexing_result_failure_raises(azure_ai_search_instance):
     mock_search_client.upload_documents.return_value = [
         _indexing_result(key="doc1", succeeded=False, status_code=400, error_message="quota exceeded")
     ]
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(RuntimeError) as exc_info:
         instance.insert([[0.1, 0.2, 0.3]], [{"user_id": "user1"}], ["doc1"])
     assert "Insert failed for document doc1" in str(exc_info.value)
     assert "quota exceeded" in str(exc_info.value)
+
+
+def test_insert_non_numeric_status_code_raises_runtime_error(azure_ai_search_instance):
+    """Non-numeric status_code must raise RuntimeError, not ValueError."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.upload_documents.return_value = [
+        {"id": "doc1", "status_code": "not-a-code", "error_message": "bad payload"}
+    ]
+    with pytest.raises(RuntimeError) as exc_info:
+        instance.insert([[0.1, 0.2, 0.3]], [{"user_id": "user1"}], ["doc1"])
+    assert "invalid status_code" in str(exc_info.value)
+    assert "not-a-code" in str(exc_info.value)
 
 
 def test_insert_with_missing_payload_fields(azure_ai_search_instance):
@@ -550,7 +562,7 @@ def test_delete_indexing_result_failure_raises(azure_ai_search_instance):
     mock_search_client.delete_documents.return_value = [
         _indexing_result(key="doc1", succeeded=False, status_code=404, error_message="not found")
     ]
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(RuntimeError) as exc_info:
         instance.delete("doc1")
     assert "Delete failed for document doc1" in str(exc_info.value)
     assert "not found" in str(exc_info.value)
@@ -572,7 +584,7 @@ def test_update_indexing_result_failure_raises(azure_ai_search_instance):
     mock_search_client.merge_or_upload_documents.return_value = [
         _indexing_result(key="doc1", succeeded=False, status_code=400, error_message="conflict")
     ]
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(RuntimeError) as exc_info:
         instance.update("doc1", vector=[0.1, 0.2, 0.3])
     assert "Update failed for document doc1" in str(exc_info.value)
     assert "conflict" in str(exc_info.value)

--- a/tests/vector_stores/test_azure_ai_search.py
+++ b/tests/vector_stores/test_azure_ai_search.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -8,6 +9,16 @@ from mem0.configs.vector_stores.azure_ai_search import AzureAISearchConfig
 
 # Import the AzureAISearch class and related models
 from mem0.vector_stores.azure_ai_search import AzureAISearch
+
+
+def _indexing_result(key="doc1", succeeded=True, status_code=201, error_message=None):
+    """Build an IndexingResult-like object (Azure SDK shape)."""
+    return SimpleNamespace(
+        key=key,
+        succeeded=succeeded,
+        status_code=status_code,
+        error_message=error_message,
+    )
 
 
 # Fixture to patch SearchClient and SearchIndexClient and create an instance of AzureAISearch.
@@ -30,12 +41,12 @@ def mock_clients():
 
         # Stub required methods on search_client.
         mock_search_client.upload_documents = Mock()
-        mock_search_client.upload_documents.return_value = [{"status": True, "id": "doc1"}]
+        mock_search_client.upload_documents.return_value = [_indexing_result(key="doc1", status_code=201)]
         mock_search_client.search = Mock()
         mock_search_client.delete_documents = Mock()
-        mock_search_client.delete_documents.return_value = [{"status": True, "id": "doc1"}]
+        mock_search_client.delete_documents.return_value = [_indexing_result(key="doc1", status_code=200)]
         mock_search_client.merge_or_upload_documents = Mock()
-        mock_search_client.merge_or_upload_documents.return_value = [{"status": True, "id": "doc1"}]
+        mock_search_client.merge_or_upload_documents.return_value = [_indexing_result(key="doc1", status_code=200)]
         mock_search_client.get_document = Mock()
         mock_search_client.close = Mock()
 
@@ -370,8 +381,7 @@ def test_insert_single(azure_ai_search_instance):
     payloads = [{"user_id": "user1", "run_id": "run1", "agent_id": "agent1"}]
     ids = ["doc1"]
 
-    # Fix: Include status_code: 201 in mock response
-    mock_search_client.upload_documents.return_value = [{"status": True, "id": "doc1", "status_code": 201}]
+    mock_search_client.upload_documents.return_value = [_indexing_result(key="doc1", status_code=201)]
 
     instance.insert(vectors, payloads, ids)
 
@@ -400,10 +410,7 @@ def test_insert_multiple(azure_ai_search_instance):
     payloads = [{"user_id": f"user{i}", "content": f"Test content {i}"} for i in range(num_docs)]
     ids = [f"doc{i}" for i in range(num_docs)]
 
-    # Configure mock to return success for all documents (fix: add status_code 201)
-    mock_search_client.upload_documents.return_value = [
-        {"status": True, "id": id_val, "status_code": 201} for id_val in ids
-    ]
+    mock_search_client.upload_documents.return_value = [_indexing_result(key=id_val, status_code=201) for id_val in ids]
 
     # Insert the documents
     instance.insert(vectors, payloads, ids)
@@ -433,36 +440,56 @@ def test_insert_with_error(azure_ai_search_instance):
     """Test insert when Azure returns an error for one or more documents."""
     instance, mock_search_client, _ = azure_ai_search_instance
 
-    # Configure mock to return an error for one document
-    mock_search_client.upload_documents.return_value = [{"status": False, "id": "doc1", "errorMessage": "Azure error"}]
+    # Dict-shaped failure (legacy / alternate mock shape)
+    mock_search_client.upload_documents.return_value = [
+        {"succeeded": False, "id": "doc1", "errorMessage": "Azure error", "status_code": 400}
+    ]
 
     vectors = [[0.1, 0.2, 0.3]]
     payloads = [{"user_id": "user1"}]
     ids = ["doc1"]
 
-    # Insert should raise an exception
     with pytest.raises(Exception) as exc_info:
         instance.insert(vectors, payloads, ids)
 
     assert "Insert failed for document doc1" in str(exc_info.value)
+    assert "Azure error" in str(exc_info.value)
 
-    # Configure mock to return mixed success/failure for multiple documents
+    # Mixed success/failure with IndexingResult-like objects
     mock_search_client.upload_documents.return_value = [
-        {"status": True, "id": "doc1"},  # This should not cause failure
-        {"status": False, "id": "doc2", "errorMessage": "Azure error"},
+        _indexing_result(key="doc1", succeeded=True, status_code=201),
+        _indexing_result(key="doc2", succeeded=False, status_code=400, error_message="Azure error"),
     ]
 
     vectors = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
     payloads = [{"user_id": "user1"}, {"user_id": "user2"}]
     ids = ["doc1", "doc2"]
 
-    # Insert should raise an exception, but now check for doc2 failure
     with pytest.raises(Exception) as exc_info:
         instance.insert(vectors, payloads, ids)
 
-    assert "Insert failed for document doc2" in str(exc_info.value) or "Insert failed for document doc1" in str(
-        exc_info.value
-    )
+    assert "Insert failed for document doc2" in str(exc_info.value)
+    assert "Azure error" in str(exc_info.value)
+
+
+def test_insert_indexing_result_success(azure_ai_search_instance):
+    """Insert succeeds when IndexingResult.succeeded is True."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.upload_documents.return_value = [_indexing_result(key="doc1", succeeded=True, status_code=201)]
+    instance.insert([[0.1, 0.2, 0.3]], [{"user_id": "user1"}], ["doc1"])
+    mock_search_client.upload_documents.assert_called_once()
+
+
+def test_insert_indexing_result_failure_raises(azure_ai_search_instance):
+    """Regression: SDK IndexingResult with succeeded=False must raise (not be ignored)."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.upload_documents.return_value = [
+        _indexing_result(key="doc1", succeeded=False, status_code=400, error_message="quota exceeded")
+    ]
+    with pytest.raises(Exception) as exc_info:
+        instance.insert([[0.1, 0.2, 0.3]], [{"user_id": "user1"}], ["doc1"])
+    assert "Insert failed for document doc1" in str(exc_info.value)
+    assert "quota exceeded" in str(exc_info.value)
 
 
 def test_insert_with_missing_payload_fields(azure_ai_search_instance):
@@ -472,10 +499,8 @@ def test_insert_with_missing_payload_fields(azure_ai_search_instance):
     payloads = [{"content": "Some content without user_id, run_id, or agent_id"}]
     ids = ["doc1"]
 
-    # Mock successful response with a proper status_code
-    mock_search_client.upload_documents.return_value = [
-        {"id": "doc1", "status_code": 201}  # Simulating a successful response
-    ]
+    # Dict success via status_code fallback (no succeeded key)
+    mock_search_client.upload_documents.return_value = [{"id": "doc1", "status_code": 201}]
 
     instance.insert(vectors, payloads, ids)
 
@@ -511,11 +536,55 @@ def test_insert_with_http_error(azure_ai_search_instance):
     assert "Azure service error" in str(exc_info.value)
 
 
+def test_delete_indexing_result_success(azure_ai_search_instance):
+    """Delete succeeds when IndexingResult.succeeded is True."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.delete_documents.return_value = [_indexing_result(key="doc1", succeeded=True, status_code=200)]
+    instance.delete("doc1")
+    mock_search_client.delete_documents.assert_called_once_with(documents=[{"id": "doc1"}])
+
+
+def test_delete_indexing_result_failure_raises(azure_ai_search_instance):
+    """Regression: delete IndexingResult with succeeded=False must raise."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.delete_documents.return_value = [
+        _indexing_result(key="doc1", succeeded=False, status_code=404, error_message="not found")
+    ]
+    with pytest.raises(Exception) as exc_info:
+        instance.delete("doc1")
+    assert "Delete failed for document doc1" in str(exc_info.value)
+    assert "not found" in str(exc_info.value)
+
+
+def test_update_indexing_result_success(azure_ai_search_instance):
+    """Update succeeds when IndexingResult.succeeded is True."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.merge_or_upload_documents.return_value = [
+        _indexing_result(key="doc1", succeeded=True, status_code=200)
+    ]
+    instance.update("doc1", vector=[0.1, 0.2, 0.3], payload={"user_id": "u1"})
+    mock_search_client.merge_or_upload_documents.assert_called_once()
+
+
+def test_update_indexing_result_failure_raises(azure_ai_search_instance):
+    """Regression: update IndexingResult with succeeded=False must raise."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.merge_or_upload_documents.return_value = [
+        _indexing_result(key="doc1", succeeded=False, status_code=400, error_message="conflict")
+    ]
+    with pytest.raises(Exception) as exc_info:
+        instance.update("doc1", vector=[0.1, 0.2, 0.3])
+    assert "Update failed for document doc1" in str(exc_info.value)
+    assert "conflict" in str(exc_info.value)
+
+
 def test_update_allows_empty_payload(azure_ai_search_instance):
     """Test updating with an empty payload explicitly clears stored payload data."""
     instance, mock_search_client, _ = azure_ai_search_instance
 
-    mock_search_client.merge_or_upload_documents.return_value = [{"status": True, "id": "doc1", "status_code": 200}]
+    mock_search_client.merge_or_upload_documents.return_value = [
+        _indexing_result(key="doc1", succeeded=True, status_code=200)
+    ]
 
     instance.update("doc1", payload={})
 
@@ -528,7 +597,9 @@ def test_update_allows_empty_vector(azure_ai_search_instance):
     """Test updating with an empty vector still sends the vector field to Azure."""
     instance, mock_search_client, _ = azure_ai_search_instance
 
-    mock_search_client.merge_or_upload_documents.return_value = [{"status": True, "id": "doc1", "status_code": 200}]
+    mock_search_client.merge_or_upload_documents.return_value = [
+        _indexing_result(key="doc1", succeeded=True, status_code=200)
+    ]
 
     instance.update("doc1", vector=[])
 
@@ -703,12 +774,14 @@ def test_build_filter_rejects_list_value(azure_ai_search_instance):
 
 def test_build_filter_accepts_scalars(azure_ai_search_instance):
     instance, _, _ = azure_ai_search_instance
-    expr = instance._build_filter_expression({
-        "user_id": "alice",
-        "count": 42,
-        "score": 0.95,
-        "active": True,
-    })
+    expr = instance._build_filter_expression(
+        {
+            "user_id": "alice",
+            "count": 42,
+            "score": 0.95,
+            "active": True,
+        }
+    )
     assert "user_id eq 'alice'" in expr
     assert "count eq 42" in expr
     assert "score eq 0.95" in expr


### PR DESCRIPTION
﻿## Linked Issue

Closes #6850

## Description

Azure AI Search `insert` / `update` / `delete` used an inverted success guard:

```python
if not hasattr(doc, "status_code") and doc.get("status_code") != 201:
    raise Exception(...)
```

The Azure SDK returns `IndexingResult` objects that **do** have `status_code`, so `not hasattr(...)` is always false and the exception never fires — including when `succeeded=False`. Failed writes looked successful to Mem0.

This PR adds `_assert_indexing_succeeded`, which:

1. Prefers the SDK `succeeded` flag (same idea as the TypeScript Azure client)
2. Falls back to `status_code` for dict-shaped results
3. Raises with the document key and Azure error message on failure

Wired into insert (expect 201), delete, and update (expect 200).

Unrelated to #6732 (`__del__` guard) and #6566 (wildcard filters).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — previously failed Azure indexing results were silently ignored. Callers that somehow depended on that silence will now see an exception when Azure reports failure, which is the intended contract.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

### How this was tested

No live Azure AI Search account was used. The failure mode is in the local success-check logic, so coverage is unit tests with a mocked `SearchClient` and `SimpleNamespace` objects shaped like Azure `IndexingResult` (`succeeded`, `status_code`, `key`, `error_message`).

**Regression tests added** in `tests/vector_stores/test_azure_ai_search.py`:

| Test | Asserts |
|------|---------|
| `test_insert_indexing_result_success` | `succeeded=True` → insert returns |
| `test_insert_indexing_result_failure_raises` | `succeeded=False` → raises (this fails on unfixed `main`) |
| `test_delete_indexing_result_success` / `_failure_raises` | same for delete |
| `test_update_indexing_result_success` / `_failure_raises` | same for update |

Also covered: mixed batch results, dict-shaped results (status_code path), and existing Azure AI Search tests.

**Commands run:**

```text
python -m pytest tests/vector_stores/test_azure_ai_search.py -q
# 33 passed
```

Reproduced the pre-fix behaviour with the same mock (`succeeded=False`, `status_code=400`): insert returned without raising. With the fix, it raises `Insert failed for document mem-1: ...`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
