### PR TITLE
fix(memory): keep memory content and entity values out of the logs

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -267,6 +267,27 @@ def _is_sensitive_field(field_name: str) -> bool:
     return any(name.endswith(suffix) for suffix in _SENSITIVE_SUFFIXES)
 
 
+def _content_hash(data) -> str:
+    """Return a non-reversible handle for user content in log lines.
+
+    This is the same md5 digest stored as a memory's `hash`, so a log line can
+    still be matched against the record it refers to without writing the
+    content itself to the log.
+    """
+    if data is None:
+        return "none"
+    if not isinstance(data, str):
+        data = str(data)
+    return hashlib.md5(data.encode()).hexdigest()
+
+
+def _describe_message(message) -> str:
+    """Describe a rejected message by shape only, never by content."""
+    if isinstance(message, dict):
+        return f"dict with keys {sorted(str(key) for key in message)}"
+    return f"{type(message).__name__}"
+
+
 def _safe_deepcopy_config(config):
     """Safely deepcopy config, falling back to dict-based cloning for non-serializable objects."""
     try:
@@ -647,7 +668,7 @@ class Memory(MemoryBase):
                     payloads=[entity_payload],
                 )
         except Exception as e:
-            logger.warning(f"Entity upsert failed for '{entity_text}': {e}")
+            logger.warning(f"Entity upsert failed for {entity_type=}, {memory_id=}: {e}")
 
     def _remove_memory_from_entity_store(self, memory_id, filters):
         """Strip `memory_id` from every entity record scoped to `filters`.
@@ -688,7 +709,7 @@ class Memory(MemoryBase):
                         try:
                             vec = self.embedding_model.embed(entity_text, "update")
                         except Exception as e:
-                            logger.debug(f"Entity re-embed failed for '{entity_text}': {e}")
+                            logger.debug(f"Entity re-embed failed for id={row.id}: {e}")
                             continue
                         new_payload = {**payload, "linked_memory_ids": remaining}
                         try:
@@ -723,7 +744,7 @@ class Memory(MemoryBase):
                 try:
                     self._upsert_entity(entity_text, entity_type, memory_id, filters)
                 except Exception as e:
-                    logger.debug(f"Entity link failed for '{entity_text}': {e}")
+                    logger.debug(f"Entity link failed for {entity_type=}, {memory_id=}: {e}")
         except Exception as e:
             logger.warning(f"Entity linking failed for memory_id={memory_id}: {e}")
 
@@ -885,7 +906,7 @@ class Memory(MemoryBase):
                     or message_dict.get("role") is None
                     or message_dict.get("content") is None
                 ):
-                    logger.warning(f"Skipping invalid message format: {message_dict}")
+                    logger.warning(f"Skipping invalid message format: {_describe_message(message_dict)}")
                     continue
 
                 if message_dict["role"] == "system":
@@ -1019,7 +1040,7 @@ class Memory(MemoryBase):
 
             mem_hash = hashlib.md5(text.encode()).hexdigest()
             if mem_hash in existing_hashes or mem_hash in seen_hashes:
-                logger.debug(f"Skipping duplicate memory (hash match): {text[:50]}")
+                logger.debug(f"Skipping duplicate memory (hash match): {mem_hash=}")
                 continue
             seen_hashes.add(mem_hash)
 
@@ -1164,7 +1185,7 @@ class Memory(MemoryBase):
                                     payload=payload,
                                 )
                             except Exception as e:
-                                logger.debug(f"Entity update failed for '{entity_text}': {e}")
+                                logger.debug(f"Entity update failed for id={match.id}: {e}")
                         else:
                             # New entity — collect for batch insert
                             to_insert_vectors.append(valid_vectors[j])
@@ -1959,7 +1980,7 @@ class Memory(MemoryBase):
         return history
 
     def _create_memory(self, data, existing_embeddings, metadata=None):
-        logger.debug(f"Creating memory with {data=}")
+        logger.debug(f"Creating memory with data_hash={_content_hash(data)}")
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]
         else:
@@ -2030,7 +2051,7 @@ class Memory(MemoryBase):
         return result
 
     def _update_memory(self, memory_id, data, existing_embeddings, metadata=None):
-        logger.info(f"Updating memory with {data=}")
+        logger.info(f"Updating memory with data_hash={_content_hash(data)}")
 
         try:
             existing_memory = self.vector_store.get(vector_id=memory_id)
@@ -2069,7 +2090,7 @@ class Memory(MemoryBase):
             vector=embeddings,
             payload=new_metadata,
         )
-        logger.info(f"Updating memory with ID {memory_id=} with {data=}")
+        logger.info(f"Updating memory with ID {memory_id=} with data_hash={_content_hash(data)}")
 
         self.db.add_history(
             memory_id,
@@ -2308,7 +2329,7 @@ class AsyncMemory(MemoryBase):
                     payloads=[entity_payload],
                 )
         except Exception as e:
-            logger.warning(f"Entity upsert failed for '{entity_text}' (async): {e}")
+            logger.warning(f"Entity upsert failed for {entity_type=}, {memory_id=} (async): {e}")
 
     async def _bulk_clear_entity_store(self, filters):
         """Delete all entity records matching the given scope filters.
