### PR TITLE
fix(memory): cap linked_memory_ids growth to guard against backend metadata limits

### DIFF
--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -55,6 +55,20 @@ class MemoryConfig(BaseModel):
         description="Custom instructions for fact extraction",
         default=None,
     )
+    entity_max_linked_memory_ids: Optional[int] = Field(
+        description=(
+            "Maximum number of memory IDs kept in an entity record's "
+            "``linked_memory_ids`` array. When appending would exceed this "
+            "cap, the oldest IDs are dropped (FIFO) so the newest are kept. "
+            "Guards against high-cardinality entities pushing a single "
+            "metadata array past a vector-store backend limit — with "
+            "embedded Chroma, arrays around 5,461 elements are known to "
+            "stall the metadata segment (see chroma-core/chroma#2181). "
+            "Set to ``None`` or ``0`` to disable the cap (previous "
+            "behavior)."
+        ),
+        default=5000,
+    )
 
 
 class AzureConfig(BaseModel):

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -90,6 +90,38 @@ def _vector_store_list_rows(listed):
     return []
 
 
+def _bounded_linked_memory_ids(existing, new_ids, cap):
+    """Return the merged linked_memory_ids list, dropping oldest entries to fit ``cap``.
+
+    ``existing`` is the current list on the entity record; ``new_ids`` is an iterable
+    of memory IDs about to be linked. IDs already present in ``existing`` keep their
+    original position (so we do not disturb ordering just because a duplicate came
+    through), and new IDs are appended in order. When ``cap`` is a positive int and
+    the merged list exceeds it, the oldest IDs are dropped (FIFO) so the newest
+    ``cap`` IDs remain — matching the intent of the cap, which is to protect vector
+    stores like embedded Chroma whose metadata segment cannot materialize a single
+    array larger than a backend-specific limit (see chroma-core/chroma#2181).
+
+    ``cap`` of ``None`` or ``0`` (or negative) disables the bound entirely; the
+    merged list is returned unchanged.
+    """
+    if not isinstance(existing, list):
+        existing = list(existing or [])
+    else:
+        existing = list(existing)
+    seen = set(existing)
+    for mid in new_ids or []:
+        if mid in seen:
+            continue
+        existing.append(mid)
+        seen.add(mid)
+    if not cap or cap <= 0:
+        return existing
+    if len(existing) <= cap:
+        return existing
+    return existing[-cap:]
+
+
 # Fields that hold runtime auth/connection objects and must be preserved.
 # These are non-serializable objects (e.g. AWSV4SignerAuth, RequestsHttpConnection)
 # needed by clients like OpenSearch — not sensitive strings to redact.
@@ -625,7 +657,9 @@ class Memory(MemoryBase):
                 payload = match.payload or {}
                 linked_ids = payload.get("linked_memory_ids", [])
                 if memory_id not in linked_ids:
