### PR TITLE
fix(ts-oss/upstash): translate filter operators instead of dropping them

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/upstash_vector.ts
+++ b/mem0-ts/src/oss/src/vector_stores/upstash_vector.ts
@@ -243,11 +243,73 @@ export class UpstashVector implements VectorStore {
       return undefined;
     }
 
-    const expressions = Object.entries(filters)
-      .filter(([, value]) => value !== undefined && value !== null)
-      .map(([key, value]) => `${key} = ${this.stringifyFilterValue(value)}`);
+    const clauses: string[] = [];
+    for (const [key, value] of Object.entries(filters)) {
+      if (value === undefined || value === null) continue;
+      const clause = this.buildFilterClause(key, value);
+      if (clause) clauses.push(clause);
+    }
+    return clauses.length > 0 ? clauses.join(" AND ") : undefined;
+  }
 
-    return expressions.length > 0 ? expressions.join(" AND ") : undefined;
+  // mem0's universal comparison operators -> Upstash filter tokens.
+  private static readonly COMPARATORS: Record<string, string> = {
+    eq: "=",
+    ne: "!=",
+    gt: ">",
+    gte: ">=",
+    lt: "<",
+    lte: "<=",
+  };
+
+  /**
+   * Translate a single field condition into Upstash filter syntax. Handles the
+   * operator dicts, "in" arrays and "*" wildcard that mem0 supports — the old
+   * version only emitted `key = value`, so anything else serialized to
+   * `key = [object Object]` and Upstash rejected the query.
+   */
+  private buildFilterClause(key: string, value: any): string | undefined {
+    // "*" means "the field must exist".
+    if (value === "*") return `HAS FIELD ${key}`;
+
+    // Array shorthand -> IN.
+    if (Array.isArray(value)) {
+      return `${key} IN (${value.map((v) => this.stringifyFilterValue(v)).join(", ")})`;
+    }
+
+    // Operator dict, e.g. { gte: 18, lte: 65 } — apply EVERY operator (AND).
+    if (typeof value === "object") {
+      const parts: string[] = [];
+      for (const [op, opValue] of Object.entries(value)) {
+        const comparator = UpstashVector.COMPARATORS[op];
+        if (comparator) {
+          parts.push(
+            `${key} ${comparator} ${this.stringifyFilterValue(opValue)}`,
+          );
+        } else if (op === "in" && Array.isArray(opValue)) {
+          parts.push(
+            `${key} IN (${opValue.map((v) => this.stringifyFilterValue(v)).join(", ")})`,
+          );
+        } else if (op === "nin" && Array.isArray(opValue)) {
+          parts.push(
+            `${key} NOT IN (${opValue.map((v) => this.stringifyFilterValue(v)).join(", ")})`,
+          );
+        } else {
+          throw new Error(this.unsupportedOperatorMessage(op, key));
+        }
+      }
+      return parts.length > 0 ? parts.join(" AND ") : undefined;
+    }
+
+    // Scalar equality.
+    return `${key} = ${this.stringifyFilterValue(value)}`;
+  }
+
+  private unsupportedOperatorMessage(op: string, key: string): string {
+    return (
+      `Unsupported Upstash filter operator '${op}' for field '${key}'. ` +
+      `Supported operators: ${Object.keys(UpstashVector.COMPARATORS).join(", ")}, in, nin.`
+    );
   }
 
   private matchesFilters(
@@ -262,8 +324,46 @@ export class UpstashVector implements VectorStore {
       if (value === undefined || value === null) {
         return true;
       }
-
-      return vector.metadata?.[key] === value;
+      return this.matchesFieldCondition(vector.metadata ?? {}, key, value);
     });