@@ -2359,7 +2380,7 @@ class AsyncMemory(MemoryBase):
                         try:
                             vec = await asyncio.to_thread(self.embedding_model.embed, entity_text, "update")
                         except Exception as e:
-                            logger.debug(f"Entity re-embed failed for '{entity_text}' (async): {e}")
+                            logger.debug(f"Entity re-embed failed for id={row.id} (async): {e}")
                             continue
                         new_payload = {**payload, "linked_memory_ids": remaining}
                         try:
@@ -2391,7 +2412,7 @@ class AsyncMemory(MemoryBase):
                 try:
                     await self._upsert_entity_async(entity_text, entity_type, memory_id, filters)
                 except Exception as e:
-                    logger.debug(f"Entity link failed for '{entity_text}' (async): {e}")
+                    logger.debug(f"Entity link failed for {entity_type=}, {memory_id=} (async): {e}")
         except Exception as e:
             logger.warning(f"Entity linking failed for memory_id={memory_id} (async): {e}")
 
@@ -2540,7 +2561,7 @@ class AsyncMemory(MemoryBase):
                     or message_dict.get("role") is None
                     or message_dict.get("content") is None
                 ):
-                    logger.warning(f"Skipping invalid message format (async): {message_dict}")
+                    logger.warning(f"Skipping invalid message format (async): {_describe_message(message_dict)}")
                     continue
 
                 if message_dict["role"] == "system":
@@ -2671,7 +2692,7 @@ class AsyncMemory(MemoryBase):
 
             mem_hash = hashlib.md5(text.encode()).hexdigest()
             if mem_hash in existing_hashes or mem_hash in seen_hashes:
-                logger.debug(f"Skipping duplicate memory (hash match, async): {text[:50]}")
+                logger.debug(f"Skipping duplicate memory (hash match, async): {mem_hash=}")
                 continue
             seen_hashes.add(mem_hash)
 
@@ -2816,7 +2837,7 @@ class AsyncMemory(MemoryBase):
                                     payload=payload,
                                 )
                             except Exception as e:
-                                logger.debug(f"Entity update failed for '{entity_text}' (async): {e}")
+                                logger.debug(f"Entity update failed for id={match.id} (async): {e}")
                         else:
                             to_insert_vectors.append(valid_vectors[j])
                             to_insert_ids.append(str(uuid.uuid4()))
@@ -3626,7 +3647,7 @@ class AsyncMemory(MemoryBase):
         return history
 
     async def _create_memory(self, data, existing_embeddings, metadata=None):
-        logger.debug(f"Creating memory with {data=}")
+        logger.debug(f"Creating memory with data_hash={_content_hash(data)}")
         if data in existing_embeddings:
             embeddings = existing_embeddings[data]
         else:
@@ -3719,7 +3740,7 @@ class AsyncMemory(MemoryBase):
         return result
 
     async def _update_memory(self, memory_id, data, existing_embeddings, metadata=None):
-        logger.info(f"Updating memory with {data=}")
+        logger.info(f"Updating memory with data_hash={_content_hash(data)}")
 
         try:
             existing_memory = await asyncio.to_thread(self.vector_store.get, vector_id=memory_id)
@@ -3759,7 +3780,7 @@ class AsyncMemory(MemoryBase):
             vector=embeddings,
             payload=new_metadata,
         )
