### PR TITLE
fix(embeddings/gemini): support the Vertex AI backend, like the Gemini LLM already does

### DIFF
--- a/mem0/configs/embeddings/base.py
+++ b/mem0/configs/embeddings/base.py
@@ -33,6 +33,9 @@ class BaseEmbedderConfig(ABC):
         memory_search_embedding_type: Optional[str] = None,
         # Gemini specific
         output_dimensionality: Optional[str] = None,
+        vertexai: Optional[bool] = None,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
         # LM Studio specific
         lmstudio_base_url: Optional[str] = "http://localhost:1234/v1",
         # AWS Bedrock specific
@@ -72,6 +75,13 @@ class BaseEmbedderConfig(ABC):
         :type memory_search_embedding_type: Optional[str], optional
         :param lmstudio_base_url: LM Studio base URL to be use, defaults to "http://localhost:1234/v1"
         :type lmstudio_base_url: Optional[str], optional
+        :param vertexai: Whether to use the Vertex AI backend for Gemini embeddings. If None, checks the
+            GOOGLE_GENAI_USE_VERTEXAI env var. Mirrors ``GeminiConfig`` on the LLM side.
+        :type vertexai: Optional[bool], optional
+        :param project: GCP project ID for Vertex AI. If None, checks the GOOGLE_CLOUD_PROJECT env var.
+        :type project: Optional[str], optional
+        :param location: GCP location for Vertex AI. If None, checks the GOOGLE_CLOUD_LOCATION env var.
+        :type location: Optional[str], optional
         """
 
         self.model = model
@@ -100,6 +110,15 @@ class BaseEmbedderConfig(ABC):
 
         # Gemini specific
         self.output_dimensionality = output_dimensionality
+        # Vertex AI backend for the `gemini` embedder. Defaults are read from the
+        # same environment variables `GeminiConfig` uses on the LLM side, so a
+        # deployment that already routes mem0's Gemini LLM through Vertex does
+        # not need extra configuration for the embedder.
+        if vertexai is None:
+            vertexai = os.getenv("GOOGLE_GENAI_USE_VERTEXAI", "").lower() in ("true", "1", "yes")
+        self.vertexai = vertexai
+        self.project = project or os.getenv("GOOGLE_CLOUD_PROJECT")
+        self.location = location or os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
 
         # LM Studio specific
         self.lmstudio_base_url = lmstudio_base_url

--- a/mem0/embeddings/gemini.py
+++ b/mem0/embeddings/gemini.py
@@ -8,16 +8,32 @@ from mem0.configs.embeddings.base import BaseEmbedderConfig
 from mem0.embeddings.base import EmbeddingBase
 
 
+DEFAULT_MODEL = "models/gemini-embedding-001"
+
+
 class GoogleGenAIEmbedding(EmbeddingBase):
     def __init__(self, config: Optional[BaseEmbedderConfig] = None):
         super().__init__(config)
 
-        self.config.model = self.config.model or "models/gemini-embedding-001"
+        self.config.model = self.config.model or DEFAULT_MODEL
         self.config.embedding_dims = self.config.embedding_dims or self.config.output_dimensionality or 768
 
-        api_key = self.config.api_key or os.getenv("GOOGLE_API_KEY")
-
-        self.client = genai.Client(api_key=api_key)
+        if getattr(self.config, "vertexai", False):
+            # Vertex AI publisher model IDs are unprefixed. The Gemini Developer
+            # API accepts (and this class defaults to) a "models/" prefix, which
+            # Vertex answers with an empty-bodied 404, so normalise it here.
+            # Without this, flipping `vertexai` on an otherwise working config
+            # fails with a message that points nowhere.
+            if self.config.model.startswith("models/"):
+                self.config.model = self.config.model[len("models/") :]
+            self.client = genai.Client(
+                vertexai=True,
+                project=self.config.project,
+                location=self.config.location,
+            )
+        else:
+            api_key = self.config.api_key or os.getenv("GOOGLE_API_KEY")
+            self.client = genai.Client(api_key=api_key)
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """

--- a/tests/embeddings/test_gemini_emeddings.py
+++ b/tests/embeddings/test_gemini_emeddings.py
@@ -117,3 +117,131 @@ def test_embed_batch_strips_newlines(mock_genai, config):
     embedder.embed_batch(["line one\nline two"])
 
     mock_genai.assert_called_once_with(model="test_model", contents=["line one line two"], config=ANY)
