### PR TITLE
Flush Valkey documents on collection reset

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -721,11 +721,44 @@ class ValkeyDB(VectorStoreBase):
             logger.error(f"Error deleting index {collection_name}: {e}")
             raise
 
+    @staticmethod
+    def _escape_glob(value):
+        """Escape glob metacharacters (``* ? [ ] \\``) so a SCAN MATCH pattern matches
+        ``value`` literally; otherwise a collection name containing one would under-match
+        and leave documents behind."""
+        return "".join(f"\\{c}" if c in "\\*?[]" else c for c in str(value))
+
+    def _delete_documents(self):
+        """Delete the document hashes backing this collection.
+
+        valkey-search's FT.DROPINDEX has no DD flag, so it leaves the ``mem0:<collection>:*``
+        hashes behind. Otherwise they would be silently re-indexed on the next FT.CREATE over
+        the same prefix (e.g. in reset()).
+        """
+        pattern = f"{self._escape_glob(self.prefix)}:*"
+        # Multi-key UNLINK across hash slots raises CROSSSLOT on a cluster, so unlink one
+        # key at a time there; batch otherwise to bound round-trips and command size.
+        chunk_size = 1 if self.cluster_mode else 500
+        keys, deleted = [], 0
+        for key in self.client.scan_iter(match=pattern, count=1000):
+            keys.append(key)
+            if len(keys) >= chunk_size:
+                self.client.unlink(*keys)
+                deleted, keys = deleted + len(keys), []
+        if keys:
+            self.client.unlink(*keys)
+            deleted += len(keys)
+        logger.info(f"Deleted {deleted} document(s) for collection {self.collection_name}")
+
     def delete_col(self):
         """
-        Delete the current collection (index).
+        Delete the current collection: drop the index and its stored documents.
+
+        Returns True if index was dropped, False if index didn't exist.
         """
-        return self._drop_index(self.collection_name, log_level="info")
+        dropped = self._drop_index(self.collection_name, log_level="info")
+        self._delete_documents()
+        return dropped
 
     def col_info(self, name=None):
         """

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -1,3 +1,4 @@
+import fnmatch
 import json
 from datetime import datetime
 from unittest.mock import MagicMock, patch
@@ -21,6 +22,8 @@ def mock_valkey_client():
         mock_client.return_value.hset = MagicMock()
         mock_client.return_value.hgetall = MagicMock()
         mock_client.return_value.delete = MagicMock()
+        mock_client.return_value.scan_iter = MagicMock(return_value=[])
+        mock_client.return_value.unlink = MagicMock()
         yield mock_client.return_value
 
 
@@ -322,6 +325,37 @@ def test_delete_col(valkey_db, mock_valkey_client):
     mock_valkey_client.execute_command.side_effect = ResponseError("Unknown index name")
     result = valkey_db.delete_col()
     assert result is False
+
+
+def test_delete_col_deletes_documents(valkey_db, mock_valkey_client):
+    """delete_col()/reset() must delete this collection's document hashes and nothing else.
+
+    valkey-search's FT.DROPINDEX has no DD flag, so leftover mem0:<col>:* keys would be
+    re-indexed on the next FT.CREATE over the same prefix. The fake keyspace verifies the
+    documents are removed while other collections are left intact.
+    """
+    keyspace = {
+        "mem0:test_collection:a",
+        "mem0:test_collection:b",
+        "mem0:test_collection_2:x",  # different collection; excluded by the ':' boundary
+        "mem0:other:z",  # unrelated collection
+    }
+    mock_valkey_client.scan_iter.side_effect = lambda match, count=None: [
+        k for k in list(keyspace) if fnmatch.fnmatchcase(k, match)
+    ]
+    mock_valkey_client.unlink.side_effect = lambda *keys: [keyspace.discard(k) for k in keys]
+
+    valkey_db.delete_col()
+
+    assert keyspace == {"mem0:test_collection_2:x", "mem0:other:z"}
+
+
+def test_escape_glob_escapes_metacharacters(valkey_db):
+    """Glob metacharacters in a collection name must be escaped so the SCAN MATCH delete
+    pattern matches literally (mirrors _escape_tag_value handling for FT.SEARCH)."""
+    assert valkey_db._escape_glob("plain_name") == "plain_name"
+    assert valkey_db._escape_glob("a*b") == "a\\*b"
+    assert valkey_db._escape_glob("x[1]?") == "x\\[1\\]\\?"
 
 
 def test_context_aware_logging(valkey_db, mock_valkey_client):
@@ -898,6 +932,8 @@ def mock_valkey_cluster_client():
         mock_client.hset = MagicMock()
         mock_client.hgetall = MagicMock()
         mock_client.delete = MagicMock()
+        mock_client.scan_iter = MagicMock(return_value=[])
+        mock_client.unlink = MagicMock()
         mock_from_url.return_value = mock_client
         yield mock_client
 


### PR DESCRIPTION
## Linked Issue

Solves #6995.

## Description

Valkey's `reset()`/`delete_col()` only dropped the index via `FT.DROPINDEX` and didn't clear the related memory documents.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

<!-- This is about the code, not this description. Writing the description with AI is fine. -->

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

<!-- If you ticked either AI box, name the tool and what you checked yourself. -->

- [] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

I don't know the code base well. Had claude explain to me the problem and worked with it on a solution. I'm not going to oversell myself here.

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [N/A] I have updated documentation if needed
