### PR TITLE
fix(memory): drop unpersisted memories from add() results

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -22,7 +22,7 @@ from mem0.configs.prompts import (
     PROCEDURAL_MEMORY_SYSTEM_PROMPT,
     generate_additive_extraction_prompt,
 )
-from mem0.exceptions import LLMError
+from mem0.exceptions import LLMError, VectorStoreError
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from mem0.memory.base import MemoryBase
 from mem0.memory.notices import (
@@ -1048,13 +1048,26 @@ class Memory(MemoryBase):
                 ids=all_ids,
                 payloads=all_payloads,
             )
-        except Exception:
-            # Fallback: insert one by one
-            for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
+        except Exception as batch_error:
+            # Fallback: insert one by one. Records the store still rejects are dropped so
+            # history, entity linking, and the returned payload never reference a memory
+            # that was not persisted.
+            persisted = []
+            for record in records:
+                mid, _, vec, pay = record
                 try:
                     self.vector_store.insert(vectors=[vec], ids=[mid], payloads=[pay])
+                    persisted.append(record)
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid}: {e}")
+
+            if not persisted:
+                raise VectorStoreError(
+                    message="Failed to persist any extracted memories to the vector store",
+                    details={"attempted": len(records)},
+                ) from batch_error
+
+            records = persisted
 
         # Batch history
         history_records = [
@@ -2701,12 +2714,26 @@ class AsyncMemory(MemoryBase):
                 ids=all_ids,
                 payloads=all_payloads,
             )
-        except Exception:
-            for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
+        except Exception as batch_error:
+            # Fallback: insert one by one. Records the store still rejects are dropped so
+            # history, entity linking, and the returned payload never reference a memory
+            # that was not persisted.
+            persisted = []
+            for record in records:
+                mid, _, vec, pay = record
                 try:
                     await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
