### PR TITLE
fix(memory): handle block-list content in remove_code_blocks

### DIFF
--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from mem0.configs.prompts import (
     AGENT_MEMORY_EXTRACTION_PROMPT,
@@ -112,7 +112,7 @@ def normalize_facts(raw_facts):
     return normalized
 
 
-def remove_code_blocks(content: str) -> str:
+def remove_code_blocks(content: Union[str, List[Union[str, Dict[str, Any]]], None]) -> str:
     """
     Removes enclosing code block markers ```[language] and ``` from a given string.
 
@@ -120,9 +120,15 @@ def remove_code_blocks(content: str) -> str:
     - The function uses a regex pattern to match code blocks that may start with ``` followed by an optional language tag (letters or numbers) and end with ```.
     - If a code block is detected, it returns only the inner content, stripping out the markers.
     - If no code block markers are found, the original content is returned as-is.
+    - Block-style content (a LangChain message whose `.content` is a list of text
+      blocks) is flattened to its concatenated text before matching.
     """
     if content is None:
         return ""
+    if isinstance(content, list):
+        content = "".join(
+            part if isinstance(part, str) else part.get("text", "") for part in content if isinstance(part, (str, dict))
+        )
     pattern = r"^```[a-zA-Z0-9]*\n([\s\S]*?)\n```$"
     match = re.match(pattern, content.strip())
     match_res=match.group(1).strip() if match else content.strip()

--- a/tests/memory/test_memory_utils.py
+++ b/tests/memory/test_memory_utils.py
@@ -192,3 +192,21 @@ class TestProcessTelemetryFilters:
 class TestRemoveCodeBlocks:
     def test_none_content_returns_empty_string(self):
         assert remove_code_blocks(None) == ""
+
+    def test_block_list_content_is_flattened(self):
+        assert remove_code_blocks([{"type": "text", "text": "step one"}]) == "step one"
+
+    def test_block_list_content_strips_code_fences(self):
+        content = [{"type": "text", "text": '```json\n{"a": 1}\n```'}]
+        assert remove_code_blocks(content) == '{"a": 1}'
+
+    def test_block_list_content_joins_multiple_blocks(self):
+        content = [{"type": "text", "text": "step one. "}, {"type": "text", "text": "step two"}]
+        assert remove_code_blocks(content) == "step one. step two"
+
+    def test_block_list_content_ignores_non_text_blocks(self):
+        content = [{"type": "thinking", "thinking": "hmm"}, {"type": "text", "text": "answer"}]
+        assert remove_code_blocks(content) == "answer"
+
+    def test_plain_string_blocks_are_supported(self):
+        assert remove_code_blocks(["step one. ", "step two"]) == "step one. step two"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1235,8 +1235,9 @@ class TestHybridSearchWarning:
     def test_warning_for_store_without_keyword_search(
         self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
     ):
-        from mem0.vector_stores.base import VectorStoreBase
         import logging
+
+        from mem0.vector_stores.base import VectorStoreBase
 
         class StoreWithoutKeywordSearch(VectorStoreBase):
             def create_col(self, *a, **kw): pass
@@ -1271,8 +1272,9 @@ class TestHybridSearchWarning:
     def test_no_warning_for_store_with_keyword_search(
         self, mock_vs_factory, mock_emb, mock_llm, mock_sqlite, _cap, caplog
     ):
-        from mem0.vector_stores.base import VectorStoreBase
         import logging
+
+        from mem0.vector_stores.base import VectorStoreBase
 
         class StoreWithKeywordSearch(VectorStoreBase):
             def keyword_search(self, query, top_k=5, filters=None):
@@ -1534,6 +1536,39 @@ async def test_async_procedural_memory_langchain_strips_code_blocks(mock_llm_fac
     insert_call = memory.vector_store.insert.call_args
     stored_data = insert_call[1]["payloads"][0]["data"]
     assert "```" not in stored_data
+
+
+@pytest.mark.asyncio
+@patch("mem0.memory.main.VectorStoreFactory")
+@patch("mem0.memory.main.EmbedderFactory")
+@patch("mem0.memory.main.LlmFactory")
+async def test_async_procedural_memory_langchain_block_list_content(mock_llm_factory, mock_emb, mock_vs):
+    """Regression #6150: block-list message content must not raise AttributeError."""
+    mock_vs.return_value = MagicMock()
+    mock_emb.return_value = MagicMock()
+    mock_emb.return_value.embed.return_value = [0.1] * 1536
+    mock_llm_factory.return_value = MagicMock()
+
+    from mem0.memory.main import AsyncMemory
+
+    config = MemoryConfig()
+    memory = AsyncMemory(config)
+    memory.vector_store = MagicMock()
+    memory.vector_store.insert = MagicMock()
+
+    mock_langchain_llm = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = [{"type": "text", "text": '```json\n{"key": "value"}\n```'}]
+    mock_langchain_llm.invoke.return_value = mock_response
+
+    messages = [{"role": "user", "content": "test"}]
+    metadata = {"user_id": "test_user"}
+
+    await memory._create_procedural_memory(messages, metadata=metadata, llm=mock_langchain_llm)
+
+    insert_call = memory.vector_store.insert.call_args
+    stored_data = insert_call[1]["payloads"][0]["data"]
+    assert stored_data == '{"key": "value"}'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Linked Issue

Closes #6150

## Description

`AsyncMemory._create_procedural_memory(..., llm=<custom LangChain LLM>)` calls
`remove_code_blocks(response.content)`. LangChain's `AIMessage.content` is typed
`str | list[str | dict]`, and providers that emit content blocks return the list
form. `remove_code_blocks` then ran `content.strip()` on a list and raised
`AttributeError: 'list' object has no attribute 'strip'`.

The earlier partial fix for this issue only guarded `content is None`, which does
not cover the list shape, so the crash stayed reachable.

`remove_code_blocks` already normalizes `None`, so the list case is handled in that
same guard rather than at the call site. Of its five callers only the LangChain one
can receive a list today (the other four pass `generate_response` output, which is
`str`), but keeping the normalization in the shared helper means no future caller
has to rediscover this.

Text blocks are concatenated and non-text blocks (e.g. `thinking`) are dropped,
matching how `parse_vision_messages` already flattens block content in this file.

Only the async path is affected: the sync `_create_procedural_memory` has no `llm`
parameter and never takes a LangChain message.

The commit also contains a small `isort` reordering in two pre-existing blocks of
`tests/test_memory.py` (lines ~1235 and ~1271), applied automatically by the repo's
pre-commit hook because the file is touched here.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. String and `None` inputs behave exactly as before; only the previously-crashing
list input changes behaviour.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Six new tests:

- `tests/memory/test_memory_utils.py` — five unit tests covering block flattening,
  code-fence stripping inside a block, multi-block joining, non-text block removal,
  and bare-string blocks.
- `tests/test_memory.py::test_async_procedural_memory_langchain_block_list_content`
  — end-to-end through `AsyncMemory._create_procedural_memory`, asserting the stored
  payload, alongside the existing `#5710` string-content test.

Each was confirmed to fail without the fix. Reverting `mem0/memory/utils.py` alone
reproduces `AttributeError: 'list' object has no attribute 'strip'` at
`mem0/memory/utils.py:127` — the exact crash reported — and all six pass with it.

`455 passed` across `tests/test_memory.py`, `tests/memory/`, and
`tests/test_chatty_llm_parsing.py`; `ruff check` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed (internal fix, no public API change)
