### PR TITLE
fix(auth): improve API key authentication performance with async hand…

### DIFF
--- a/server/alembic/versions/007_api_keys_indexes.py
+++ b/server/alembic/versions/007_api_keys_indexes.py
@@ -1,0 +1,40 @@
+"""Add indexes on api_keys.key_prefix and api_keys.created_by
+
+key_prefix is queried on every API-key authenticated request (WHERE key_prefix = ?
+AND revoked_at IS NULL). Without an index this is a full table scan that grows
+linearly with the number of keys.
+
+created_by is queried when a user lists their own keys (GET /api-keys).
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-08-14
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "007"
+down_revision: Union[str, None] = "006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Partial index — only active (non-revoked) keys are looked up during auth.
+    op.execute(
+        text(
+            "CREATE INDEX ix_api_keys_key_prefix_active"
+            " ON api_keys (key_prefix)"
+            " WHERE revoked_at IS NULL"
+        )
+    )
+    op.create_index("ix_api_keys_created_by", "api_keys", ["created_by"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_api_keys_key_prefix_active", table_name="api_keys")
+    op.drop_index("ix_api_keys_created_by", table_name="api_keys")

--- a/server/auth.py
+++ b/server/auth.py
@@ -11,6 +11,7 @@ from models import APIKey, RefreshTokenJti, User
 from passlib.context import CryptContext
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
+from starlette.concurrency import run_in_threadpool
 
 JWT_SECRET = os.environ.get("JWT_SECRET", "")
 JWT_ALGORITHM = "HS256"
@@ -123,14 +124,15 @@ def _resolve_user_from_jwt(token: str, db: Session) -> User:
     return user
 
 
-def _resolve_user_from_api_key(key: str, db: Session) -> User:
+async def _resolve_user_from_api_key(key: str, db: Session) -> User:
     prefix = key[:12] if len(key) >= 12 else key
     candidates = (
         db.execute(select(APIKey).where(APIKey.key_prefix == prefix, APIKey.revoked_at.is_(None))).scalars().all()
     )
 
     for candidate in candidates:
-        if verify_api_key_hash(key, candidate.key_hash):
+        match = await run_in_threadpool(verify_api_key_hash, key, candidate.key_hash)
+        if match:
             candidate.last_used_at = datetime.now(timezone.utc)
             db.commit()
             user = db.get(User, candidate.created_by)
@@ -162,7 +164,7 @@ async def verify_auth(
             return None
         _mark_auth_type(request, "api_key")
         with SessionLocal() as db:
-            return _resolve_user_from_api_key(x_api_key, db)
+            return await _resolve_user_from_api_key(x_api_key, db)
 
     if AUTH_DISABLED:
         _mark_auth_type(request, "disabled")


### PR DESCRIPTION
Closes #6977 

## Summary

- Add a partial index on `api_keys.key_prefix WHERE revoked_at IS NULL` — covers the
  exact predicate used on every API-key auth lookup. Also adds an index on `created_by`
  for the key-listing query (`GET /api-keys`).
- Move bcrypt off the event loop in `_resolve_user_from_api_key` by awaiting
  `run_in_threadpool(verify_api_key_hash, ...)`. The ~200ms bcrypt call now runs in
  a thread pool, leaving the event loop free to handle other requests concurrently.

## Changes

- `server/alembic/versions/007_api_keys_indexes.py` — new migration (additive, safe
  to apply on existing deployments with no downtime)
- `server/auth.py` — `_resolve_user_from_api_key` promoted to `async def`;
  bcrypt call wrapped in `run_in_threadpool`; call site updated to `await`