### PR TITLE
docs: distinguish structured exports from raw backups

### DIFF
--- a/docs/cookbooks/essentials/exporting-memories.mdx
+++ b/docs/cookbooks/essentials/exporting-memories.mdx
@@ -4,9 +4,13 @@ description: "Retrieve, review, and migrate user memories with structured export
 ---
 
 
-Mem0 is a dynamic memory store that gives you full control over your data. Along with storing memories, it gives you the ability to retrieve, export, and migrate your data whenever you need.
+Mem0 is a dynamic memory store that lets you retrieve memories as raw records or transform them into a structured export for downstream use.
 
 This cookbook shows you how to retrieve and export your data for inspection, migration, or compliance.
+
+<Warning>
+The structured export job is not a raw backup. It uses the schema and instructions you provide to transform matching memories. Use paginated `get_all()` calls when you need the original memory records. For an account-level data access or compliance request that the API cannot complete, contact support.
+</Warning>
 
 ---
 
@@ -254,7 +258,7 @@ You can also export memories directly from the Mem0 platform UI:
 3. Select your filters and schema
 4. Download the completed export as JSON
 
-This is useful for one-off exports or manual data reviews.
+This is useful for one-off structured exports or manual data reviews. It does not create a raw backup of every memory record; use paginated `get_all()` calls for raw retrieval.
 
 <Warning>
 Exported data expires after 7 days. Download and store exports locally if you need long-term archives. After expiration, you'll need to recreate the export job.
@@ -272,13 +276,13 @@ A complete memory export system with multiple retrieval methods:
 - **Export instructions** - Guide conflict resolution and data formatting
 - **Platform UI exports** - One-off manual downloads via dashboard
 
-This covers data portability, GDPR compliance, system migrations, and manual reviews.
+These approaches support data inspection, portability workflows, system migrations, and manual reviews. Use raw retrieval or contact support when a compliance request requires the original records rather than a schema-transformed export.
 
 ---
 
 ## Summary
 
-Use **`get_all()`** for bulk retrieval, **`search()`** for specific questions, and **`create_memory_export()`** for structured data exports with custom schemas. Remember exports expire after 7 days: download them locally for long-term archives.
+Use **`get_all()`** for paginated raw retrieval, **`search()`** for specific questions, and **`create_memory_export()`** for schema-transformed data. Structured exports expire after 7 days, so download completed results promptly. Do not treat them as raw backups.
 
 <CardGroup cols={2}>
   <Card title="Build a Mem0 Companion" icon="users" href="/cookbooks/essentials/building-ai-companion">

--- a/docs/platform/features/memory-export.mdx
+++ b/docs/platform/features/memory-export.mdx
@@ -7,6 +7,10 @@ description: 'Export memories in a structured format using customizable Pydantic
 
 The Memory Export feature allows you to create structured exports of memories using customizable Pydantic schemas. This process enables you to transform your stored memories into specific data formats that match your needs. You can apply various filters to narrow down which memories to export and define exactly how the data should be structured.
 
+<Warning>
+Memory Export transforms matching memories into the schema you provide. It is not a raw backup or a byte-for-byte download of every stored memory record. If you need the original memory records, retrieve them with the paginated `get_all()` API instead. For an account-level data access or compliance request that cannot be completed through the API, contact support.
+</Warning>
+
 ## Creating a Memory Export
 
 To create a memory export, you'll need to:
@@ -277,6 +281,8 @@ You can apply various filters to customize which memories are included in the ex
 <Note>
 The export process may take some time to complete, especially when dealing with a large number of memories or complex schemas.
 </Note>
+
+If an export remains in progress unexpectedly, do not submit duplicate jobs. Retrieve the job by its export ID to check its status, then contact support with that ID if it does not complete.
 
 If you have any questions, please feel free to reach out to us using one of the following methods:
 


### PR DESCRIPTION
## Linked Issue

No public issue. This is a support-driven documentation correction; opening an issue would duplicate private customer context.

## Description

Recent support conversations showed that customers and Fin were treating the structured Memory Export feature as a raw backup path. This PR:

- states that Memory Export transforms matching memories into a supplied schema
- distinguishes structured exports from raw, paginated `get_all()` retrieval
- directs account-level data access requests that the API cannot complete to support
- tells users with unexpectedly long-running exports to check the export ID and avoid duplicate jobs

## Why

Three support cases involved stuck exports or requests for a complete backup. The existing docs described the feature broadly enough to imply that the dashboard export was a raw copy suitable for every backup or compliance workflow. That ambiguity produced incorrect expectations and support escalation.

## User impact

Users can choose the correct path before starting an export:

- `get_all()` for original memory records
- Memory Export for schema-transformed output
- support for account-level requests the API cannot complete

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually: reviewed both MDX flows and checked the diff
- [x] No code tests needed: documentation-only change

Validation:

- `python3 scripts/check-llms-txt-coverage.py`
- `git diff --check`

## Risk and rollback

Green, documentation-only, and reversible. No schema, authentication, security, billing, permissions, infrastructure, deployment, or data-path behavior changes. Roll back by reverting commit `2e09cc3`.

## Measurement and acceptance criteria

- Published export docs explicitly distinguish structured exports from raw backups.
- Support and Fin guidance can link to one unambiguous explanation.
- Track repeat conversations mentioning stuck exports, full backups, or confusion about schemas after publication.

## Checklist

- [x] My change follows the project's documentation style
- [x] I performed a self-review
- [x] Relevant validation passes locally
- [x] Documentation is updated
