### PR TITLE
fix(memory): stop writing memory content, raw messages, and entity values to logs

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -642,7 +642,7 @@ class Memory(MemoryBase):
                     payloads=[entity_payload],
                 )
         except Exception as e:
-            logger.warning(f"Entity upsert failed for '{entity_text}': {e}")
+            logger.warning(f"Entity upsert failed for {entity_type} entity on memory {memory_id}: {e}")
 
     def _remove_memory_from_entity_store(self, memory_id, filters):
         """Strip `memory_id` from every entity record scoped to `filters`.
@@ -683,7 +683,7 @@ class Memory(MemoryBase):
                         try:
                             vec = self.embedding_model.embed(entity_text, "update")
                         except Exception as e:
-                            logger.debug(f"Entity re-embed failed for '{entity_text}': {e}")
+                            logger.debug(f"Entity re-embed failed for entity id={row.id}: {e}")
                             continue
                         new_payload = {**payload, "linked_memory_ids": remaining}
                         try:
@@ -718,7 +718,7 @@ class Memory(MemoryBase):
                 try:
                     self._upsert_entity(entity_text, entity_type, memory_id, filters)
                 except Exception as e:
-                    logger.debug(f"Entity link failed for '{entity_text}': {e}")
+                    logger.debug(f"Entity link failed for {entity_type} entity on memory {memory_id}: {e}")
         except Exception as e:
             logger.warning(f"Entity linking failed for memory_id={memory_id}: {e}")
 
@@ -880,7 +880,10 @@ class Memory(MemoryBase):
                     or message_dict.get("role") is None
                     or message_dict.get("content") is None
                 ):
-                    logger.warning(f"Skipping invalid message format: {message_dict}")
+                    logger.warning(
+                        "Skipping invalid message format: expected dict with 'role' and 'content', "
+                        f"got {type(message_dict).__name__}"
+                    )
                     continue
 
                 if message_dict["role"] == "system":
@@ -1014,7 +1017,7 @@ class Memory(MemoryBase):
 
             mem_hash = hashlib.md5(text.encode()).hexdigest()
             if mem_hash in existing_hashes or mem_hash in seen_hashes:
-                logger.debug(f"Skipping duplicate memory (hash match): {text[:50]}")
+                logger.debug(f"Skipping duplicate memory (hash match): {mem_hash}")
                 continue
             seen_hashes.add(mem_hash)
 
@@ -1159,7 +1162,7 @@ class Memory(MemoryBase):
                                     payload=payload,
                                 )
                             except Exception as e:
-                                logger.debug(f"Entity update failed for '{entity_text}': {e}")
+                                logger.debug(f"Entity update failed for {entity_type} entity id={match.id}: {e}")
                         else:
                             # New entity — collect for batch insert
                             to_insert_vectors.append(valid_vectors[j])
@@ -1954,7 +1957,7 @@ class Memory(MemoryBase):
         return history
 
     def _create_memory(self, data, existing_embeddings, metadata=None):
-        logger.debug(f"Creating memory with {data=}")
+        logger.debug(f"Creating memory ({len(data)} chars)")
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]
         else:
@@ -2025,7 +2028,7 @@ class Memory(MemoryBase):
         return result
 
     def _update_memory(self, memory_id, data, existing_embeddings, metadata=None):
-        logger.info(f"Updating memory with {data=}")
+        logger.info(f"Updating memory with {memory_id=}")
 
         try:
             existing_memory = self.vector_store.get(vector_id=memory_id)
@@ -2064,7 +2067,6 @@ class Memory(MemoryBase):
             vector=embeddings,
             payload=new_metadata,
         )
-        logger.info(f"Updating memory with ID {memory_id=} with {data=}")
 
         self.db.add_history(
             memory_id,
@@ -2303,7 +2305,7 @@ class AsyncMemory(MemoryBase):
                     payloads=[entity_payload],
                 )
         except Exception as e:
-            logger.warning(f"Entity upsert failed for '{entity_text}' (async): {e}")
+            logger.warning(f"Entity upsert failed for {entity_type} entity on memory {memory_id} (async): {e}")
 
     async def _bulk_clear_entity_store(self, filters):
         """Delete all entity records matching the given scope filters.
