### PR TITLE
fix(vector_stores/cassandra): filter before applying top_k in list()

### DIFF
--- a/mem0/vector_stores/cassandra.py
+++ b/mem0/vector_stores/cassandra.py
@@ -447,15 +447,25 @@ class CassandraDB(VectorStoreBase):
             List[List[OutputData]]: List of vectors
         """
         try:
+            # The filters below are applied client side, so the server side LIMIT
+            # has to come after them, not before. Capping the scan first would
+            # return top_k arbitrary rows of the whole table and then filter those
+            # down, yielding a fraction of the caller's matching vectors. This
+            # mirrors the ordering search() already uses.
             query = f"""
                 SELECT id, vector, payload
                 FROM {self.keyspace}.{self.collection_name}
-                LIMIT {top_k}
             """
             rows = self.session.execute(query)
 
             results = []
             for row in rows:
+                # Checked before the append so top_k=0 yields nothing, matching
+                # the old server-side LIMIT, and so iteration stops as soon as
+                # the cap is reached.
+                if len(results) >= top_k:
+                    break
+
                 # Apply filters if provided
                 if filters:
                     try:

--- a/tests/vector_stores/test_cassandra.py
+++ b/tests/vector_stores/test_cassandra.py
@@ -315,3 +315,101 @@ def test_insert_without_payloads(cassandra_instance):
     assert cassandra_instance.session.prepare.called
     assert cassandra_instance.session.execute.called
 
+
+
+# --- list() must filter before applying top_k -------------------------------
+#
+# The filters in list() are evaluated client side, so a server side LIMIT that
+# runs first caps the scan to top_k arbitrary rows and only then filters, which
+# returns a fraction of the caller's matching vectors. search() in the same file
+# already filters first and slices afterwards.
+
+
+def _table_rows(n_per_tenant=10, tenants=("alice", "bob", "carol")):
+    """Interleaved rows so a naive LIMIT slices across tenants."""
+    rows = []
+    for i in range(n_per_tenant):
+        for t in tenants:
+            r = Mock()
+            r.id = f"{t}-{i}"
+            r.vector = [0.1, 0.2]
+            r.payload = json.dumps({"user_id": t, "data": f"{t} memory {i}"})
+            rows.append(r)
+    return rows
+
+
+def _session_honouring_limit(rows):
+    """Fake execute() that applies a server side `LIMIT n` if the query has one."""
+    import re
+
+    def _execute(query, *args, **kwargs):
+        m = re.search(r"LIMIT\s+(\d+)", str(query))
+        return rows[: int(m.group(1))] if m else rows
+
+    return Mock(side_effect=_execute)
+
+
+def test_list_filters_before_applying_top_k(cassandra_instance):
+    """A tenant with 10 memories must get all 10 back, not a slice of the table."""
+    rows = _table_rows(n_per_tenant=10)  # 30 rows, 10 per tenant
+    cassandra_instance.session.execute = _session_honouring_limit(rows)
+
+    [results] = cassandra_instance.list(filters={"user_id": "alice"}, top_k=10)
+
+    assert len(results) == 10, f"expected alice's 10 memories, got {len(results)}"
+    assert all(r.payload["user_id"] == "alice" for r in results)
+
+
+def test_list_still_caps_at_top_k(cassandra_instance):
+    """The cap must still be honoured once filtering has been applied."""
+    rows = _table_rows(n_per_tenant=10)
+    cassandra_instance.session.execute = _session_honouring_limit(rows)
+
+    [results] = cassandra_instance.list(filters={"user_id": "alice"}, top_k=3)
+
+    assert len(results) == 3
+    assert all(r.payload["user_id"] == "alice" for r in results)
+
+
+def test_list_without_filters_is_bounded_by_top_k(cassandra_instance):
+    """No filters means no behaviour change: still at most top_k rows."""
+    rows = _table_rows(n_per_tenant=10)
+    cassandra_instance.session.execute = _session_honouring_limit(rows)
+
+    [results] = cassandra_instance.list(top_k=5)
+
+    assert len(results) == 5
+
+
+def test_list_stops_scanning_once_top_k_matches_are_found(cassandra_instance):
+    """Iteration breaks early, so the lazily paged driver stops fetching."""
+    consumed = []
+
+    class _CountingRows:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def __iter__(self):
+            for r in self._rows:
+                consumed.append(r.id)
+                yield r
+
+    rows = _table_rows(n_per_tenant=10)
+    cassandra_instance.session.execute = Mock(return_value=_CountingRows(rows))
+
+    [results] = cassandra_instance.list(filters={"user_id": "alice"}, top_k=2)
+
+    assert len(results) == 2
+    # alice's 2nd match is the 4th row of the interleaved table, so the scan must
+    # stop there rather than walking all 30 rows.
+    assert len(consumed) < len(rows)
+
+
+def test_list_top_k_zero_returns_nothing(cassandra_instance):
+    """top_k=0 must yield no rows, as the old server-side LIMIT 0 did."""
+    rows = _table_rows(n_per_tenant=10)
+    cassandra_instance.session.execute = _session_honouring_limit(rows)
+
+    [results] = cassandra_instance.list(filters={"user_id": "alice"}, top_k=0)
+
+    assert results == []


### PR DESCRIPTION
## Linked Issue

Closes #6867

## Description

`CassandraDB.list()` pushed `top_k` to the server as a CQL `LIMIT` but evaluated `filters` client side in the row loop, so the cap was applied to the wrong set. The query capped the scan to `top_k` arbitrary rows of the whole table and only then kept the rows matching the caller's filters.

```
alice has 10 memories, table has 30 rows, top_k=10  -> got 4
alice has 10 memories, table has 30 rows, top_k=100 -> got 10
```

The result is only correct while `top_k` exceeds the entire table, which is the opposite of the real deployment case.

`search()` in this same file already does it the right way round: it selects without a cap, filters inside the row loop, sorts, and slices to `top_k` afterwards. `list()` was the odd one out.

### Why this matters beyond recall

`_get_all_from_vector_store` calls `list(filters=filters, top_k=limit)` (`mem0/memory/main.py:1322`), so `get_all()` silently returned an arbitrary subset.

On `delete_all()` it is worse. The drain loop stops on the first empty batch:

```python
memories = self.vector_store.list(filters=filters, top_k=DELETE_ALL_BATCH_SIZE)[0]
if not memories:
    break
```

`DELETE_ALL_BATCH_SIZE` is 1000, so if the caller's rows sit beyond the first 1000 rows of the table, that batch filters down to zero, the loop breaks immediately, and the caller gets `{"message": "Memories deleted successfully!"}` having deleted nothing. Reproduced with one tenant owning 5 rows placed after 1000 rows belonging to another tenant:

```
alice owns 5 rows; delete_all's first batch returns 0 of them
-> drain loop hits `if not memories: break`: True
```

### The fix

Drop the server side `LIMIT`, keep the client side filter, and stop once `top_k` matches have been collected.

The cap is checked at the top of the loop rather than after the append, so `top_k=0` still yields nothing, matching the old `LIMIT` behaviour. I caught that as a regression in self-review before opening this, and there is a test pinning it.

The driver returns a lazily paged `ResultSet` (`Session.default_fetch_size` is 5000, and `ResultSet` exposes `has_more_pages` / `fetch_next_page`), so breaking early stops fetching further pages rather than materialising the table. This also does not introduce a new scan pattern: `search()` in this file already selects unbounded.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

None. Row counts are unchanged for every input that previously behaved correctly:

- `filters=None`: previously `LIMIT top_k` server side, now unbounded select with a break at `top_k`. Same count. Cassandra does not guarantee ordering without a clustering key, so the exact set was never deterministic here either way.
- `top_k=0`: still returns nothing.
- Filtered calls now return the rows the caller asked for instead of a subset, which is the fix.

## Test Coverage

- [x] I added/updated unit tests

Five tests in `tests/vector_stores/test_cassandra.py`. The session fake parses `LIMIT n` out of the query string so it models a real server side cap rather than ignoring it, which is what makes the red run meaningful:

- `test_list_filters_before_applying_top_k` - a tenant with 10 memories in a 30 row table gets all 10
- `test_list_still_caps_at_top_k` - the cap is still honoured after filtering
- `test_list_stops_scanning_once_top_k_matches_are_found` - iteration breaks early, asserted with a counting iterator
- `test_list_top_k_zero_returns_nothing` - regression guard for the boundary above
- `test_list_without_filters_is_bounded_by_top_k` - compatibility guard for the unfiltered path

**Proof, red on `upstream/main` and green with the fix** (source file reverted to `upstream/main` with the new tests kept, then restored):

```
# BEFORE (upstream/main source, new tests):
$ pytest tests/vector_stores/test_cassandra.py -q
  3 failed, 19 passed

# AFTER (this branch):
  22 passed

$ ruff check mem0/vector_stores/cassandra.py tests/vector_stores/test_cassandra.py
  All checks passed!
```

To be precise about what each test proves: three go red on `main` and are load-bearing on the bug. `test_list_top_k_zero_returns_nothing` and `test_list_without_filters_is_bounded_by_top_k` pass in both states by design; they guard the two behaviours this change must not alter.

## Scope

Ordering only. This is adjacent to, but distinct from, the `delete_all` pagination work in #4869: that fixes how many batches are drained, this fixes each batch containing the wrong rows in the first place. Both are needed on Cassandra. `search()` is untouched, and I did not add `"*"` wildcard handling since that is #6539's territory.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A, internal store behaviour, no public API or documented contract change)
