### PR TITLE
fix(memory): persist LLM-computed linked_memory_ids into the add pipeline

### DIFF
--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -506,11 +506,13 @@ Memories already captured from recent messages in this session (up to 20). This 
 ## Existing Memories
 
 Memories currently in the system relevant to this conversation. Formatted as:
-[{"id": "uuid-string", "text": "..."}, ...]
+[{"id": "0", "text": "..."}, {"id": "1", "text": "..."}, ...]
+
+The "id" values are sequential index strings, matching your ADD output ID scheme — not the memories' real underlying IDs.
 
 Use these ONLY for deduplication and linking — do NOT extract new memories from Existing Memories. Your extractions must come exclusively from New Messages. If new information in New Messages is semantically equivalent to an Existing Memory with no meaningful new context, skip it.
 
-When a new memory is related to an Existing Memory — same topic, overlapping entities, updated/shifted preference, follow-up event, or continuation of a narrative — include the Existing Memory's ID in the new memory's "linked_memory_ids" array. Your ADD output IDs remain sequential ("0", "1", ...) but linked_memory_ids uses the UUIDs from this list.
+When a new memory is related to an Existing Memory — same topic, overlapping entities, updated/shifted preference, follow-up event, or continuation of a narrative — include the Existing Memory's "id" (the index string, e.g. "0", "1") in the new memory's "linked_memory_ids" array. Your ADD output IDs remain sequential ("0", "1", ...) and linked_memory_ids uses those same index strings from the Existing Memories list — never invent a different ID format.
 
 
 IMPORTANT: An existing memory about an entity (e.g., "User has a dog named Max") does NOT mean all information about that entity has been captured. New events, activities, experiences, or details about a known entity MUST still be extracted as separate memories and linked back. Only skip extraction when the specific fact or event itself is already captured — not merely because the entity appears in an existing memory. "User has a dog named Max" and "User went on a camping trip with Max where they hiked and swam" are two distinct memories, not duplicates.
@@ -844,15 +846,15 @@ Every count (4 Mummies, 2 Construct Guardians, 6 Skeletal Warriors) and every sp
 
 Summary: ""
 Recently Extracted: []
-Existing Memories: [{"id": "a1b2c3d4-5678-9abc-def0-111111111111", "text": "User has a dog named Poppy, a golden retriever"}, {"id": "b2c3d4e5-6789-abcd-ef01-222222222222", "text": "User works as a Senior Engineer at Shopify"}]
+Existing Memories: [{"id": "0", "text": "User has a dog named Poppy, a golden retriever"}, {"id": "1", "text": "User works as a Senior Engineer at Shopify"}]
 New Messages:
 [{"role": "user", "content": "Poppy had her vet checkup yesterday — she's healthy but needs to lose a few pounds. Also, I'm switching teams at work next month to the payments platform."}]
 Observation Date: 2025-03-15
 
 Output:
 {"memory": [
-  {"id": "0", "text": "User's dog Poppy had a vet checkup around March 14, 2025, is healthy but needs to lose weight", "linked_memory_ids": ["a1b2c3d4-5678-9abc-def0-111111111111"]},
-  {"id": "1", "text": "User is switching teams at Shopify to the payments platform in April 2025", "linked_memory_ids": ["b2c3d4e5-6789-abcd-ef01-222222222222"]}
+  {"id": "0", "text": "User's dog Poppy had a vet checkup around March 14, 2025, is healthy but needs to lose weight", "linked_memory_ids": ["0"]},
+  {"id": "1", "text": "User is switching teams at Shopify to the payments platform in April 2025", "linked_memory_ids": ["1"]}
 ]}
 
 Both new memories link to related existing memories — the vet checkup links to the existing Poppy memory, and the team switch links to the existing Shopify memory. This enables the system to build a graph of related memories.
@@ -887,7 +889,7 @@ FIVE topics across 5 messages — each one extracted separately. Do not stop aft
 
 Summary: "John has a dog named Max."
 Recently Extracted: []
-Existing Memories: [{"id": "a1b2c3d4-0000-0000-0000-111111111111", "text": "John has a dog named Max"}]
+Existing Memories: [{"id": "0", "text": "John has a dog named Max"}]
 New Messages:
 [{"role": "user", "content": "John: Max and I had a blast on our camping trip last summer. We hiked, swam, and made great memories. It was a really peaceful experience."},
  {"role": "assistant", "content": "Maria: That sounds amazing! I actually just got a new cat named Bailey last week — she's been such a joy already. Camping with pets is so soul-nourishing."},
@@ -896,7 +898,7 @@ Observation Date: 2023-08-11
 
 Output:
 {"memory": [
-  {"id": "0", "text": "John and his dog Max went on a camping trip in the summer of 2023 where they hiked, swam, and found it a peaceful experience", "linked_memory_ids": ["a1b2c3d4-0000-0000-0000-111111111111"]},
+  {"id": "0", "text": "John and his dog Max went on a camping trip in the summer of 2023 where they hiked, swam, and found it a peaceful experience", "linked_memory_ids": ["0"]},
   {"id": "1", "text": "Maria got a new cat named Bailey around early August 2023 and describes her as a joy"},
   {"id": "2", "text": "John has a daughter named Sara and the family took a trip for her birthday in fall 2022"}
 ]}
@@ -923,7 +925,7 @@ Return ONLY valid JSON parsable by json.loads(). No text, reasoning, explanation
 
 {
   "memory": [
-    {"id": "0", "text": "First extracted memory", "attributed_to": "user", "linked_memory_ids": ["uuid-of-related-existing-memory"]},
+    {"id": "0", "text": "First extracted memory", "attributed_to": "user", "linked_memory_ids": ["0"]},
     {"id": "1", "text": "Second extracted memory", "attributed_to": "assistant"}
   ]
 }
@@ -933,7 +935,7 @@ Return ONLY valid JSON parsable by json.loads(). No text, reasoning, explanation
 - **id** (string, required): Sequential integers as strings starting at "0".
 - **text** (string, required): A contextually rich, self-contained factual statement (15-80 words).
 - **attributed_to** (string, required): Who this memory is about. Use "user" for facts stated by or about the user (preferences, plans, personal facts). Use "assistant" for information provided by the assistant (recommendations, confirmations, plans created, information researched).
-- **linked_memory_ids** (array of strings, optional): IDs of Existing Memories that this new memory relates to. Use the exact IDs from the Existing Memories list. Omit or pass [] if no existing memories are related.
+- **linked_memory_ids** (array of strings, optional): IDs of Existing Memories that this new memory relates to. Use the exact "id" index strings from the Existing Memories list (e.g. "0", "1") — not a different ID format. Omit or pass [] if no existing memories are related.
 
 ## Rules
 

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -484,6 +484,37 @@ class _AsyncOSSProject:
         raise ValueError(_PROJECT_UPDATE_UNSUPPORTED_ERROR)
 
 
+def _resolve_linked_memory_ids(raw, uuid_mapping):
+    """Translate the LLM's ``linked_memory_ids`` into real vector-store IDs.
+
+    The Existing Memories shown to the LLM during extraction use sequential
+    anti-hallucination index strings ("0", "1", ...) rather than their real
+    IDs (see ``uuid_mapping`` in ``_add_to_vector_store``), so any entry the
+    LLM returns in ``linked_memory_ids`` is one of those indices, not a real
+    memory ID. This resolves each index through ``uuid_mapping`` back to the
+    real ID it refers to.
+
+    Entries that aren't strings, that don't match any index in
+    ``uuid_mapping`` (a hallucinated or malformed value), or that resolve to
+    a duplicate are dropped silently rather than persisted — a bad link must
+    not corrupt the payload. Returns a de-duplicated list preserving order;
+    ``[]`` if ``raw`` isn't a non-empty list.
+    """
+    if not isinstance(raw, list):
+        return []
+    resolved = []
+    seen = set()
+    for entry in raw:
+        if not isinstance(entry, str):
+            continue
+        real_id = uuid_mapping.get(entry)
+        if real_id is None or real_id in seen:
+            continue
+        resolved.append(real_id)
+        seen.add(real_id)
+    return resolved
+
+
 class Memory(MemoryBase):
     def __init__(self, config: MemoryConfig = MemoryConfig()):
         self.config = config
@@ -1035,6 +1066,9 @@ class Memory(MemoryBase):
             mem_metadata["updated_at"] = mem_metadata["created_at"]
             if mem.get("attributed_to"):
                 mem_metadata["attributed_to"] = mem["attributed_to"]
+            linked_ids = _resolve_linked_memory_ids(mem.get("linked_memory_ids"), uuid_mapping)
+            if linked_ids:
+                mem_metadata["linked_memory_ids"] = linked_ids
 
             records.append((memory_id, text, embed_map[text], mem_metadata))
 
@@ -2687,6 +2721,9 @@ class AsyncMemory(MemoryBase):
             mem_metadata["updated_at"] = mem_metadata["created_at"]
             if mem.get("attributed_to"):
                 mem_metadata["attributed_to"] = mem["attributed_to"]
+            linked_ids = _resolve_linked_memory_ids(mem.get("linked_memory_ids"), uuid_mapping)
+            if linked_ids:
+                mem_metadata["linked_memory_ids"] = linked_ids
 
             records.append((memory_id, text, embed_map[text], mem_metadata))
 

--- a/tests/memory/test_linked_memory_ids_from_llm.py
+++ b/tests/memory/test_linked_memory_ids_from_llm.py
@@ -1,0 +1,272 @@
+"""Regression tests for issue #6982.
+
+The V3 additive extraction prompt (`ADDITIVE_EXTRACTION_PROMPT`) asks the LLM to
+emit a `linked_memory_ids` field on each extracted memory, pointing at related
+Existing Memories so retrieval can build a semantic graph between them. But
+`_add_to_vector_store`'s Phase 4 (sync and async) only ever read `text` and
+`attributed_to` off each extracted memory dict — `linked_memory_ids` was parsed
+out of the LLM response and then silently discarded before it ever reached the
+vector-store payload.
+
+There is a second, related defect the fix also addresses: Existing Memories are
+shown to the LLM with anti-hallucination index strings ("0", "1", ...) instead
+of their real vector-store IDs (`uuid_mapping` in `_add_to_vector_store` maps
+index -> real ID), but the prompt told the LLM those Existing Memory ids were
+UUIDs and to emit UUIDs back in `linked_memory_ids`. Since the LLM was never
+shown a real UUID, any `linked_memory_ids` value it produced already had to be
+one of the index strings — the prompt's stated contract didn't match what the
+pipeline actually presented.
+
+The fix:
+  * `_resolve_linked_memory_ids(raw, uuid_mapping)` translates the LLM's index
+    strings back to real vector-store IDs, dropping anything that isn't a
+    string or doesn't resolve to a known index (a hallucinated/malformed
+    value) rather than persisting it.
+  * Phase 4 (sync + async) now calls this and, when non-empty, stores the
+    resolved list under `linked_memory_ids` in the payload sent to
+    `vector_store.insert`.
+  * The prompt's "Existing Memories" section and its two linking examples
+    (Example 10, Example 12) now describe/use index strings consistently
+    instead of claiming UUIDs.
+
+Layers covered:
+  * `_resolve_linked_memory_ids` directly — translation/dedup/drop semantics.
+  * The sync and async `_add_to_vector_store` Phase 4 loops — the resolved
+    field actually lands in the persisted payload.
+"""
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from mem0.memory.main import AsyncMemory, Memory, _resolve_linked_memory_ids
+
+from tests.memory.test_main import _setup_mocks
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure helper: index -> real-ID translation semantics
+# ---------------------------------------------------------------------------
+
+
+class TestResolveLinkedMemoryIds:
+    def test_resolves_known_indices_to_real_ids(self):
+        mapping = {"0": "uuid-a", "1": "uuid-b"}
+        assert _resolve_linked_memory_ids(["0", "1"], mapping) == ["uuid-a", "uuid-b"]
+
+    def test_preserves_input_order(self):
+        mapping = {"0": "uuid-a", "1": "uuid-b", "2": "uuid-c"}
+        assert _resolve_linked_memory_ids(["2", "0"], mapping) == ["uuid-c", "uuid-a"]
+
+    def test_drops_unknown_index_silently(self):
+        # The LLM hallucinated an index that was never shown to it.
+        mapping = {"0": "uuid-a"}
+        assert _resolve_linked_memory_ids(["0", "5"], mapping) == ["uuid-a"]
+
+    def test_drops_non_string_entries(self):
+        mapping = {"0": "uuid-a"}
+        assert _resolve_linked_memory_ids(["0", 1, None, 3.5], mapping) == ["uuid-a"]
+
+    def test_dedupes_repeated_indices(self):
+        mapping = {"0": "uuid-a"}
+        assert _resolve_linked_memory_ids(["0", "0"], mapping) == ["uuid-a"]
+
+    def test_dedupes_when_two_indices_map_to_same_real_id(self):
+        # Defensive: shouldn't happen given how uuid_mapping is built, but the
+        # resolver must not emit a duplicate real ID either way.
+        mapping = {"0": "uuid-a", "1": "uuid-a"}
+        assert _resolve_linked_memory_ids(["0", "1"], mapping) == ["uuid-a"]
+
+    def test_empty_list_returns_empty(self):
+        assert _resolve_linked_memory_ids([], {"0": "uuid-a"}) == []
+
+    def test_none_returns_empty(self):
+        assert _resolve_linked_memory_ids(None, {"0": "uuid-a"}) == []
+
+    def test_non_list_returns_empty(self):
+        assert _resolve_linked_memory_ids("0", {"0": "uuid-a"}) == []
+
+    def test_empty_mapping_drops_everything(self):
+        assert _resolve_linked_memory_ids(["0", "1"], {}) == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Sync Phase 4: the resolved field must reach the persisted payload
+# ---------------------------------------------------------------------------
+
+
+class TestSyncAddPersistsLinkedMemoryIds:
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        memory = Memory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        memory._entity_store = Mock()
+        memory._entity_store.search_batch = Mock(return_value=[[]])
+        return memory
+
+    def test_linked_memory_ids_resolved_into_payload(self, mock_memory, mocker):
+        existing = MagicMock(id="uuid-poppy", payload={"data": "User has a dog named Poppy", "hash": "h1"})
+        mock_memory.vector_store.search = Mock(return_value=[existing])
+        mock_memory.llm.generate_response.return_value = (
+            '{"memory": [{"text": "Poppy had a vet checkup", "linked_memory_ids": ["0"]}]}'
+        )
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+        mocker.patch("mem0.memory.main.capture_event")
+
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Poppy had a vet checkup"}],
+            metadata={"user_id": "u1"},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert len(result) == 1
+        payload = mock_memory.vector_store.insert.call_args.kwargs["payloads"][0]
+        assert payload["linked_memory_ids"] == ["uuid-poppy"], (
+            "the LLM-computed link to the Existing Memory must survive into the persisted payload"
+        )
+
+    def test_hallucinated_index_is_dropped_not_persisted(self, mock_memory, mocker):
+        # No Existing Memories were shown to the LLM, so uuid_mapping is empty —
+        # any linked_memory_ids value it produces is necessarily hallucinated.
+        mock_memory.vector_store.search = Mock(return_value=[])
+        mock_memory.llm.generate_response.return_value = (
+            '{"memory": [{"text": "User likes tea", "linked_memory_ids": ["0"]}]}'
+        )
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+        mocker.patch("mem0.memory.main.capture_event")
+
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "User likes tea"}],
+            metadata={"user_id": "u1"},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        payload = mock_memory.vector_store.insert.call_args.kwargs["payloads"][0]
+        assert "linked_memory_ids" not in payload
+
+    def test_omitted_field_leaves_payload_unchanged(self, mock_memory, mocker):
+        mock_memory.vector_store.search = Mock(return_value=[])
+        mock_memory.llm.generate_response.return_value = '{"memory": [{"text": "User likes coffee"}]}'
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+        mocker.patch("mem0.memory.main.capture_event")
+
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "User likes coffee"}],
+            metadata={"user_id": "u1"},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        payload = mock_memory.vector_store.insert.call_args.kwargs["payloads"][0]
+        assert "linked_memory_ids" not in payload
+
+    def test_multiple_links_resolved_in_order(self, mock_memory, mocker):
+        poppy = MagicMock(id="uuid-poppy", payload={"data": "User has a dog named Poppy", "hash": "h1"})
+        shopify = MagicMock(id="uuid-shopify", payload={"data": "User works at Shopify", "hash": "h2"})
+        mock_memory.vector_store.search = Mock(return_value=[poppy, shopify])
+        mock_memory.llm.generate_response.return_value = (
+            '{"memory": [{"text": "Poppy checkup and team switch", "linked_memory_ids": ["1", "0"]}]}'
+        )
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+        mocker.patch("mem0.memory.main.capture_event")
+
+        mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Poppy checkup and team switch"}],
+            metadata={"user_id": "u1"},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        payload = mock_memory.vector_store.insert.call_args.kwargs["payloads"][0]
+        assert payload["linked_memory_ids"] == ["uuid-shopify", "uuid-poppy"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Async Phase 4: same contract as sync
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncAddPersistsLinkedMemoryIds:
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        mock_llm, _ = _setup_mocks(mocker)
+        memory = AsyncMemory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+        memory.db.batch_add_history = MagicMock()
+        memory._entity_store = Mock()
+        memory._entity_store.search_batch = Mock(return_value=[[]])
+        return memory
+
+    @pytest.mark.asyncio
+    async def test_linked_memory_ids_resolved_into_payload(self, mock_memory, mocker):
+        existing = MagicMock(id="uuid-poppy", payload={"data": "User has a dog named Poppy", "hash": "h1"})
+        mock_memory.vector_store.search = Mock(return_value=[existing])
+        mock_memory.llm.generate_response.return_value = (
+            '{"memory": [{"text": "Poppy had a vet checkup", "linked_memory_ids": ["0"]}]}'
+        )
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+        mocker.patch("mem0.memory.main.capture_event")
+
+        result = await mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "Poppy had a vet checkup"}],
+            metadata={"user_id": "u1"},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert len(result) == 1
+        payload = mock_memory.vector_store.insert.call_args.kwargs["payloads"][0]
+        assert payload["linked_memory_ids"] == ["uuid-poppy"]
+
+    @pytest.mark.asyncio
+    async def test_hallucinated_index_is_dropped_not_persisted(self, mock_memory, mocker):
+        mock_memory.vector_store.search = Mock(return_value=[])
+        mock_memory.llm.generate_response.return_value = (
+            '{"memory": [{"text": "User likes tea", "linked_memory_ids": ["0"]}]}'
+        )
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+        mock_memory.embedding_model.embed_batch = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+        mocker.patch("mem0.memory.main.capture_event")
+
+        await mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "User likes tea"}],
+            metadata={"user_id": "u1"},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        payload = mock_memory.vector_store.insert.call_args.kwargs["payloads"][0]
+        assert "linked_memory_ids" not in payload


