### PR TITLE
fix: compare expiration date against local calendar day, not UTC (#6931)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -446,7 +446,11 @@ def _payload_is_expired(payload: Optional[Dict[str, Any]]) -> bool:
     if not expiration_date:
         return False
     try:
-        return date.fromisoformat(str(expiration_date)) < datetime.now(timezone.utc).date()
+        # ``_normalize_expiration_date`` stores the caller's wall-clock calendar
+        # day (``value.date()`` strips any timezone). Compare against the local
+        # calendar day for symmetry: comparing with the UTC day drifted the
+        # decision by the local UTC offset around every date boundary (#6931).
+        return date.fromisoformat(str(expiration_date)) < datetime.now().date()
     except ValueError:
         return False
 

--- a/tests/memory/test_expiration_tz.py
+++ b/tests/memory/test_expiration_tz.py
@@ -1,0 +1,77 @@
+"""Regression tests for expiration-date timezone handling (#6931).
+
+The stored expiration value is a calendar date taken from the caller's
+wall-clock (``value.date()``), but the expiry check compared it against the
+UTC calendar day. Around every date boundary the decision drifted by the
+local UTC offset: a memory could stay visible up to one day too long, or
+expire up to one day early.
+"""
+
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import patch
+
+from mem0.memory.main import _normalize_expiration_date, _payload_is_expired
+
+_UTC_PLUS_8 = timezone(timedelta(hours=8))
+
+
+class _FrozenDatetime(datetime):
+    """datetime subclass whose ``now()`` returns a frozen wall-clock instant.
+
+    ``now(tz=...)`` converts the frozen local instant to the requested zone,
+    mirroring the stdlib's behavior of ``datetime.now(timezone.utc)``.
+    """
+
+    frozen_local: datetime | None = None
+
+    @classmethod
+    def set_now(cls, local_dt: datetime) -> None:
+        cls.frozen_local = local_dt
+
+    @classmethod
+    def now(cls, tz=None):
+        if cls.frozen_local is None:
+            return datetime.now(tz)
+        if tz is not None:
+            return cls.frozen_local.astimezone(tz)
+        return cls.frozen_local
+
+
+def _freeze(local_dt: datetime):
+    _FrozenDatetime.set_now(local_dt)
+    return patch("mem0.memory.main.datetime", _FrozenDatetime)
+
+
+def test_expired_uses_local_calendar_day_not_utc():
+    """Local date has advanced past the expiration while UTC has not.
+
+    Local time is 2026-08-14 00:30 (+08:00) == 2026-08-13T16:30Z. The memory
+    expires on 2026-08-13, so it must be considered expired — but comparing
+    against the UTC calendar day (still 08-13) kept it visible for another
+    7.5 hours.
+    """
+    with _freeze(datetime(2026, 8, 14, 0, 30, tzinfo=_UTC_PLUS_8)):
+        assert _payload_is_expired({"expiration_date": "2026-08-13"})
+
+
+def test_not_expired_on_expiration_day():
+    """Still valid on the expiration date itself (local calendar day)."""
+    with _freeze(datetime(2026, 8, 13, 23, 59, tzinfo=_UTC_PLUS_8)):
+        assert not _payload_is_expired({"expiration_date": "2026-08-13"})
+
+
+def test_no_expiration_not_expired():
+    assert not _payload_is_expired({})
+    assert not _payload_is_expired({"expiration_date": None})
+
+
+def test_normalize_preserves_caller_calendar_day():
+    """An aware datetime keeps the caller's wall-clock calendar day."""
+    aware = datetime(2026, 8, 13, 23, 30, tzinfo=_UTC_PLUS_8)
+    assert _normalize_expiration_date(aware) == "2026-08-13"
+
+
+def test_normalize_accepts_plain_date_and_string():
+    assert _normalize_expiration_date(date(2026, 8, 13)) == "2026-08-13"
+    assert _normalize_expiration_date("2026-08-13") == "2026-08-13"
+    assert _normalize_expiration_date(None) is None


### PR DESCRIPTION
Fixes #6931

## Summary

`_normalize_expiration_date` stores the caller's wall-clock calendar day (`value.date()` drops any timezone), but `_payload_is_expired` compared that stored date against the **UTC** calendar day. Around every date boundary the decision drifted by the local UTC offset: a memory could stay visible up to one day too long, or expire up to one day early — e.g. with a UTC+8 host, a memory expiring on Aug 13 was still visible until Aug 14 08:00 local.

## Change

- `_payload_is_expired` now compares against `datetime.now().date()` (local calendar day) instead of `datetime.now(timezone.utc).date()`.
- Rationale for this option (the issue also floated normalizing to UTC or a configurable timezone):
  - The stored value is already a **calendar day in the caller's frame** — `value.date()` on an aware datetime keeps the caller's wall-clock day and discards the zone. That information is gone at storage time.
  - Re-normalizing to UTC is therefore impossible without guessing the caller's timezone; a configurable timezone is a new knob with no consumer.
  - Comparing in the local calendar day makes both sides of the comparison use the same frame and preserves the documented semantics: *still valid on the expiration date itself, expired after*.

## Testing

New `tests/memory/test_expiration_tz.py`:

- red-before/green-after regression: local 2026-08-14 00:30 (+08:00, i.e. UTC still 08-13) with expiration 2026-08-13 must be expired — fails on the old UTC comparison, passes now
- still valid on the expiration day itself
- no-expiration payloads
- `_normalize_expiration_date` keeps the caller's calendar day for aware datetimes, and still accepts `date` / ISO strings / `None`

Validated with `pytest tests/memory/test_expiration_tz.py` (5 passed), `pytest tests/memory/test_main.py` (52 passed), and `ruff check` on both changed files.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI-assisted coding. It located the two helpers, and drafted the fix and the regression tests; I reviewed, chose between the timezone-semantics options described in the issue, and finalized every line.

Human verification performed for this change:

- Read and understood every line of the diff (2 files, 82 insertions, 1 deletion)
- Reproduced the drift reasoning by hand before coding (UTC+8 host, Aug-13 expiration stays visible until Aug-14 08:00 local)
- Ran the regression test against the old code and watched it fail, then watched it pass after the one-line comparison change
- Ran the neighboring test module and ruff on both files
- Verified the diff touches nothing beyond the comparison line, a clarifying comment, and the new test module
