### PR TITLE
fix(llms): omit max_tokens for Gemma OpenAI endpoints

### DIFF
--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -12,6 +12,12 @@ from mem0.memory.utils import extract_json
 
 
 class OpenAILLM(LLMBase):
+    @staticmethod
+    def _is_gemma_model(model: Optional[str]) -> bool:
+        """Return whether an OpenAI-compatible model is part of the Gemma family."""
+        base_model = (model or "").lower().rsplit("/", 1)[-1]
+        return base_model.startswith(("gemma", "google.gemma"))
+
     def __init__(self, config: Optional[Union[BaseLlmConfig, OpenAIConfig, Dict]] = None):
         # Convert to OpenAIConfig if needed
         if config is None:
@@ -105,6 +111,11 @@ class OpenAILLM(LLMBase):
         """
         params = self._get_supported_params(messages=messages, **kwargs)
         
+        # Some OpenAI-compatible Gemma endpoints reject the legacy max_tokens
+        # field instead of ignoring it. Let the endpoint apply its default.
+        if self._is_gemma_model(self.config.model):
+            params.pop("max_tokens", None)
+
         params.update({
             "model": self.config.model,
             "messages": messages,

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -416,6 +416,25 @@ def test_gpt4_uses_max_tokens(mock_openai_client):
     assert "max_completion_tokens" not in call_kwargs
 
 
+@pytest.mark.parametrize("model", ["gemma-4-31b", "google.gemma-4-31b"])
+def test_gemma_does_not_send_max_tokens(mock_openai_client, model):
+    """Gemma endpoints can reject max_tokens even through the OpenAI-compatible API."""
+    config = OpenAIConfig(model=model, temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+    assert "max_tokens" not in call_kwargs
+    assert call_kwargs["temperature"] == 0.7
+    assert call_kwargs["top_p"] == 1.0
+
+
 def test_callback_with_tools(mock_openai_client):
     mock_callback = Mock()
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", response_callback=mock_callback)


### PR DESCRIPTION
Closes #6920

## Description

OpenAI-compatible Gemma endpoints can reject the legacy `max_tokens` request field. Mem0 currently adds it from the default LLM configuration, so Gemma models fail before generation starts.

This keeps the existing token handling for other OpenAI-compatible models and omits `max_tokens` only for Gemma model names, including provider-prefixed names.

## Test Coverage

- `uv run --extra test --extra dev pytest tests/llms/test_openai.py -q` (23 passed)
- `uv run --extra test --extra dev ruff check mem0/llms/openai.py tests/llms/test_openai.py`
- `git diff --check`
