### PR TITLE
fix(embeddings): make OpenAI embed_batch size configurable

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -40,6 +40,8 @@ class BaseEmbedderConfig(ABC):
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
         aws_region: Optional[str] = None,
+        # Batch embedding
+        embedding_batch_size: Optional[int] = None,
     ):
         """
         Initializes a configuration class instance for the Embeddings.
@@ -72,6 +74,10 @@ class BaseEmbedderConfig(ABC):
         :type memory_search_embedding_type: Optional[str], optional
         :param lmstudio_base_url: LM Studio base URL to be use, defaults to "http://localhost:1234/v1"
         :type lmstudio_base_url: Optional[str], optional
+        :param embedding_batch_size: Max number of texts per embed_batch() request. Lets providers with
+            per-request limits below the embedder default (e.g. DashScope's 10) batch without HTTP 400s.
+            Defaults to None, which keeps the embedder's own default.
+        :type embedding_batch_size: Optional[int], optional
         """
 
         self.model = model
@@ -109,3 +115,9 @@ class BaseEmbedderConfig(ABC):
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_session_token = aws_session_token
         self.aws_region = aws_region or os.environ.get("AWS_REGION") or "us-west-2"
+
+        # Batch embedding: max texts per embed_batch() request. Some
+        # OpenAI-compatible providers cap this well below the OpenAI default of
+        # 100 (for example DashScope text-embedding-v4 allows 10), so it needs
+        # to be overridable. None keeps the embedder's own default.
+        self.embedding_batch_size = embedding_batch_size

--- a/mem0/embeddings/openai.py
+++ b/mem0/embeddings/openai.py
@@ -57,13 +57,16 @@ class OpenAIEmbedding(EmbeddingBase):
     def embed_batch(self, texts, memory_action="add"):
         """Embed multiple texts in a single OpenAI API call.
 
-        Automatically chunks into batches of 100 to stay within API limits.
+        Chunks into batches to stay within API limits. The batch size defaults
+        to 100 (OpenAI's limit) but can be lowered with
+        ``BaseEmbedderConfig.embedding_batch_size`` for OpenAI-compatible
+        providers that cap requests lower (for example DashScope allows 10).
         """
-        MAX_BATCH = 100
+        max_batch = self.config.embedding_batch_size or 100
         texts = [text.replace("\n", " ") for text in texts]
         all_embeddings = []
-        for i in range(0, len(texts), MAX_BATCH):
-            chunk = texts[i : i + MAX_BATCH]
+        for i in range(0, len(texts), max_batch):
+            chunk = texts[i : i + max_batch]
             kwargs = {
                 "input": chunk,
                 "model": self.config.model,

--- a/tests/embeddings/test_openai_embeddings.py
+++ b/tests/embeddings/test_openai_embeddings.py
@@ -149,3 +149,48 @@ def test_embed_batch_count_mismatch_raises(mock_openai_client):
 
     with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
         embedder.embed_batch(["first text", "second text"])
+
+
+def test_embed_batch_respects_configured_batch_size(mock_openai_client):
+    # DashScope text-embedding-v4 and similar OpenAI-compatible providers cap a
+    # request at 10 texts. With embedding_batch_size set, 11 texts must go out
+    # as two requests (10 + 1) instead of one oversized request that 400s.
+    config = BaseEmbedderConfig(embedding_batch_size=10)
+    embedder = OpenAIEmbedding(config)
+
+    def fake_create(**kwargs):
+        response = Mock()
+        response.data = [Mock(index=i, embedding=[float(i)]) for i in range(len(kwargs["input"]))]
+        return response
+
+    mock_openai_client.embeddings.create.side_effect = fake_create
+
+    result = embedder.embed_batch([f"text {i}" for i in range(11)])
+
+    assert mock_openai_client.embeddings.create.call_count == 2
+    call_args = mock_openai_client.embeddings.create.call_args_list
+    assert len(call_args[0].kwargs["input"]) == 10
+    assert len(call_args[1].kwargs["input"]) == 1
+    assert len(result) == 11
+
+
+def test_embed_batch_defaults_to_100(mock_openai_client):
+    # Without an override, the batch size stays at OpenAI's limit of 100, so
+    # 150 texts go out as two requests (100 + 50).
+    config = BaseEmbedderConfig()
+    embedder = OpenAIEmbedding(config)
+
+    def fake_create(**kwargs):
+        response = Mock()
+        response.data = [Mock(index=i, embedding=[float(i)]) for i in range(len(kwargs["input"]))]
+        return response
+
+    mock_openai_client.embeddings.create.side_effect = fake_create
+
+    result = embedder.embed_batch([f"text {i}" for i in range(150)])
+
+    assert mock_openai_client.embeddings.create.call_count == 2
+    call_args = mock_openai_client.embeddings.create.call_args_list
+    assert len(call_args[0].kwargs["input"]) == 100
+    assert len(call_args[1].kwargs["input"]) == 50
+    assert len(result) == 150


### PR DESCRIPTION
### What / why

`OpenAIEmbedding.embed_batch()` hardcodes the request batch size to 100:

```python
MAX_BATCH = 100
for i in range(0, len(texts), MAX_BATCH):
    ...
```

100 is OpenAI's own per-request limit, but several OpenAI-compatible providers cap it lower. DashScope `text-embedding-v4`, for example, accepts at most 10 texts per request. So an `embed_batch()` of 11 texts against DashScope goes out in a single call and comes back as HTTP 400. In the paths that catch a batch failure this also means an avoidable failed request followed by a slower per-text fallback, instead of correct provider-sized batching.

Reported in #6861.

### Change

- Add an optional `embedding_batch_size` to `BaseEmbedderConfig`.
- Use it in `embed_batch()` as `self.config.embedding_batch_size or 100`, so the default is unchanged and anyone can lower it to match their provider.

It is fully backward compatible: existing configs do not set the field, so they keep the 100 default. A falsy value (0 or None) also falls back to 100.

```python
from mem0.configs.embeddings.base import BaseEmbedderConfig
from mem0.embeddings.openai import OpenAIEmbedding

embedder = OpenAIEmbedding(
    BaseEmbedderConfig(
        model="text-embedding-v4",
        openai_base_url=DASHSCOPE_BASE_URL,
        embedding_batch_size=10,   # now batches 10 at a time
    )
)
embedder.embed_batch([f"text {i}" for i in range(11)])  # two requests: 10 + 1
```

### Tests

Added two tests to `tests/embeddings/test_openai_embeddings.py`:

- `test_embed_batch_respects_configured_batch_size`: with `embedding_batch_size=10`, 11 texts go out as two requests (10 then 1).
- `test_embed_batch_defaults_to_100`: without the override, 150 texts still go out as 100 + 50.

Note: the TypeScript OpenAI embedder in `mem0-ts` has the same hardcoded 100. I kept this PR to the Python SDK where the issue was reproduced; happy to follow up on the TS side in a separate PR if you'd like.
