### PR TITLE
docs(llms): fix wrong read snippets, dead reranking link, and 24 mis-scoped integration tags

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -612,6 +612,10 @@
   },
   "redirects": [
     {
+      "source": "/open-source/features/reranking",
+      "destination": "/open-source/features/reranker-search"
+    },
+    {
       "source": "/platform/features/contextual-add",
       "destination": "/core-concepts/memory-operations/add"
     },

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -264,7 +264,7 @@ If the user is on a pre-current major (Python < 2, TS < 3, or a Platform call st
 - [Vercel AI SDK](https://docs.mem0.ai/integrations/vercel-ai-sdk) [Both]: Use when the user is on the Vercel AI SDK.
 
 ### AI Coding Tools
-- [Claude Code](https://docs.mem0.ai/integrations/claude-code) [Platform]: Use when wiring memory into Claude Code.
+- [Claude Code](https://docs.mem0.ai/integrations/claude-code) [Both]: Use when wiring memory into Claude Code.
 - [Cursor](https://docs.mem0.ai/integrations/cursor) [Platform]: Use when wiring memory into Cursor.
 - [Codex](https://docs.mem0.ai/integrations/codex) [Platform]: Use when wiring memory into Codex / other editor assistants.
 - [OpenCode](https://docs.mem0.ai/integrations/opencode) [Platform]: Use when wiring memory into OpenCode.
@@ -409,10 +409,10 @@ The `integrations/mem0-plugin/` directory provides MCP server connection, lifecy
 Editor-specific setup docs (already listed above under `## Integrations > AI Coding Tools`):
 
 - `integrations/claude-code` [Both]
-- `integrations/cursor` [Both]
-- `integrations/codex` [Both]
-- `integrations/opencode` [Both]
-- `integrations/antigravity` [Both]
+- `integrations/cursor` [Platform]
+- `integrations/codex` [Platform]
+- `integrations/opencode` [Platform]
+- `integrations/antigravity` [Platform]
 - `integrations/openclaw` [Both]
 
 ### MCP Endpoints

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -56,8 +56,8 @@ client.add(
 )
 
 # Read
-client.search("What does Alice like to do?", user_id="alice")
-client.get_all(user_id="alice")
+client.search("What does Alice like to do?", filters={"user_id": "alice"})
+client.get_all(filters={"user_id": "alice"})
 client.get(memory_id="<id>")
 
 # Update
@@ -86,8 +86,8 @@ await client.add(
 );
 
 // Read
-await client.search("What does Alice like to do?", { user_id: "alice" });
-await client.getAll({ user_id: "alice" });
+await client.search("What does Alice like to do?", { filters: { user_id: "alice" } });
+await client.getAll({ filters: { user_id: "alice" } });
 await client.get("<memory_id>");
 
 // Update
@@ -113,8 +113,8 @@ m = Memory()   # needs OPENAI_API_KEY; see components/ for custom providers
 m.add("I love hiking on weekends", user_id="alice")
 
 # Read
-m.search("What does Alice like to do?", user_id="alice")
-m.get_all(user_id="alice")
+m.search("What does Alice like to do?", filters={"user_id": "alice"})
+m.get_all(filters={"user_id": "alice"})
 m.get(memory_id="<id>")
 
 # Update
@@ -140,8 +140,8 @@ const memory = new Memory();
 await memory.add("I love hiking on weekends", { userId: "alice" });
 
 // Read
-await memory.search("What does Alice like to do?", { userId: "alice" });
-await memory.getAll({ userId: "alice" });
+await memory.search("What does Alice like to do?", { filters: { user_id: "alice" } });
+await memory.getAll({ filters: { user_id: "alice" } });
 await memory.get("<memory_id>");
 
 // Update

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -164,7 +164,7 @@ npm list mem0ai --depth 0 2>/dev/null | grep mem0ai
 mem0 --version          # Python or Node CLI, whichever is on PATH
 ```
 
-If the user is on a pre-current major (Python < 2, TS < 3, or Platform `output_format: "v1.1"`), route them through the matching migration guide in the Platform section before quoting current docs. If no Mem0 package is installed, recommend `pip install mem0ai` or `npm install mem0ai` and the corresponding quickstart above.
+If the user is on a pre-current major (Python < 2, TS < 3, or a Platform call still passing `output_format`, `api_version`, `async_mode`, or `enable_graph`, all removed in the current major), route them through the matching migration guide in the Platform section before quoting current docs. If no Mem0 package is installed, recommend `pip install mem0ai` or `npm install mem0ai` and the corresponding quickstart above.
 
 ## Getting Started
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -246,46 +246,46 @@ If the user is on a pre-current major (Python < 2, TS < 3, or a Platform call st
 - [Integrations Overview](https://docs.mem0.ai/integrations) [Both]: Use when surveying every available integration.
 
 ### Agent Frameworks
-- [LangChain](https://docs.mem0.ai/integrations/langchain) [Both]: Use when the user is on LangChain.
-- [LangGraph](https://docs.mem0.ai/integrations/langgraph) [Both]: Use when building stateful multi-actor LangGraph apps.
-- [LangChain Tools](https://docs.mem0.ai/integrations/langchain-tools) [Both]: Use when Mem0 should be exposed as a LangChain tool.
+- [LangChain](https://docs.mem0.ai/integrations/langchain) [Platform]: Use when the user is on LangChain.
+- [LangGraph](https://docs.mem0.ai/integrations/langgraph) [Platform]: Use when building stateful multi-actor LangGraph apps.
+- [LangChain Tools](https://docs.mem0.ai/integrations/langchain-tools) [Platform]: Use when Mem0 should be exposed as a LangChain tool.
 - [LlamaIndex](https://docs.mem0.ai/integrations/llama-index) [Both]: Use when layering memory on a LlamaIndex RAG app.
-- [CrewAI](https://docs.mem0.ai/integrations/crewai) [Both]: Use when building CrewAI multi-agent systems.
-- [AutoGen](https://docs.mem0.ai/integrations/autogen) [Both]: Use when the user is on Microsoft AutoGen.
-- [Agno](https://docs.mem0.ai/integrations/agno) [Both]: Use when the user is on Agno.
+- [CrewAI](https://docs.mem0.ai/integrations/crewai) [Platform]: Use when building CrewAI multi-agent systems.
+- [AutoGen](https://docs.mem0.ai/integrations/autogen) [Platform]: Use when the user is on Microsoft AutoGen.
+- [Agno](https://docs.mem0.ai/integrations/agno) [Platform]: Use when the user is on Agno.
 - [Camel AI](https://docs.mem0.ai/integrations/camel-ai) [Both]: Use when the user is on Camel AI.
-- [ChatDev](https://docs.mem0.ai/integrations/chatdev) [Both]: Use when the user is on ChatDev.
+- [ChatDev](https://docs.mem0.ai/integrations/chatdev) [Platform]: Use when the user is on ChatDev.
 - [Hermes](https://docs.mem0.ai/integrations/hermes) [Both]: Use when the user is on Hermes.
 - [Pi Agent](https://docs.mem0.ai/integrations/pi-agent) [Platform]: Use when adding persistent memory to Pi Agent with the Mem0 plugin.
-- [OpenAI Agents SDK](https://docs.mem0.ai/integrations/openai-agents-sdk) [Both]: Use when the user is on the OpenAI Agents SDK.
-- [Google AI ADK](https://docs.mem0.ai/integrations/google-ai-adk) [Both]: Use when the user is on Google's Agent Development Kit.
-- [Mastra](https://docs.mem0.ai/integrations/mastra) [Both]: Use when the user is on Mastra (TypeScript).
+- [OpenAI Agents SDK](https://docs.mem0.ai/integrations/openai-agents-sdk) [Platform]: Use when the user is on the OpenAI Agents SDK.
+- [Google AI ADK](https://docs.mem0.ai/integrations/google-ai-adk) [Platform]: Use when the user is on Google's Agent Development Kit.
+- [Mastra](https://docs.mem0.ai/integrations/mastra) [Platform]: Use when the user is on Mastra (TypeScript).
 - [OpenClaw](https://docs.mem0.ai/integrations/openclaw) [Both]: Use when wiring Mem0 into Claude Code or editors via OpenClaw.
 - [Vercel AI SDK](https://docs.mem0.ai/integrations/vercel-ai-sdk) [Both]: Use when the user is on the Vercel AI SDK.
 
 ### AI Coding Tools
-- [Claude Code](https://docs.mem0.ai/integrations/claude-code) [Both]: Use when wiring memory into Claude Code.
-- [Cursor](https://docs.mem0.ai/integrations/cursor) [Both]: Use when wiring memory into Cursor.
-- [Codex](https://docs.mem0.ai/integrations/codex) [Both]: Use when wiring memory into Codex / other editor assistants.
-- [OpenCode](https://docs.mem0.ai/integrations/opencode) [Both]: Use when wiring memory into OpenCode.
-- [Antigravity](https://docs.mem0.ai/integrations/antigravity) [Both]: Use when wiring memory into Google Antigravity.
+- [Claude Code](https://docs.mem0.ai/integrations/claude-code) [Platform]: Use when wiring memory into Claude Code.
+- [Cursor](https://docs.mem0.ai/integrations/cursor) [Platform]: Use when wiring memory into Cursor.
+- [Codex](https://docs.mem0.ai/integrations/codex) [Platform]: Use when wiring memory into Codex / other editor assistants.
+- [OpenCode](https://docs.mem0.ai/integrations/opencode) [Platform]: Use when wiring memory into OpenCode.
+- [Antigravity](https://docs.mem0.ai/integrations/antigravity) [Platform]: Use when wiring memory into Google Antigravity.
 
 ### Voice & Real-time
-- [LiveKit](https://docs.mem0.ai/integrations/livekit) [Both]: Use when building real-time voice/video with memory.
-- [Pipecat](https://docs.mem0.ai/integrations/pipecat) [Both]: Use when the voice pipeline is Pipecat.
-- [ElevenLabs](https://docs.mem0.ai/integrations/elevenlabs) [Both]: Use when voice synthesis uses ElevenLabs.
+- [LiveKit](https://docs.mem0.ai/integrations/livekit) [Platform]: Use when building real-time voice/video with memory.
+- [Pipecat](https://docs.mem0.ai/integrations/pipecat) [Platform]: Use when the voice pipeline is Pipecat.
+- [ElevenLabs](https://docs.mem0.ai/integrations/elevenlabs) [Platform]: Use when voice synthesis uses ElevenLabs.
 
 ### Cloud & Infrastructure
-- [AWS Bedrock](https://docs.mem0.ai/integrations/aws-bedrock) [Both]: Use when the user is on AWS Bedrock managed AI services.
+- [AWS Bedrock](https://docs.mem0.ai/integrations/aws-bedrock) [OSS]: Use when the user is on AWS Bedrock managed AI services.
 
 ### Developer Tools
-- [Dify](https://docs.mem0.ai/integrations/dify) [Both]: Use when the user is on Dify LLMOps.
-- [Flowise](https://docs.mem0.ai/integrations/flowise) [Both]: Use when the user is on Flowise no-code.
+- [Dify](https://docs.mem0.ai/integrations/dify) [Platform]: Use when the user is on Dify LLMOps.
+- [Flowise](https://docs.mem0.ai/integrations/flowise) [Platform]: Use when the user is on Flowise no-code.
 - [n8n](https://docs.mem0.ai/integrations/n8n) [Both]: Use when the user builds workflows or AI agents in n8n.
 - [Zapier](https://docs.mem0.ai/integrations/zapier) [Both]: Use when the user automates workflows with Zapier.
 - [AgentOps](https://docs.mem0.ai/integrations/agentops) [Both]: Use when tracking agent observability with memory metadata.
-- [Respan](https://docs.mem0.ai/integrations/respan) [Both]: Use when monitoring Mem0 with Respan (formerly Keywords AI) LLM observability.
-- [Raycast](https://docs.mem0.ai/integrations/raycast) [Both]: Use when the user wants quick memory access via Raycast.
+- [Respan](https://docs.mem0.ai/integrations/respan) [OSS]: Use when monitoring Mem0 with Respan (formerly Keywords AI) LLM observability.
+- [Raycast](https://docs.mem0.ai/integrations/raycast) [Platform]: Use when the user wants quick memory access via Raycast.
 
 ## Cookbooks
 
@@ -317,10 +317,10 @@ If the user is on a pre-current major (Python < 2, TS < 3, or a Platform call st
 ### Integration Examples
 - [Agents SDK Tool](https://docs.mem0.ai/cookbooks/integrations/agents-sdk-tool) [Platform]: Use when exposing Mem0 as a tool in OpenAI Agents SDK.
 - [OpenAI Tool Calls](https://docs.mem0.ai/cookbooks/integrations/openai-tool-calls) [Platform]: Use when hooking Mem0 into OpenAI function calling.
-- [Mastra Agent](https://docs.mem0.ai/cookbooks/integrations/mastra-agent) [Both]: Use when the agent is built in Mastra.
-- [Healthcare Google ADK](https://docs.mem0.ai/cookbooks/integrations/healthcare-google-adk) [Both]: Use when the domain is medical and the framework is Google ADK.
-- [AWS Bedrock](https://docs.mem0.ai/cookbooks/integrations/aws-bedrock) [Both]: Use when deploying with AWS managed model services.
-- [Tavily Search](https://docs.mem0.ai/cookbooks/integrations/tavily-search) [Both]: Use when the agent layers web search on memory.
+- [Mastra Agent](https://docs.mem0.ai/cookbooks/integrations/mastra-agent) [Platform]: Use when the agent is built in Mastra.
+- [Healthcare Google ADK](https://docs.mem0.ai/cookbooks/integrations/healthcare-google-adk) [Platform]: Use when the domain is medical and the framework is Google ADK.
+- [AWS Bedrock](https://docs.mem0.ai/cookbooks/integrations/aws-bedrock) [OSS]: Use when deploying with AWS managed model services.
+- [Tavily Search](https://docs.mem0.ai/cookbooks/integrations/tavily-search) [Platform]: Use when the agent layers web search on memory.
 
 ### Framework Examples
 - [LlamaIndex React](https://docs.mem0.ai/cookbooks/frameworks/llamaindex-react) [Both]: Use when building a React UI with LlamaIndex and memory.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -235,7 +235,6 @@ If the user is on a pre-current major (Python < 2, TS < 3, or Platform `output_f
 - [Open Source Features Overview](https://docs.mem0.ai/open-source/features/overview) [OSS]: Use when surveying OSS-only capabilities.
 - [Metadata Filtering](https://docs.mem0.ai/open-source/features/metadata-filtering) [OSS]: Use when filtering by custom metadata fields in self-hosted.
 - [Reranker Search](https://docs.mem0.ai/open-source/features/reranker-search) [OSS]: Use when improving OSS search quality with a reranker.
-- [Reranking](https://docs.mem0.ai/open-source/features/reranking) [OSS]: Use when configuring reranking end-to-end in OSS.
 - [Async Memory](https://docs.mem0.ai/open-source/features/async-memory) [OSS]: Use when the self-hosted app needs `AsyncMemory`.
 - [OSS Multimodal Support (features)](https://docs.mem0.ai/open-source/features/multimodal-support) [OSS]: Use when handling images and PDFs self-hosted (feature guide).
 - [Custom Instructions (OSS)](https://docs.mem0.ai/open-source/features/custom-instructions) [OSS]: Use when tailoring extraction prompts in OSS.

--- a/docs/open-source/features/reranker-search.mdx
+++ b/docs/open-source/features/reranker-search.mdx
@@ -53,7 +53,7 @@ const memory = new Memory({
 });
 
 const results = await memory.search("What are my food preferences?", {
-  filters: { userId: "alice" },
+  filters: { user_id: "alice" },
   rerank: true,
 });
 ```
@@ -86,7 +86,7 @@ const memory = new Memory({
 });
 
 const results = await memory.search("What movies do I like?", {
-  filters: { userId: "alice" },
+  filters: { user_id: "alice" },
   rerank: true,
 });
 ```
@@ -108,7 +108,7 @@ const memory = new Memory({
 });
 
 const results = await memory.search("What movies do I like?", {
-  filters: { userId: "alice" },
+  filters: { user_id: "alice" },
   rerank: true,
 });
 ```

--- a/docs/open-source/features/reranking.mdx
+++ b/docs/open-source/features/reranking.mdx
@@ -1,6 +1,0 @@
----
-title: Reranking
-description: 'Redirect to the canonical reranker-enhanced search guide.'
----
-
-<Redirect href="/open-source/features/reranker-search" />

--- a/docs/open-source/node-quickstart.mdx
+++ b/docs/open-source/node-quickstart.mdx
@@ -43,7 +43,7 @@ await memory.add(messages, { userId: "alice", metadata: { category: "movie_recom
 
 <Step title="Search memories">
 ```ts
-const results = await memory.search("What do you know about me?", { filters: { userId: "alice" } });
+const results = await memory.search("What do you know about me?", { filters: { user_id: "alice" } });
 console.log(results);
 ```
 


### PR DESCRIPTION
## Linked Issue

No GitHub issue. Tracked internally as **MEM-5806** (`docs/llms.txt` accuracy audit).

## Description

`docs/llms.txt` is the index agents load before answering Mem0 questions, so a wrong line there is copied into user code. Four problems, one commit each.

**Read snippets called the wrong signature.** All four quickstart blocks (Platform Python/TS, OSS Python/TS) showed `search(query, user_id="alice")` and `get_all(user_id="alice")`. Neither SDK accepts that any more:

- `MemoryClient.search()` explicitly rejects it: `Top-level entity parameters {'user_id'} are not supported in search(). Use filters={'user_id': '...'} instead.` (`mem0/client/main.py`)
- OSS `Memory.search()` / `.get_all()` are keyword-only with no `user_id` parameter at all: `filters` is the only entity channel (`mem0/memory/main.py`)

Fixed to `filters={"user_id": "alice"}` / `{ filters: { user_id: "alice" } }`.

**Version-probe line said "deprecated".** `output_format: "v1.1"` was described as a pre-current-major marker. `docs/migration/platform-v2-to-v3.mdx` lists `api_version`, `output_format`, `async_mode`, and `enable_graph` under **Removed parameters**, and none of them exist in `mem0/client/`. Reworded to name all four as removed, so the probe catches a v2-era call regardless of which one it uses.

**Dead Reranking link.** `docs/open-source/features/reranking.mdx` was a six-line stub whose entire body was `<Redirect href="/open-source/features/reranker-search" />`, which is not a Mintlify component, so the page rendered empty. It was not in `docs.json` navigation either. Deleted the stub, moved the redirect into `docs.json` where Mintlify actually honors it, and dropped its `llms.txt` entry.

**24 integration entries were tagged `[Both]` when the page only documents one mode.** Retagged from the page content, not from whether the integration could theoretically work self-hosted:

- → `[Platform]` (page uses `MemoryClient` / a hosted API key and shows no OSS path): LangChain, LangGraph, LangChain Tools, CrewAI, AutoGen, Agno, ChatDev, OpenAI Agents SDK, Google AI ADK, Mastra, Cursor, Codex, OpenCode, Antigravity, LiveKit, Pipecat, ElevenLabs, Dify, Flowise, Raycast, plus the Mastra / Healthcare-ADK / Tavily cookbooks
- → `[OSS]` (page uses `from mem0 import Memory` only): AWS Bedrock (integration and cookbook), Respan

`claude-code` deliberately stays `[Both]`: #6949 adds a documented self-hosted section to that page. `openclaw` stays `[Both]` for its existing Open-Source Mode section. The same five editor pages are listed a second time under "Editor Plugin (shared glue)"; those duplicate tags are synced so the file no longer contradicts itself.

Also fixed three `filters: { userId: ... }` snippets in `docs/open-source/features/reranker-search.mdx` and one in `docs/open-source/node-quickstart.mdx` — the OSS TS `Memory` reads `filters.user_id`, so the camelCase form threw. (#6946 separately makes camelCase work too; these pages should teach the canonical form either way.)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A. `/open-source/features/reranking` keeps working — the redirect moves from a non-functional page component to a real `docs.json` redirect.

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Docs-only, so verification was by checking each claim against the code it describes:

- `python3 scripts/check-llms-txt-coverage.py` → in sync
- `docs/docs.json` parses; `open-source/features/reranking` appears only in `redirects`, never in navigation, and nothing else in `docs/` links to it
- every retag confirmed by grepping the page for `from mem0 import Memory` / `mem0ai/oss` versus `MemoryClient` / `MEM0_API_KEY`
- both snippet fixes confirmed against the live signatures in `mem0/client/main.py` and `mem0/memory/main.py`
- a consistency scan over `llms.txt` confirms no page is tagged two different ways in the two places it is listed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
