### PR TITLE
fix(pi-agent-plugin): trim blank content in auto-capture conversation extraction

### DIFF
--- a/integrations/pi-agent-plugin/src/capture/index.ts
+++ b/integrations/pi-agent-plugin/src/capture/index.ts
@@ -11,11 +11,15 @@ interface MessageLike {
 }
 
 function extractText(content: unknown): string | null {
-  if (typeof content === "string") return content;
+  if (typeof content === "string") {
+    const trimmed = content.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
   if (Array.isArray(content)) {
     const texts = content
       .filter((b: any) => b.type === "text" && typeof b.text === "string")
-      .map((b: any) => b.text);
+      .map((b: any) => b.text.trim())
+      .filter((t: string) => t.length > 0);
     return texts.length > 0 ? texts.join("\n") : null;
   }
   return null;


### PR DESCRIPTION
## Problem

Auto-capture (`agent_end` → `mem0.add`) intermittently fails with:

```
ValidationError: {"error":"{'messages': [{}, {'content': [ErrorDetail(string='This field may not be blank.', code='blank')]}, {}, {}]}"}
```

The mem0 API rejects the request with HTTP 400 when any message in the
conversation has blank `content`. The server serializer strips whitespace
(`trim_whitespace`), so a message whose `extractText` result is only spaces
or newlines — e.g. an assistant turn with `content: [{type: "text", text: " "}]`
or a string of just `"\n"` — passes the `!text` falsy check in
`extractConversation` and is sent to the API. One blank message fails the
entire add, so no memories are captured for the turn.

Observed: error message shows 4 messages where index 1 was blank.

## Fix

Normalize text in `extractText`:

- Strings: trim and return `null` when empty after trim.
- Content block arrays: trim each text block, drop whitespace-only blocks,
  and return `null` when nothing usable remains.

`extractConversation` then naturally skips messages whose content is blank,
so the payload never contains blank content.

## Testing

- Reproduced: `extractText([{type:"text", text:" "}])` previously returned
  `" "` (sent to API → 400); now returns `null` and the message is skipped.
- Type-checked the change; no other behavior changes (normal text is
  unaffected apart from trimming leading/trailing whitespace, matching the
  server's `trim_whitespace` semantics).

## Impact

Prevents HTTP 400 failures in auto-capture; conversation-level writes no
longer fail spuriously.
