### PR TITLE
feat(ollama): support a configurable context window (#6857)

### DIFF
--- a/mem0/configs/llms/ollama.py
+++ b/mem0/configs/llms/ollama.py
@@ -23,6 +23,7 @@ class OllamaConfig(BaseLlmConfig):
         http_client_proxies: Optional[dict] = None,
         # Ollama-specific parameters
         ollama_base_url: Optional[str] = None,
+        num_ctx: Optional[int] = None,
     ):
         """
         Initialize Ollama configuration.
@@ -38,6 +39,10 @@ class OllamaConfig(BaseLlmConfig):
             vision_details: Vision detail level, defaults to "auto"
             http_client_proxies: HTTP client proxy settings, defaults to None
             ollama_base_url: Ollama base URL, defaults to None
+            num_ctx: Context window size (Ollama's `num_ctx` option), defaults to
+                None which leaves the model's own default in place. Pinning this
+                keeps the context size stable across calls, which avoids Ollama
+                reloading the model whenever the requested window changes.
         """
         # Initialize base parameters
         super().__init__(
@@ -54,3 +59,4 @@ class OllamaConfig(BaseLlmConfig):
 
         # Ollama-specific parameters
         self.ollama_base_url = ollama_base_url
+        self.num_ctx = num_ctx

--- a/mem0/llms/ollama.py
+++ b/mem0/llms/ollama.py
@@ -132,7 +132,15 @@ class OllamaLLM(LLMBase):
             "num_predict": self.config.max_tokens,
             "top_p": self.config.top_p,
         }
+        if self.config.num_ctx is not None:
+            options["num_ctx"] = self.config.num_ctx
+        # Per-call options refine the config-derived ones rather than replacing them.
+        options.update(kwargs.pop("options", None) or {})
         params["options"] = options
+
+        # Remaining kwargs are top-level ollama.Client.chat() parameters
+        # (e.g. keep_alive, think).
+        params.update(kwargs)
 
         # Remove OpenAI-specific parameters that Ollama doesn't support
         params.pop("max_tokens", None)  # Ollama uses different parameter names

--- a/tests/llms/test_ollama.py
+++ b/tests/llms/test_ollama.py
@@ -34,6 +34,61 @@ def test_generate_response_without_tools(mock_ollama_client):
     assert response == "I'm doing well, thank you for asking!"
 
 
+def test_generate_response_forwards_configured_num_ctx(mock_ollama_client):
+    """A configured context window reaches Ollama as the num_ctx option."""
+    config = OllamaConfig(model="llama3.1:70b", temperature=0.7, max_tokens=100, top_p=1.0, num_ctx=8192)
+    llm = OllamaLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_ollama_client.chat.return_value = {"message": {"content": "hi"}}
+    llm.generate_response(messages)
+
+    mock_ollama_client.chat.assert_called_once_with(
+        model="llama3.1:70b",
+        messages=messages,
+        options={"temperature": 0.7, "num_predict": 100, "top_p": 1.0, "num_ctx": 8192},
+    )
+
+
+def test_generate_response_omits_num_ctx_when_unset(mock_ollama_client):
+    """Without an explicit context window, Ollama keeps the model's own default."""
+    config = OllamaConfig(model="llama3.1:70b", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OllamaLLM(config)
+
+    mock_ollama_client.chat.return_value = {"message": {"content": "hi"}}
+    llm.generate_response([{"role": "user", "content": "Hello"}])
+
+    assert "num_ctx" not in mock_ollama_client.chat.call_args.kwargs["options"]
+
+
+def test_generate_response_merges_per_call_options(mock_ollama_client):
+    """Per-call options refine the config-derived ones instead of replacing them."""
+    config = OllamaConfig(model="llama3.1:70b", temperature=0.7, max_tokens=100, top_p=1.0, num_ctx=8192)
+    llm = OllamaLLM(config)
+
+    mock_ollama_client.chat.return_value = {"message": {"content": "hi"}}
+    llm.generate_response([{"role": "user", "content": "Hello"}], options={"num_ctx": 4096, "seed": 7})
+
+    assert mock_ollama_client.chat.call_args.kwargs["options"] == {
+        "temperature": 0.7,
+        "num_predict": 100,
+        "top_p": 1.0,
+        "num_ctx": 4096,
+        "seed": 7,
+    }
+
+
+def test_generate_response_forwards_extra_kwargs(mock_ollama_client):
+    """Documented Ollama-specific kwargs reach client.chat() instead of being dropped."""
+    config = OllamaConfig(model="llama3.1:70b", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OllamaLLM(config)
+
+    mock_ollama_client.chat.return_value = {"message": {"content": "hi"}}
+    llm.generate_response([{"role": "user", "content": "Hello"}], keep_alive="30m")
+
+    assert mock_ollama_client.chat.call_args.kwargs["keep_alive"] == "30m"
+
+
 def test_generate_response_with_tools_passes_tools_to_client(mock_ollama_client):
     """Tools should be forwarded to ollama client.chat()."""
     config = OllamaConfig(model="llama3.1:70b", temperature=0.1, max_tokens=100, top_p=1.0)


### PR DESCRIPTION
Fixes #6857.

## Problem

`OllamaConfig` exposes no way to set Ollama's context window. Ollama reloads a model whenever the requested `num_ctx` changes, so a caller who wants a stable context size — the load/unload thrashing described in #6857 — currently has to build a custom model file just to pin it.

The issue also suggests "just have a kwargs thing for ollama". That already exists in the signature but does nothing: `OllamaLLM.generate_response(..., **kwargs)` documents `**kwargs: Additional Ollama-specific parameters`, and the body never references `kwargs`. Every other provider in `mem0/llms/` forwards them (`openai`, `lmstudio`, `vllm`, `deepseek` via `_get_supported_params`, `together` via `params.update(kwargs)`); Ollama is the only one that drops them silently.

## Change

- `OllamaConfig` gains an optional `num_ctx`. When set it is forwarded as the `num_ctx` option; when left `None` the model's own default applies, so existing behaviour is unchanged.
- `generate_response` no longer discards `**kwargs`. A per-call `options` mapping *refines* the config-derived options instead of replacing them, and any remaining kwargs (`keep_alive`, `think`, …) are passed through to `ollama.Client.chat()`.

`num_ctx` flows through the normal config path, so this works from a plain config dict:

```python
config = {"llm": {"provider": "ollama", "config": {"model": "llama3.1:8b", "num_ctx": 16384}}}
# -> client.chat(..., options={'temperature': 0.1, 'num_predict': 2000, 'top_p': 0.1, 'num_ctx': 16384})
```

`top_k` is deliberately still not forwarded: `OllamaConfig` defaults it to `1`, so passing it through would silently make every Ollama call greedy. That is a separate question from this issue.

## Verification

Ran against `pip install mem0ai==2.0.17`, whose `mem0/llms/ollama.py`, `mem0/configs/llms/ollama.py`, `mem0/llms/base.py` and `mem0/configs/llms/base.py` are byte-identical to `main`, with the changed files copied over the installed package.

Four tests added to `tests/llms/test_ollama.py`. On `main` three of them fail (`num_ctx` is not an accepted config kwarg; per-call `options` and `keep_alive` never reach `client.chat()`); the fourth guards that `num_ctx` stays absent when unset and passes both before and after.

```
# main:      3 failed, 6 passed
# this branch: 9 passed
```

`uvx ruff@0.16.0 check` passes with the repo `pyproject.toml`. `ruff format --check` reports two pre-existing diffs in `mem0/llms/ollama.py` and `tests/llms/test_ollama.py` that are already present on `main` at the same lines; left untouched to avoid unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
