### PR TITLE
fix(llms): preserve separated reasoning content

### DIFF
--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -80,7 +80,10 @@ class OpenAILLM(LLMBase):
 
             return processed_response
         else:
-            return response.choices[0].message.content
+            message = response.choices[0].message
+            if message.content:
+                return message.content
+            return getattr(message, "reasoning_content", None) or message.content
 
     def generate_response(
         self,

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -62,6 +62,49 @@ def test_generate_response_without_tools(mock_openai_client):
     assert response == "I'm doing well, thank you for asking!"
 
 
+def test_generate_response_falls_back_to_reasoning_content(mock_openai_client):
+    config = OpenAIConfig(model="glm-5.1", temperature=0.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Extract facts"}]
+
+    mock_message = Mock(content="", reasoning_content='{"facts": ["User lives in Guadalajara"]}')
+    mock_response = Mock(choices=[Mock(message=mock_message)])
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    assert response == '{"facts": ["User lives in Guadalajara"]}'
+
+
+def test_generate_response_prefers_content_over_reasoning_content(mock_openai_client):
+    config = OpenAIConfig(model="glm-5.1", temperature=0.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Extract facts"}]
+
+    mock_message = Mock(content='{"facts": ["final answer"]}', reasoning_content="internal reasoning")
+    mock_response = Mock(choices=[Mock(message=mock_message)])
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    assert response == '{"facts": ["final answer"]}'
+
+
+def test_generate_response_preserves_empty_content_without_reasoning(mock_openai_client):
+    config = OpenAIConfig(model="glm-5.1", temperature=0.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Extract facts"}]
+
+    mock_message = Mock(spec=["content"])
+    mock_message.content = ""
+    mock_response = Mock(choices=[Mock(message=mock_message)])
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    assert response == ""
+
+
 def test_generate_response_with_tools(mock_openai_client):
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0)
     llm = OpenAILLM(config)


### PR DESCRIPTION
## Linked Issue

Closes #4932

## Description

OpenAI-compatible reasoning endpoints can return an empty `message.content` while placing their usable response in `message.reasoning_content`. `OpenAILLM` previously returned only `content`, causing fact extraction to silently receive an empty string.

This change preserves non-empty `content` as the first choice and falls back to `reasoning_content` only when needed. When neither field is usable, the original empty-content behavior is preserved. Tool-call parsing is unchanged.

This is a clean, current-main resubmission of the focused parser fix from #4937, which was closed because its original author could not complete the CLA. Credit to @octo-patch for the original implementation direction; the commit includes a `Co-authored-by` trailer.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

- `pytest tests/llms/test_openai.py -q` -> 24 passed
- `ruff check mem0/llms/openai.py tests/llms/test_openai.py` -> passed
- Red-green proof: reverting the parser change makes the new fallback regression test fail (`''` instead of the populated reasoning JSON); restoring it returns 24/24 passing.
- `git diff --check` -> passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (not needed; internal response parsing fix)