### PR TITLE
fix(embeddings/huggingface): resolve api_key from HUGGINGFACE_API_KEY and default it

### DIFF
--- a/docs/components/embedders/models/huggingface.mdx
+++ b/docs/components/embedders/models/huggingface.mdx
@@ -99,6 +99,7 @@ Here are the parameters available for configuring the Hugging Face embedder:
 | `embedding_dims` | Dimensions of the embedding model | `selected_model_dimensions` |
 | `model_kwargs` | Additional arguments for the model | `None` |
 | `huggingface_base_url` | URL to connect to Text Embeddings Inference (TEI) API | `None` |
+| `api_key` | API key for the endpoint; falls back to the `HUGGINGFACE_API_KEY` env var. Only used on the `huggingface_base_url` path | `"hf"` |
 </Tab>
 <Tab title="TypeScript">
 | Parameter | Description | Default Value |

--- a/mem0/embeddings/huggingface.py
+++ b/mem0/embeddings/huggingface.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Literal, Optional
 
 from openai import OpenAI
@@ -17,6 +18,10 @@ class HuggingFaceEmbedding(EmbeddingBase):
         super().__init__(config)
 
         if self.config.huggingface_base_url:
+            # Without a placeholder the OpenAI client falls back to OPENAI_API_KEY and raises
+            # when that is unset, so an unauthenticated TEI endpoint cannot be constructed at
+            # all. Mirrors mem0/embeddings/lmstudio.py and the Node SDK's huggingface.ts.
+            self.config.api_key = self.config.api_key or os.getenv("HUGGINGFACE_API_KEY") or "hf"
             self.client = OpenAI(base_url=self.config.huggingface_base_url, api_key=self.config.api_key)
             self.config.model = self.config.model or "tei"
         else:

--- a/tests/embeddings/test_huggingface_embeddings.py
+++ b/tests/embeddings/test_huggingface_embeddings.py
@@ -72,7 +72,8 @@ def test_embed_with_custom_embedding_dims(mock_sentence_transformer):
     assert result == [1.0, 1.1, 1.2]
 
 
-def test_embed_with_huggingface_base_url():
+def test_embed_with_huggingface_base_url(monkeypatch):
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
     config = BaseEmbedderConfig(
         huggingface_base_url="http://localhost:8080",
         model="my-custom-model",
@@ -94,7 +95,7 @@ def test_embed_with_huggingface_base_url():
         embedder = HuggingFaceEmbedding(config)
         result = embedder.embed("Hello from custom endpoint")
 
-        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key=None)
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="hf")
         mock_client.embeddings.create.assert_called_once_with(
             input="Hello from custom endpoint",
             model="my-custom-model",
@@ -103,7 +104,8 @@ def test_embed_with_huggingface_base_url():
         assert result == [0.1, 0.2, 0.3]
 
 
-def test_embed_with_huggingface_base_url_forwards_api_key():
+def test_embed_with_huggingface_base_url_forwards_api_key(monkeypatch):
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
     config = BaseEmbedderConfig(
         huggingface_base_url="http://localhost:8080",
         model="my-custom-model",
@@ -113,6 +115,49 @@ def test_embed_with_huggingface_base_url_forwards_api_key():
         HuggingFaceEmbedding(config)
 
         mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="tei-token")
+
+
+def test_base_url_api_key_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("HUGGINGFACE_API_KEY", "hf_from_env")
+    config = BaseEmbedderConfig(huggingface_base_url="http://localhost:8080")
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="hf_from_env")
+
+
+def test_base_url_config_api_key_wins_over_env(monkeypatch):
+    monkeypatch.setenv("HUGGINGFACE_API_KEY", "hf_from_env")
+    config = BaseEmbedderConfig(huggingface_base_url="http://localhost:8080", api_key="tei-token")
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="tei-token")
+
+
+def test_base_url_api_key_defaults_to_placeholder(monkeypatch):
+    """An unauthenticated TEI endpoint must construct without any credential set.
+
+    With api_key=None the OpenAI client resolves OPENAI_API_KEY and raises when it is
+    unset, so the placeholder is what keeps a no-auth local endpoint usable.
+    """
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    config = BaseEmbedderConfig(huggingface_base_url="http://localhost:8080")
+    with patch("mem0.embeddings.huggingface.OpenAI") as mock_openai:
+        HuggingFaceEmbedding(config)
+
+        mock_openai.assert_called_once_with(base_url="http://localhost:8080", api_key="hf")
+
+
+def test_base_url_no_auth_endpoint_constructs_without_credentials(monkeypatch):
+    """End-to-end guard with the real OpenAI client, not the patched one."""
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    embedder = HuggingFaceEmbedding(BaseEmbedderConfig(huggingface_base_url="http://localhost:8080"))
+
+    assert embedder.client.api_key == "hf"
 
 
 def test_embed_batch_sentence_transformer(mock_sentence_transformer):


