### PR TITLE
fix(mem0-plugin): stop search errors from looking like empty results

### DIFF
--- a/integrations/mem0-plugin/scripts/_search.py
+++ b/integrations/mem0-plugin/scripts/_search.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import urllib.request
 
 SEARCH_URL = "https://api.mem0.ai/v3/memories/search/"
@@ -83,7 +84,8 @@ def search_memories(
         if min_score > 0:
             results = [m for m in results if m.get("score", 0) >= min_score]
         return results
-    except Exception:
+    except Exception as e:
+        print(f"[mem0] search request failed: {e}", file=sys.stderr)
         return []
 
 

--- a/integrations/mem0-plugin/tests/test_search.py
+++ b/integrations/mem0-plugin/tests/test_search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import urllib.error
 from unittest.mock import MagicMock, patch
 
 
@@ -99,6 +100,39 @@ def test_search_memories_no_api_key_returns_empty():
 
     results = search_memories("", "user", "proj", "query")
     assert results == []
+
+
+def test_search_memories_logs_rate_limit_error(capsys):
+    """Bug bash #22: a 429 must not look identical to a genuine empty result."""
+    from _search import search_memories
+
+    def mock_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError("http://x", 429, "Too Many Requests", {}, None)
+
+    with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+        results = search_memories("key", "user", "proj", "query")
+
+    assert results == []
+    err = capsys.readouterr().err
+    assert "429" in err
+    assert "Too Many Requests" in err
+
+
+def test_search_memories_happy_path_is_silent(capsys):
+    from _search import search_memories
+
+    def mock_urlopen(req, timeout=None):
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({"results": []}).encode()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+        results = search_memories("key", "user", "proj", "query")
+
+    assert results == []
+    assert capsys.readouterr().err == ""
 
 
 def test_search_memories_omits_rerank_by_default():


### PR DESCRIPTION
## Linked Issue

This has no linked issue: it comes from the July 31 bug bash triage, item 22.

## Description

`integrations/mem0-plugin/scripts/_search.py` caught every exception from the mem0 search API call and returned an empty list, with no distinction between "the search genuinely found nothing" and "the request failed" (for example a 429 when a user has exhausted their quota). Since `file_context.py` renders an empty list as "no memories found," a rate-limited user saw the same silent message as a user with no matching memories.

The fix logs the caught exception to stderr before returning the empty list, matching the plain `print(..., file=sys.stderr)` convention already used by the other lean scripts in this directory (`import_competing_tools.py`, `session_stats.py`, `setup_coding_categories.py`). The function still returns a list on every path so it keeps behaving safely inside editor hooks; the failure is now visible in the hook logs instead of silent.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `test_search_memories_logs_rate_limit_error` (mocks a 429 `HTTPError`, asserts the status code and reason land on stderr while the return value stays `[]`) and `test_search_memories_happy_path_is_silent` (asserts a genuine empty result produces no stderr output) to `integrations/mem0-plugin/tests/test_search.py`. Full suite: `python -m pytest integrations/mem0-plugin/tests/ -q` passes, 169 passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed