### PR TITLE
fix(embeddings): make Azure OpenAI and Gemini embed_batch size configurable

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -16,6 +16,8 @@ class BaseEmbedderConfig(ABC):
         model: Optional[str] = None,
         api_key: Optional[str] = None,
         embedding_dims: Optional[int] = None,
+        # Batch embedding
+        embedding_batch_size: Optional[int] = None,
         # Ollama specific
         ollama_base_url: Optional[str] = None,
         # Openai specific
@@ -50,6 +52,11 @@ class BaseEmbedderConfig(ABC):
         :type api_key: Optional[str], optional
         :param embedding_dims: The number of dimensions in the embedding, defaults to None
         :type embedding_dims: Optional[int], optional
+        :param embedding_batch_size: Max number of texts sent in one embed_batch() request. Lets
+            OpenAI-compatible providers whose per-request limit is below the embedder default
+            (e.g. some Azure OpenAI deployments, or Gemini) batch without hitting HTTP 400s.
+            Defaults to None (each embedder falls back to its own safe default).
+        :type embedding_batch_size: Optional[int], optional
         :param ollama_base_url: Base URL for the Ollama API, defaults to None
         :type ollama_base_url: Optional[str], optional
         :param model_kwargs: key-value arguments for the huggingface embedding model, defaults a dict inside init
@@ -74,10 +81,18 @@ class BaseEmbedderConfig(ABC):
         :type lmstudio_base_url: Optional[str], optional
         """
 
+        if embedding_batch_size is not None and (
+            isinstance(embedding_batch_size, bool)
+            or not isinstance(embedding_batch_size, int)
+            or embedding_batch_size <= 0
+        ):
+            raise ValueError("embedding_batch_size must be a positive integer")
+
         self.model = model
         self.api_key = api_key
         self.openai_base_url = openai_base_url
         self.embedding_dims = embedding_dims
+        self.embedding_batch_size = embedding_batch_size
 
         # AzureOpenAI specific
         self.http_client_proxies = http_client_proxies

--- a/mem0/embeddings/azure_openai.py
+++ b/mem0/embeddings/azure_openai.py
@@ -57,13 +57,15 @@ class AzureOpenAIEmbedding(EmbeddingBase):
     def embed_batch(self, texts, memory_action="add"):
         """Embed multiple texts in a single Azure OpenAI API call.
 
