### PR TITLE
fix(setup): do not crash import mem0 when ~/.mem0 cannot be created

### DIFF
--- a/mem0/memory/setup.py
+++ b/mem0/memory/setup.py
@@ -9,9 +9,12 @@ from hashlib import sha256
 VECTOR_ID = str(uuid.uuid4())
 home_dir = os.path.expanduser("~")
 mem0_dir = os.environ.get("MEM0_DIR") or os.path.join(home_dir, ".mem0")
-os.makedirs(mem0_dir, exist_ok=True)
 
 _logger = logging.getLogger(__name__)
+try:
+    os.makedirs(mem0_dir, exist_ok=True)
+except OSError as e:
+    _logger.debug("Failed to create mem0 config dir %s: %s", mem0_dir, e)
 
 
 def _config_path():

--- a/tests/memory/test_setup.py
+++ b/tests/memory/test_setup.py
@@ -1,0 +1,19 @@
+import importlib
+import os
+
+import pytest
+
+
+def test_import_survives_unwritable_mem0_dir(monkeypatch, tmp_path):
+    """import mem0 must not require creating ~/.mem0 (read-only HOME / Lambda)."""
+    blocked = tmp_path / "nope"
+    blocked.write_text("not-a-directory")
+    monkeypatch.setenv("MEM0_DIR", str(blocked))
+
+    import mem0.memory.setup as setup
+
+    importlib.reload(setup)
+
+    assert setup.mem0_dir == str(blocked)
+    assert setup.get_user_id() == "anonymous_user"
+    setup._write_config({"user_id": "x"})  # best-effort, must not raise


### PR DESCRIPTION
## Summary
- Closes #6812
- Unguarded `os.makedirs(~/.mem0)` ran at import time, so `import mem0` failed on read-only HOME / Lambda / distroless.
- Directory creation is now best-effort, matching `_write_config`.

## Test plan
- [x] `test_import_survives_unwritable_mem0_dir`
