### PR TITLE
fix(ts-oss): surface entity link failures at console.warn

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -365,7 +365,7 @@ export class Memory {
           : (listed as any)
       ) as Array<{ id: string; payload: Record<string, any> }>;
     } catch (e) {
-      console.debug(
+      console.warn(
         `Exact entity lookup failed, falling back to semantic dedup: ${e}`,
       );
       return rowsByText;
@@ -398,7 +398,7 @@ export class Memory {
     try {
       entityStore = await this.getEntityStore();
     } catch (e) {
-      console.debug(`Entity store unavailable during cleanup: ${e}`);
+      console.warn(`Entity store unavailable during cleanup: ${e}`);
       return;
     }
 
@@ -411,7 +411,7 @@ export class Memory {
           : (listed as any)
       ) as Array<{ id: string; payload: Record<string, any> }>;
     } catch (e) {
-      console.debug(`Entity store list failed during cleanup: ${e}`);
+      console.warn(`Entity store list failed during cleanup: ${e}`);
       return;
     }
 
@@ -428,7 +428,7 @@ export class Memory {
           try {
             await entityStore.delete(row.id);
           } catch (e) {
-            console.debug(`Entity delete failed for id=${row.id}: ${e}`);
+            console.warn(`Entity delete failed for id=${row.id}: ${e}`);
           }
         } else {
           const newPayload = { ...payload, linkedMemoryIds: remaining };
@@ -437,7 +437,7 @@ export class Memory {
             typeof payload.data === "string" ? payload.data : "";
           if (!entityText) {
             // Can't re-embed without text; skip gracefully.
-            console.debug(
+            console.warn(
               `Entity id=${row.id} missing 'data'; skipping update during cleanup`,
             );
             continue;
@@ -446,17 +446,17 @@ export class Memory {
           try {
             vec = await this.embedder.embed(entityText, "update");
           } catch (e) {
-            console.debug(`Entity re-embed failed for '${entityText}': ${e}`);
+            console.warn(`Entity re-embed failed for '${entityText}': ${e}`);
             continue;
           }
           try {
             await entityStore.update(row.id, vec, newPayload);
           } catch (e) {
-            console.debug(`Entity update failed for id=${row.id}: ${e}`);
+            console.warn(`Entity update failed for id=${row.id}: ${e}`);
           }
         }
       } catch (e) {
-        console.debug(`Entity cleanup error for id=${row?.id}: ${e}`);
+        console.warn(`Entity cleanup error for id=${row?.id}: ${e}`);
       }
     }
   }
@@ -490,7 +490,7 @@ export class Memory {
           try {
             entityVec = await this.embedder.embed(entity.text, "add");
           } catch (e) {
-            console.debug(`Entity embed failed for '${entity.text}': ${e}`);
+            console.warn(`Entity embed failed for '${entity.text}': ${e}`);
             continue;
           }
 
@@ -525,7 +525,7 @@ export class Memory {
             try {
               await entityStore.update(match.id, entityVec, payload);
             } catch (e) {
-              console.debug(`Entity update failed for '${entity.text}': ${e}`);
+              console.warn(`Entity update failed for '${entity.text}': ${e}`);
             }
           } else {
             const entityPayload: Record<string, any> = {
@@ -544,11 +544,11 @@ export class Memory {
                 [entityPayload],
               );
             } catch (e) {
-              console.debug(`Entity insert failed for '${entity.text}': ${e}`);
+              console.warn(`Entity insert failed for '${entity.text}': ${e}`);
             }
           }
         } catch (e) {
-          console.debug(`Entity link error for '${entity.text}': ${e}`);
+          console.warn(`Entity link error for '${entity.text}': ${e}`);
         }
       }
     } catch (e) {
@@ -1154,7 +1154,8 @@ export class Memory {
           for (const t of entityTexts) {
             try {
               entityEmbeddings.push(await this.embedder.embed(t, "add"));
-            } catch {
+            } catch (e) {
+              console.warn(`Entity embed failed for '${t}': ${e}`);
               entityEmbeddings.push(null);
             }
           }
@@ -1210,7 +1211,7 @@ export class Memory {
               try {
                 await entityStore.update(match.id, entityVec, payload);
               } catch (e) {
-                console.debug(`Entity update failed for '${entityText}': ${e}`);
+                console.warn(`Entity update failed for '${entityText}': ${e}`);
               }
             } else {
               // New entity — collect for batch insert

--- a/mem0-ts/src/oss/tests/memory.entity-log-level.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-log-level.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Entity failure observability (#6795).
+ *
+ * Entity linking/cleanup failures used to be logged with console.debug, which
+ * is filtered out by most production log configs. Retrieval quality then
+ * degrades quietly. These failures must surface at console.warn.
+ */
+/// <reference types="jest" />
+import { Memory } from "../src/memory";
+
+jest.setTimeout(15000);
+
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
+
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockResolvedValue(
+      JSON.stringify({
+        memory: [
+          {
+            id: "0",
+            text: "Alice works at OpenAI",
+            attributed_to: "user",
+          },
+        ],
+      }),
+    ),
+  })),
+}));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 1536,
+  })),
+}));
+
+function createMemory(): Memory {
+  return new Memory({
+    version: "v1.1",
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-entity-log-${Date.now()}-${Math.random()}`,
+        dimension: 1536,
+        dbPath: ":memory:",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-5-mini" },
+    },
+    historyDbPath: ":memory:",
+  });
+}
+
+describe("Entity failure log level (#6795)", () => {
+  let memory: Memory;
+  let warnSpy: jest.SpyInstance;
+  let debugSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    memory = createMemory();
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    debugSpy = jest.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
+    jest.restoreAllMocks();
+    await memory.reset();
+  });
+
+  it("warns when entity embed fails during _linkEntitiesForMemory", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    m._entityStore = {
+      list: jest.fn().mockResolvedValue([]),
+      search: jest.fn().mockResolvedValue([]),
+      insert: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m.embedder = {
+      embed: jest.fn().mockRejectedValue(new Error("embed down")),
+      embedBatch: jest.fn().mockRejectedValue(new Error("embed down")),
+    };
+
+    await m._linkEntitiesForMemory("mem-1", "Alice works at OpenAI", {
+      user_id: "u1",
+    });
+
+    const messages = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(messages).toMatch(/Entity embed failed/);
+    const debugMessages = debugSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(debugMessages).not.toMatch(/Entity embed failed/);
+  });
+
+  it("warns when entity re-embed fails during cleanup", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    m._entityStore = {
+      list: jest.fn().mockResolvedValue([
+        {
+          id: "ent-1",
+          payload: {
+            data: "Alice",
+            linkedMemoryIds: ["mem-1", "mem-2"],
+          },
+        },
+      ]),
+      search: jest.fn().mockResolvedValue([]),
+      insert: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m.embedder = {
+      embed: jest.fn().mockRejectedValue(new Error("re-embed down")),
+      embedBatch: jest.fn().mockRejectedValue(new Error("re-embed down")),
+    };
+
+    await m._removeMemoryFromEntityStore("mem-1", { user_id: "u1" });
+
+    const messages = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(messages).toMatch(/Entity re-embed failed/);
+    const debugMessages = debugSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(debugMessages).not.toMatch(/Entity re-embed failed/);
+  });
+
+  it("warns when entity insert fails during _linkEntitiesForMemory", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    m._entityStore = {
+      list: jest.fn().mockResolvedValue([]),
+      search: jest.fn().mockResolvedValue([]),
+      insert: jest.fn().mockRejectedValue(new Error("insert down")),
+      update: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m.embedder = {
+      embed: jest.fn().mockResolvedValue(mockEmbedding),
+      embedBatch: jest
+        .fn()
+        .mockImplementation((texts: string[]) =>
+          Promise.resolve(texts.map(() => mockEmbedding)),
+        ),
+    };
+
+    await m._linkEntitiesForMemory("mem-1", "Alice works at OpenAI", {
+      user_id: "u1",
+    });
+
+    const messages = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(messages).toMatch(/Entity insert failed/);
+    const debugMessages = debugSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(debugMessages).not.toMatch(/Entity insert failed/);
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6795

## Description

Entity linking/cleanup failures on the TS OSS `add` / search / cleanup paths were logged with `console.debug`, which most production log configs filter out. A dropped entity never loses the stored memory row, so the system still looks healthy while entity-boosted search quietly gets worse over time.

This raises those entity-path failure logs from `console.debug` to `console.warn`. No public API change. Also logs the previously silent per-entity embed failure in the phase-7 batch-embed fallback.

Covered drop sites in `mem0-ts/src/oss/src/memory/index.ts`:
- exact entity lookup / entity store unavailable / list failures during cleanup
- entity delete / re-embed / update / cleanup errors
- entity embed / update / insert / link errors in `_linkEntitiesForMemory`
- entity update failure and per-entity embed fallback failure in phase 7 `add()`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `mem0-ts/src/oss/tests/memory.entity-log-level.test.ts` covering:
1. entity embed failure during `_linkEntitiesForMemory`
2. entity re-embed failure during cleanup
3. entity insert failure during `_linkEntitiesForMemory`

Ran locally:
```bash
cd mem0-ts && pnpm exec jest src/oss/tests/memory.entity-log-level.test.ts --coverage=false
# 3 passed
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed