### PR TITLE
fix(milvus): convert COSINE distance to similarity in _parse_output

### DIFF
--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -175,12 +175,14 @@ class MilvusDB(VectorStoreBase):
 
         return " and ".join(operands)
 
-    def _parse_output(self, data: list):
+    def _parse_output(self, data: list, is_keyword: bool = False):
         """
         Parse the output data.
 
         Args:
             data (Dict): Output data.
+            is_keyword (bool): Whether this is a keyword (BM25) search result. BM25
+                scores are higher-is-better and must not be distance-converted.
 
         Returns:
             List[OutputData]: Parsed output data.
@@ -192,10 +194,23 @@ class MilvusDB(VectorStoreBase):
             raw_distance = value.get("distance")
             metadata = value.get("entity", {}).get("metadata")
 
-            if raw_distance is not None and self.metric_type in (MetricType.L2, "L2"):
-                score = 1.0 / (1.0 + raw_distance)
-            else:
+            if is_keyword:
+                # BM25 full-text hits: score is higher-is-better already.
                 score = raw_distance
+            elif raw_distance is not None:
+                # Dense vector hits: convert distance to similarity per the
+                # VectorStoreBase contract (base.py:19-23).
+                if self.metric_type in (MetricType.COSINE, "COSINE"):
+                    score = max(0.0, 1.0 - raw_distance)
+                elif self.metric_type in (MetricType.L2, "L2"):
+                    score = 1.0 / (1.0 + raw_distance)
+                else:
+                    # IP returns the inner product (higher = better); HAMMING/JACCARD
+                    # are distance-based but have no defined contract conversion here,
+                    # so pass the raw value through rather than inverting it.
+                    score = raw_distance
+            else:
+                score = None
 
             memory_obj = OutputData(id=uid, score=score, payload=metadata)
             memory.append(memory_obj)
@@ -263,7 +278,7 @@ class MilvusDB(VectorStoreBase):
                 filter=query_filter,
                 output_fields=["*"],
             )
-            result = self._parse_output(data=hits[0])
+            result = self._parse_output(data=hits[0], is_keyword=True)
             return result
         except Exception as e:
             logger.debug(f"Keyword search not available for collection {self.collection_name}: {e}")

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -139,7 +139,8 @@ class TestMilvusDB:
         # Verify results are parsed correctly
         assert len(results) == 1
         assert results[0].id == "mem1"
-        assert results[0].score == 0.8
+        # fixture uses COSINE metric: distance must be converted to similarity
+        assert results[0].score == pytest.approx(0.2)  # max(0, 1 - 0.8)
 
     def test_search_different_user_ids(self, milvus_db, mock_milvus_client):
         """Test that search works with different user_ids (reproduces reported bug)."""
@@ -241,13 +242,14 @@ class TestMilvusDB:
         ]
         
         parsed = milvus_db._parse_output(raw_data)
-        
+
         assert len(parsed) == 2
         assert parsed[0].id == "mem1"
-        assert parsed[0].score == 0.9
+        # fixture uses COSINE metric: distance must be converted to similarity
+        assert parsed[0].score == pytest.approx(0.1)  # max(0, 1 - 0.9)
         assert parsed[0].payload == {"user_id": "alice"}
         assert parsed[1].id == "mem2"
-        assert parsed[1].score == 0.85
+        assert parsed[1].score == pytest.approx(0.15)  # max(0, 1 - 0.85)
 
     def test_update_with_none_vector_fetches_existing(self, milvus_db, mock_milvus_client):
         """Test that update with vector=None fetches the existing vector (fixes #3708)."""
@@ -394,6 +396,37 @@ class TestMilvusDB:
 
         # create_collection should not be called
         mock_milvus_client.create_collection.assert_not_called()
+
+    def test_keyword_search_keeps_raw_bm25_score(self, milvus_db, mock_milvus_client):
+        """BM25 keyword hits must keep their higher-is-better score, not be distance-converted."""
+        mock_milvus_client.search.return_value = [[
+            {"id": "mem1", "distance": 5.0, "entity": {"metadata": {"user_id": "alice"}}}
+        ]]
+
+        # Force the BM25 schema path so keyword_search proceeds.
+        milvus_db._has_bm25_schema = True
+
+        results = milvus_db.keyword_search("hello", top_k=5, filters={"user_id": "alice"})
+
+        assert len(results) == 1
+        # BM25 score 5.0 must pass through unchanged (not 1/(1+5) = ~0.167).
+        assert results[0].score == 5.0
+
+    def test_cosine_distance_converted_to_similarity(self, milvus_db):
+        """Regression for #6933: COSINE distance must become similarity per the base contract."""
+        # milvus_db fixture uses MetricType.COSINE
+        raw_data = [
+            {"id": "mem1", "distance": 0.0, "entity": {"metadata": {"user_id": "alice"}}},
+            {"id": "mem2", "distance": 1.0, "entity": {"metadata": {"user_id": "bob"}}},
+            {"id": "mem3", "distance": 2.0, "entity": {"metadata": {"user_id": "carol"}}},
+        ]
+
+        parsed = milvus_db._parse_output(raw_data)
+
+        # Best match (distance 0) must score highest, per base.py contract
+        assert parsed[0].score == pytest.approx(1.0)  # max(0, 1-0)
+        assert parsed[1].score == pytest.approx(0.0)  # max(0, 1-1)
+        assert parsed[2].score == pytest.approx(0.0)  # max(0, 1-2) clamps at 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #6933

## Summary

`MilvusVectorStore._parse_output` returned the **raw Milvus distance** as the score for every metric except L2. For `COSINE` (the default and most common metric for text embeddings), Milvus returns cosine **distance** = `1 - cosine_similarity` in `[0, 2]` where **lower is better**. Passing it through unchanged:

1. **Inverted the ranking** — `score_and_rank` sorts descending, so the least-similar vectors ranked first.
2. **Dropped the best match** — the closest vector (distance ≈ 0 → score ≈ 0) fell below the default `threshold=0.1` and was excluded.
3. **Broke entity boosting** — `_compute_entity_boosts` gates on `similarity < 0.5`, so real entity matches (distance ≈ 0) were skipped.

This violated the `VectorStoreBase` contract (`base.py:19-23`), which requires `cosine distance → score = max(0.0, 1.0 - distance)`. `pgvector.py:367` already implements this conversion; **Milvus was the one store that did not**.

## Change

`mem0/vector_stores/milvus.py` — `_parse_output` now:
- Converts **COSINE** distance to similarity (`max(0.0, 1.0 - distance)`), per the base contract.
- Keeps **L2** conversion (`1 / (1 + distance)`) unchanged.
- Passes through **IP** (already higher-is-better) and HAMMING/JACCARD (no defined contract conversion) unchanged.
- Adds an `is_keyword` flag so **BM25 keyword hits** keep their higher-is-better score instead of being distance-converted.

## Testing

`tests/vector_stores/test_milvus.py`:
- Fixed two assertions that had codified the buggy behavior (COSINE distance `0.8`/`0.9` were asserted as the score; now they assert the converted similarity `0.2`/`0.1`).
- Added `test_cosine_distance_converted_to_similarity` — verifies distance 0 (best match) → score 1.0, distance ≥1 → clamped to 0.
- Added `test_keyword_search_keeps_raw_bm25_score` — verifies BM25 scores pass through unconverted.

All 30 tests in `tests/vector_stores/test_milvus.py` pass locally. `ruff check` passes on both changed files. Verified the regression tests fail against the pre-fix code (red before / green after).