+
+
+# ---------------------------------------------------------------------------
+# Backend selection: Gemini Developer API vs Vertex AI
+#
+# The Gemini *LLM* has honoured Vertex AI since GeminiConfig gained
+# vertexai/project/location (defaulted from GOOGLE_GENAI_USE_VERTEXAI /
+# GOOGLE_CLOUD_PROJECT / GOOGLE_CLOUD_LOCATION). The embedder used the same
+# SDK but always constructed genai.Client(api_key=...), so a deployment with
+# mem0's Gemini LLM on Vertex still had to supply a GOOGLE_API_KEY purely for
+# embeddings. These tests pin the embedder to the same contract as the LLM.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_client_class():
+    with patch("mem0.embeddings.gemini.genai.Client") as mock_cls:
+        yield mock_cls
+
+
+@pytest.fixture(autouse=True)
+def clear_google_env(monkeypatch):
+    """Backend selection reads the environment, so isolate it per test."""
+    for var in (
+        "GOOGLE_GENAI_USE_VERTEXAI",
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_CLOUD_LOCATION",
+        "GOOGLE_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_defaults_to_developer_api_client(mock_client_class):
+    GoogleGenAIEmbedding(BaseEmbedderConfig(api_key="dummy_api_key"))
+
+    mock_client_class.assert_called_once_with(api_key="dummy_api_key")
+
+
+def test_default_model_keeps_models_prefix_on_developer_api(mock_client_class):
+    embedder = GoogleGenAIEmbedding(BaseEmbedderConfig(api_key="dummy_api_key"))
+
+    assert embedder.config.model == "models/gemini-embedding-001"
+
+
+def test_vertexai_config_builds_vertex_client(mock_client_class):
+    config = BaseEmbedderConfig(vertexai=True, project="my-project", location="europe-west4")
+
+    GoogleGenAIEmbedding(config)
+
+    mock_client_class.assert_called_once_with(
+        vertexai=True, project="my-project", location="europe-west4"
+    )
+
+
+def test_vertexai_enabled_from_environment(monkeypatch, mock_client_class):
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "true")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "env-project")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-east1")
+
+    GoogleGenAIEmbedding(BaseEmbedderConfig())
+
+    mock_client_class.assert_called_once_with(
+        vertexai=True, project="env-project", location="us-east1"
+    )
+
+
+def test_vertexai_location_defaults_when_env_absent(monkeypatch, mock_client_class):
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "1")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "env-project")
+
+    GoogleGenAIEmbedding(BaseEmbedderConfig())
+
+    mock_client_class.assert_called_once_with(
+        vertexai=True, project="env-project", location="us-central1"
+    )
+
+
+def test_explicit_vertexai_false_overrides_environment(monkeypatch, mock_client_class):
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "true")
+
+    GoogleGenAIEmbedding(BaseEmbedderConfig(vertexai=False, api_key="dummy_api_key"))
+
+    mock_client_class.assert_called_once_with(api_key="dummy_api_key")
+
+
+def test_vertexai_strips_models_prefix_from_default_model(mock_client_class):
+    """Vertex publisher model IDs are unprefixed.
+
+    Vertex answers a "models/"-prefixed ID with an empty-bodied 404, so the
+    Developer-API default must be normalised rather than passed through.
+    """
+    embedder = GoogleGenAIEmbedding(BaseEmbedderConfig(vertexai=True, project="p"))
+
+    assert embedder.config.model == "gemini-embedding-001"
+
+
+def test_vertexai_strips_models_prefix_from_explicit_model(mock_client_class):
+    config = BaseEmbedderConfig(
+        vertexai=True, project="p", model="models/text-embedding-005"
+    )
+
+    embedder = GoogleGenAIEmbedding(config)
+
+    assert embedder.config.model == "text-embedding-005"
+
+
+def test_vertexai_leaves_unprefixed_model_untouched(mock_client_class):
+    config = BaseEmbedderConfig(vertexai=True, project="p", model="gemini-embedding-001")
+
+    embedder = GoogleGenAIEmbedding(config)
+
+    assert embedder.config.model == "gemini-embedding-001"
+
+
+def test_vertexai_client_receives_no_api_key(monkeypatch, mock_client_class):
+    """Vertex auth is ADC; an api_key would switch the SDK to Express mode.
+
+    google-genai routes to the Vertex Express endpoints when it is given an API
+    key, and the regular Vertex prediction endpoints reject those credentials.
+    Passing the key through would therefore break the ADC path for anyone who
+    happens to also have GOOGLE_API_KEY set.
+    """
+    monkeypatch.setenv("GOOGLE_API_KEY", "leftover-key")
+
+    GoogleGenAIEmbedding(BaseEmbedderConfig(vertexai=True, project="p", location="us-central1"))
+
+    _, kwargs = mock_client_class.call_args
+    assert "api_key" not in kwargs


### PR DESCRIPTION
## Problem

