### PR TITLE
fix(server): offload API-key auth to a worker thread and index its lookups

### DIFF
--- a/server/alembic/versions/007_api_keys_indexes.py
+++ b/server/alembic/versions/007_api_keys_indexes.py
@@ -1,0 +1,38 @@
+"""Index api_keys lookup columns (key_prefix, created_by)
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-08-14
+
+Every API-key authenticated request resolves the caller with
+``WHERE key_prefix = ? AND revoked_at IS NULL`` (see auth._resolve_user_from_api_key),
+and the key-listing endpoint filters on ``created_by``. Neither column was
+indexed, so both queries fell back to a sequential scan whose cost grows with
+the number of keys. Add:
+
+  * a partial index on ``key_prefix`` restricted to live keys, so it stays small
+    and matches the auth query's ``revoked_at IS NULL`` predicate exactly;
+  * a plain index on ``created_by`` for the per-user listing query.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "007"
+down_revision: Union[str, None] = "006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE INDEX ix_api_keys_key_prefix_active "
+        "ON api_keys (key_prefix) WHERE revoked_at IS NULL"
+    )
+    op.create_index("ix_api_keys_created_by", "api_keys", ["created_by"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_api_keys_created_by", table_name="api_keys")
+    op.drop_index("ix_api_keys_key_prefix_active", table_name="api_keys")

--- a/server/auth.py
+++ b/server/auth.py
@@ -3,6 +3,7 @@ import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
 
+from anyio import to_thread
 from db import SessionLocal
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
@@ -141,6 +142,18 @@ def _resolve_user_from_api_key(key: str, db: Session) -> User:
     raise HTTPException(status_code=401, detail="Invalid API key.")
 
 
+def _resolve_user_from_api_key_sync(key: str) -> User:
+    """Open a short-lived session and resolve the API key inside it.
+
+    Wraps _resolve_user_from_api_key so the whole blocking unit — the DB query
+    plus the bcrypt verify — runs in a single worker thread (see verify_auth),
+    and the pooled connection is opened and released on that thread rather than
+    held across an await.
+    """
+    with SessionLocal() as db:
+        return _resolve_user_from_api_key(key, db)
+
+
 async def verify_auth(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
@@ -161,8 +174,10 @@ async def verify_auth(
             _mark_auth_type(request, "admin_api_key")
             return None
         _mark_auth_type(request, "api_key")
-        with SessionLocal() as db:
-            return _resolve_user_from_api_key(x_api_key, db)
+        # bcrypt verify (~100-300ms) plus the DB lookup are blocking and CPU-bound.
+        # Run them in a worker thread so a single in-flight API-key request does not
+        # stall the event loop for every other concurrent request.
+        return await to_thread.run_sync(_resolve_user_from_api_key_sync, x_api_key)
 
     if AUTH_DISABLED:
         _mark_auth_type(request, "disabled")

--- a/tests/test_server_auth_perf.py
+++ b/tests/test_server_auth_perf.py
@@ -1,0 +1,162 @@
+"""Regression tests for API-key auth performance (issue #6977).
+
+Two problems, one per test class:
+
+  * ``verify_auth`` ran the API-key resolver — a DB query plus a ~100-300ms
+    bcrypt verify — directly on the event loop thread, so a single in-flight
+    API-key request stalled every other concurrent request. The fix offloads
+    it with ``anyio.to_thread.run_sync``; the test asserts the resolver runs on
+    a worker thread, not the loop thread.
+
+  * Migration 007 adds the indexes the auth and key-listing queries rely on.
+    The test runs the migration against SQLite and checks the indexes exist
+    (and that the ``key_prefix`` one keeps its partial ``WHERE`` predicate).
+
+Neither test needs a live Postgres.
+"""
+
+import asyncio
+import importlib.util
+import os
+import sys
+import threading
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+# server/ modules use bare imports (from auth import ...), so the server
+# directory itself must be importable, mirroring how it runs in Docker.
+_SERVER_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "server")
+if _SERVER_DIR not in sys.path:
+    sys.path.insert(0, _SERVER_DIR)
+
+from alembic.operations import Operations  # noqa: E402
+from alembic.runtime.migration import MigrationContext  # noqa: E402
+from sqlalchemy import create_engine, text  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# 1. bcrypt / DB lookup must not run on the event loop thread
+# ---------------------------------------------------------------------------
+
+class TestApiKeyResolutionOffloadsEventLoop:
+    def test_resolver_runs_off_the_event_loop_thread(self, monkeypatch):
+        """verify_auth must dispatch the blocking API-key resolver to a worker
+        thread. We record the thread the resolver runs on and compare it to the
+        event loop's thread; before the fix they were identical."""
+        import auth
+
+        loop_thread_id = {}
+        resolver_thread_id = {}
+
+        def fake_resolver(key):
+            resolver_thread_id["id"] = threading.get_ident()
+            return "sentinel-user"
+
+        monkeypatch.setattr(auth, "_resolve_user_from_api_key_sync", fake_resolver)
+
+        class _Req:
+            def __init__(self):
+                self.state = type("S", (), {})()
+
+        async def run():
+            loop_thread_id["id"] = threading.get_ident()
+            return await auth.verify_auth(_Req(), credentials=None, x_api_key="m0sk_" + "a" * 40)
+
+        result = asyncio.run(run())
+
+        assert result == "sentinel-user"
+        assert resolver_thread_id["id"] != loop_thread_id["id"], (
+            "API-key resolver ran on the event loop thread; bcrypt/DB work must be "
+            "offloaded with anyio.to_thread.run_sync so it does not block other requests"
+        )
+
+    def test_admin_key_still_short_circuits_without_db(self, monkeypatch):
+        """The legacy ADMIN_API_KEY fast path must not touch the resolver."""
+        import auth
+
+        monkeypatch.setattr(auth, "ADMIN_API_KEY", "admin-secret")
+
+        def boom(key):  # pragma: no cover - should never run
+            raise AssertionError("admin key path must not resolve against the DB")
+
+        monkeypatch.setattr(auth, "_resolve_user_from_api_key_sync", boom)
+
+        class _Req:
+            def __init__(self):
+                self.state = type("S", (), {})()
+
+        req = _Req()
+        result = asyncio.run(auth.verify_auth(req, credentials=None, x_api_key="admin-secret"))
+        assert result is None
+        assert req.state.auth_type == "admin_api_key"
+
+
+# ---------------------------------------------------------------------------
+# 2. Migration 007 creates the api_keys lookup indexes
+# ---------------------------------------------------------------------------
+
+def _load_migration_007():
+    path = os.path.join(_SERVER_DIR, "alembic", "versions", "007_api_keys_indexes.py")
+    spec = importlib.util.spec_from_file_location("migration_007", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_api_keys_table(conn):
+    conn.execute(
+        text(
+            "CREATE TABLE api_keys ("
+            "id TEXT PRIMARY KEY, key_prefix VARCHAR(12), key_hash TEXT, "
+            "label VARCHAR(255), created_by TEXT, last_used_at TIMESTAMP, "
+            "revoked_at TIMESTAMP, created_at TIMESTAMP)"
+        )
+    )
+
+
+class TestMigration007Indexes:
+    def test_revision_chains_after_006(self):
+        migration = _load_migration_007()
+        assert migration.revision == "007"
+        assert migration.down_revision == "006"
+
+    def test_upgrade_creates_both_indexes_and_downgrade_removes_them(self):
+        migration = _load_migration_007()
+        engine = create_engine("sqlite://")
+        with engine.connect() as conn:
+            _make_api_keys_table(conn)
+            ctx = MigrationContext.configure(conn)
+
+            with Operations.context(ctx):
+                migration.upgrade()
+
+            indexes = {row[1] for row in conn.execute(text("PRAGMA index_list('api_keys')")).fetchall()}
+            assert "ix_api_keys_key_prefix_active" in indexes
+            assert "ix_api_keys_created_by" in indexes
+
+            with Operations.context(ctx):
+                migration.downgrade()
+
+            indexes_after = {row[1] for row in conn.execute(text("PRAGMA index_list('api_keys')")).fetchall()}
+            assert "ix_api_keys_key_prefix_active" not in indexes_after
+            assert "ix_api_keys_created_by" not in indexes_after
+
+    def test_key_prefix_index_is_partial_on_live_keys(self):
+        """The auth query filters ``revoked_at IS NULL``; the index must carry
+        the same predicate so it stays small and is actually used."""
+        migration = _load_migration_007()
+        engine = create_engine("sqlite://")
+        with engine.connect() as conn:
+            _make_api_keys_table(conn)
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.upgrade()
+
+            sql = conn.execute(
+                text("SELECT sql FROM sqlite_master WHERE name = 'ix_api_keys_key_prefix_active'")
+            ).scalar()
+            assert sql is not None
+            assert "key_prefix" in sql
+            assert "revoked_at IS NULL" in sql


### PR DESCRIPTION
## Linked Issue

Closes #6977

## Description

API-key authentication had two compounding performance problems on every request:

1. **No index on `api_keys.key_prefix`** — `verify_auth` runs `WHERE key_prefix = ? AND revoked_at IS NULL` on every request, causing a full sequential scan that degrades linearly with key count.
2. **Bcrypt ran on the event loop** — `_resolve_user_from_api_key` (DB lookup + `pwd_context.verify`, ~100-300ms) was called synchronously inside the async `verify_auth` dependency, blocking FastAPI's single event-loop thread and serializing all concurrent API-key requests behind it.

This PR:
- Adds Alembic migration `007_api_keys_indexes.py`: a partial index `ix_api_keys_key_prefix_active ON api_keys (key_prefix) WHERE revoked_at IS NULL` (matching the exact predicate used by `verify_auth`), plus a supporting index on `created_by`.
- Offloads the resolver (`_resolve_user_from_api_key_sync`) to a worker thread via `anyio.to_thread.run_sync(...)`, so bcrypt/DB work no longer blocks the event loop. Admin-key auth is untouched — it still short-circuits before reaching this path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [x] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [ ] AI-generated (an agent wrote most or all of this diff)

Used an AI coding assistant to draft the migration boilerplate and the thread-identity
test helper. I designed the `to_thread.run_sync` fix and reviewed/adjusted every
assertion myself; I can explain why `anyio.to_thread.run_sync` (not a raw
`ThreadPoolExecutor`) is the correct primitive given FastAPI's anyio-based async stack,
and why the partial index predicate must exactly match the query's `WHERE` clause to be
used by the planner.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

`tests/test_server_auth_perf.py` (5 tests, all passing locally):
- Resolver executes on a different thread than the event loop (captured via `threading.get_ident()` on both sides).
- Admin-key path never touches the resolver.
- Migration `007` upgrade creates both indexes against an in-memory SQLite DB via Alembic's `Operations` context; downgrade removes them.
- Revision chain `006 → 007` is intact.
- `key_prefix` index carries the `revoked_at IS NULL` partial predicate.

`ruff check` (CI's exact lint command) is clean on all changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
