### PR TITLE
fix(vector_stores/azure_ai_search): raise on failed indexing results

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -169,6 +169,14 @@ class AzureAISearch(VectorStoreBase):
                 document[field] = payload[field]
         return document
 
+    @staticmethod
+    def _result_status_code(result):
+        """Return the HTTP status code from an IndexingResult object or a mapping."""
+        status_code = getattr(result, "status_code", None)
+        if status_code is None and hasattr(result, "get"):
+            status_code = result.get("status_code")
+        return status_code
+
     # Note: Explicit "insert" calls may later be decoupled from memory management decisions.
     def insert(self, vectors, payloads=None, ids=None):
         """
@@ -185,8 +193,9 @@ class AzureAISearch(VectorStoreBase):
         ]
         response = self.search_client.upload_documents(documents)
         for doc in response:
-            if not hasattr(doc, "status_code") and doc.get("status_code") != 201:
-                raise Exception(f"Insert failed for document {doc.get('id')}: {doc}")
+            if self._result_status_code(doc) != 201:
+                doc_id = doc.get("id") if hasattr(doc, "get") else getattr(doc, "key", None)
+                raise Exception(f"Insert failed for document {doc_id}: {doc}")
         return response
 
     def _sanitize_key(self, key: str) -> str:
@@ -290,7 +299,7 @@ class AzureAISearch(VectorStoreBase):
         """
         response = self.search_client.delete_documents(documents=[{"id": vector_id}])
         for doc in response:
-            if not hasattr(doc, "status_code") and doc.get("status_code") != 200:
+            if self._result_status_code(doc) != 200:
                 raise Exception(f"Delete failed for document {vector_id}: {doc}")
         logger.info(f"Deleted document with ID '{vector_id}' from index '{self.index_name}'.")
         return response
@@ -314,7 +323,7 @@ class AzureAISearch(VectorStoreBase):
                 document[field] = payload.get(field)
         response = self.search_client.merge_or_upload_documents(documents=[document])
         for doc in response:
-            if not hasattr(doc, "status_code") and doc.get("status_code") != 200:
+            if self._result_status_code(doc) != 200:
                 raise Exception(f"Update failed for document {vector_id}: {doc}")
         return response
 

--- a/tests/vector_stores/test_azure_ai_search.py
+++ b/tests/vector_stores/test_azure_ai_search.py
@@ -719,3 +719,103 @@ def test_build_filter_escapes_quotes(azure_ai_search_instance):
     instance, _, _ = azure_ai_search_instance
     expr = instance._build_filter_expression({"name": "O'Brien"})
     assert "name eq 'O''Brien'" in expr
+
+
+# --- Regression tests for IndexingResult status handling ---
+
+
+class _FakeIndexingResult:
+    """Mimic the azure.search.documents.models.IndexingResult attribute shape."""
+
+    def __init__(self, key, status_code, status=True, error_message=None):
+        self.key = key
+        self.status_code = status_code
+        self.status = status
+        self.error_message = error_message
+
+
+def test_insert_accepts_successful_sdk_results(azure_ai_search_instance):
+    """IndexingResult objects with a successful status_code must not raise."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.upload_documents.return_value = [_FakeIndexingResult("doc1", 201)]
+
+    instance.insert([[0.1, 0.2, 0.3]], [{"user_id": "user1"}], ["doc1"])
+
+    mock_search_client.upload_documents.assert_called_once()
+
+
+def test_insert_raises_on_failed_sdk_result(azure_ai_search_instance):
+    """A failed IndexingResult object must raise instead of being silently ignored."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.upload_documents.return_value = [
+        _FakeIndexingResult("doc1", 400, status=False, error_message="bad request")
+    ]
+
+    with pytest.raises(Exception) as exc_info:
+        instance.insert([[0.1, 0.2, 0.3]], [{"user_id": "user1"}], ["doc1"])
+
+    assert "Insert failed for document doc1" in str(exc_info.value)
+
+
+def test_update_accepts_successful_sdk_results(azure_ai_search_instance):
+    """IndexingResult objects with a successful status_code must not raise."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.merge_or_upload_documents.return_value = [_FakeIndexingResult("doc1", 200)]
+
+    instance.update("doc1", payload={"user_id": "user1"})
+
+    mock_search_client.merge_or_upload_documents.assert_called_once()
+
+
+def test_update_raises_on_failed_sdk_result(azure_ai_search_instance):
+    """A failed IndexingResult object must raise instead of being silently ignored."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.merge_or_upload_documents.return_value = [
+        _FakeIndexingResult("doc1", 500, status=False, error_message="server error")
+    ]
+
+    with pytest.raises(Exception) as exc_info:
+        instance.update("doc1", payload={"user_id": "user1"})
+
+    assert "Update failed for document doc1" in str(exc_info.value)
+
+
+def test_delete_accepts_successful_sdk_results(azure_ai_search_instance):
+    """IndexingResult objects with a successful status_code must not raise."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.delete_documents.return_value = [_FakeIndexingResult("doc1", 200)]
+
+    instance.delete("doc1")
+
+    mock_search_client.delete_documents.assert_called_once()
+
+
+def test_delete_raises_on_failed_sdk_result(azure_ai_search_instance):
+    """A failed IndexingResult object must raise instead of being silently ignored."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.delete_documents.return_value = [
+        _FakeIndexingResult("doc1", 404, status=False, error_message="not found")
+    ]
+
+    with pytest.raises(Exception) as exc_info:
+        instance.delete("doc1")
+
+    assert "Delete failed for document doc1" in str(exc_info.value)
+
+
+def test_failed_dict_results_raise_on_update_and_delete(azure_ai_search_instance):
+    """Mapping/dict results keep working: non-success status codes raise."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+    mock_search_client.merge_or_upload_documents.return_value = [{"status": False, "id": "doc1", "status_code": 409}]
+
+    with pytest.raises(Exception) as exc_info:
+        instance.update("doc1", payload={"user_id": "user1"})
+
+    assert "Update failed for document doc1" in str(exc_info.value)
+
+    mock_search_client.delete_documents.return_value = [{"status": False, "id": "doc1", "status_code": 404}]
+
+    with pytest.raises(Exception) as exc_info:
+        instance.delete("doc1")
+
+    assert "Delete failed for document doc1" in str(exc_info.value)


### PR DESCRIPTION
Fixes #6850

### Summary

- Handle Azure SDK `IndexingResult` objects and mapping results through one status-code helper.
- Raise on failed insert, update, and delete responses instead of silently treating them as successful.
- Add focused regression coverage for successful and failed SDK-shaped results and failed mappings.

### Verification

local verification not run; relying on upstream CI

The focused test collection requires the Azure SDK dependency, which is not installed in this fresh worktree.