### PR DESCRIPTION
## Summary

The V3 additive extraction prompt (`ADDITIVE_EXTRACTION_PROMPT`) asks the LLM to emit a `linked_memory_ids` field on each extracted memory so retrieval can build a semantic graph between new and existing memories. But Phase 4 of `_add_to_vector_store` (both sync and async) only ever read `text` and `attributed_to` off each extracted memory dict — `linked_memory_ids` was parsed out of the LLM's JSON response and then silently discarded before it ever reached the vector-store payload.

There's a second, related defect: the prompt's "Existing Memories" section claimed those ids were UUIDs and told the LLM to return UUIDs in `linked_memory_ids`, but the pipeline only ever shows the LLM sequential anti-hallucination index strings (`"0"`, `"1"`, ...) via a local `uuid_mapping`. The documented contract never matched what was actually presented to the model.

## Fix

1. Added `_resolve_linked_memory_ids(raw, uuid_mapping)` — translates the LLM's index strings back to real vector-store IDs using the `uuid_mapping` already built in Phase 1. Drops anything that isn't a string, doesn't resolve to a known index (hallucinated/malformed), or resolves to a duplicate, rather than persisting it.
2. Phase 4 (sync + async) now calls this and, when the result is non-empty, stores it under `linked_memory_ids` in the payload sent to `vector_store.insert`.
3. Updated `ADDITIVE_EXTRACTION_PROMPT`'s "Existing Memories" section and its two linking examples (Example 10, Example 12) plus the output-schema example to describe/use index strings consistently instead of claiming UUIDs.

## Testing

New file `tests/memory/test_linked_memory_ids_from_llm.py` (16 tests):
- `_resolve_linked_memory_ids` unit tests: resolves known indices, preserves order, drops hallucinated/non-string/duplicate entries, handles empty/None/non-list input and an empty mapping.
- Sync + async integration tests against `_add_to_vector_store`, asserting the resolved `linked_memory_ids` lands in the payload passed to `vector_store.insert` — including "hallucinated index dropped, not persisted" and "field omitted leaves payload unchanged".

Verified locally:
```
$ python -m pytest tests/memory/test_linked_memory_ids_from_llm.py -v
============================== 16 passed in 0.50s ==============================

$ python -m pytest tests/memory/ tests/test_memory.py -q
444 passed in 2.82s

$ ruff check mem0/memory/main.py mem0/configs/prompts.py tests/memory/test_linked_memory_ids_from_llm.py
All checks passed!
```

Closes #6982

## AI Assistance Disclosure

I used an AI coding assistant (Claude Code) to help investigate the root cause, implement the fix, and write the test suite. I reviewed the change and verified it by running the test suites shown above myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