mem0's Gemini **LLM** has supported Vertex AI ever since `GeminiConfig` gained `vertexai` / `project` / `location`, defaulted from `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`:

```python
# mem0/llms/gemini.py
if self.config.vertexai:
    self.client = genai.Client(vertexai=True, project=..., location=...)
else:
    self.client = genai.Client(api_key=api_key)
```

The **embedder** uses the same `google-genai` SDK but never got the same treatment:

```python
# mem0/embeddings/gemini.py
api_key = self.config.api_key or os.getenv("GOOGLE_API_KEY")
self.client = genai.Client(api_key=api_key)
```

So a deployment that already routes mem0's Gemini LLM through Vertex still has to keep a `GOOGLE_API_KEY` around purely for embeddings, and can't use ADC / workload identity for the embedding half. On GCP that means holding a long-lived API key next to a service account that already has `roles/aiplatform.user`.

The existing `vertexai` embedder isn't an answer either: it imports `vertexai.language_models` from `google-cloud-aiplatform`, the SDK Google is [retiring in favour of `google-genai`](https://cloud.google.com/vertex-ai/generative-ai/docs/deprecations/genai-vertexai-sdk), and pulling it in drags `google-cloud-{storage,bigquery,resource-manager}` along with it. The modern SDK is already a dependency — it just wasn't wired to Vertex on this path.

## Change

Mirrors the LLM's contract on the embedder:

- `BaseEmbedderConfig` accepts `vertexai` / `project` / `location`, defaulted from the same three env vars. Placed in the base config next to the existing Gemini-specific `output_dimensionality`, matching how the embedder side already carries per-provider fields (`vertex_credentials_json`, `lmstudio_base_url`, `aws_*`), rather than introducing a `GeminiEmbedderConfig` subclass.
- `GoogleGenAIEmbedding` builds `genai.Client(vertexai=True, project=..., location=...)` when enabled, otherwise the existing API-key client. An explicit `vertexai=False` still overrides the env var.

No new provider name, no `validate_config` allow-list change, no new dependency. Default behaviour is unchanged when `vertexai` is unset.

### Model-name normalisation is required, not cosmetic

Vertex publisher model IDs are unprefixed, and this class defaults to the Developer-API spelling `models/gemini-embedding-001`. Against a live Vertex endpoint:

```
gemini-embedding-001          -> 200, 768 dims
models/gemini-embedding-001   -> 404 Not Found   (empty message body)
```

Passing the default straight through would fail with an error that points nowhere, so a leading `models/` is stripped in Vertex mode. The same normalisation covers an explicit model that carries the prefix, which is what makes flipping an already-working config over to Vertex a one-line change.

### A note on `api_key` and Vertex Express

The Vertex client is deliberately constructed **without** `api_key`. `google-genai` routes to the Vertex Express endpoints when handed an API key, and the regular prediction endpoints reject those credentials, so forwarding a stray `GOOGLE_API_KEY` would break the ADC path. There's a test for it.

Worth flagging: the SDK may still pick that variable up from the environment on its own, so callers wanting strict ADC should unset it. I've left that alone — the LLM path behaves identically, and changing it belongs in its own patch.

## Tests

In `tests/embeddings/test_gemini_emeddings.py`: backend selection from explicit config and from env, explicit-`False` precedence, the `location` default, prefix stripping for default / explicit / already-bare model IDs, and no `api_key` on the Vertex client.

```
without this change    8 failed, 11 passed
with this change      19 passed
```

An autouse fixture clears the four `GOOGLE_*` variables so backend selection can't be influenced by the developer's or CI's environment. That also makes the pre-existing tests in this file hermetic, which they weren't — previously they'd have constructed a Vertex client and failed on any machine with `GOOGLE_GENAI_USE_VERTEXAI` set.

## Live validation

Exercised end-to-end against a real Vertex endpoint, no mocks, through both configuration paths:

```
1. explicit config: vertexai=True, project/location passed in
  [PASS] default model normalised  — gemini-embedding-001
  [PASS] live Vertex embed() returned a vector  — 768 dims
  [PASS] values are floats
2. env-var config: the same three vars mem0's Gemini LLM already reads
  [PASS] picked up vertexai from env
  [PASS] picked up project from env
  [PASS] live Vertex embed() via env config  — 768 dims
3. embed_batch against live Vertex
  [PASS] batch returned one vector per text  — 3 vectors
  [PASS] batch vectors have the right width
4. custom output_dimensionality is honoured
  [PASS] 1536-dim request honoured  — 1536 dims
```

The equivalent change has been running in production as a downstream plugin for several weeks, embedding against `gemini-embedding-001` on Vertex with ADC from a GCE metadata server. That deployment is what surfaced both the missing backend and the model-prefix 404.