-        Automatically chunks into batches of 100 to stay within API limits.
+        Chunks requests to stay within API limits. The batch size defaults to 100
+        but can be lowered via ``BaseEmbedderConfig.embedding_batch_size`` for Azure
+        deployments whose per-request input limit is below 100.
         """
-        MAX_BATCH = 100
+        max_batch = self.config.embedding_batch_size or 100
         texts = [text.replace("\n", " ") for text in texts]
         all_embeddings = []
-        for i in range(0, len(texts), MAX_BATCH):
-            chunk = texts[i : i + MAX_BATCH]
+        for i in range(0, len(texts), max_batch):
+            chunk = texts[i : i + max_batch]
             response = self.client.embeddings.create(
                 input=chunk,
                 model=self.config.model,

--- a/mem0/embeddings/gemini.py
+++ b/mem0/embeddings/gemini.py
@@ -42,10 +42,10 @@ class GoogleGenAIEmbedding(EmbeddingBase):
         if not texts:
             return []
         config = types.EmbedContentConfig(output_dimensionality=self.config.embedding_dims)
-        MAX_BATCH = 100
+        max_batch = self.config.embedding_batch_size or 100
         all_embeddings = []
-        for i in range(0, len(texts), MAX_BATCH):
-            chunk = [t.replace("\n", " ") for t in texts[i : i + MAX_BATCH]]
+        for i in range(0, len(texts), max_batch):
+            chunk = [t.replace("\n", " ") for t in texts[i : i + max_batch]]
             response = self.client.models.embed_content(model=self.config.model, contents=chunk, config=config)
             all_embeddings.extend(e.values for e in response.embeddings)
         if len(all_embeddings) != len(texts):

--- a/tests/embeddings/test_azure_openai_embeddings.py
+++ b/tests/embeddings/test_azure_openai_embeddings.py
@@ -191,3 +191,32 @@ def test_embed_batch_count_mismatch_raises(mock_openai_client):
 
     with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
         embedder.embed_batch(["first text", "second text"])
+
+
+def test_embed_batch_honors_configured_batch_size(mock_openai_client):
+    """A lower embedding_batch_size must shrink the per-request chunk size.
+
+    Azure deployments can cap embedding inputs below 100; without an override the
+    hardcoded 100 sends them all in one call and the deployment rejects the batch.
+    """
+    config = BaseEmbedderConfig(model="text-embedding-ada-002", embedding_batch_size=10)
+    embedder = AzureOpenAIEmbedding(config)
+
+    def make_chunk_response(input, model):
+        return Mock(data=[Mock(index=i, embedding=[0.1, 0.2]) for i in range(len(input))])
+
+    mock_openai_client.embeddings.create.side_effect = make_chunk_response
+
+    texts = [f"text {i}" for i in range(25)]
+    result = embedder.embed_batch(texts)
+
+    # 25 texts at batch size 10 -> 3 requests, and no request exceeds 10 inputs.
+    assert mock_openai_client.embeddings.create.call_count == 3
+    assert all(len(call.kwargs["input"]) <= 10 for call in mock_openai_client.embeddings.create.call_args_list)
+    assert len(result) == 25
+
+
+def test_invalid_embedding_batch_size_raises():
+    for bad in (0, -5, True, 3.5):
+        with pytest.raises(ValueError, match="embedding_batch_size must be a positive integer"):
+            BaseEmbedderConfig(model="text-embedding-ada-002", embedding_batch_size=bad)

--- a/tests/embeddings/test_gemini_emeddings.py
+++ b/tests/embeddings/test_gemini_emeddings.py
@@ -109,6 +109,32 @@ def test_embed_batch_chunks_over_100_texts(mock_genai, config):
     assert len(result) == 150
 
 
+def test_embed_batch_honors_configured_batch_size(mock_genai):
+    """A lower embedding_batch_size must shrink the per-request chunk size.
+
+    Some Gemini deployments accept fewer than 100 inputs per request; without an
+    override the hardcoded 100 sends them all in one call and the API rejects it.
+    """
+    def make_chunk_response(**kwargs):
+        chunk = kwargs["contents"]
+        emb = type("Embedding", (), {"values": [0.1, 0.2]})
+        return type("Response", (), {"embeddings": [emb() for _ in chunk]})()
+
+    mock_genai.side_effect = make_chunk_response
+
+    config = BaseEmbedderConfig(
+        api_key="dummy_api_key", model="test_model", embedding_dims=786, embedding_batch_size=10
+    )
+    embedder = GoogleGenAIEmbedding(config)
+    texts = [f"text {i}" for i in range(25)]
+    result = embedder.embed_batch(texts)
+
+    # 25 texts at batch size 10 -> 3 requests, and no request exceeds 10 inputs.
+    assert mock_genai.call_count == 3
+    assert all(len(call.kwargs["contents"]) <= 10 for call in mock_genai.call_args_list)
+    assert len(result) == 25
+
+
 def test_embed_batch_strips_newlines(mock_genai, config):
     emb0 = type("Embedding", (), {"values": [0.1, 0.2, 0.3]})()
     mock_genai.return_value = type("Response", (), {"embeddings": [emb0]})()


### PR DESCRIPTION
## Linked Issue

Closes #6885

## Description

`AzureOpenAIEmbedding.embed_batch()` and `GoogleGenAIEmbedding.embed_batch()` both hardcoded `MAX_BATCH = 100`. Azure OpenAI deployments (and some Gemini tiers) cap the number of inputs per embedding request below 100, so a large `embed_batch()` call sends an oversized request and the provider returns HTTP 400 — with no way for the caller to lower the batch size.

This adds a provider-agnostic `embedding_batch_size` to `BaseEmbedderConfig` (validated as a positive integer) and honors it in both embedders, defaulting to `100` so existing behavior is unchanged:

```python
max_batch = self.config.embedding_batch_size or 100
```

This is the same class of fix already open for the OpenAI embedder (#6861) and the Vertex AI embedder (#6189). This PR deliberately covers only the **Azure OpenAI** and **Gemini** embedders — the two that neither of those PRs touch — and reuses a single shared config knob so the embedders converge instead of each inventing their own flag. It does **not** modify `openai.py` or `vertexai.py`, to avoid overlapping those PRs. Happy to align the field name with whatever the OpenAI PR lands on.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A — `embedding_batch_size` defaults to `None`, and both embedders fall back to the previous hardcoded `100`.

## Test Coverage

- [x] I added/updated unit tests

New tests assert that a lowered `embedding_batch_size` actually shrinks the per-request chunk (25 texts at batch size 10 → 3 requests, none exceeding 10 inputs), for both the Azure and Gemini embedders, plus a validation test rejecting non-positive / non-int / bool values. Verified the batch-size tests fail without the embedder wiring and pass with it. `ruff check` and `ruff format --check` clean on the changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (config docstring updated)
