### PR TITLE
feat(memory): add get_summary() to summarize a scope's memories

### DIFF
--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -403,12 +403,12 @@ You are a memory summarization system that records and preserves the complete in
 """
 
 
-MEMORY_SUMMARY_PROMPT = """You are a memory summarization assistant. You are given a list of memories already stored about a user (their facts, preferences, decisions, and context). Produce a concise narrative summary another AI agent can read to instantly understand who the user is and what has been established, without re-reading every memory.
+MEMORY_SUMMARY_PROMPT = """You are a memory summarization assistant. You are given the memories already stored about a user (their facts, preferences, decisions, plans, project context, and history). Produce a thorough context brief another AI agent can load to continue working with full context, without re-reading every memory or asking the user to repeat themselves.
 
 Guidelines:
-- Write 1-2 short paragraphs, or a tight bulleted list when there are many distinct facts.
-- Preserve concrete details: names, preferences, ongoing projects, key decisions, constraints.
-- Group related facts and drop near-duplicates.
+- Be comprehensive. Capture every meaningful detail: the user's identity and preferences; each project and its current state; decisions made and their rationale; plans and next steps; constraints; and any open questions.
+- Completeness matters more than brevity. Do not drop important specifics to keep it short. Prefer an organized, structured write-up (grouped headings or bullets) over a terse paragraph.
+- Group related facts and remove exact duplicates, but keep distinct details distinct.
 - Do not invent anything that is not present in the memories.
 - Output only the summary, with no preamble or commentary.
 """

