### PR TITLE
fix(turbopuffer): validate filter values are scalars before building filter tuples

### DIFF
--- a/mem0/vector_stores/turbopuffer.py
+++ b/mem0/vector_stores/turbopuffer.py
@@ -131,6 +131,14 @@ class TurbopufferDB(VectorStoreBase):
             ))
         return results
 
+    _SCALAR_TYPES = (str, int, float, bool)
+
+    def _validate_filter_value(self, key: str, op: str, value) -> None:
+        if not isinstance(value, self._SCALAR_TYPES):
+            raise ValueError(
+                f"Filter value for {key!r} ({op}) must be a string, int, float, or bool; got {type(value).__name__}"
+            )
+
     def _convert_filters(self, filters: Optional[Dict]):
         """
         Convert mem0 filters to Turbopuffer filter format.
@@ -144,10 +152,13 @@ class TurbopufferDB(VectorStoreBase):
         for key, value in filters.items():
             if isinstance(value, dict):
                 if "gte" in value:
+                    self._validate_filter_value(key, "gte", value["gte"])
                     conditions.append((key, "Gte", value["gte"]))
                 if "lte" in value:
+                    self._validate_filter_value(key, "lte", value["lte"])
                     conditions.append((key, "Lte", value["lte"]))
             else:
+                self._validate_filter_value(key, "eq", value)
                 conditions.append((key, "Eq", value))
 
         if not conditions:

--- a/tests/vector_stores/test_turbopuffer.py
+++ b/tests/vector_stores/test_turbopuffer.py
@@ -276,6 +276,33 @@ class TestConvertFilters:
         assert ("user_id", "Eq", "u1") in conditions
         assert ("score", "Gte", 0.5) in conditions
 
+    def test_eq_rejects_dict_value(self, db):
+        with pytest.raises(ValueError, match="string, int, float, or bool"):
+            db._convert_filters({"user_id": {"$exists": True}})
+
+    def test_eq_rejects_list_value(self, db):
+        with pytest.raises(ValueError, match="string, int, float, or bool"):
+            db._convert_filters({"user_id": ["alice", "bob"]})
+
+    def test_gte_rejects_dict_value(self, db):
+        with pytest.raises(ValueError, match="string, int, float, or bool"):
+            db._convert_filters({"score": {"gte": {"nested": "object"}}})
+
+    def test_lte_rejects_list_value(self, db):
+        with pytest.raises(ValueError, match="string, int, float, or bool"):
+            db._convert_filters({"score": {"lte": [1, 2, 3]}})
+
+    def test_accepts_bool_value(self, db):
+        result = db._convert_filters({"active": False})
+        assert result == ("active", "Eq", False)
+
+    def test_accepts_int_and_float_range(self, db):
+        result = db._convert_filters({"score": {"gte": 1, "lte": 10.5}})
+        assert result[0] == "And"
+        conditions = result[1]
+        assert ("score", "Gte", 1) in conditions
+        assert ("score", "Lte", 10.5) in conditions
+
 
 # ── search ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

`_convert_filters()` accepted any Python type for `Eq`, `Gte`, and `Lte` operators and passed them directly to the Turbopuffer query API:

```python
conditions.append((key, "Gte", value["gte"]))  # no type check
conditions.append((key, "Eq", value))           # no type check
```

Passing a dict or list as a comparison value (e.g. `{"gte": {"nested": "object"}}`) could inject unexpected filter logic depending on how the Turbopuffer client serializes the tuple.

## Fix

Add `_validate_filter_value()` which raises `ValueError` when a filter value is not a `str`, `int`, `float`, or `bool`. It is called for all three operators before appending to `conditions`.

## Tests

Added tests covering:
- Dict values for `eq`, `gte`, `lte` raise `ValueError`
- List values for `eq`, `lte` raise `ValueError`
- Valid scalar types (`bool`, `int`, `float`, `str`) pass through correctly