### PR TITLE
docs: contrast the advanced retrieval modes with distinct examples

### DIFF
--- a/docs/platform/features/advanced-retrieval.mdx
+++ b/docs/platform/features/advanced-retrieval.mdx
@@ -99,16 +99,23 @@ results = client.search(
 
 ### Recommended Configurations
 
+`rerank` is the only lever here that changes result *order*. `filters`, `top_k`, and `threshold` change *which* memories come back, not how they're ordered. The two functions below send the same query and filters; the only difference is the `rerank` flag.
+
 <CodeGroup>
 ```python Python
-# Basic search - good for exploration
+# Fast path - use for exploratory search, or anywhere the user scans a list
+# of results instead of trusting result #1 (dashboards, "show me everything
+# about X" style queries). No reranking overhead.
 def quick_search(query, user_id):
     return client.search(
         query=query,
         filters={"user_id": user_id},
     )
 
-# Reranked search - good when result order matters
+# Precision path - use when only the top result reaches the user, e.g. an
+# agent that injects a single fact into a prompt. Reranking (see above)
+# re-scores every match and moves the closest one to position 1, at the
+# cost of ~150-200ms added latency.
 def standard_search(query, user_id):
     return client.search(
         query=query,
@@ -118,14 +125,19 @@ def standard_search(query, user_id):
 ```
 
 ```javascript JavaScript
-// Basic search - good for exploration
+// Fast path - use for exploratory search, or anywhere the user scans a list
+// of results instead of trusting result #1 (dashboards, "show me everything
+// about X" style queries). No reranking overhead.
 function quickSearch(query, userId) {
     return client.search(query, {
         filters: { user_id: userId },
     });
 }
 
-// Reranked search - good when result order matters
+// Precision path - use when only the top result reaches the user, e.g. an
+// agent that injects a single fact into a prompt. Reranking (see above)
+// re-scores every match and moves the closest one to position 1, at the
+// cost of ~150-200ms added latency.
 function standardSearch(query, userId) {
     return client.search(query, {
         filters: { user_id: userId },
@@ -134,6 +146,8 @@ function standardSearch(query, userId) {
 }
 ```
 </CodeGroup>
+
+**What changes in the response:** both calls return the same fields on each memory (see the [Search Memories API reference](/api-reference/memory/search-memories) for the full response shape). The only difference is the *order* of the `results` array, the same effect shown in the [Reranking example above](#reranking): `quick_search` returns results ranked by raw similarity, `standard_search` returns the reranked order.
 
 ## Best Practices
 


### PR DESCRIPTION
## Linked Issue

This covers item 19 from the July 31 bug bash (no tracking issue was filed).

## Description

On the advanced retrieval page (`docs/platform/features/advanced-retrieval.mdx`), the `standard_search`/`precise_search` examples used to be byte-identical, so a reader couldn't tell the two search modes apart or know when to pick one over the other.

A prior commit (760dca6f3) already deleted the duplicate `precise_search`/`preciseSearch` function, but that only removed the copy-paste; it never explained the actual tradeoff between the two remaining functions (`quick_search` vs `standard_search`).

I traced the real behavior in code before writing anything:
- `mem0/client/types.py` (`SearchMemoryOptions`) and `docs/openapi.json` (`/v3/memories/search/`) show `rerank` is a plain boolean, default `false`, described as "Apply the managed reranker for better ordering (adds latency)."
- `docs/api-reference/memory/search-memories.mdx` documents the full `results` response shape for the v3 search endpoint; the schema does not vary with `rerank`.
- `filters`, `top_k`, and `threshold` change *which* memories are returned, not their order, so they aren't the right axis to contrast here.
- `keyword_search` (present as a legacy field on both client SDK types) is explicitly listed as a **removed** parameter in `docs/migration/platform-v2-to-v3.mdx` and `docs/migration/oss-v2-to-v3.mdx`, and does not appear on the v3 search endpoint in `docs/openapi.json`. I did not use it as a second "mode" since it isn't part of the current v3 contract.

So `rerank` on/off is the only verified behavioral difference. I rewrote the `quick_search`/`standard_search` (and JS `quickSearch`/`standardSearch`) examples to:
- State a concrete scenario where each one wins (exploratory/dashboard search vs. an agent that only uses the top-1 result).
- Explain what changes in the response: only the *order* of the `results` array, not the fields on each memory, per the Search Memories API reference. No new sample response was fabricated; the ordering claim points back to the page's existing "before/after" reranking illustration instead of inventing a new JSON payload.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

Docs-only change to prose and code comments in an `.mdx` page; no executable code changed. Ran `python scripts/check-llms-txt-coverage.py`, which passes (no new page was added, so `docs/llms.txt` did not need updates).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed