### PR TITLE
Protect against None timestamps in Valkey layer

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -299,20 +299,15 @@ class ValkeyDB(VectorStoreBase):
                 # Create the key for the hash
                 key = f"{self.prefix}:{id}"
 
-                # Check for required fields and provide defaults if missing
-                if "data" not in payload:
-                    # Silently use default value for missing 'data' field
-                    pass
-
-                # Ensure created_at is present
-                if "created_at" not in payload:
+                # Default created_at when missing or None to current time
+                if not payload.get("created_at"):
                     payload["created_at"] = datetime.now(pytz.timezone(self.timezone)).isoformat()
 
                 # Prepare the hash data
                 hash_data = {
                     "memory_id": id,
-                    "hash": payload.get("hash", f"hash_{id}"),  # Use a default hash if not provided
-                    "memory": payload.get("data", f"data_{id}"),  # Use a default data if not provided
+                    "hash": payload.get("hash", ""),
+                    "memory": payload.get("data", ""),
                     "created_at": int(datetime.fromisoformat(payload["created_at"]).timestamp()),
                     "embedding": np.array(vector, dtype=np.float32).tobytes(),
                 }
@@ -499,20 +494,15 @@ class ValkeyDB(VectorStoreBase):
         try:
             key = f"{self.prefix}:{vector_id}"
 
-            # Check for required fields and provide defaults if missing
-            if "data" not in payload:
-                # Silently use default value for missing 'data' field
-                pass
-
-            # Ensure created_at is present
-            if "created_at" not in payload:
+            # Default created_at when missing or None to current time
+            if not payload.get("created_at"):
                 payload["created_at"] = datetime.now(pytz.timezone(self.timezone)).isoformat()
 
             # Prepare the hash data
             hash_data = {
                 "memory_id": vector_id,
-                "hash": payload.get("hash", f"hash_{vector_id}"),  # Use a default hash if not provided
-                "memory": payload.get("data", f"data_{vector_id}"),  # Use a default data if not provided
+                "hash": payload.get("hash", ""),
+                "memory": payload.get("data", ""),
                 "created_at": int(datetime.fromisoformat(payload["created_at"]).timestamp()),
             }
 
@@ -521,7 +511,7 @@ class ValkeyDB(VectorStoreBase):
                 hash_data["embedding"] = np.array(vector, dtype=np.float32).tobytes()
 
             # Add updated_at if available
-            if "updated_at" in payload:
+            if payload.get("updated_at"):
                 hash_data["updated_at"] = int(datetime.fromisoformat(payload["updated_at"]).timestamp())
 
             # Add optional fields

--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -306,8 +306,8 @@ class ValkeyDB(VectorStoreBase):
                 # Prepare the hash data
                 hash_data = {
                     "memory_id": id,
-                    "hash": payload.get("hash", ""),
-                    "memory": payload.get("data", ""),
+                    "hash": payload.get("hash", f"hash_{id}"),  # Use a default hash if not provided
+                    "memory": payload.get("data", f"data_{id}"),  # Use a default data if not provided
                     "created_at": int(datetime.fromisoformat(payload["created_at"]).timestamp()),
                     "embedding": np.array(vector, dtype=np.float32).tobytes(),
                 }
@@ -501,8 +501,8 @@ class ValkeyDB(VectorStoreBase):
             # Prepare the hash data
             hash_data = {
                 "memory_id": vector_id,
-                "hash": payload.get("hash", ""),
-                "memory": payload.get("data", ""),
+                "hash": payload.get("hash", f"hash_{vector_id}"),  # Use a default hash if not provided
+                "memory": payload.get("data", f"data_{vector_id}"),  # Use a default data if not provided
                 "created_at": int(datetime.fromisoformat(payload["created_at"]).timestamp()),
             }
 

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -158,19 +158,32 @@ def test_insert_handles_missing_created_at(valkey_db, mock_valkey_client):
     assert "created_at" in kwargs["mapping"]  # Should be added automatically
 
 
-def test_insert_and_update_with_empty_timestamps(valkey_db, mock_valkey_client):
+def test_insert_and_update_with_none_timestamps(valkey_db, mock_valkey_client):
     """Regression: None created_at/updated_at must not crash insert() or update().
 
-    Realistic (infer=True) consolidation feeds back payloads with None timestamps;
-    fromisoformat(None) previously would be hit and raise a TypeError.
+    created_at falls back to now, and a None updated_at is omitted from the hash
+    rather than passed to fromisoformat().
     """
     vector = np.random.rand(1536).tolist()
-    payload = {"hash": "h", "data": "d", "created_at": None, "updated_at": None}
 
-    valkey_db.insert(vectors=[vector], payloads=[payload], ids=["id1"])
-    valkey_db.update(vector_id="id1", vector=vector, payload=payload)
+    # Separate dicts: insert() backfills created_at in place, which would hide the
+    # same fallback in update().
+    valkey_db.insert(
+        vectors=[vector],
+        payloads=[{"hash": "h", "data": "d", "created_at": None, "updated_at": None}],
+        ids=["id1"],
+    )
+    _, insert_kwargs = mock_valkey_client.hset.call_args
+    assert isinstance(insert_kwargs["mapping"]["created_at"], int)
 
-    assert mock_valkey_client.hset.call_count == 2
+    valkey_db.update(
+        vector_id="id1",
+        vector=vector,
+        payload={"hash": "h", "data": "d", "created_at": None, "updated_at": None},
+    )
+    _, update_kwargs = mock_valkey_client.hset.call_args
+    assert isinstance(update_kwargs["mapping"]["created_at"], int)
+    assert "updated_at" not in update_kwargs["mapping"]
 
 
 def test_delete(valkey_db, mock_valkey_client):

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -159,15 +159,13 @@ def test_insert_handles_missing_created_at(valkey_db, mock_valkey_client):
 
 
 def test_insert_and_update_with_none_timestamps(valkey_db, mock_valkey_client):
-    """Regression: None created_at/updated_at must not crash insert() or update().
+    """Regression: a None timestamp must not crash insert() or update().
 
-    created_at falls back to now, and a None updated_at is omitted from the hash
-    rather than passed to fromisoformat().
+    A None created_at falls back to now and a None updated_at is skipped, so
+    neither reaches fromisoformat() which only accepts a str.
     """
     vector = np.random.rand(1536).tolist()
 
-    # Separate dicts: insert() backfills created_at in place, which would hide the
-    # same fallback in update().
     valkey_db.insert(
         vectors=[vector],
         payloads=[{"hash": "h", "data": "d", "created_at": None, "updated_at": None}],

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -158,6 +158,21 @@ def test_insert_handles_missing_created_at(valkey_db, mock_valkey_client):
     assert "created_at" in kwargs["mapping"]  # Should be added automatically
 
 
+def test_insert_and_update_with_empty_timestamps(valkey_db, mock_valkey_client):
+    """Regression: None created_at/updated_at must not crash insert() or update().
+
+    Realistic (infer=True) consolidation feeds back payloads with None timestamps;
+    fromisoformat(None) previously would be hit and raise a TypeError.
+    """
+    vector = np.random.rand(1536).tolist()
+    payload = {"hash": "h", "data": "d", "created_at": None, "updated_at": None}
+
+    valkey_db.insert(vectors=[vector], payloads=[payload], ids=["id1"])
+    valkey_db.update(vector_id="id1", vector=vector, payload=payload)
+
+    assert mock_valkey_client.hset.call_count == 2
+
+
 def test_delete(valkey_db, mock_valkey_client):
     """Test deleting a vector."""
     # Call delete


### PR DESCRIPTION
## Linked Issue

closes #6994

## Description

`ValkeyDB.insert()`/`update()` called `datetime.fromisoformat()` on `created_at`/`updated_at` unconditionally, so a None timestamp raised `TypeError: fromisoformat: argument must be str`. This hits infer=True consolidation, where entity records (which never set timestamps) get read back with None and fed into update().

I changed the default `hash` and `memory` values to empty strings too. Doesn't look like it would be hit in practice, but if it was I don't see why we'd want to crowd the text and tag prefix trees with dedicated nodes for each key. A search for "hash" or "data" would also return all these keys that actually don't have a value.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

<!-- This is about the code, not this description. Writing the description with AI is fine. -->

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

<!-- If you ticked either AI box, name the tool and what you checked yourself. -->

- [] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

I don't know the code base well. Had claude explain to me the problem and worked with it on a solution. I'm not going to oversell myself here.

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [X] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [ X] My code follows the project's style guidelines
- [X ] I have performed a self-review of my code
- [ X] I have added tests that prove my fix/feature works
- [ X] New and existing tests pass locally
- [ N/A] I have updated documentation if needed