-        logger.info(f"Updating memory with ID {memory_id=} with {data=}")
+        logger.info(f"Updating memory with ID {memory_id=} with data_hash={_content_hash(data)}")
 
         await asyncio.to_thread(
             self.db.add_history,

--- a/tests/memory/test_log_redaction.py
+++ b/tests/memory/test_log_redaction.py
@@ -1,0 +1,84 @@
+"""Memory content must never reach the application log.
+
+See https://github.com/mem0ai/mem0/issues/6915
+"""
+
+import hashlib
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mem0 import Memory
+from mem0.memory.main import _content_hash, _describe_message
+
+SECRET = "I have type 2 diabetes and take metformin daily"
+
+
+@pytest.fixture
+def memory():
+    with patch.object(Memory, "__init__", return_value=None):
+        instance = Memory()
+
+    existing = MagicMock()
+    existing.payload = {"data": "an older memory", "created_at": "2024-01-01T00:00:00+00:00"}
+
+    instance.vector_store = MagicMock()
+    instance.vector_store.get.return_value = existing
+    instance.embedding_model = MagicMock()
+    instance.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+    instance.db = MagicMock()
+    instance._remove_memory_from_entity_store = MagicMock()
+    instance._link_entities_for_memory = MagicMock()
+    return instance
+
+
+def test_update_memory_does_not_log_content(memory, caplog):
+    with caplog.at_level(logging.DEBUG, logger="mem0.memory.main"):
+        memory._update_memory("mem-1", SECRET, {})
+
+    messages = [record.message for record in caplog.records]
+    assert messages, "expected the update to log something"
+    assert not any(SECRET in message for message in messages)
+    # the hash still lets an operator match the log line to the stored record
+    assert any(hashlib.md5(SECRET.encode()).hexdigest() in message for message in messages)
+
+
+def test_create_memory_does_not_log_content(memory, caplog):
+    memory.db.add_history = MagicMock()
+
+    with caplog.at_level(logging.DEBUG, logger="mem0.memory.main"):
+        memory._create_memory(SECRET, {})
+
+    assert not any(SECRET in record.message for record in caplog.records)
+
+
+def test_invalid_message_is_logged_by_shape_only(memory, caplog):
+    memory.vector_store.insert = MagicMock()
+
+    with caplog.at_level(logging.WARNING, logger="mem0.memory.main"):
+        memory._add_to_vector_store(
+            [{"content": "my social security number is 078-05-1120"}],
+            metadata={},
+            filters={},
+            infer=False,
+        )
+
+    warnings = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+    assert any("Skipping invalid message format" in message for message in warnings)
+    assert not any("078-05-1120" in message for message in warnings)
+    assert any("keys ['content']" in message for message in warnings)
+
+
+def test_content_hash_matches_the_stored_hash():
+    assert _content_hash(SECRET) == hashlib.md5(SECRET.encode()).hexdigest()
+    assert _content_hash(None) == "none"
+
+
+def test_describe_message_keeps_keys_and_drops_values():
+    described = _describe_message({"role": "user", "content": SECRET})
+
+    assert "role" in described
+    assert "content" in described
+    assert SECRET not in described
+    assert _describe_message("not a dict") == "str"


### PR DESCRIPTION
## Linked Issue

Closes #6915

## Description

`Memory` and `AsyncMemory` write user content into the application log. `_update_memory` logs the full memory text at INFO, twice per update, and the reference server sets `logging.basicConfig(level=logging.INFO)`, so this happens in mem0's own default deployment. A message missing `role` is logged whole at WARNING, content included. Entity failures log the extracted entity value.

All 18 sites in `mem0/memory/main.py` now log a correlation handle instead, which is the pattern `_delete_memory` already follows:

- memory content (6 sites) becomes `data_hash=<md5>`, the same digest already stored as a record's `hash`, so a log line can still be matched to the row it refers to
- the two `text[:50]` dedup lines log the `mem_hash` that path already computed
- rejected messages (2 sites) are described by shape: `dict with keys ['content']`
- entity failures (8 sites) log `entity_type` and `memory_id`, or the record `id` where that is what the surrounding code has

Two small module-level helpers were added next to `_is_sensitive_field`: `_content_hash` and `_describe_message`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A. Log lines change shape, but no API or stored data changes.

## Test Coverage

- [x] I added/updated unit tests

`tests/memory/test_log_redaction.py` drives `_update_memory`, `_create_memory` and the invalid-message path with `caplog` at DEBUG, and asserts the content never appears while the hash does.

```
5 passed
```

Reverting just the log lines (keeping the helpers so collection still works) turns them red on exactly the leaks from the issue:

```
>       assert not any(SECRET in message for message in messages)
E       assert not True
>       assert not any("078-05-1120" in message for message in warnings)
E       assert not True
FAILED tests/memory/test_log_redaction.py::test_update_memory_does_not_log_content
FAILED tests/memory/test_log_redaction.py::test_create_memory_does_not_log_content
FAILED tests/memory/test_log_redaction.py::test_invalid_message_is_logged_by_shape_only
```

Existing suites: `tests/test_memory.py tests/memory tests/test_main.py` gives `477 passed`. I could not run `tests/vector_stores` and `tests/llms` locally, they need optional provider deps I did not install.

`ruff check` is clean on both files. `ruff format --check` reports pre-existing diffs elsewhere in `main.py` (none of the 51 hunks touch the changed lines), so I left the file's formatting alone.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (no user-facing docs cover these log lines)