### PR TITLE
fix(embeddings): make OpenAI batch size configurable

### DIFF
--- a/docs/components/embedders/models/openai.mdx
+++ b/docs/components/embedders/models/openai.mdx
@@ -61,6 +61,7 @@ Here are the parameters available for configuring OpenAI embedder:
 | --- | --- | --- |
 | `model` | The name of the embedding model to use | `text-embedding-3-small` |
 | `embedding_dims` | Dimensions of the embedding model | `1536` |
+| `batch_size` | Maximum number of texts sent in one embedding request | `100` |
 | `api_key` | The OpenAI API key | `None` |
 </Tab>
 <Tab title="TypeScript">

--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -16,6 +16,7 @@ class BaseEmbedderConfig(ABC):
         model: Optional[str] = None,
         api_key: Optional[str] = None,
         embedding_dims: Optional[int] = None,
+        batch_size: Optional[int] = None,
         # Ollama specific
         ollama_base_url: Optional[str] = None,
         # Openai specific
@@ -50,6 +51,8 @@ class BaseEmbedderConfig(ABC):
         :type api_key: Optional[str], optional
         :param embedding_dims: The number of dimensions in the embedding, defaults to None
         :type embedding_dims: Optional[int], optional
+        :param batch_size: Maximum number of texts to send in one embedding request, defaults to None
+        :type batch_size: Optional[int], optional
         :param ollama_base_url: Base URL for the Ollama API, defaults to None
         :type ollama_base_url: Optional[str], optional
         :param model_kwargs: key-value arguments for the huggingface embedding model, defaults a dict inside init
@@ -78,6 +81,11 @@ class BaseEmbedderConfig(ABC):
         self.api_key = api_key
         self.openai_base_url = openai_base_url
         self.embedding_dims = embedding_dims
+        if batch_size is not None and (
+            isinstance(batch_size, bool) or not isinstance(batch_size, int) or batch_size <= 0
+        ):
+            raise ValueError("batch_size must be a positive integer")
+        self.batch_size = batch_size
 
         # AzureOpenAI specific
         self.http_client_proxies = http_client_proxies

--- a/mem0/embeddings/openai.py
+++ b/mem0/embeddings/openai.py
@@ -17,6 +17,7 @@ class OpenAIEmbedding(EmbeddingBase):
         # OpenAI-compatible backends (vLLM, Voyage, etc.) reject the parameter
         self._pass_dimensions_to_api = self.config.embedding_dims is not None
         self.config.embedding_dims = self.config.embedding_dims or 1536
+        self.config.batch_size = self.config.batch_size or 100
 
         api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
         base_url = (
@@ -57,13 +58,12 @@ class OpenAIEmbedding(EmbeddingBase):
     def embed_batch(self, texts, memory_action="add"):
         """Embed multiple texts in a single OpenAI API call.
 
-        Automatically chunks into batches of 100 to stay within API limits.
+        Automatically chunks requests according to the configured batch size.
         """
-        MAX_BATCH = 100
         texts = [text.replace("\n", " ") for text in texts]
         all_embeddings = []
-        for i in range(0, len(texts), MAX_BATCH):
-            chunk = texts[i : i + MAX_BATCH]
+        for i in range(0, len(texts), self.config.batch_size):
+            chunk = texts[i : i + self.config.batch_size]
             kwargs = {
                 "input": chunk,
                 "model": self.config.model,

--- a/tests/embeddings/test_openai_embeddings.py
+++ b/tests/embeddings/test_openai_embeddings.py
@@ -139,6 +139,44 @@ def test_embed_batch_returns_all_embeddings(mock_openai_client):
     assert result == [[0.1, 0.2], [0.3, 0.4]]
 
 
+def test_embed_batch_respects_configured_batch_size(mock_openai_client):
+    config = BaseEmbedderConfig(batch_size=10)
+    embedder = OpenAIEmbedding(config)
+    texts = [f"text {index}" for index in range(11)]
+
+    def create_response(**kwargs):
+        return Mock(data=[Mock(index=index, embedding=[text]) for index, text in enumerate(kwargs["input"])])
+
+    mock_openai_client.embeddings.create.side_effect = create_response
+
+    result = embedder.embed_batch(texts)
+
+    batches = [call.kwargs["input"] for call in mock_openai_client.embeddings.create.call_args_list]
+    assert batches == [texts[:10], texts[10:]]
+    assert result == [[text] for text in texts]
+
+
+def test_embed_batch_defaults_to_100(mock_openai_client):
+    embedder = OpenAIEmbedding(BaseEmbedderConfig())
+    texts = [f"text {index}" for index in range(101)]
+
+    def create_response(**kwargs):
+        return Mock(data=[Mock(index=index, embedding=[text]) for index, text in enumerate(kwargs["input"])])
+
+    mock_openai_client.embeddings.create.side_effect = create_response
+
+    embedder.embed_batch(texts)
+
+    batch_sizes = [len(call.kwargs["input"]) for call in mock_openai_client.embeddings.create.call_args_list]
+    assert batch_sizes == [100, 1]
+
+
+@pytest.mark.parametrize("batch_size", [0, -1, 1.5, "10", True])
+def test_embed_batch_rejects_invalid_batch_size(batch_size):
+    with pytest.raises(ValueError, match="batch_size must be a positive integer"):
+        BaseEmbedderConfig(batch_size=batch_size)
+
+
 def test_embed_batch_count_mismatch_raises(mock_openai_client):
     config = BaseEmbedderConfig()
     embedder = OpenAIEmbedding(config)


### PR DESCRIPTION
## Linked Issue

Closes #6861

## Description

Makes the Python OpenAI embedder's maximum request batch size configurable through `BaseEmbedderConfig(batch_size=...)`.

OpenAI-compatible providers do not all share OpenAI's request limits. DashScope `text-embedding-v4`, for example, accepts at most 10 texts per request, while the existing implementation always chunks at 100. This change:

- preserves the current default of 100 for backward compatibility
- validates that configured batch sizes are positive integers
- uses the configured value when chunking `embed_batch()` requests
- documents the new Python OpenAI embedder option
- adds regression coverage for a configured `[10, 1]` split, the default `[100, 1]` split, and invalid values

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. Existing users continue to use a batch size of 100 unless they explicitly configure another value.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Validation performed:

- `91 passed`: complete `tests/embeddings` directory plus `tests/test_http_client_proxies.py`
- `23 passed`: focused OpenAI embedding and base-config regression tests after final validation tightening
- Ruff check, Ruff format check, isort check, and `git diff --check` all pass
- Live DashScope verification with `text-embedding-v4`, 1024 dimensions, `batch_size=10`: 11 inputs returned 11 vectors successfully

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing relevant tests pass locally
- [x] I have updated documentation if needed