--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -403,6 +403,17 @@ You are a memory summarization system that records and preserves the complete in
 """
 
 
+MEMORY_SUMMARY_PROMPT = """You are a memory summarization assistant. You are given a list of memories already stored about a user (their facts, preferences, decisions, and context). Produce a concise narrative summary another AI agent can read to instantly understand who the user is and what has been established, without re-reading every memory.
+
+Guidelines:
+- Write 1-2 short paragraphs, or a tight bulleted list when there are many distinct facts.
+- Preserve concrete details: names, preferences, ongoing projects, key decisions, constraints.
+- Group related facts and drop near-duplicates.
+- Do not invent anything that is not present in the memories.
+- Output only the summary, with no preamble or commentary.
+"""
+
+
 def get_update_memory_messages(retrieved_old_memory_dict, response_content, custom_update_memory_prompt=None):
     if custom_update_memory_prompt is None:
         global DEFAULT_UPDATE_MEMORY_PROMPT

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -10,7 +10,7 @@ import uuid
 import warnings
 from copy import deepcopy
 from datetime import date, datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import ValidationError
 
@@ -19,6 +19,7 @@ from mem0.configs.enums import MemoryType
 from mem0.configs.prompts import (
     ADDITIVE_EXTRACTION_PROMPT,
     AGENT_CONTEXT_SUFFIX,
+    MEMORY_SUMMARY_PROMPT,
     PROCEDURAL_MEMORY_SYSTEM_PROMPT,
     generate_additive_extraction_prompt,
 )
@@ -1317,6 +1318,57 @@ class Memory(MemoryBase):
         else:
             display_first_run_notice(self, "sync", "get_all")
         return {"results": all_memories_result}
+
+    def get_summary(self, *, filters: Optional[Dict[str, Any]] = None, limit: int = 100) -> Dict[str, Any]:
+        """
+        Summarize a scope's memories into a compact context brief.
+
+        Fetches the scope's non-expired memories and runs a single LLM pass to produce a
+        narrative summary an agent can load as prior context instead of re-reading every
+        memory. Read-only: nothing is stored.
+
+        Args:
+            filters (dict): Filter dict; must contain at least one of user_id, agent_id, run_id.
+                Example: filters={"user_id": "u1"}
+            limit (int, optional): Maximum number of memories to summarize. Defaults to 100.
+
+        Returns:
+            dict: {"summary": str, "memory_count": int}. summary is "" when the scope has no
+                  memories (no LLM call is made in that case).
+
+        Raises:
+            ValueError: If filters doesn't contain at least one of user_id, agent_id, run_id,
+                or if limit is invalid.
+            LLMError: If the summarization LLM call fails.
+        """
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+            raise ValueError("limit must be a positive integer.")
+
+        memories = self.get_all(filters=filters, top_k=limit).get("results", [])
+
+        keys, encoded_ids = process_telemetry_filters(dict(filters) if filters else {})
+        capture_event(
+            "mem0.get_summary", self, {"limit": limit, "keys": keys, "encoded_ids": encoded_ids, "sync_type": "sync"}
+        )
+
+        if not memories:
+            return {"summary": "", "memory_count": 0}
+
+        return {"summary": self._summarize_memories(memories), "memory_count": len(memories)}
+
+    def _summarize_memories(self, memories: List[Dict[str, Any]]) -> str:
+        memory_lines = "\n".join(f"- {m['memory']}" for m in memories if m.get("memory"))
+        try:
+            summary = self.llm.generate_response(
+                messages=[
+                    {"role": "system", "content": MEMORY_SUMMARY_PROMPT},
+                    {"role": "user", "content": f"Memories:\n{memory_lines}"},
+                ]
+            )
+        except Exception as e:
+            logger.error(f"Memory summary generation failed: {e}")
+            raise LLMError(f"Memory summary generation failed: {e}") from e
+        return remove_code_blocks(summary).strip()
 
     def _get_all_from_vector_store(self, filters, limit, show_expired=False, output_limit=None):
         memories_result = self.vector_store.list(filters=filters, top_k=limit)
@@ -2969,6 +3021,58 @@ class AsyncMemory(MemoryBase):
         else:
             await display_first_run_notice_async(self, "async", "get_all")
         return {"results": all_memories_result}
+
+    async def get_summary(self, *, filters: Optional[Dict[str, Any]] = None, limit: int = 100) -> Dict[str, Any]:
+        """
+        Summarize a scope's memories into a compact context brief.
+
+        Fetches the scope's non-expired memories and runs a single LLM pass to produce a
+        narrative summary an agent can load as prior context instead of re-reading every
+        memory. Read-only: nothing is stored.
+
+        Args:
+            filters (dict): Filter dict; must contain at least one of user_id, agent_id, run_id.
+                Example: filters={"user_id": "u1"}
+            limit (int, optional): Maximum number of memories to summarize. Defaults to 100.
+
+        Returns:
+            dict: {"summary": str, "memory_count": int}. summary is "" when the scope has no
+                  memories (no LLM call is made in that case).
+
+        Raises:
+            ValueError: If filters doesn't contain at least one of user_id, agent_id, run_id,
+                or if limit is invalid.
+            LLMError: If the summarization LLM call fails.
+        """
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+            raise ValueError("limit must be a positive integer.")
+
+        memories = (await self.get_all(filters=filters, top_k=limit)).get("results", [])
+
+        keys, encoded_ids = process_telemetry_filters(dict(filters) if filters else {})
+        capture_event(
+            "mem0.get_summary", self, {"limit": limit, "keys": keys, "encoded_ids": encoded_ids, "sync_type": "async"}
+        )
+
+        if not memories:
+            return {"summary": "", "memory_count": 0}
+
+        return {"summary": await self._summarize_memories(memories), "memory_count": len(memories)}
+
+    async def _summarize_memories(self, memories: List[Dict[str, Any]]) -> str:
+        memory_lines = "\n".join(f"- {m['memory']}" for m in memories if m.get("memory"))
+        try:
+            summary = await asyncio.to_thread(
+                self.llm.generate_response,
+                messages=[
+                    {"role": "system", "content": MEMORY_SUMMARY_PROMPT},
+                    {"role": "user", "content": f"Memories:\n{memory_lines}"},
+                ],
+            )
+        except Exception as e:
+            logger.error(f"Memory summary generation failed: {e}")
+            raise LLMError(f"Memory summary generation failed: {e}") from e
+        return remove_code_blocks(summary).strip()
 
     async def _get_all_from_vector_store(self, filters, limit, show_expired=False, output_limit=None):
         memories_result = await asyncio.to_thread(self.vector_store.list, filters=filters, top_k=limit)

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1321,11 +1321,11 @@ class Memory(MemoryBase):
 
     def get_summary(self, *, filters: Optional[Dict[str, Any]] = None, limit: int = 100) -> Dict[str, Any]:
         """
