### PR TITLE
fix(vector-stores): normalize LangChain search scores

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class OutputData(BaseModel):
     id: Optional[str]  # memory id
-    score: Optional[float]  # distance
+    score: Optional[float]  # similarity score
     payload: Optional[Dict]  # metadata
 
 
@@ -26,8 +26,8 @@ class OutputData(BaseModel):
 # but exposed by several concrete implementations.
 _SCORED_BY_VECTOR_METHODS = [
     "similarity_search_by_vector_with_relevance_scores",  # Chroma
-    "similarity_search_with_score_by_vector",             # FAISS, Qdrant
-    "similarity_search_by_vector_with_score",             # Pinecone, YDB
+    "similarity_search_with_score_by_vector",  # FAISS, Qdrant
+    "similarity_search_by_vector_with_score",  # Pinecone, YDB
 ]
 
 
@@ -35,6 +35,57 @@ class Langchain(VectorStoreBase):
     def __init__(self, client: VectorStore, collection_name: str = "mem0"):
         self.client = client
         self.collection_name = collection_name
+
+    def _uses_distance_scores(self, method_name: str) -> bool:
+        """Return whether the client's scored method reports a distance."""
+        distance_strategy = getattr(self.client, "distance_strategy", None)
+        strategy_name = getattr(distance_strategy, "value", distance_strategy)
+        if str(strategy_name).upper() in {
+            "EUCLIDEAN_DISTANCE",
+            "EUCLIDEAN",
+            "EUCLID",
+            "L2",
+        }:
+            return True
+
+        # Chroma exposes raw distances through a method whose name includes
+        # "relevance". Its metric is stored on the collection instead of on
+        # the vector store, and its default metric is L2.
+        collection = getattr(self.client, "_collection", None)
+        if method_name == "similarity_search_by_vector_with_relevance_scores":
+            return collection is not None
+
+        metadata = getattr(collection, "metadata", None)
+        return isinstance(metadata, dict) and "hnsw:space" in metadata
+
+    def _normalize_score(self, score: float, method_name: str) -> float:
+        """Convert a raw distance into a higher-is-better score."""
+        if not self._uses_distance_scores(method_name):
+            return float(score)
+
+        select_relevance_score_fn = getattr(self.client, "_select_relevance_score_fn", None)
+        relevance_score_fn = None
+        if callable(select_relevance_score_fn):
+            try:
+                relevance_score_fn = select_relevance_score_fn()
+            except (NotImplementedError, TypeError, ValueError):
+                pass
+
+        if relevance_score_fn is None:
+            relevance_score_fn = getattr(self.client, "relevance_score_fn", None)
+
+        if relevance_score_fn is None:
+            relevance_score_fn = getattr(self.client, "override_relevance_score_fn", None)
+
+        if callable(relevance_score_fn):
+            try:
+                return float(relevance_score_fn(score))
+            except (TypeError, ValueError):
+                pass
+
+        # Keep the adapter's documented score contract even for a custom
+        # distance-based client that does not expose a normalizer.
+        return 1.0 / (1.0 + float(score))
 
     def _parse_output(self, data: Dict) -> List[OutputData]:
         """
@@ -120,7 +171,7 @@ class Langchain(VectorStoreBase):
                 return [
                     OutputData(
                         id=getattr(doc, "id", None),
-                        score=float(score),
+                        score=self._normalize_score(score, method_name),
                         payload=getattr(doc, "metadata", {}),
                     )
                     for doc, score in results

--- a/tests/vector_stores/test_langchain_vector_store.py
+++ b/tests/vector_stores/test_langchain_vector_store.py
@@ -72,7 +72,7 @@ def test_search_vectors_with_agent_id_run_id_filters(langchain_instance):
     # Mock search results
     mock_docs = [
         Mock(metadata={"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}, id="id1"),
-        Mock(metadata={"user_id": "bob", "agent_id": "agent2", "run_id": "run2"}, id="id2")
+        Mock(metadata={"user_id": "bob", "agent_id": "agent2", "run_id": "run2"}, id="id2"),
     ]
     langchain_instance.client.similarity_search_by_vector.return_value = mock_docs
 
@@ -120,9 +120,7 @@ def test_search_vectors_with_no_filters(langchain_instance):
     results = langchain_instance.search(query="", vectors=vectors, top_k=2, filters=None)
 
     # Verify that no filters were passed to the underlying vector store
-    langchain_instance.client.similarity_search_by_vector.assert_called_once_with(
-        embedding=vectors, k=2
-    )
+    langchain_instance.client.similarity_search_by_vector.assert_called_once_with(embedding=vectors, k=2)
 
     assert len(results) == 1
 
@@ -153,7 +151,7 @@ def test_list_with_filters(langchain_instance):
     mock_collection.get.return_value = {
         "ids": [["id1"]],
         "metadatas": [[{"user_id": "alice", "agent_id": "agent1", "run_id": "run1"}]],
-        "documents": [["test document"]]
+        "documents": [["test document"]],
     }
     langchain_instance.client._collection = mock_collection
 
@@ -178,7 +176,7 @@ def test_list_with_single_filter(langchain_instance):
     mock_collection.get.return_value = {
         "ids": [["id1"]],
         "metadatas": [[{"user_id": "alice"}]],
-        "documents": [["test document"]]
+        "documents": [["test document"]],
     }
     langchain_instance.client._collection = mock_collection
 
@@ -201,7 +199,7 @@ def test_list_with_no_filters(langchain_instance):
     mock_collection.get.return_value = {
         "ids": [["id1"]],
         "metadatas": [[{"name": "vector1"}]],
-        "documents": [["test document"]]
+        "documents": [["test document"]],
     }
     langchain_instance.client._collection = mock_collection
 
@@ -265,12 +263,72 @@ def test_search_uses_scored_method_when_available(langchain_instance):
     assert results[1].score == pytest.approx(0.42)
 
 
+def test_search_normalizes_raw_scores_with_client_relevance_function(langchain_instance):
+    """Raw distance scores are converted before mem0 ranks the results."""
+    mock_docs = [Mock(metadata={"data": "mem A"}, id="id1"), Mock(metadata={"data": "mem B"}, id="id2")]
+    langchain_instance.client.similarity_search_with_score_by_vector = Mock(
+        return_value=[(mock_docs[0], 0.05), (mock_docs[1], 1.8)]
+    )
+    langchain_instance.client.distance_strategy = "EUCLIDEAN_DISTANCE"
+    langchain_instance.client._select_relevance_score_fn.return_value = lambda score: 1.0 / (1.0 + score)
+
+    results = langchain_instance.search(query="test", vectors=[[0.1, 0.2]], top_k=5)
+
+    assert results[0].score == pytest.approx(1.0 / 1.05)
+    assert results[1].score == pytest.approx(1.0 / 2.8)
+
+    from mem0.utils.scoring import score_and_rank
+
+    ranked = score_and_rank(
+        [{"id": result.id, "score": result.score} for result in results],
+        {},
+        {},
+        threshold=0.1,
+        top_k=5,
+    )
+    assert [result["id"] for result in ranked] == ["id1", "id2"]
+
+
+def test_search_uses_default_normalization_without_client_relevance_function(langchain_instance):
+    """Distance clients still satisfy the score contract without a hook."""
+    mock_doc = Mock(metadata={"data": "mem A"}, id="id1")
+    langchain_instance.client.similarity_search_with_score_by_vector = Mock(return_value=[(mock_doc, 0.42)])
+    langchain_instance.client.distance_strategy = "EUCLIDEAN_DISTANCE"
+    langchain_instance.client._select_relevance_score_fn.side_effect = NotImplementedError
+
+    results = langchain_instance.search(query="test", vectors=[[0.1, 0.2]], top_k=5)
+
+    assert results[0].score == pytest.approx(1.0 / 1.42)
+
+
+def test_search_keeps_similarity_scores_for_cosine_clients(langchain_instance):
+    """Cosine clients such as Qdrant already return higher-is-better scores."""
+    mock_doc = Mock(metadata={"data": "mem A"}, id="id1")
+    langchain_instance.client.similarity_search_with_score_by_vector = Mock(return_value=[(mock_doc, 0.95)])
+    langchain_instance.client.distance_strategy = "COSINE"
+    langchain_instance.client._select_relevance_score_fn.return_value = lambda score: 1.0 - score
+
+    results = langchain_instance.search(query="test", vectors=[[0.1, 0.2]], top_k=5)
+
+    assert results[0].score == pytest.approx(0.95)
+
+
+def test_search_normalizes_chroma_distance_scores(langchain_instance):
+    """Chroma's raw distance method is normalized despite its method name."""
+    mock_doc = Mock(metadata={"data": "mem A"}, id="id1")
+    langchain_instance.client.similarity_search_by_vector_with_relevance_scores = Mock(return_value=[(mock_doc, 0.05)])
+    langchain_instance.client._collection = Mock(metadata=None)
+    langchain_instance.client._select_relevance_score_fn.return_value = lambda score: 1.0 / (1.0 + score)
+
+    results = langchain_instance.search(query="test", vectors=[[0.1, 0.2]], top_k=5)
+
+    assert results[0].score == pytest.approx(1.0 / 1.05)
+
+
 def test_search_falls_back_when_scored_method_raises_not_implemented(langchain_instance):
     """If the scored method raises NotImplementedError, fall back to score=1.0."""
     mock_docs = [Mock(metadata={"data": "mem A"}, id="id1")]