+                    persisted.append(record)
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid} (async): {e}")
+
+            if not persisted:
+                raise VectorStoreError(
+                    message="Failed to persist any extracted memories to the vector store",
+                    details={"attempted": len(records)},
+                ) from batch_error
+
+            records = persisted
 
         # Batch history
         history_records = [

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -7,6 +7,7 @@ import pytest
 
 from mem0 import Memory
 from mem0.configs.base import MemoryConfig
+from mem0.exceptions import VectorStoreError
 from mem0.memory.main import _entity_collection_name
 from mem0.memory.utils import normalize_facts
 
@@ -477,6 +478,178 @@ def test_add_infer_with_malformed_llm_facts(mock_sqlite, mock_llm_factory, mock_
         filters={"user_id": "test_user"},
         infer=True,
     )
+
+
+def _reject_insert_of(rejected_text):
+    """Force the batch insert to fail, then reject one record on the per-record retry."""
+
+    def _insert(vectors, ids, payloads):
+        if len(ids) > 1:
+            raise RuntimeError("batch insert rejected")
+        if payloads[0].get("data") == rejected_text:
+            raise RuntimeError("record rejected by vector store")
+
+    return _insert
+
+
+def _build_memory_for_add(memory_cls, mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory, texts):
+    """Build a memory instance whose LLM extracts `texts`, with its stores mocked out."""
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.1, 0.2, 0.3]
+    embedder.embed_batch.side_effect = lambda batch, action: [[0.1, 0.2, 0.3] for _ in batch]
+    embedder.config = MagicMock(embedding_dims=3)
+    mock_embedder_factory.return_value = embedder
+
+    mock_vector_store = MagicMock()
+    mock_vector_store.search.return_value = []
+    mock_vector_factory.return_value = mock_vector_store
+
+    mock_llm = MagicMock()
+    mock_llm.generate_response.return_value = json.dumps({"memory": [{"text": text} for text in texts]})
+    mock_llm_factory.return_value = mock_llm
+
+    mock_db = MagicMock()
+    mock_db.get_last_messages.return_value = []
+    mock_sqlite.return_value = mock_db
+
+    memory = memory_cls(MemoryConfig())
+    memory._entity_store = MagicMock(search_batch=MagicMock(return_value=[]))
+
+    return memory, mock_vector_store, mock_db
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+def test_add_omits_memories_the_vector_store_rejected(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """A memory the vector store rejected must not be returned to the caller as an ADD.
+
+    The per-record fallback used to log the failure and continue, while the returned
+    payload was still built from every extracted record - handing callers ids that
+    were never persisted.
+    """
+    from mem0.memory.main import Memory as MemoryClass
+
+    rejected = "User is allergic to penicillin"
+    memory, mock_vector_store, _ = _build_memory_for_add(
+        MemoryClass,
+        mock_sqlite,
+        mock_llm_factory,
+        mock_vector_factory,
+        mock_embedder_factory,
+        ["User's name is Aryan", rejected, "User works as an engineer"],
+    )
+    mock_vector_store.insert.side_effect = _reject_insert_of(rejected)
+
+    results = memory._add_to_vector_store(
+        messages=[{"role": "user", "content": "some conversation"}],
+        metadata={"user_id": "test_user"},
+        filters={"user_id": "test_user"},
+        infer=True,
+    )
+
+    assert [result["memory"] for result in results] == ["User's name is Aryan", "User works as an engineer"]
+    assert all(result["event"] == "ADD" for result in results)
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+def test_add_skips_history_for_memories_the_vector_store_rejected(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """History must not record an ADD for a memory that is not in the vector store."""
+    from mem0.memory.main import Memory as MemoryClass
+
+    rejected = "User is allergic to penicillin"
+    memory, mock_vector_store, mock_db = _build_memory_for_add(
+        MemoryClass,
+        mock_sqlite,
+        mock_llm_factory,
+        mock_vector_factory,
+        mock_embedder_factory,
+        ["User's name is Aryan", rejected],
+    )
+    mock_vector_store.insert.side_effect = _reject_insert_of(rejected)
+
+    memory._add_to_vector_store(
+        messages=[{"role": "user", "content": "some conversation"}],
+        metadata={"user_id": "test_user"},
+        filters={"user_id": "test_user"},
+        infer=True,
+    )
+
+    history_records = mock_db.batch_add_history.call_args.args[0]
+    assert [record["new_memory"] for record in history_records] == ["User's name is Aryan"]
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+def test_add_raises_when_no_memory_could_be_persisted(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """A total persistence failure surfaces as VectorStoreError, not an empty result.
+
+    Returning [] here is indistinguishable from 'the LLM extracted nothing', which is
+    the ambiguity add() already avoids for LLM failures.
+    """
+    from mem0.memory.main import Memory as MemoryClass
+
+    memory, mock_vector_store, _ = _build_memory_for_add(
+        MemoryClass,
+        mock_sqlite,
+        mock_llm_factory,
+        mock_vector_factory,
+        mock_embedder_factory,
+        ["User's name is Aryan"],
+    )
+    mock_vector_store.insert.side_effect = RuntimeError("vector store unreachable")
+
+    with pytest.raises(VectorStoreError, match="Failed to persist any extracted memories"):
+        memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "some conversation"}],
+            metadata={"user_id": "test_user"},
+            filters={"user_id": "test_user"},
+            infer=True,
+        )
+
+
+@pytest.mark.asyncio
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+async def test_async_add_omits_memories_the_vector_store_rejected(
+    mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory
+):
+    """Async twin: rejected records are dropped from the returned payload."""
+    from mem0.memory.main import AsyncMemory
+
+    rejected = "User is allergic to penicillin"
+    memory, mock_vector_store, _ = _build_memory_for_add(
+        AsyncMemory,
+        mock_sqlite,
+        mock_llm_factory,
+        mock_vector_factory,
+        mock_embedder_factory,
+        ["User's name is Aryan", rejected],
+    )
+    mock_vector_store.insert.side_effect = _reject_insert_of(rejected)
+
+    results = await memory._add_to_vector_store(
+        messages=[{"role": "user", "content": "some conversation"}],
+        metadata={"user_id": "test_user"},
+        effective_filters={"user_id": "test_user"},
+        infer=True,
+    )
+
+    assert [result["memory"] for result in results] == ["User's name is Aryan"]
 
 
 def test_normalize_facts_plain_strings():