### PR DESCRIPTION
Closes #6301.

#6770 forwarded `api_key` to the `OpenAI` client on the `huggingface_base_url` path, which fixed the first failure mode in #6301. The second one is still live on `main`: the resolve stops at the config value, so `api_key` is `None` whenever the caller does not pass one explicitly, and the OpenAI client then resolves `OPENAI_API_KEY` and raises when that is unset.

Two consequences on current `main`:

1. `HUGGINGFACE_API_KEY` is a no-op in Python. Setting it and no config key still raises.
2. An unauthenticated local TEI endpoint cannot be constructed at all.

## Repro on current main

```python
import os
os.environ.pop("OPENAI_API_KEY", None)
os.environ["HUGGINGFACE_API_KEY"] = "hf_fromEnvToken"

from mem0.configs.embeddings.base import BaseEmbedderConfig
from mem0.embeddings.huggingface import HuggingFaceEmbedding

HuggingFaceEmbedding(BaseEmbedderConfig(huggingface_base_url="http://localhost:8080"))
```

```
openai.OpenAIError: Missing credentials. Please pass an `api_key`, `workload_identity`,
`admin_api_key`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable.
```

Same error with nothing set at all, which is the no-auth TEI case.

## Fix

```python
self.config.api_key = self.config.api_key or os.getenv("HUGGINGFACE_API_KEY") or "hf"
```

The three-step resolve and the `"hf"` placeholder are not invented here, they are what the rest of the codebase already does:

- `mem0/embeddings/lmstudio.py:15` does `self.config.api_key = self.config.api_key or "lm-studio"` for the same OpenAI-compatible-endpoint situation, including the same assignment back onto the config.
- `mem0-ts/src/oss/src/embeddings/huggingface.ts:39` does `apiKey: config.apiKey || process.env.HUGGINGFACE_API_KEY || "hf"`.
- The TypeScript tab of `docs/components/embedders/models/huggingface.mdx` already documents `apiKey` falling back to `HUGGINGFACE_API_KEY` with a `"hf"` default. The Python tab had no `api_key` row at all, so this PR adds one.

## Note on the changed assertion

`test_embed_with_huggingface_base_url` asserted `api_key=None`, which pins the behaviour this PR fixes, so it is updated to `api_key="hf"`. Both pre-existing base_url tests also gained a `monkeypatch.delenv("HUGGINGFACE_API_KEY")` so they do not depend on the ambient environment.

## Tests

Four new tests: env fallback, config wins over env, placeholder default, and one end-to-end guard that constructs against the real `OpenAI` client rather than a patched one and asserts a no-auth endpoint builds.

Verified red then green. With the source change reverted and the tests kept:

```
FAILED tests/embeddings/test_huggingface_embeddings.py::test_embed_with_huggingface_base_url
FAILED tests/embeddings/test_huggingface_embeddings.py::test_base_url_api_key_falls_back_to_env
FAILED tests/embeddings/test_huggingface_embeddings.py::test_base_url_api_key_defaults_to_placeholder
FAILED tests/embeddings/test_huggingface_embeddings.py::test_base_url_no_auth_endpoint_constructs_without_credentials
4 failed, 12 passed
```

With the fix applied:

```
16 passed
```

Suite also passes with `HUGGINGFACE_API_KEY` set in the ambient environment, confirming the new tests are not env-sensitive. `ruff check` is clean.

## History

#6301 drew four PRs: #6302, #6315, #6486 and #6755. All four independently included this same `config or HUGGINGFACE_API_KEY or "hf"` resolve, so this part is not a preference of mine. #6770 landed the first step of it and the rest was never picked up. I have closed my #6302 rather than rebasing it, since only this one line of it is still relevant and a fresh minimal diff is easier to review.
