### PR TITLE
fix: make OpenAI embedding batch size configurable

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -20,6 +20,7 @@ class BaseEmbedderConfig(ABC):
         ollama_base_url: Optional[str] = None,
         # Openai specific
         openai_base_url: Optional[str] = None,
+        batch_size: Optional[int] = None,
         # Huggingface specific
         model_kwargs: Optional[dict] = None,
         huggingface_base_url: Optional[str] = None,
@@ -58,6 +59,8 @@ class BaseEmbedderConfig(ABC):
         :type huggingface_base_url: Optional[str], optional
         :param openai_base_url: Openai base URL to be use, defaults to "https://api.openai.com/v1"
         :type openai_base_url: Optional[str], optional
+        :param batch_size: Max number of texts per batch embedding request, defaults to 100 (the OpenAI API limit)
+        :type batch_size: Optional[int], optional
         :param azure_kwargs: key-value arguments for the AzureOpenAI embedding model, defaults a dict inside init
         :type azure_kwargs: Optional[Dict[str, Any]], defaults a dict inside init
         :param http_client_proxies: The proxy server settings used to create self.http_client, defaults to None
@@ -78,6 +81,11 @@ class BaseEmbedderConfig(ABC):
         self.api_key = api_key
         self.openai_base_url = openai_base_url
         self.embedding_dims = embedding_dims
+
+        # Openai specific: chunk size for batched embedding requests
+        if batch_size is not None and (not isinstance(batch_size, int) or batch_size <= 0):
+            raise ValueError(f"batch_size must be a positive integer, got {batch_size!r}")
+        self.batch_size = batch_size if batch_size is not None else 100
 
         # AzureOpenAI specific
         self.http_client_proxies = http_client_proxies

--- a/mem0/embeddings/openai.py
+++ b/mem0/embeddings/openai.py
@@ -55,15 +55,19 @@ class OpenAIEmbedding(EmbeddingBase):
         return self.client.embeddings.create(**kwargs).data[0].embedding
 
     def embed_batch(self, texts, memory_action="add"):
-        """Embed multiple texts in a single OpenAI API call.
+        """Embed multiple texts with batched OpenAI API calls.
 
-        Automatically chunks into batches of 100 to stay within API limits.
+        Automatically chunks into batches of ``self.config.batch_size``
+        (default 100, matching the OpenAI API limit) to stay within API
+        limits. OpenAI-compatible providers enforcing smaller limits
+        (e.g. some vLLM or LiteLLM deployments) can lower it via the
+        embedder config ``batch_size`` (#6861).
         """
-        MAX_BATCH = 100
+        max_batch = self.config.batch_size
         texts = [text.replace("\n", " ") for text in texts]
         all_embeddings = []
-        for i in range(0, len(texts), MAX_BATCH):
-            chunk = texts[i : i + MAX_BATCH]
+        for i in range(0, len(texts), max_batch):
+            chunk = texts[i : i + max_batch]
             kwargs = {
                 "input": chunk,
                 "model": self.config.model,

--- a/tests/embeddings/test_openai_embeddings.py
+++ b/tests/embeddings/test_openai_embeddings.py
@@ -149,3 +149,46 @@ def test_embed_batch_count_mismatch_raises(mock_openai_client):
 
     with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
         embedder.embed_batch(["first text", "second text"])
+
+
+def _make_batch_response(*args, **kwargs):
+    """Return a mock embeddings response aligned with the requested chunk."""
+    chunk = kwargs["input"]
+    return Mock(data=[Mock(index=i, embedding=[float(i)]) for i in range(len(chunk))])
+
+
+def test_embed_batch_default_chunk_size_is_100(mock_openai_client):
+    """Default batch limit stays 100 for backward compatibility (#6861)."""
+    config = BaseEmbedderConfig()
+    embedder = OpenAIEmbedding(config)
+    mock_openai_client.embeddings.create.side_effect = _make_batch_response
+
+    result = embedder.embed_batch([f"text {i}" for i in range(201)])
+
+    calls = mock_openai_client.embeddings.create.call_args_list
+    assert [len(call.kwargs["input"]) for call in calls] == [100, 100, 1]
+    assert len(result) == 201
+
+
+def test_embed_batch_respects_custom_batch_size(mock_openai_client):
+    """A lower batch_size chunks requests for providers with smaller limits (#6861)."""
+    config = BaseEmbedderConfig(batch_size=50)
+    embedder = OpenAIEmbedding(config)
+    mock_openai_client.embeddings.create.side_effect = _make_batch_response
+
+    result = embedder.embed_batch([f"text {i}" for i in range(120)])
+
+    calls = mock_openai_client.embeddings.create.call_args_list
+    assert [len(call.kwargs["input"]) for call in calls] == [50, 50, 20]
+    assert len(result) == 120
+
+
+@pytest.mark.parametrize("invalid_batch_size", [0, -1, -100])
+def test_batch_size_rejects_zero_and_negative(invalid_batch_size):
+    with pytest.raises(ValueError, match="batch_size must be a positive integer"):
+        BaseEmbedderConfig(batch_size=invalid_batch_size)
+
+
+def test_batch_size_rejects_non_integer():
+    with pytest.raises(ValueError, match="batch_size must be a positive integer"):
+        BaseEmbedderConfig(batch_size=2.5)


### PR DESCRIPTION
### Summary

Make the OpenAI embedding batch size configurable while preserving the existing default of 100. Validate positive integer settings and add focused regression coverage for default and custom chunking.

### Testing

local verification not run; relying on upstream CI

The worktree does not have the Python dependencies installed, so the focused pytest suite could not be executed locally.

Closes #6861