### PR DESCRIPTION
## Linked Issue

Closes #6911

## Description

When a batch insert into the vector store fails, `_add_to_vector_store` retries record-by-record. Records that also failed the retry were logged and skipped — but the returned payload, the history rows, and entity linking were all still built from the full extracted set. Callers got `{"id": ..., "event": "ADD"}` for memories that were never stored, and `get()` on those ids returned nothing. The vector store and the SQLite history could also diverge permanently, and entity `linked_memory_ids` could point at memories that don't exist.

The fix narrows `records` to those that actually persisted, immediately after the insert phase. Because every downstream phase (history, entity linking, return value) is driven off `records`, one reassignment corrects all three — smaller than patching each site.

Additionally, when *nothing* persists the call now raises `VectorStoreError` instead of returning `[]`. Rationale:

- `add()`'s docstring already documents `VectorStoreError: If vector store operations fail` (`main.py` L807), but nothing in the codebase ever raised it.
- The LLM path in the same function already established this principle — see the comment at L958-964 rejecting a silent `return []` because callers can't distinguish "infrastructure down" from "nothing extracted". Returning `[]` on a total store outage reintroduces exactly that ambiguity.

Applied symmetrically to `Memory` and `AsyncMemory`. 39 lines changed in `mem0/memory/main.py`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

Not breaking in the usual sense, but two behaviour changes reviewers should weigh deliberately rather than let slip through:

1. **Total persistence failure now raises `VectorStoreError` instead of returning `{"results": []}`.** Callers that silently tolerated an empty result during a store outage will now see an exception. This is the documented contract being honoured for the first time, but it is observable.
2. **On total failure, conversation messages are no longer written to the messages table** — the raise precedes `db.save_messages()`. This seems correct (the whole `add` failed, so nothing should persist), and partial failures still save messages normally. One-line reorder if you'd prefer messages survive an outage.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Four unit tests in `tests/test_memory.py`: rejected records excluded from results, excluded from history, total failure raises `VectorStoreError`, plus the async twin.

Manual verification via a 26-check behavioural matrix covering paths the unit tests don't: happy path unchanged (still a single batch insert call, no extra round trips), `infer=False` unaffected, public `add()` surface filters and propagates correctly, exception `__cause__`/`error_code`/`details` populated, and — importantly — entity `linked_memory_ids` contain no dangling references after a partial failure. All 26 passed, sync and async.

Regression check on every test file that references `_add_to_vector_store`, comparing failure sets by name rather than by count:

```
baseline:  467 passed, 1 failed, 19 skipped, 52 errors
with fix:  471 passed, 1 failed, 19 skipped, 52 errors
failures introduced: none
```

The +4 are this PR's tests. The 1 remaining failure (`test_async_procedural_memory_langchain_strips_code_blocks`) and the 52 errors (`tests/vector_stores/*` collection failures from optional deps unavailable in my env) are present in both columns and unrelated.

**I could not run the full suite locally** — `tests/vector_stores/*` won't collect without those optional dependencies. This PR doesn't touch that package and none of those files reference `_add_to_vector_store`, but CI is the real gate there.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

Notes: `ruff check` passes on both changed files. `ruff format` reports pre-existing deviations in both files at baseline; I matched surrounding style rather than reformat unrelated hunks. "Tests pass locally" is scoped to the affected subset described above, not the full suite. No documentation change needed — `add()`'s docstring already documents `VectorStoreError`; this PR makes the code match it.