-                    linked_ids.append(memory_id)
+                    linked_ids = _bounded_linked_memory_ids(
+                        linked_ids, [memory_id], self.config.entity_max_linked_memory_ids
+                    )
                     payload["linked_memory_ids"] = linked_ids
                     self.entity_store.update(
                         vector_id=match.id,
@@ -1154,9 +1188,11 @@ class Memory(MemoryBase):
                         if match:
                             # Update existing entity
                             payload = match.payload or {}
-                            linked = set(payload.get("linked_memory_ids", []))
-                            linked |= memory_ids
-                            payload["linked_memory_ids"] = sorted(linked)
+                            payload["linked_memory_ids"] = _bounded_linked_memory_ids(
+                                payload.get("linked_memory_ids", []),
+                                memory_ids,
+                                self.config.entity_max_linked_memory_ids,
+                            )
                             try:
                                 self.entity_store.update(
                                     vector_id=match.id,
@@ -1172,7 +1208,9 @@ class Memory(MemoryBase):
                             to_insert_payloads.append({
                                 "data": entity_text,
                                 "entity_type": entity_type,
-                                "linked_memory_ids": sorted(memory_ids),
+                                "linked_memory_ids": _bounded_linked_memory_ids(
+                                    [], memory_ids, self.config.entity_max_linked_memory_ids
+                                ),
                                 **search_filters,
                             })
 
@@ -2285,7 +2323,9 @@ class AsyncMemory(MemoryBase):
                 payload = match.payload or {}
                 linked_ids = payload.get("linked_memory_ids", [])
                 if memory_id not in linked_ids:
-                    linked_ids.append(memory_id)
+                    linked_ids = _bounded_linked_memory_ids(
+                        linked_ids, [memory_id], self.config.entity_max_linked_memory_ids
+                    )
                     payload["linked_memory_ids"] = linked_ids
                     await asyncio.to_thread(
                         self.entity_store.update,
@@ -2805,9 +2845,11 @@ class AsyncMemory(MemoryBase):
                         match = exact_match or semantic_match
                         if match:
                             payload = match.payload or {}
-                            linked = set(payload.get("linked_memory_ids", []))
-                            linked |= memory_ids
-                            payload["linked_memory_ids"] = sorted(linked)
+                            payload["linked_memory_ids"] = _bounded_linked_memory_ids(
+                                payload.get("linked_memory_ids", []),
+                                memory_ids,
+                                self.config.entity_max_linked_memory_ids,
+                            )
                             try:
                                 await asyncio.to_thread(
                                     self.entity_store.update,
@@ -2823,7 +2865,9 @@ class AsyncMemory(MemoryBase):
                             to_insert_payloads.append({
                                 "data": entity_text,
                                 "entity_type": entity_type,
-                                "linked_memory_ids": sorted(memory_ids),
+                                "linked_memory_ids": _bounded_linked_memory_ids(
+                                    [], memory_ids, self.config.entity_max_linked_memory_ids
+                                ),
                                 **search_filters,
                             })
 

--- a/tests/memory/test_entity_linked_memory_ids_cap.py
+++ b/tests/memory/test_entity_linked_memory_ids_cap.py
@@ -1,0 +1,323 @@
+"""Regression tests for unbounded `linked_memory_ids` growth (issue #6923).
+
+The OSS entity index stores every memory linked to an entity in one
+`linked_memory_ids` metadata array, rewritten in full on each update. With no
+bound, a high-cardinality entity can push that single array past a backend
+metadata limit — e.g. embedded Chroma's SQLite segment, which is known to
+stall around 5,461 elements (chroma-core/chroma#2181). `MemoryConfig` now
+exposes `entity_max_linked_memory_ids` (default 5000): once the merged list
+would exceed the cap, `_bounded_linked_memory_ids` drops the oldest IDs
+(FIFO) so the newest ones are kept. `cap=None`/`0` restores the old
+unbounded behavior.
+
+Two layers are covered:
+  * `_bounded_linked_memory_ids` directly — the merge/evict/dedup logic.
+  * All four growth sites (sync/async, single-entity/batch) actually apply
+    the cap via `self.config.entity_max_linked_memory_ids`, using the same
+    mocked-entity_store pattern as TestAddPipelineEntityEmbeddingCountGuard.
+"""
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from mem0.configs.base import MemoryConfig
+from mem0.memory.main import AsyncMemory, Memory, _bounded_linked_memory_ids
+
+from tests.memory.test_main import _setup_mocks
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure helper: merge / evict / dedup semantics
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedLinkedMemoryIds:
+    def test_appends_new_id_under_cap(self):
+        assert _bounded_linked_memory_ids(["a", "b"], ["c"], 5) == ["a", "b", "c"]
+
+    def test_evicts_oldest_when_over_cap(self):
+        # 3 existing + 2 new = 5, cap 3 -> keep the 3 newest, oldest-first order.
+        result = _bounded_linked_memory_ids(["a", "b", "c"], ["d", "e"], 3)
+        assert result == ["c", "d", "e"]
+
+    def test_duplicate_new_id_is_not_double_counted(self):
+        # "b" is already present; re-adding it must not push out "a".
+        result = _bounded_linked_memory_ids(["a", "b"], ["b"], 2)
+        assert result == ["a", "b"]
+
+    def test_cap_none_disables_bound(self):
+        many = [f"m{i}" for i in range(10)]
+        result = _bounded_linked_memory_ids(many, ["m-new"], None)
+        assert result == many + ["m-new"]
+
+    def test_cap_zero_disables_bound(self):
+        many = [f"m{i}" for i in range(10)]
+        result = _bounded_linked_memory_ids(many, ["m-new"], 0)
+        assert result == many + ["m-new"]
+
+    def test_cap_negative_disables_bound(self):
+        result = _bounded_linked_memory_ids(["a"], ["b"], -1)
+        assert result == ["a", "b"]
+
+    def test_does_not_exceed_cap_when_many_new_ids_at_once(self):
+        # Batch-add path can union many memory_ids into one entity in one call.
+        result = _bounded_linked_memory_ids([], [f"m{i}" for i in range(10)], 3)
+        assert len(result) == 3
+        assert result == ["m7", "m8", "m9"]
+
+    def test_existing_not_a_list_is_coerced(self):
+        # Defensive: a set/tuple existing value (should not normally occur, but
+        # payload.get(..., []) could return anything a caller stashed there).
+        result = _bounded_linked_memory_ids(("a", "b"), ["c"], 5)
+        assert result == ["a", "b", "c"]
+
+    def test_does_not_mutate_existing_list_argument(self):
+        original = ["a", "b"]
+        _bounded_linked_memory_ids(original, ["c"], 5)
+        assert original == ["a", "b"], "helper must not mutate the caller's list in place"
+
+
+# ---------------------------------------------------------------------------
+# 2. Sync single-entity path: Memory._upsert_entity
+# ---------------------------------------------------------------------------
+
+
+class TestSyncSingleEntityCap:
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = Memory()
+        memory.config = MemoryConfig(entity_max_linked_memory_ids=3)
+        memory.embedding_model = Mock()
+        memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        return memory
+
+    def test_update_path_evicts_oldest_when_over_cap(self, mock_memory):
+        existing_payload = {"data": "Alice", "linked_memory_ids": ["m1", "m2", "m3"]}
+        match = MagicMock(id="entity-1", payload=existing_payload)
+
+        mock_memory._entity_store = Mock()
+        mock_memory._entity_store.list = Mock(return_value=[])
+        mock_memory._entity_store.search = Mock(return_value=[])
+        mock_memory._existing_entities_by_text = Mock(return_value={"alice": match})
+        mock_memory._entity_store.update = Mock()
+
+        mock_memory._upsert_entity("Alice", "person", "m4", {"user_id": "u1"})
+
+        mock_memory._entity_store.update.assert_called_once()
+        sent_payload = mock_memory._entity_store.update.call_args.kwargs["payload"]
+        assert sent_payload["linked_memory_ids"] == ["m2", "m3", "m4"]
+
+    def test_new_entity_insert_is_a_single_id_list(self, mock_memory):
+        mock_memory._entity_store = Mock()
+        mock_memory._entity_store.list = Mock(return_value=[])
+        mock_memory._entity_store.search = Mock(return_value=[])
+        mock_memory._existing_entities_by_text = Mock(return_value={})
+        mock_memory._entity_store.insert = Mock()
+
+        mock_memory._upsert_entity("Bob", "person", "m1", {"user_id": "u1"})
+
+        mock_memory._entity_store.insert.assert_called_once()
+        payloads = mock_memory._entity_store.insert.call_args.kwargs["payloads"]
+        assert payloads[0]["linked_memory_ids"] == ["m1"]
+
+    def test_uncapped_config_preserves_old_unbounded_behavior(self, mocker):
+        _setup_mocks(mocker)
+        memory = Memory()
+        memory.config = MemoryConfig(entity_max_linked_memory_ids=None)
+        memory.embedding_model = Mock()
+        memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+        existing_payload = {"data": "Alice", "linked_memory_ids": ["m1", "m2", "m3"]}
+        match = MagicMock(id="entity-1", payload=existing_payload)
+        memory._entity_store = Mock()
+        memory._entity_store.list = Mock(return_value=[])
+        memory._entity_store.search = Mock(return_value=[])
+        memory._existing_entities_by_text = Mock(return_value={"alice": match})
+        memory._entity_store.update = Mock()
+
+        memory._upsert_entity("Alice", "person", "m4", {"user_id": "u1"})
+
+        sent_payload = memory._entity_store.update.call_args.kwargs["payload"]
+        assert sent_payload["linked_memory_ids"] == ["m1", "m2", "m3", "m4"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Sync batch path: Memory._add_to_vector_store Phase 7 (batch entity linking)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncBatchEntityCap:
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        memory = Memory()
+        memory.config = MemoryConfig(entity_max_linked_memory_ids=3)
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        return memory
+
+    def test_batch_update_evicts_oldest_when_over_cap(self, mock_memory, mocker):
+        mock_memory.llm.generate_response.return_value = (
+            '{"memory": [{"text": "Alice met Bob"}, {"text": "Alice called Carol"}]}'
+        )
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed_batch = Mock(side_effect=lambda texts, action: [[0.1] * 10 for _ in texts])
+
+        existing_payload = {"data": "Alice", "linked_memory_ids": ["m1", "m2", "m3"]}
+        match = MagicMock(id="entity-1", payload=existing_payload, score=1.0)
+        mock_memory._entity_store = Mock()
+        mock_memory._entity_store.search_batch = Mock(return_value=[[match]])
+        mock_memory._entity_store.update = Mock()
+        mock_memory._entity_store.insert = Mock()
+
+        mocker.patch(
+            "mem0.memory.main.extract_entities_batch",
+            return_value=[[("person", "Alice")], [("person", "Alice")]],
+        )
+        mocker.patch("mem0.memory.main.capture_event")
+
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Alice met Bob; Alice called Carol"}],
+            metadata={},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert len(result) == 2
+        mock_memory._entity_store.update.assert_called_once()
+        sent_payload = mock_memory._entity_store.update.call_args.kwargs["payload"]
+        # 3 pre-existing ids + 2 new ones = 5, cap 3 -> the 2 new ids must survive
+        # (they are the newest) and exactly 1 of the 3 pre-existing ids is evicted.
+        assert len(sent_payload["linked_memory_ids"]) == 3
+        new_ids = {r["id"] for r in result}
+        assert new_ids <= set(sent_payload["linked_memory_ids"])
+
+    def test_batch_new_entity_insert_is_capped(self, mock_memory, mocker):
+        mock_memory.llm.generate_response.return_value = (
+            '{"memory": [{"text": "Dave met Erin"}, {"text": "Dave called Frank"}, '
+            '{"text": "Dave emailed Grace"}, {"text": "Dave texted Heidi"}]}'
+        )
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed_batch = Mock(side_effect=lambda texts, action: [[0.1] * 10 for _ in texts])
+
+        mock_memory._entity_store = Mock()
+        mock_memory._entity_store.search_batch = Mock(return_value=[[]])
+        mock_memory._entity_store.update = Mock()
+        mock_memory._entity_store.insert = Mock()
+
+        mocker.patch(
+            "mem0.memory.main.extract_entities_batch",
+            return_value=[
+                [("person", "Dave")],
+                [("person", "Dave")],
+                [("person", "Dave")],
+                [("person", "Dave")],
+            ],
+        )
+        mocker.patch("mem0.memory.main.capture_event")
+
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Dave met Erin; Dave called Frank; Dave emailed Grace; Dave texted Heidi"}],
+            metadata={},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert len(result) == 4
+        mock_memory._entity_store.insert.assert_called_once()
+        payloads = mock_memory._entity_store.insert.call_args.kwargs["payloads"]
+        assert len(payloads[0]["linked_memory_ids"]) == 3, (
+            "a brand-new entity linked to 4 memories in one add() call must still respect the cap"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Async single-entity path: AsyncMemory._upsert_entity_async
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncSingleEntityCap:
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = AsyncMemory()
+        memory.config = MemoryConfig(entity_max_linked_memory_ids=3)
+        memory.embedding_model = Mock()
+        memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        return memory
+
+    @pytest.mark.asyncio
+    async def test_update_path_evicts_oldest_when_over_cap(self, mock_async_memory):
+        existing_payload = {"data": "Alice", "linked_memory_ids": ["m1", "m2", "m3"]}
+        match = MagicMock(id="entity-1", payload=existing_payload)
+
+        mock_async_memory._entity_store = Mock()
+        mock_async_memory._entity_store.list = Mock(return_value=[])
+        mock_async_memory._entity_store.search = Mock(return_value=[])
+        mock_async_memory._existing_entities_by_text = Mock(return_value={"alice": match})
+        mock_async_memory._entity_store.update = Mock()
+
+        await mock_async_memory._upsert_entity_async("Alice", "person", "m4", {"user_id": "u1"})
+
+        mock_async_memory._entity_store.update.assert_called_once()
+        sent_payload = mock_async_memory._entity_store.update.call_args.kwargs["payload"]
+        assert sent_payload["linked_memory_ids"] == ["m2", "m3", "m4"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Async batch path: AsyncMemory._add_to_vector_store Phase 7
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncBatchEntityCap:
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        memory = AsyncMemory()
+        memory.config = MemoryConfig(entity_max_linked_memory_ids=3)
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        return memory
+
+    @pytest.mark.asyncio
+    async def test_batch_update_evicts_oldest_when_over_cap(self, mock_async_memory, mocker):
+        mock_async_memory.llm.generate_response.return_value = (
+            '{"memory": [{"text": "Alice met Bob"}, {"text": "Alice called Carol"}]}'
+        )
+        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model.embed_batch = Mock(side_effect=lambda texts, action: [[0.1] * 10 for _ in texts])
+
+        existing_payload = {"data": "Alice", "linked_memory_ids": ["m1", "m2", "m3"]}
+        match = MagicMock(id="entity-1", payload=existing_payload, score=1.0)
+        mock_async_memory._entity_store = Mock()
+        mock_async_memory._entity_store.search_batch = Mock(return_value=[[match]])
+        mock_async_memory._entity_store.update = Mock()
+        mock_async_memory._entity_store.insert = Mock()
+
+        mocker.patch(
+            "mem0.memory.main.extract_entities_batch",
+            return_value=[[("person", "Alice")], [("person", "Alice")]],
+        )
+        mocker.patch("mem0.memory.main.capture_event")
+
+        result = await mock_async_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Alice met Bob; Alice called Carol"}],
+            metadata={},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert len(result) == 2
+        mock_async_memory._entity_store.update.assert_called_once()
+        sent_payload = mock_async_memory._entity_store.update.call_args.kwargs["payload"]
+        assert len(sent_payload["linked_memory_ids"]) == 3
+        new_ids = {r["id"] for r in result}
+        assert new_ids <= set(sent_payload["linked_memory_ids"])

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1067,6 +1067,7 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         memory.config = mocker.MagicMock()
         memory.config.custom_instructions = None
         memory.config.custom_update_memory_prompt = None
+        memory.config.entity_max_linked_memory_ids = None
         memory.custom_instructions = None
         memory.api_version = "v1.1"
         memory.db.get_last_messages = MagicMock(return_value=[])
@@ -1081,12 +1082,14 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         memory.config = mocker.MagicMock()
         memory.config.custom_instructions = None
         memory.config.custom_update_memory_prompt = None
+        memory.config.entity_max_linked_memory_ids = None
         memory.custom_instructions = None
         memory.api_version = "v1.1"
         memory.db.get_last_messages = MagicMock(return_value=[])
         memory.db.save_messages = MagicMock()
         memory.db.batch_add_history = MagicMock()
         return memory
+
 
     @staticmethod
     def _short_entity_embed_batch(texts, memory_action="add"):


### PR DESCRIPTION
## Linked Issue

Closes #6923

## Description

The OSS entity index stores every memory ID linked to an extracted entity in a single
`linked_memory_ids` metadata array on that entity's vector-store payload, rewritten in
full (read-modify-write) on every update, with no bound. With embedded Chroma, a
high-cardinality entity can push this array past Chroma's SQLite metadata-segment
materialization limit (~5,461 elements, chroma-core/chroma#2181), stalling that entity's
row and queuing all future updates to it indefinitely.

This PR adds a configurable cap, `MemoryConfig.entity_max_linked_memory_ids` (default
`5000`), enforced via FIFO eviction (oldest IDs dropped first) at all four sites that
grow this array:

- Sync single-entity: `Memory._upsert_entity`
- Sync batch: `Memory._add_to_vector_store` (Phase 7 entity linking)
- Async single-entity: `AsyncMemory._upsert_entity_async`
- Async batch: `AsyncMemory._add_to_vector_store` (Phase 7 entity linking)

`entity_max_linked_memory_ids=None`/`0` disables the cap, restoring today's unbounded
behavior for callers on backends without this specific limit. The fix caps growth at
the mem0 layer rather than trying to change how any one backend batches metadata, since
any backend with a per-field size ceiling would eventually hit an equivalent failure.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [x] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [ ] AI-generated (an agent wrote most or all of this diff)

Used an AI coding assistant to help enumerate the growth sites and draft test
scaffolding. I designed the eviction semantics (FIFO-by-append-order, not
LRU-by-access — these arrays are only ever appended to, never read for recency) and
the default cap value myself, and reviewed/adjusted every assertion.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A — new config field defaults to a value (5000) well above realistic entity
cardinality for most users; behavior only changes for entities that would have
exceeded the old unbounded growth anyway.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

`tests/memory/test_entity_linked_memory_ids_cap.py` (16 new tests):
- `_bounded_linked_memory_ids` helper in isolation: eviction order, dedup without
  double-counting, `None`/`0`/negative cap disabling the bound, non-list input
  coercion, no in-place mutation of the caller's list.
- All four growth sites exercised through `Memory`/`AsyncMemory` with a capped config,
  asserting the exact `linked_memory_ids` payload sent to `entity_store.update`/`insert`
  once over cap.

Ran the full `tests/memory/` suite (385 tests) — zero regressions. One pre-existing test
class (`TestAddPipelineEntityEmbeddingCountGuard`) fully mocks `memory.config`, so its
fixtures now explicitly set `entity_max_linked_memory_ids = None` to keep exercising the
old unbounded path it was written for.

`ruff check` clean on all changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
