### PR TITLE
fix(s3vectors): validate filter keys and values before passing to AWS API

### DIFF
--- a/mem0/vector_stores/s3_vectors.py
+++ b/mem0/vector_stores/s3_vectors.py
@@ -1,10 +1,30 @@
 import json
 import logging
+import re
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
 from mem0.vector_stores.base import VectorStoreBase
+
+_VALID_FILTER_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]{0,127}$")
+_SCALAR_TYPES = (str, int, float, bool)
+
+
+def _validate_filters(filters: dict) -> None:
+    """Validate filter keys and values before passing to the AWS S3 Vectors API.
+
+    S3 Vectors filter keys are metadata attribute names; values must be scalars.
+    Accepting arbitrary nested structures would allow callers to inject unexpected
+    filter operators into the API request.
+    """
+    for key, value in filters.items():
+        if not _VALID_FILTER_KEY.match(key):
+            raise ValueError(f"Invalid filter key {key!r}: only letters, digits, underscores, and dots are allowed")
+        if not isinstance(value, _SCALAR_TYPES):
+            raise ValueError(
+                f"Invalid filter value for key {key!r}: expected a string, int, float, or bool, got {type(value).__name__}"
+            )
 
 try:
     import boto3
@@ -111,6 +131,7 @@ class S3Vectors(VectorStoreBase):
             "returnDistance": True,
         }
         if filters:
+            _validate_filters(filters)
             params["filter"] = filters
 
         response = self.client.query_vectors(**params)

--- a/tests/vector_stores/test_s3_vectors.py
+++ b/tests/vector_stores/test_s3_vectors.py
@@ -251,6 +251,77 @@ def test_reset(mock_boto_client):
     assert mock_boto_client.create_index.call_count == 2
 
 
+def test_search_rejects_dict_filter_value(mock_boto_client):
+    """search() must raise ValueError when a filter value is a dict (injection risk)."""
+    mock_boto_client.get_vector_bucket.return_value = {}
+    mock_boto_client.get_index.return_value = {}
+    store = S3Vectors(
+        vector_bucket_name=BUCKET_NAME,
+        collection_name=INDEX_NAME,
+        embedding_model_dims=EMBEDDING_DIMS,
+    )
+
+    with pytest.raises(ValueError, match="string, int, float, or bool"):
+        store.search(
+            query="test",
+            vectors=[0.1, 0.2],
+            filters={"user_id": {"$exists": True}},
+        )
+
+
+def test_search_rejects_list_filter_value(mock_boto_client):
+    """search() must raise ValueError when a filter value is a list."""
+    mock_boto_client.get_vector_bucket.return_value = {}
+    mock_boto_client.get_index.return_value = {}
+    store = S3Vectors(
+        vector_bucket_name=BUCKET_NAME,
+        collection_name=INDEX_NAME,
+        embedding_model_dims=EMBEDDING_DIMS,
+    )
+
+    with pytest.raises(ValueError, match="string, int, float, or bool"):
+        store.search(
+            query="test",
+            vectors=[0.1, 0.2],
+            filters={"user_id": ["alice", "bob"]},
+        )
+
+
+def test_search_rejects_invalid_filter_key(mock_boto_client):
+    """search() must raise ValueError when a filter key contains special characters."""
+    mock_boto_client.get_vector_bucket.return_value = {}
+    mock_boto_client.get_index.return_value = {}
+    store = S3Vectors(
+        vector_bucket_name=BUCKET_NAME,
+        collection_name=INDEX_NAME,
+        embedding_model_dims=EMBEDDING_DIMS,
+    )
+
+    with pytest.raises(ValueError, match="Invalid filter key"):
+        store.search(
+            query="test",
+            vectors=[0.1, 0.2],
+            filters={"user_id; DROP TABLE memories": "alice"},
+        )
+
+
+def test_search_accepts_valid_scalar_filters(mock_boto_client):
+    """search() must pass valid scalar filters through to the AWS API."""
+    mock_boto_client.get_vector_bucket.return_value = {}
+    mock_boto_client.get_index.return_value = {}
+    mock_boto_client.query_vectors.return_value = {"vectors": []}
+    store = S3Vectors(
+        vector_bucket_name=BUCKET_NAME,
+        collection_name=INDEX_NAME,
+        embedding_model_dims=EMBEDDING_DIMS,
+    )
+
+    store.search(query="test", vectors=[0.1, 0.2], filters={"user_id": "alice"})
+
+    call_kwargs = mock_boto_client.query_vectors.call_args[1]
+    assert call_kwargs["filter"] == {"user_id": "alice"}
+
+
 def test_list_filters_metadata_client_side(mock_boto_client):
     """S3 list_vectors does not support metadata filters, so the store filters returned payloads locally."""
     mock_paginator = mock_boto_client.get_paginator.return_value


### PR DESCRIPTION
## Problem

`search()` passed the caller-supplied `filters` dict directly to `boto3.client.query_vectors()` without any validation:

```python
if filters:
    params["filter"] = filters
```

An attacker controlling the `filters` argument could pass nested dicts or lists as values to inject unexpected AWS S3 Vectors filter operators, or use special characters in keys to break the expected filter structure.

## Fix

Add `_validate_filters()` which is called before the filters are forwarded to boto3. It rejects:
- Keys that do not match `^[A-Za-z_][A-Za-z0-9_.]{0,127}$`
- Values that are not a scalar (`str`, `int`, `float`, or `bool`)

Both raise `ValueError` with a descriptive message.

## Tests

Added tests verifying:
- Dict filter values raise `ValueError`
- List filter values raise `ValueError`
- Keys with special characters raise `ValueError`
- Valid scalar filters are forwarded to the AWS API unchanged