-    langchain_instance.client.similarity_search_by_vector_with_relevance_scores = Mock(
-        side_effect=NotImplementedError
-    )
+    langchain_instance.client.similarity_search_by_vector_with_relevance_scores = Mock(side_effect=NotImplementedError)
     langchain_instance.client.similarity_search_by_vector.return_value = mock_docs
 
     results = langchain_instance.search(query="test", vectors=[[0.1, 0.2]], top_k=5)


### PR DESCRIPTION
## Linked Issue

Closes #6884

## Description

LangChain vector stores do not all use the same meaning for the float returned by a scored search. The adapter was forwarding raw values as similarity scores, so FAISS L2 distances were treated as higher-is-better scores. A close result could then be filtered out by the semantic threshold while a farther result ranked ahead of it.

This patch:

- uses LangChain's relevance-score function for distance-based stores
- handles Chroma's raw-distance method despite its `relevance_scores` name
- falls back to mem0's documented `1 / (1 + distance)` mapping when a store does not expose a normalizer
- leaves similarity scores from cosine and dot-product stores unchanged
- adds regression coverage for distance stores, Chroma, and similarity-preserving clients

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (FAISS L2 smoke test confirms the nearest result is ranked first)
- [ ] No tests needed (explain why)

Focused checks completed locally:

- `pytest tests/vector_stores/test_langchain_vector_store.py -q` — 18 passed
- `ruff format --check` and `ruff check` on the changed files — passed
- FAISS smoke test with near and far vectors — passed

The full test suite could not be collected in this environment because the optional vector-store dependencies are not installed. The unrelated proxy tests also attempt to install `litellm` through a virtual environment without `pip`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally (see test-environment limitation above)
- [x] I have updated documentation if needed

AI assistance was used to investigate the issue and prepare this patch. The changed code and tests were reviewed before opening the PR.
