### PR TITLE
fix: use max_output_tokens for Gemma 4

### DIFF
--- a/mem0/llms/openai.py
+++ b/mem0/llms/openai.py
@@ -52,6 +52,12 @@ class OpenAILLM(LLMBase):
 
             self.client = OpenAI(api_key=api_key, base_url=base_url)
 
+    @staticmethod
+    def _is_gemma_4_model(model: str) -> bool:
+        """Return whether an OpenAI-compatible model belongs to the Gemma 4 family."""
+        base_model = (model or "").lower().rsplit("/", 1)[-1]
+        return base_model == "gemma-4" or base_model.startswith(("gemma-4-", "gemma-4.", "gemma-4_"))
+
     def _parse_response(self, response, tools):
         """
         Process the response based on whether tools are used or not.
@@ -127,6 +133,16 @@ class OpenAILLM(LLMBase):
             params.update(**openrouter_params)
         
         else:
+            # Bedrock Mantle's OpenAI-compatible Gemma 4 endpoint rejects the
+            # legacy max_tokens field and expects max_output_tokens in the body.
+            if self._is_gemma_4_model(self.config.model):
+                max_output_tokens = params.pop("max_tokens", None)
+                extra_body = dict(params.get("extra_body") or {})
+                if max_output_tokens is not None:
+                    extra_body.setdefault("max_output_tokens", max_output_tokens)
+                if extra_body:
+                    params["extra_body"] = extra_body
+
             # Only send OpenAI-specific parameters when the user has explicitly
             # configured them. OpenAI-compatible backends (Gemini, Groq, vLLM, etc.)
             # reject unknown fields, so `store` must be opt-in, not opt-out.

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -399,6 +399,62 @@ def test_gpt5_uses_max_completion_tokens(mock_openai_client):
     assert "max_tokens" not in call_kwargs
 
 
+def test_gemma4_uses_max_output_tokens(mock_openai_client, monkeypatch):
+    """Gemma 4 on Bedrock Mantle expects max_output_tokens in the request body."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    config = OpenAIConfig(model="gemma-4-31b", temperature=0.7, max_tokens=100, top_p=1.0)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+    assert "max_tokens" not in call_kwargs
+    assert "max_completion_tokens" not in call_kwargs
+    assert "max_output_tokens" not in call_kwargs
+    assert call_kwargs["extra_body"] == {"max_output_tokens": 100}
+    assert call_kwargs["temperature"] == 0.7
+    assert call_kwargs["top_p"] == 1.0
+
+
+def test_gemma4_preserves_explicit_max_output_tokens(mock_openai_client, monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    config = OpenAIConfig(model="bedrock/gemma-4-31b", max_tokens=100)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages, extra_body={"max_output_tokens": 250, "custom": "value"})
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+    assert "max_tokens" not in call_kwargs
+    assert call_kwargs["extra_body"] == {"max_output_tokens": 250, "custom": "value"}
+
+
+def test_openrouter_gemma4_keeps_max_tokens(mock_openai_client, monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    config = OpenAIConfig(model="gemma-4-31b", max_tokens=100)
+    llm = OpenAILLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+    assert call_kwargs["max_tokens"] == 100
+    assert "extra_body" not in call_kwargs
+
+
 def test_gpt4_uses_max_tokens(mock_openai_client):
     """Older models (gpt-4.x) keep using max_tokens — guards against regressions."""
     config = OpenAIConfig(model="gpt-4.1-nano-2025-04-14", temperature=0.7, max_tokens=100, top_p=1.0)


### PR DESCRIPTION
## Linked Issue

Closes #6920

## Description

Gemma 4 models served through Bedrock Mantle reject the legacy `max_tokens` field on the OpenAI-compatible Chat Completions path. This change maps the configured output limit to `extra_body.max_output_tokens` for non-OpenRouter Gemma 4 requests.

The mapping preserves an explicitly supplied `extra_body.max_output_tokens` value and any other custom body fields. OpenRouter and non-Gemma request behavior remains unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

- Targeted request-routing checks cover the default mapping, explicit `extra_body` precedence, and unchanged OpenRouter behavior.
- Existing GPT-4 and GPT-5 parameter-routing checks were exercised as compatibility guards.
- The complete relevant test file passes locally: 24 tests on Python 3.13.
- The changed implementation and test files pass the repository-pinned Ruff 0.16.0 check.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
