### PR TITLE
fix(embedder): honor Upstash enable_embeddings instead of comparing the wrong provider name

### DIFF
--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -166,7 +166,15 @@ class EmbedderFactory:
 
     @classmethod
     def create(cls, provider_name, config, vector_config: Optional[dict]):
-        if provider_name == "upstash_vector" and vector_config and vector_config.enable_embeddings:
+        # enable_embeddings lives on the *vector store* config (Upstash), not
+        # the embedder provider name. Comparing provider_name to
+        # "upstash_vector" never matches the default embedder ("openai").
+        embeddings_enabled = (
+            vector_config.get("enable_embeddings")
+            if isinstance(vector_config, dict)
+            else getattr(vector_config, "enable_embeddings", False)
+        )
+        if embeddings_enabled:
             return MockEmbeddings()
         class_type = cls.provider_to_class.get(provider_name)
         if class_type:

--- a/tests/utils/test_factory.py
+++ b/tests/utils/test_factory.py
@@ -4,7 +4,8 @@ from mem0.configs.llms.anthropic import AnthropicConfig
 from mem0.configs.llms.aws_bedrock import AWSBedrockConfig
 from mem0.configs.llms.base import BaseLlmConfig
 from mem0.configs.llms.openai import OpenAIConfig
-from mem0.utils.factory import LlmFactory
+from mem0.embeddings.mock import MockEmbeddings
+from mem0.utils.factory import EmbedderFactory, LlmFactory
 
 
 def _capture_config(provider_name, config):
@@ -60,3 +61,20 @@ def test_dict_config_not_mutated_by_kwargs():
         LlmFactory.create("openai", config, api_key="secret")
 
     assert config == {"model": "gpt-4o-mini"}
+
+
+def test_embedder_factory_uses_vector_store_enable_embeddings():
+    """Upstash server-side embeddings are a vector-store flag, not an embedder name."""
+    embedder = EmbedderFactory.create("openai", {"model": "text-embedding-3-small"}, {"enable_embeddings": True})
+    assert isinstance(embedder, MockEmbeddings)
+
+
+def test_embedder_factory_uses_object_vector_config_enable_embeddings():
+    from types import SimpleNamespace
+
+    embedder = EmbedderFactory.create(
+        "openai",
+        {"model": "text-embedding-3-small"},
+        SimpleNamespace(enable_embeddings=True),
+    )
+    assert isinstance(embedder, MockEmbeddings)


### PR DESCRIPTION
## Summary
- Closes #6814
- `EmbedderFactory` compared the embedder provider (default `openai`) to `upstash_vector`, so the documented `enable_embeddings: True` bypass never ran.
- Check `enable_embeddings` on the vector-store config (dict or object).

## Test plan
- [x] dict config with `enable_embeddings=True` returns `MockEmbeddings`
- [x] object config with the same flag also returns `MockEmbeddings`
