### PR TITLE
fix(memory): reject boolean values for threshold in search parameter validation (#6854)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -221,7 +221,7 @@ def _validate_search_params(threshold: Optional[float] = None, top_k: Optional[i
         ValueError: If threshold or top_k are invalid
     """
     if threshold is not None:
-        if not isinstance(threshold, (int, float)):
+        if not isinstance(threshold, (int, float)) or isinstance(threshold, bool):
             raise ValueError("threshold must be a valid number")
         if threshold < 0 or threshold > 1:
             raise ValueError(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+
 import logging
 import os
 from unittest.mock import Mock, patch
@@ -512,6 +513,14 @@ class TestSearchParamValidation:
         """Search should reject negative threshold."""
         with pytest.raises(ValueError, match="Invalid threshold.*Must be between 0 and 1"):
             memory_instance.search("test query", filters={"user_id": "test"}, threshold=-0.5)
+
+    def test_search_rejects_boolean_threshold(self, memory_instance):
+        """Search should reject boolean threshold (True/False)."""
+        with pytest.raises(ValueError, match="threshold must be a valid number"):
+            memory_instance.search("test query", filters={"user_id": "test"}, threshold=True)
+
+        with pytest.raises(ValueError, match="threshold must be a valid number"):
+            memory_instance.search("test query", filters={"user_id": "test"}, threshold=False)
 
     def test_search_rejects_negative_top_k(self, memory_instance):
         """Search should reject negative top_k."""


### PR DESCRIPTION
## Linked Issue

Closes #6854

## Description

Fixes an inconsistency in `_validate_search_params` where boolean inputs (`threshold=True` or `threshold=False`) were silently accepted instead of raising a `ValueError`.

### Root Cause
In Python, `bool` is a subclass of `int` (`isinstance(True, (int, float))` evaluates to `True`). 

While line 232 explicitly guards `top_k` against boolean values (`or isinstance(top_k, bool)`), line 225 checked `if not isinstance(threshold, (int, float)):` without an equivalent boolean check. Consequently, boolean thresholds passed validation silently and got evaluated as numerical `1.0` or `0.0`.

### Changes Made
1. Added `or isinstance(threshold, bool)` to `_validate_search_params` in `mem0/memory/main.py`.
2. Added unit test `test_search_rejects_boolean_threshold` in `tests/test_main.py` verifying that `threshold=True` and `threshold=False` raise `ValueError("threshold must be a valid number")`.

### Affected Call Sites
This validation fix applies across all 4 search parameter validation entry points:
- `Memory.search()`
- `Memory.get_all()`
- `AsyncMemory.search()`
- `AsyncMemory.get_all()`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Ran full test suite locally:
- `pytest tests/test_main.py` (45 passed, including new `test_search_rejects_boolean_threshold`)
- `pytest tests/test_memory.py` (59 passed)
- `pytest tests/test_client.py tests/test_project.py` (48 passed)
- Verified live that `threshold=True` and `threshold=False` raise `ValueError("threshold must be a valid number")`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