@@ -2354,7 +2356,7 @@ class AsyncMemory(MemoryBase):
                         try:
                             vec = await asyncio.to_thread(self.embedding_model.embed, entity_text, "update")
                         except Exception as e:
-                            logger.debug(f"Entity re-embed failed for '{entity_text}' (async): {e}")
+                            logger.debug(f"Entity re-embed failed for entity id={row.id} (async): {e}")
                             continue
                         new_payload = {**payload, "linked_memory_ids": remaining}
                         try:
@@ -2386,7 +2388,7 @@ class AsyncMemory(MemoryBase):
                 try:
                     await self._upsert_entity_async(entity_text, entity_type, memory_id, filters)
                 except Exception as e:
-                    logger.debug(f"Entity link failed for '{entity_text}' (async): {e}")
+                    logger.debug(f"Entity link failed for {entity_type} entity on memory {memory_id} (async): {e}")
         except Exception as e:
             logger.warning(f"Entity linking failed for memory_id={memory_id} (async): {e}")
 
@@ -2535,7 +2537,10 @@ class AsyncMemory(MemoryBase):
                     or message_dict.get("role") is None
                     or message_dict.get("content") is None
                 ):
-                    logger.warning(f"Skipping invalid message format (async): {message_dict}")
+                    logger.warning(
+                        "Skipping invalid message format (async): expected dict with 'role' and "
+                        f"'content', got {type(message_dict).__name__}"
+                    )
                     continue
 
                 if message_dict["role"] == "system":
@@ -2666,7 +2671,7 @@ class AsyncMemory(MemoryBase):
 
             mem_hash = hashlib.md5(text.encode()).hexdigest()
             if mem_hash in existing_hashes or mem_hash in seen_hashes:
-                logger.debug(f"Skipping duplicate memory (hash match, async): {text[:50]}")
+                logger.debug(f"Skipping duplicate memory (hash match, async): {mem_hash}")
                 continue
             seen_hashes.add(mem_hash)
 
@@ -2811,7 +2816,7 @@ class AsyncMemory(MemoryBase):
                                     payload=payload,
                                 )
                             except Exception as e:
-                                logger.debug(f"Entity update failed for '{entity_text}' (async): {e}")
+                                logger.debug(f"Entity update failed for {entity_type} entity id={match.id} (async): {e}")
                         else:
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
@@ -3621,7 +3626,7 @@ class AsyncMemory(MemoryBase):
         return history
 
     async def _create_memory(self, data, existing_embeddings, metadata=None):
-        logger.debug(f"Creating memory with {data=}")
+        logger.debug(f"Creating memory ({len(data)} chars)")
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]
         else:
@@ -3714,7 +3719,7 @@ class AsyncMemory(MemoryBase):
         return result
 
     async def _update_memory(self, memory_id, data, existing_embeddings, metadata=None):
-        logger.info(f"Updating memory with {data=}")
+        logger.info(f"Updating memory with {memory_id=}")
 
         try:
             existing_memory = await asyncio.to_thread(self.vector_store.get, vector_id=memory_id)
@@ -3754,7 +3759,6 @@ class AsyncMemory(MemoryBase):
             vector=embeddings,
             payload=new_metadata,
         )