-        Summarize a scope's memories into a compact context brief.
+        Summarize a scope's memories into a comprehensive context brief.
 
         Fetches the scope's non-expired memories and runs a single LLM pass to produce a
-        narrative summary an agent can load as prior context instead of re-reading every
-        memory. Read-only: nothing is stored.
+        thorough context brief an agent can load to continue with full context instead of
+        re-reading every memory. Read-only: nothing is stored.
 
         Args:
             filters (dict): Filter dict; must contain at least one of user_id, agent_id, run_id.
@@ -3024,11 +3024,11 @@ class AsyncMemory(MemoryBase):
 
     async def get_summary(self, *, filters: Optional[Dict[str, Any]] = None, limit: int = 100) -> Dict[str, Any]:
         """
-        Summarize a scope's memories into a compact context brief.
+        Summarize a scope's memories into a comprehensive context brief.
 
         Fetches the scope's non-expired memories and runs a single LLM pass to produce a
-        narrative summary an agent can load as prior context instead of re-reading every
-        memory. Read-only: nothing is stored.
+        thorough context brief an agent can load to continue with full context instead of
+        re-reading every memory. Read-only: nothing is stored.
 
         Args:
             filters (dict): Filter dict; must contain at least one of user_id, agent_id, run_id.

--- a/tests/memory/test_get_summary.py
+++ b/tests/memory/test_get_summary.py
@@ -1,0 +1,103 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from mem0.exceptions import LLMError
+from mem0.memory.main import AsyncMemory, Memory
+
+
+def _setup_mocks(mocker):
+    """Mock the factories so Memory/AsyncMemory construct without real providers."""
+    mock_embedder = mocker.MagicMock()
+    mock_embedder.return_value.embed.return_value = [0.1, 0.2, 0.3]
+    mocker.patch("mem0.utils.factory.EmbedderFactory.create", mock_embedder)
+
+    mock_vector_store = mocker.MagicMock()
+    mocker.patch(
+        "mem0.utils.factory.VectorStoreFactory.create",
+        side_effect=[mock_vector_store.return_value, mocker.MagicMock()],
+    )
+
+    mocker.patch("mem0.utils.factory.LlmFactory.create", mocker.MagicMock())
+    mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+    mocker.patch("mem0.memory.main.capture_event")
+
+
+_MEMORIES = [
+    {"id": "1", "memory": "User's name is Yash"},
+    {"id": "2", "memory": "User prefers dark mode"},
+]
+
+
+class TestGetSummarySync:
+    @pytest.fixture
+    def memory(self, mocker):
+        _setup_mocks(mocker)
+        return Memory()
+
+    def test_returns_summary_and_count(self, memory):
+        memory.get_all = MagicMock(return_value={"results": _MEMORIES})
+        memory.llm.generate_response = MagicMock(return_value="Yash prefers dark mode.")
+
+        result = memory.get_summary(filters={"user_id": "u1"})
+
+        assert result == {"summary": "Yash prefers dark mode.", "memory_count": 2}
+        memory.get_all.assert_called_once_with(filters={"user_id": "u1"}, top_k=100)
+        # every memory's text is fed to the summarizer
+        user_msg = memory.llm.generate_response.call_args[1]["messages"][1]["content"]
+        assert "User's name is Yash" in user_msg
+        assert "User prefers dark mode" in user_msg
+
+    def test_empty_scope_returns_blank_without_calling_llm(self, memory):
+        memory.get_all = MagicMock(return_value={"results": []})
+        memory.llm.generate_response = MagicMock()
+
+        result = memory.get_summary(filters={"user_id": "u1"})
+
+        assert result == {"summary": "", "memory_count": 0}
+        memory.llm.generate_response.assert_not_called()
+
+    def test_missing_scope_raises_value_error(self, memory):
+        # get_all enforces "at least one of user_id/agent_id/run_id"; get_summary must surface it.
+        with pytest.raises(ValueError):
+            memory.get_summary(filters={})
+
+    @pytest.mark.parametrize("bad_limit", [0, -5, True])
+    def test_invalid_limit_raises_value_error(self, memory, bad_limit):
+        with pytest.raises(ValueError, match="limit must be a positive integer"):
+            memory.get_summary(filters={"user_id": "u1"}, limit=bad_limit)
+
+    def test_llm_failure_raises_llmerror_with_cause(self, memory):
+        memory.get_all = MagicMock(return_value={"results": _MEMORIES})
+        memory.llm.generate_response = MagicMock(side_effect=RuntimeError("429 rate limit"))
+
+        with pytest.raises(LLMError) as exc_info:
+            memory.get_summary(filters={"user_id": "u1"})
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+class TestGetSummaryAsync:
+    @pytest.fixture
+    def memory(self, mocker):
+        _setup_mocks(mocker)
+        return AsyncMemory()
+
+    @pytest.mark.asyncio
+    async def test_returns_summary_and_count(self, memory, mocker):
+        memory.get_all = mocker.AsyncMock(return_value={"results": _MEMORIES})
+        memory.llm.generate_response = MagicMock(return_value="Yash prefers dark mode.")
+
+        result = await memory.get_summary(filters={"user_id": "u1"})
+
+        assert result == {"summary": "Yash prefers dark mode.", "memory_count": 2}
+        memory.get_all.assert_awaited_once_with(filters={"user_id": "u1"}, top_k=100)
+
+    @pytest.mark.asyncio
+    async def test_empty_scope_returns_blank_without_calling_llm(self, memory, mocker):
+        memory.get_all = mocker.AsyncMock(return_value={"results": []})
+        memory.llm.generate_response = MagicMock()
+
+        result = await memory.get_summary(filters={"user_id": "u1"})
+
+        assert result == {"summary": "", "memory_count": 0}
+        memory.llm.generate_response.assert_not_called()


### PR DESCRIPTION
## Linked Issue

Closes #6889

## Description

Adds `Memory.get_summary()` and `AsyncMemory.get_summary()` to the OSS SDK: fetch a scope's memories via `get_all` and run one LLM pass to return a comprehensive context brief - `{"summary": str, "memory_count": int}`.

This brings the hosted platform's summary (`MemoryClient.get_summary` -> `/v1/summary/`) to self-hosted users, and serves cross-agent / cross-session handoff: a new agent loads prior context in one call instead of re-reading every memory.

```python
m.get_summary(filters={"user_id": "u1"})
# {"summary": "...", "memory_count": 12}
```

Read-only (stores nothing), opt-in, sync + async, core extraction pipeline untouched.

Notes:
- Reuses `get_all`, so it inherits scope validation + expiration filtering across all vector stores. That also fires `get_all`'s telemetry / first-run notice; happy to switch to the internal path if you'd rather avoid that.
- Empty scope short-circuits to `{"summary": "", "memory_count": 0}` with no LLM call.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. Purely additive - two new methods.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

`tests/memory/test_get_summary.py` (9 tests): summary + count, empty-scope short-circuit (no LLM call), missing-scope ValueError, invalid-limit guard, LLMError chaining, and async parity. ruff (0.16) + isort clean; full `tests/memory/` suite green (370 passed).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (will add the docs/ page once the direction is confirmed)