### PR TITLE
fix(server): keep text_lemmatized out of admin GET /memories metadata

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -383,7 +383,21 @@ def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
 
 
 ALL_MEMORIES_LIMIT = 1000
-_RESERVED_PAYLOAD_KEYS = {"data", "user_id", "agent_id", "run_id", "hash", "created_at", "updated_at", "expiration_date"}
+_RESERVED_PAYLOAD_KEYS = {
+    "data",
+    "id",
+    "hash",
+    "created_at",
+    "updated_at",
+    "expiration_date",
+    "user_id",
+    "agent_id",
+    "run_id",
+    "actor_id",
+    "role",
+    "attributed_to",
+    "text_lemmatized",
+}
 
 
 def _serialize_memory(row: Any) -> Dict[str, Any]:

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -652,6 +652,30 @@ class TestGetMemories:
         assert response.status_code == 422
         mock_memory.get_all.assert_not_called()
 
+    def test_admin_list_all_memories_excludes_internal_payload_keys(self, client, mock_memory):
+        row = MagicMock()
+        row.id = "mem-1"
+        row.payload = {
+            "data": "I love hiking on weekends",
+            "text_lemmatized": "love hike weekend",
+            "user_id": "alice",
+            "hash": "abc",
+            "created_at": "2024-01-01T00:00:00+00:00",
+            "updated_at": "2024-01-01T00:00:00+00:00",
+            "role": "user",
+            "category": "outdoors",
+        }
+        mock_memory.vector_store.list.return_value = [[row]]
+
+        response = client.get("/memories")
+
+        assert response.status_code == 200
+        item = response.json()["results"][0]
+        assert item["memory"] == "I love hiking on weekends"
+        assert "text_lemmatized" not in (item.get("metadata") or {})
+        assert "role" not in (item.get("metadata") or {})
+        assert item["metadata"] == {"category": "outdoors"}
+
 
 # ===========================================================================
 # SearchRequest: entity IDs mapped into filters (fix for server 502)


### PR DESCRIPTION
## Summary
- Closes #6825
- Admin `GET /memories` serialized the internal BM25 field `text_lemmatized` (and other reserved keys) as user metadata.
- Scoped `GET /memories?user_id=` already strips these via the SDK. Align the admin serializer.

## Test plan
- [x] admin list-all excludes `text_lemmatized` / `role` and keeps real metadata
