### PR TITLE
fix(ts-oss): stop a failed entity lookup from inserting a duplicate row

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -505,7 +505,10 @@ export class Memory {
           if (!exactMatch) {
             try {
               matches = await entityStore.search(entityVec, 1, filters);
-            } catch {}
+            } catch (e) {
+              console.warn(`Entity search failed for '${entity.text}': ${e}`);
+              continue;
+            }
           }
 
           const semanticMatch =
@@ -1200,7 +1203,10 @@ export class Memory {
             if (!exactMatch) {
               try {
                 matches = await entityStore.search(entityVec, 1, filters);
-              } catch {}
+              } catch (e) {
+                console.warn(`Entity search failed for '${entityText}': ${e}`);
+                continue;
+              }
             }
 
             const semanticMatch =

--- a/mem0-ts/src/oss/tests/memory.entity-search-failure.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-search-failure.test.ts
@@ -1,0 +1,141 @@
+/**
+ * A failed entity lookup must not be treated as "no match found".
+ *
+ * Both entity-linking paths wrapped `entityStore.search()` in an empty catch,
+ * so a store error left `matches` empty and control fell through to the branch
+ * that inserts a new entity row. The result was a duplicate row instead of a
+ * link to the row that already existed, with nothing logged.
+ */
+/// <reference types="jest" />
+import { Memory } from "../src/memory";
+
+jest.setTimeout(15000);
+
+jest.mock("../src/embeddings/google", () => ({
+  GoogleEmbedder: jest.fn(),
+}));
+jest.mock("../src/llms/google", () => ({
+  GoogleLLM: jest.fn(),
+}));
+
+jest.mock("../src/llms/openai", () => ({
+  OpenAILLM: jest.fn().mockImplementation(() => ({
+    generateResponse: jest.fn().mockResolvedValue(
+      JSON.stringify({
+        memory: [{ id: "0", text: "Alice met Bob", attributed_to: "user" }],
+      }),
+    ),
+  })),
+}));
+
+const mockEmbedding = new Array(1536).fill(0.1);
+jest.mock("../src/embeddings/openai", () => ({
+  OpenAIEmbedder: jest.fn().mockImplementation(() => ({
+    embed: jest.fn().mockResolvedValue(mockEmbedding),
+    embedBatch: jest
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => mockEmbedding)),
+      ),
+    embeddingDims: 1536,
+  })),
+}));
+
+function createMemory(): Memory {
+  return new Memory({
+    version: "v1.1",
+    embedder: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "text-embedding-3-small" },
+    },
+    vectorStore: {
+      provider: "memory",
+      config: {
+        collectionName: `test-entity-fail-${Date.now()}-${Math.random()}`,
+        dimension: 1536,
+        dbPath: ":memory:",
+      },
+    },
+    llm: {
+      provider: "openai",
+      config: { apiKey: "test-key", model: "gpt-5-mini" },
+    },
+    historyDbPath: ":memory:",
+  });
+}
+
+function makeEntityStore(searchImpl: () => Promise<any[]>) {
+  return {
+    initialize: jest.fn().mockResolvedValue(undefined),
+    list: jest.fn().mockResolvedValue([]),
+    search: jest.fn().mockImplementation(searchImpl),
+    insert: jest.fn().mockResolvedValue(undefined),
+    update: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+const throwing = () => Promise.reject(new Error("entity store unavailable"));
+const empty = () => Promise.resolve([]);
+
+describe("entity search failures are not treated as no-match", () => {
+  let memory: Memory;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    memory = createMemory();
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    warnSpy.mockRestore();
+    await memory.reset();
+  });
+
+  it("skips the entity instead of inserting a duplicate when the lookup throws", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+    const store = makeEntityStore(throwing);
+    m._entityStore = store;
+
+    await m._linkEntitiesForMemory("mem-1", "Alice met Bob", {
+      user_id: "u1",
+    });
+
+    expect(store.search).toHaveBeenCalled();
+    expect(store.insert).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("skips the entity in the add pipeline when the lookup throws", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+    const store = makeEntityStore(throwing);
+    m._entityStore = store;
+
+    await m.addToVectorStore(
+      [{ role: "user", content: "Alice met Bob" }],
+      {},
+      { user_id: "u1" },
+      true,
+    );
+
+    expect(store.search).toHaveBeenCalled();
+    expect(store.insert).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("still inserts when the lookup succeeds and genuinely finds nothing", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+    const store = makeEntityStore(empty);
+    m._entityStore = store;
+
+    await m._linkEntitiesForMemory("mem-1", "Alice met Bob", {
+      user_id: "u1",
+    });
+
+    expect(store.search).toHaveBeenCalled();
+    expect(store.insert).toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Linked Issue

Closes #6925

## Description

Two entity-linking paths in `mem0-ts/src/oss/src/memory/index.ts` wrapped `entityStore.search()` in an empty catch. When the store threw, `matches` stayed `[]`, so `semanticMatch` was `undefined`, `match` was `undefined`, and control fell through to the branch that inserts a new entity row. A transient lookup failure therefore forked the entity graph into two rows for the same entity, each holding a different set of `linkedMemoryIds`, with nothing logged.

Both sites now warn and skip the entity. A lookup that failed is not the same as a lookup that found nothing, and skipping leaves the existing row intact rather than adding a competing one.

Sites: `_linkEntitiesForMemory` and the phase 7 batch path in `addToVectorStore`. Eight lines changed, no behaviour change on the success path.

This is separate from #6795 and #6888, which raise the log level on the entity failures that already log. These two sites logged nothing, so a level change does not reach them. The diffs do not overlap.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

`mem0-ts/src/oss/tests/memory.entity-search-failure.test.ts`, three tests covering both sites plus a positive control so the fix cannot pass by simply never inserting.

Against this branch: 3 passed. With the source change reverted and the same tests: 2 failed, 1 passed, the two failures being the duplicate inserts.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