+  }
+
+  /** Client-side equivalent of buildFilterClause, applying every operator. */
+  private matchesFieldCondition(
+    metadata: Record<string, any>,
+    key: string,
+    value: any,
+  ): boolean {
+    const fieldValue = metadata[key];
+
+    if (value === "*") return key in metadata;
+    if (Array.isArray(value)) return value.includes(fieldValue);
+
+    if (value && typeof value === "object") {
+      return Object.entries(value).every(([op, opValue]) => {
+        switch (op) {
+          case "eq":
+            return fieldValue === opValue;
+          case "ne":
+            return fieldValue !== opValue;
+          case "gt":
+            return fieldValue > (opValue as any);
+          case "gte":
+            return fieldValue >= (opValue as any);
+          case "lt":
+            return fieldValue < (opValue as any);
+          case "lte":
+            return fieldValue <= (opValue as any);
+          case "in":
+            return Array.isArray(opValue) && opValue.includes(fieldValue);
+          case "nin":
+            return !Array.isArray(opValue) || !opValue.includes(fieldValue);
+          default:
+            throw new Error(this.unsupportedOperatorMessage(op, key));
+        }
+      });
+    }
+
+    return fieldValue === value;
   }
 }

--- a/mem0-ts/src/oss/tests/upstash_vector.unit.test.ts
+++ b/mem0-ts/src/oss/tests/upstash_vector.unit.test.ts
@@ -79,6 +79,62 @@ describe("UpstashVector", () => {
     ]);
   });
 
+  // Regression: operator dicts, "in" arrays and "*" used to serialize to
+  // `key = [object Object]` (a filter Upstash rejects) or, on the client-side
+  // list() path, silently match nothing.
+  it("translates operator dicts, in-arrays and the * wildcard to Upstash syntax", async () => {
+    const client = createClient();
+    const store = new UpstashVector({
+      collectionName: namespace,
+      client: client as any,
+    });
+
+    await store.search([0.1, 0.2], 3, {
+      user_id: "user-1",
+      age: { gte: 18, lte: 65 },
+      tier: { in: ["gold", "silver"] },
+      city: "*",
+    } as any);
+
+    expect(client.query.mock.calls[0][0].filter).toBe(
+      'user_id = "user-1" AND age >= 18 AND age <= 65 ' +
+        'AND tier IN ("gold", "silver") AND HAS FIELD city',
+    );
+  });
+
+  it("applies every operator when listing (client-side range filter)", async () => {
+    const client = createClient({
+      range: jest.fn().mockResolvedValue({
+        nextCursor: "",
+        vectors: [
+          { id: "1", metadata: { user_id: "u", age: 10 } },
+          { id: "2", metadata: { user_id: "u", age: 30 } },
+          { id: "3", metadata: { user_id: "u", age: 100 } },
+        ],
+      }),
+    });
+    const store = new UpstashVector({
+      collectionName: namespace,
+      client: client as any,
+    });
+
+    const [rows] = await store.list(
+      { user_id: "u", age: { gte: 18, lte: 65 } } as any,
+      100,
+    );
+    expect(rows.map((r) => r.payload.age)).toEqual([30]);
+  });
+
+  it("throws on an unsupported filter operator rather than dropping it", async () => {
+    const store = new UpstashVector({
+      collectionName: namespace,
+      client: createClient() as any,
+    });
+    await expect(
+      store.search([0.1, 0.2], 3, { name: { regex: "^a" } } as any),
+    ).rejects.toThrow(/Unsupported Upstash filter operator 'regex'/);
+  });
+
   it("fetches, updates, deletes, resets, and lists vectors in the namespace", async () => {
     const client = createClient({
       fetch: jest.fn().mockResolvedValue([


### PR DESCRIPTION
## Linked Issue

Closes #6880

## Description

`convertFilters` only ever emitted `key = value`, so operator dicts (`{ gte, lte }`), `in` arrays and the `*` wildcard serialized to `key = [object Object]` — Upstash rejects that, so any non-equality `search()` errored. `matchesFilters` (the `getAll()`/`list()` path) had the mirror bug: a strict `=== value` against the operator object, silently matching nothing.

Both paths now translate `eq/ne/gt/gte/lt/lte`, `in/nin` and `*` (→ `HAS FIELD`), applying every operator in a compound condition. Anything unsupported throws a clear error rather than being dropped — same approach as the turbopuffer fix (#6578). Upstash's filter DSL supports all of these, so this is just a missing translation, not a limitation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Coverage

- [x] I added/updated unit tests

Added cases for the generated query string (operators + `in` + `*`), the client-side range match on `list()`, and the throw on an unsupported operator. Also verified end-to-end against a live Upstash index: range/`ne`/`in`/`nin`/wildcard all return the right rows, and an unknown operator throws.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