-        logger.info(f"Updating memory with ID {memory_id=} with {data=}")
 
         await asyncio.to_thread(
             self.db.add_history,

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1178,3 +1178,88 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+# Memory content is personal data by design - the extraction prompts explicitly
+# harvest health, dietary, relationship and professional details. It must never
+# reach application logs, which have different retention and access controls than
+# the memory store the operator actually vetted.
+SENSITIVE_TEXT = "User has type 2 diabetes and takes metformin daily"
+
+
+def _log_messages(caplog):
+    return " || ".join(record.message for record in caplog.records)
+
+
+class TestMemoryContentNotLogged:
+    def test_update_memory_does_not_log_content(self, mocker, caplog):
+        memory = _build_memory_instance(mocker, Memory)
+        memory.vector_store.get.return_value = SimpleNamespace(
+            payload={"data": "old value", "created_at": "2026-01-01T00:00:00+00:00"}
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            memory._update_memory("mem-1", SENSITIVE_TEXT, {})
+
+        assert SENSITIVE_TEXT not in _log_messages(caplog)
+
+    def test_update_memory_still_logs_the_memory_id(self, mocker, caplog):
+        """Redaction must not cost us the correlation handle."""
+        memory = _build_memory_instance(mocker, Memory)
+        memory.vector_store.get.return_value = SimpleNamespace(
+            payload={"data": "old value", "created_at": "2026-01-01T00:00:00+00:00"}
+        )
+
+        with caplog.at_level(logging.INFO):
+            memory._update_memory("mem-correlate-42", SENSITIVE_TEXT, {})
+
+        assert "mem-correlate-42" in _log_messages(caplog)
+
+    def test_create_memory_does_not_log_content(self, mocker, caplog):
+        memory = _build_memory_instance(mocker, Memory)
+
+        with caplog.at_level(logging.DEBUG):
+            memory._create_memory(SENSITIVE_TEXT, {SENSITIVE_TEXT: [0.1, 0.2, 0.3]}, metadata={})
+
+        assert SENSITIVE_TEXT not in _log_messages(caplog)
+
+    def test_invalid_message_is_not_logged_verbatim(self, mocker, caplog):
+        """The rejected dict carries raw conversation content - log its shape, not its value."""
+        memory = _build_memory_instance(mocker, Memory)
+
+        with caplog.at_level(logging.DEBUG):
+            memory._add_to_vector_store(
+                messages=[{"content": SENSITIVE_TEXT}],  # no 'role' -> rejected
+                metadata={},
+                filters={"user_id": "u1"},
+                infer=False,
+            )
+
+        messages = _log_messages(caplog)
+        assert SENSITIVE_TEXT not in messages
+        assert "Skipping invalid message format" in messages
+
+    def test_entity_upsert_failure_does_not_log_entity_value(self, mocker, caplog):
+        """Entity values are extracted names, orgs and locations - personal data."""
+        memory = _build_memory_instance(mocker, Memory)
+        memory._entity_store = mocker.MagicMock()
+        memory._entity_store.search.side_effect = RuntimeError("entity store down")
+
+        with caplog.at_level(logging.DEBUG):
+            memory._upsert_entity("Gwendolyn Fairweather-Blythe", "PERSON", "mem-1", {"user_id": "u1"})
+
+        messages = _log_messages(caplog)
+        assert "Gwendolyn Fairweather-Blythe" not in messages
+        assert "Entity upsert failed" in messages
+
+    @pytest.mark.asyncio
+    async def test_async_update_memory_does_not_log_content(self, mocker, caplog):
+        memory = _build_memory_instance(mocker, AsyncMemory)
+        memory.vector_store.get.return_value = SimpleNamespace(
+            payload={"data": "old value", "created_at": "2026-01-01T00:00:00+00:00"}
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            await memory._update_memory("mem-1", SENSITIVE_TEXT, {})
+
+        assert SENSITIVE_TEXT not in _log_messages(caplog)


### PR DESCRIPTION
## Linked Issue

Closes #6915 

## Description

`Memory`/`AsyncMemory` wrote user content to application logs. `_update_memory` logged the full memory text at **INFO** — twice per update — and mem0's own reference server runs at `level=logging.INFO` (`server/main.py:46`), so it was emitted by default. Memory content is personal data by construction: the extraction prompts specifically harvest health, dietary, relationship and professional details.

A sweep of `mem0/memory/main.py` found 18 sites across three categories, all the same defect:

- **memory content** — `{data=}` at INFO/DEBUG, `{text[:50]}` at DEBUG (8 sites)
- **raw conversation** — the whole rejected `{message_dict}` at WARNING, including its `content` (2 sites)
- **entity values** — extracted names, orgs and locations at WARNING/DEBUG (8 sites)

This PR removes user content from all of them, replacing it with non-reversible correlation handles: `memory_id`, the already-computed content hash, `entity_type`, and record ids. That follows the pattern `_delete_memory` already uses (`logger.info(f"Deleting memory with {memory_id=}")` — id only) and mirrors the server's existing `SENSITIVE_CONFIG_KEYS` redaction posture.

Applied symmetrically to `Memory` and `AsyncMemory`. 40 lines in `main.py`, net −1 log statement: after redaction, the post-write line in `_update_memory` became a verbatim duplicate of the entry log, so it was dropped.

No new configuration surface. I deliberately did not add a `MEM0_LOG_MEMORY_CONTENT` opt-in flag — for a compliance fix, "never logged" is more defensible than "logged unless a flag is set", since flags get enabled and forgotten. Happy to add one if maintainers prefer.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

No API change. One observable difference: log *messages* change shape. Anyone grepping logs for memory text will no longer find it — that is the point of the fix, but it is worth stating for operators with log-based alerting. Correlation by `memory_id` is preserved and covered by a test.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Six `caplog` tests in `tests/memory/test_main.py` (`TestMemoryContentNotLogged`), using the file's existing `mocker`/`caplog` convention and its `_build_memory_instance` helper. They assert at **DEBUG** — the strictest bar, no content at any level — across update, create, invalid-message and entity-failure paths, plus the async twin. Five of the six fail against the unfixed code; the sixth guards that redaction did not cost the correlation handle, so it passes both ways by design.

Verified three independent ways:

1. **Static audit** — AST scan of every `logger.*` call in `main.py` for interpolated names that can carry user content (treating `x.id`, `len(x)`, `type(x).__name__` as safe): **18 risky calls before → 0 after**.
2. **Runtime sweep** — canary strings for memory content, an SSN in raw conversation, and an entity name, driven through update / create / `infer=False` / invalid-message / dedup / entity-failure / async paths at DEBUG: **17/17 clean**, and the same sweep scores 9/17 against the unfixed code, so it is a real detector.
3. **Adversarial branch audit** — most redacted lines live inside `except` handlers, where a `NameError` on `entity_type` or `AttributeError` on `row.id`/`match.id` would mask the original error or crash a non-fatal path. Every branch was forced to execute, plus edge cases for `len(data)` and `type(message_dict).__name__` (empty string, CJK unicode, 24k-char payload; messages as `dict`/`str`/`None`/`list`/`int`): **52/52** — no exception, no formatting error, no leak, and logs still name the entity type, memory id, row id, match id and hash.

Regression check on the affected scope, comparing failure sets by name:

```
baseline:  487 passed, 6 failed, 19 skipped
with fix:  493 passed, 6 failed, 19 skipped
failures introduced: none
```

The +6 are this PR's tests; the 6 failures are identical in both columns and unrelated.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

Notes: `ruff check` passes on both changed files. "Tests pass locally" is scoped to the affected subset above — I could not run `tests/vector_stores/*` locally (optional deps unavailable in my environment), and this PR does not touch that package. No documentation change needed.

**Out of scope, flagged for a maintainer's call:** four vector-store providers log the raw search query on their error paths — `mongodb.py:219,277`, `baidu.py:280`, `upstash_vector.py:213`, `valkey.py:389`. A search query is user content too, but that is a different package and belongs in its own PR.
