### PR TITLE
fix(memory): prevent cross-scope entity merges

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -132,12 +132,18 @@ _SENSITIVE_SUFFIXES = (
 )
 
 # Entity parameters that must be passed via filters, not top-level kwargs
-ENTITY_PARAMS = frozenset({"user_id", "agent_id", "run_id"})
+_ENTITY_SCOPE_KEYS = ("user_id", "agent_id", "run_id")
+ENTITY_PARAMS = frozenset(_ENTITY_SCOPE_KEYS)
 DELETE_ALL_BATCH_SIZE = 1000
 
 # Tenant-scoping fields that caller-supplied metadata must never set, on either the
 # creation or the update path (issues #4490, #6277, #6655).
 _IDENTITY_KEYS = ENTITY_PARAMS | {"actor_id"}
+
+
+def _extract_entity_scope(payload):
+    payload = payload or {}
+    return {key: payload[key] for key in _ENTITY_SCOPE_KEYS if payload.get(key)}
 
 
 def _strip_identity_keys(
@@ -615,6 +621,8 @@ class Memory(MemoryBase):
 
             semantic_match = existing[0] if existing and existing[0].score >= 0.95 else None
             match = exact_match or semantic_match
+            if match and _extract_entity_scope(match.payload) != search_filters:
+                match = None
             if match:
                 # Update existing entity's linked_memory_ids
                 payload = match.payload or {}
@@ -1146,6 +1154,8 @@ class Memory(MemoryBase):
 
                         semantic_match = matches[0] if matches and matches[0].score >= 0.95 else None
                         match = exact_match or semantic_match
+                        if match and _extract_entity_scope(match.payload) != search_filters:
+                            match = None
                         if match:
                             # Update existing entity
                             payload = match.payload or {}
@@ -2276,6 +2286,8 @@ class AsyncMemory(MemoryBase):
 
             semantic_match = existing[0] if existing and existing[0].score >= 0.95 else None
             match = exact_match or semantic_match
+            if match and _extract_entity_scope(match.payload) != search_filters:
+                match = None
             if match:
                 payload = match.payload or {}
                 linked_ids = payload.get("linked_memory_ids", [])
@@ -2798,6 +2810,8 @@ class AsyncMemory(MemoryBase):
 
                         semantic_match = matches[0] if matches and matches[0].score >= 0.95 else None
                         match = exact_match or semantic_match
+                        if match and _extract_entity_scope(match.payload) != search_filters:
+                            match = None
                         if match:
                             payload = match.payload or {}
                             linked = set(payload.get("linked_memory_ids", []))

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1049,6 +1049,147 @@ class TestEntityBoostParallelism:
         assert len(boosts) == 4
 
 
+class TestEntityScopeGate:
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = Memory()
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        return memory
+
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = AsyncMemory()
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        return memory
+
+    @staticmethod
+    def _match(scope):
+        return SimpleNamespace(
+            id="entity-1",
+            score=0.99,
+            payload={"data": "Alice", "linked_memory_ids": ["existing-memory"], **scope},
+        )
+
+    @staticmethod
+    def _prepare_batch_add(memory, mocker, *, exact_match=None, semantic_match=None):
+        memory.llm.generate_response.return_value = '{"memory": [{"text": "Alice works here"}]}'
+        memory.embedding_model = Mock()
+        memory.embedding_model.embed_batch = Mock(return_value=[[0.1] * 10])
+        memory.embedding_model.embed = Mock(return_value=[0.1] * 10)
+        memory._entity_store = Mock()
+        memory._entity_store.search_batch = Mock(return_value=[[semantic_match] if semantic_match else []])
+        memory._entity_store.insert = Mock()
+        memory._entity_store.update = Mock()
+        mocker.patch.object(
+            memory,
+            "_existing_entities_by_text",
+            return_value={"alice": exact_match} if exact_match else {},
+        )
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[("person", "Alice")]])
+        mocker.patch("mem0.memory.main.capture_event")
+
+    @pytest.mark.parametrize(
+        ("stored_scope", "request_scope", "should_merge"),
+        [
+            ({"user_id": "alice"}, {"user_id": "alice"}, True),
+            ({"user_id": "bob"}, {"user_id": "alice"}, False),
+            ({}, {"user_id": "alice"}, False),
+            ({"user_id": "alice"}, {}, False),
+            ({}, {}, True),
+        ],
+        ids=["same-scope", "cross-scope", "stored-scope-missing", "request-unscoped", "both-unscoped"],
+    )
+    def test_sync_exact_match_respects_scope(self, mock_memory, mocker, stored_scope, request_scope, should_merge):
+        match = self._match(stored_scope)
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1] * 10)
+        mock_memory._entity_store = Mock()
+        mocker.patch.object(mock_memory, "_existing_entities_by_text", return_value={"alice": match})
+
+        mock_memory._upsert_entity("Alice", "person", "new-memory", request_scope)
+
+        if should_merge:
+            mock_memory._entity_store.update.assert_called_once()
+            mock_memory._entity_store.insert.assert_not_called()
+            assert match.payload["linked_memory_ids"] == ["existing-memory", "new-memory"]
+        else:
+            mock_memory._entity_store.update.assert_not_called()
+            mock_memory._entity_store.insert.assert_called_once()
+            payload = mock_memory._entity_store.insert.call_args.kwargs["payloads"][0]
+            assert payload["linked_memory_ids"] == ["new-memory"]
+            assert {key: payload[key] for key in request_scope} == request_scope
+            assert match.payload["linked_memory_ids"] == ["existing-memory"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("stored_scope", "should_merge"),
+        [
+            ({"user_id": "alice", "run_id": "run-1"}, True),
+            ({"user_id": "alice", "run_id": "run-2"}, False),
+        ],
+        ids=["same-scope", "cross-scope"],
+    )
+    async def test_async_semantic_match_respects_scope(self, mock_async_memory, mocker, stored_scope, should_merge):
+        match = self._match(stored_scope)
+        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model.embed = Mock(return_value=[0.1] * 10)
+        mock_async_memory._entity_store = Mock()
+        mock_async_memory._entity_store.search = Mock(return_value=[match])
+        mocker.patch.object(mock_async_memory, "_existing_entities_by_text", return_value={})
+        request_scope = {"user_id": "alice", "run_id": "run-1"}
+
+        await mock_async_memory._upsert_entity_async("Alice", "person", "new-memory", request_scope)
+
+        if should_merge:
+            mock_async_memory._entity_store.update.assert_called_once()
+            mock_async_memory._entity_store.insert.assert_not_called()
+        else:
+            mock_async_memory._entity_store.update.assert_not_called()
+            payload = mock_async_memory._entity_store.insert.call_args.kwargs["payloads"][0]
+            assert payload["user_id"] == "alice"
+            assert payload["run_id"] == "run-1"
+            assert match.payload["linked_memory_ids"] == ["existing-memory"]
+
+    def test_sync_batch_exact_match_rejects_cross_scope(self, mock_memory, mocker):
+        match = self._match({"user_id": "bob"})
+        self._prepare_batch_add(mock_memory, mocker, exact_match=match)
+
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Alice works here"}],
+            metadata={},
+            filters={"user_id": "alice"},
+            infer=True,
+        )
+
+        mock_memory._entity_store.update.assert_not_called()
+        payload = mock_memory._entity_store.insert.call_args.kwargs["payloads"][0]
+        assert payload["user_id"] == "alice"
+        assert match.payload["linked_memory_ids"] == ["existing-memory"]
+
+    @pytest.mark.asyncio
+    async def test_async_batch_semantic_match_rejects_cross_scope(self, mock_async_memory, mocker):
+        match = self._match({"user_id": "bob"})
+        self._prepare_batch_add(mock_async_memory, mocker, semantic_match=match)
+
+        await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Alice works here"}],
+            metadata={},
+            effective_filters={"user_id": "alice"},
+            infer=True,
+        )
+
+        mock_async_memory._entity_store.update.assert_not_called()
+        payload = mock_async_memory._entity_store.insert.call_args.kwargs["payloads"][0]
+        assert payload["user_id"] == "alice"
+        assert match.payload["linked_memory_ids"] == ["existing-memory"]
+
+
 class TestAddPipelineEntityEmbeddingCountGuard:
     """A misbehaving embedder returning fewer (or more) vectors than entity
     texts must not silently drop ALL entity links via a swallowed IndexError.


### PR DESCRIPTION
## Linked Issue

Closes #5439

## Description

This PR prevents existing entities from being reused across different memory scopes defined by truthy `user_id`, `agent_id`, and `run_id` values.

The core memory layer now extracts the scope from both the incoming filters and a matched entity's payload. A candidate is reused only when those scopes are exactly equal; otherwise it is treated as no match so a new entity is created. The same guard is applied to exact and semantic matches across the synchronous, asynchronous, single-item, and batch paths.

This PR revives and supersedes #5441 as an updated port for the current `main` branch. Many thanks to @zhushen12580 for the original implementation and the substantial review work that shaped this solution.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Validated locally with the project's Hatch Python 3.12 environment:

- 9 focused scope-regression tests pass, covering same-scope, cross-scope, missing-scope, unscoped, exact/semantic, sync/async, and single/batch behavior.
- `tests/memory/test_main.py`: 61 passed.
- Ruff checks pass for the changed production and test files.

Red-green evidence: before the production guard was added, 5 of the initial 8 regression cases failed because a cross-scope candidate was updated. After the guard, all 9 final regression cases pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
