### PR TITLE
fix(mem0-plugin): drop unused pytest import breaking make lint on main

### DIFF
--- a/integrations/mem0-plugin/tests/test_kimi_manifests.py
+++ b/integrations/mem0-plugin/tests/test_kimi_manifests.py
@@ -13,8 +13,6 @@ the structural contract so a stray edit cannot silently break the plugin:
 import json
 import os
 
-import pytest
-
 PLUGIN_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 REPO_ROOT = os.path.dirname(os.path.dirname(PLUGIN_DIR))
 


### PR DESCRIPTION
## Linked Issue

No issue - `main` is currently red and this unblocks it.

## Description

`ba2fb9f4c` (#6919) added `integrations/mem0-plugin/tests/test_kimi_manifests.py` with an `import pytest` the file never uses. Ruff's F401 fires on it, so `make lint` fails on **every** Python PR against `main`, not just plugin PRs.

Reproduce on a clean checkout of `main`:

```
$ make lint
integrations/mem0-plugin/tests/test_kimi_manifests.py:16:8: F401 [*] `pytest` imported but unused
Found 1 error.
make: *** [Makefile:28: lint] Error 1
```

The file uses plain `assert`, no fixtures, marks or parametrisation, so the import is dead. Sibling tests in the same directory that don't use pytest (`test_project.py`, `test_search.py`, `test_message_roles.py`, ...) don't import it either, so removing it matches the local convention.

After: `make lint` passes and `pytest integrations/mem0-plugin/tests/test_kimi_manifests.py` is still 6 passed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [x] I tested manually (ran `make lint` and the plugin test file before/after)
- [x] No tests needed (removing a dead import; the existing 6 tests cover the file)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] Tests added that prove my fix works (existing tests suffice)
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (N/A)