### PR TITLE
Fix langchain_community deprecation warning

### DIFF
--- a/mem0/configs/vector_stores/langchain.py
+++ b/mem0/configs/vector_stores/langchain.py
@@ -5,10 +5,10 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 class LangchainConfig(BaseModel):
     try:
-        from langchain_community.vectorstores import VectorStore
+        from langchain_core.vectorstores import VectorStore
     except ImportError:
         raise ImportError(
-            "The 'langchain_community' library is required. Please install it using 'pip install langchain_community'."
+            "The 'langchain_core' library is required. Please install it using 'pip install langchain_core'."
         )
     VectorStore: ClassVar[type] = VectorStore
 

--- a/mem0/llms/langchain.py
+++ b/mem0/llms/langchain.py
@@ -60,7 +60,7 @@ class LangchainLLM(LLMBase):
         **kwargs,
     ):
         """
-        Generate a response based on the given messages using langchain_community.
+        Generate a response based on the given messages using langchain.
 
         Args:
             messages (list): List of message dicts containing 'role' and 'content'.

--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -4,10 +4,10 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel
 
 try:
-    from langchain_community.vectorstores import VectorStore
+    from langchain_core.vectorstores import VectorStore
 except ImportError:
     raise ImportError(
-        "The 'langchain_community' library is required. Please install it using 'pip install langchain_community'."
+        "The 'langchain_core' library is required. Please install it using 'pip install langchain_core'."
     )
 
 from mem0.vector_stores.base import VectorStoreBase

--- a/tests/vector_stores/test_langchain_vector_store.py
+++ b/tests/vector_stores/test_langchain_vector_store.py
@@ -1,14 +1,15 @@
 from unittest.mock import Mock, patch
 
 import pytest
-from langchain_community.vectorstores import VectorStore
+from langchain_core.vectorstores import VectorStore
 
+from mem0.configs.vector_stores.langchain import LangchainConfig
 from mem0.vector_stores.langchain import Langchain
 
 
 @pytest.fixture
 def mock_langchain_client():
-    with patch("langchain_community.vectorstores.VectorStore") as mock_client:
+    with patch("langchain_core.vectorstores.VectorStore") as mock_client:
         yield mock_client
 
 


### PR DESCRIPTION
## Description

**Fix `langchain_community` deprecation warning**

This PR addresses a deprecation warning in the `mem0` Python SDK. The `langchain-community` package is being sunset in favor of standalone integration packages and core abstractions. The base `VectorStore` class used in the `langchain` vector store implementation is available in `langchain_core`, so all imports have been updated to use `langchain_core.vectorstores` instead of `langchain_community.vectorstores`.

This removes the deprecation warning during test collection and execution, and reduces our reliance on the bloated community package.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Ran `make test` locally to verify that `tests/vector_stores/test_langchain_vector_store.py` passes and no longer throws the `langchain_community` deprecation warning.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
