### PR TITLE
fix(proxy): restore background memory writes

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -148,15 +148,21 @@ class Completions:
 
     def _async_add_to_memory(self, messages, user_id, agent_id, run_id, metadata, filters):
         def add_task():
-            logger.debug("Adding to memory asynchronously")
-            self.mem0_client.add(
-                messages=messages,
-                user_id=user_id,
-                agent_id=agent_id,
-                run_id=run_id,
-                metadata=metadata,
-                filters=filters,
-            )
+            try:
+                logger.debug("Adding to memory asynchronously")
+                if isinstance(self.mem0_client, MemoryClient):
+                    entity_filters = {
+                        key: value
+                        for key, value in {"user_id": user_id, "agent_id": agent_id, "run_id": run_id}.items()
+                        if value is not None
+                    }
+                    add_kwargs = {"filters": {**(filters or {}), **entity_filters}}
+                else:
+                    add_kwargs = {"user_id": user_id, "agent_id": agent_id, "run_id": run_id}
+
+                self.mem0_client.add(messages=messages, metadata=metadata, **add_kwargs)
+            except Exception:
+                logger.exception("Failed to add messages to memory asynchronously")
 
         threading.Thread(target=add_task, daemon=True).start()
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,8 +1,9 @@
 import builtins
 import importlib
 import inspect
+import logging
 import sys
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, create_autospec, patch
 
 import pytest
 
@@ -62,6 +63,80 @@ def test_mem0_initialization_without_params(mock_openai_embedding_client, mock_o
 def test_chat_initialization(mock_memory_client):
     chat = Chat(mock_memory_client)
     assert isinstance(chat.completions, Completions)
+
+
+def test_async_add_to_memory_uses_oss_add_signature():
+    memory = create_autospec(Memory, instance=True)
+    completions = Completions(memory)
+    messages = [{"role": "user", "content": "Remember this"}]
+
+    with patch("mem0.proxy.main.threading.Thread") as mock_thread:
+        completions._async_add_to_memory(
+            messages=messages,
+            user_id="alice",
+            agent_id=None,
+            run_id="run-1",
+            metadata={"source": "proxy"},
+            filters={"category": "preference"},
+        )
+        add_task = mock_thread.call_args.kwargs["target"]
+        add_task()
+
+    memory.add.assert_called_once_with(
+        messages=messages,
+        user_id="alice",
+        agent_id=None,
+        run_id="run-1",
+        metadata={"source": "proxy"},
+    )
+    mock_thread.assert_called_once()
+    assert mock_thread.call_args.kwargs["daemon"] is True
+    mock_thread.return_value.start.assert_called_once_with()
+
+
+def test_async_add_to_memory_combines_hosted_filters(mock_memory_client):
+    completions = Completions(mock_memory_client)
+    messages = [{"role": "user", "content": "Remember this"}]
+    filters = {"category": "preference", "user_id": "outdated"}
+
+    with patch("mem0.proxy.main.threading.Thread") as mock_thread:
+        completions._async_add_to_memory(
+            messages=messages,
+            user_id="alice",
+            agent_id="assistant",
+            run_id=None,
+            metadata={"source": "proxy"},
+            filters=filters,
+        )
+        mock_thread.call_args.kwargs["target"]()
+
+    mock_memory_client.add.assert_called_once_with(
+        messages=messages,
+        metadata={"source": "proxy"},
+        filters={"category": "preference", "user_id": "alice", "agent_id": "assistant"},
+    )
+    assert filters == {"category": "preference", "user_id": "outdated"}
+
+
+def test_async_add_to_memory_logs_background_failures(caplog):
+    memory = create_autospec(Memory, instance=True)
+    memory.add.side_effect = RuntimeError("storage unavailable")
+    completions = Completions(memory)
+
+    with patch("mem0.proxy.main.threading.Thread") as mock_thread:
+        completions._async_add_to_memory(
+            messages=[{"role": "user", "content": "Remember this"}],
+            user_id="alice",
+            agent_id=None,
+            run_id=None,
+            metadata=None,
+            filters=None,
+        )
+        with caplog.at_level(logging.ERROR, logger="mem0.proxy.main"):
+            mock_thread.call_args.kwargs["target"]()
+
+    assert "Failed to add messages to memory asynchronously" in caplog.text
+    assert "storage unavailable" in caplog.text
 
 
 def test_completions_create(mock_memory_client, mock_litellm):


### PR DESCRIPTION
## Linked Issue

Closes #6819

## Description

The proxy background writer passed the same keyword arguments to both memory backends even though their add APIs use different identity shapes. OSS Memory.add rejects filters entirely, so its daemon thread raised TypeError before storing any conversation. MemoryClient.add, on the other hand, expects entity IDs inside filters.

This change:

- calls OSS Memory.add with top-level user_id, agent_id, and run_id only;
- merges hosted entity IDs into a copy of filters for MemoryClient.add, with explicit entity arguments taking precedence;
- catches and logs background write failures so they no longer disappear in an unobserved daemon thread.

The caller-provided filters dictionary is not mutated. There is no public API change.

## Scope note

This PR fixes the background **write** failure in #6819. The subsequent OSS search path has a separate top-level-entity-parameter bug tracked in #4907, with an existing fix in #4908. That independent search issue can still prevent the full proxy `create()` flow from completing after the write is scheduled; it is deliberately not duplicated or folded into this focused PR.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (described below)
- [ ] No tests needed (explain why)

Added deterministic regression coverage for the OSS signature, hosted filter merging, input immutability, and background exception logging. I also ran a real daemon-thread probe for both the successful write and failure-log paths.

Local validation:

- Python 3.12 full suite: 1814 passed, 75 skipped
- Python 3.10, 3.11, and 3.12 proxy tests: 10 passed on each version
- Ruff 0.16.0 check: full repository passed
- isort check: changed Python files passed
- compileall and git diff --check: passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (not needed: internal bug fix with no public API change)
