### PR TITLE
fix(memory): route entity-store cleanup through the lazy property in fresh processes

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -657,16 +657,18 @@ class Memory(MemoryBase):
           - otherwise re-embed the entity text and update the payload
             (the vector store's update() requires a vector).
 
-        No-op if the entity store has never been initialized in this process.
         Errors on individual entities are swallowed at debug level; outer
         failures are swallowed at warning level so the primary delete/update
         path is never broken by entity cleanup.
         """
-        if self._entity_store is None:
+        try:
+            entity_store = self.entity_store
+        except Exception as e:
+            logger.warning(f"Entity store initialization failed for memory_id={memory_id}: {e}")
             return
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         try:
-            listed = self.entity_store.list(filters=search_filters, top_k=10000)
+            listed = entity_store.list(filters=search_filters, top_k=10000)
             rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
             for row in rows or []:
                 try:
@@ -677,7 +679,7 @@ class Memory(MemoryBase):
                     remaining = [mid for mid in linked if mid != memory_id]
                     if not remaining:
                         try:
-                            self.entity_store.delete(vector_id=row.id)
+                            entity_store.delete(vector_id=row.id)
                         except Exception as e:
                             logger.debug(f"Entity delete failed for id={row.id}: {e}")
                     else:
@@ -692,7 +694,7 @@ class Memory(MemoryBase):
                             continue
                         new_payload = {**payload, "linked_memory_ids": remaining}
                         try:
-                            self.entity_store.update(
+                            entity_store.update(
                                 vector_id=row.id,
                                 vector=vec,
                                 payload=new_payload,
@@ -2142,10 +2144,17 @@ class Memory(MemoryBase):
             self.vector_store = VectorStoreFactory.create(
                 self.config.vector_store.provider, self.config.vector_store.config
             )
-        # Reset entity store if initialized
-        if self._entity_store is not None:
+        # Reset the entity store, initializing it if needed so a persistent
+        # entity collection from a prior process is still cleared even when
+        # nothing in this process has touched the lazy entity store yet.
+        try:
+            entity_store = self.entity_store
+        except Exception as e:
+            logger.warning(f"Failed to initialize entity store for reset: {e}")
+            entity_store = None
+        if entity_store is not None:
             try:
-                self._entity_store.reset()
+                entity_store.reset()
             except Exception as e:
                 logger.warning(f"Failed to reset entity store: {e}")
             self._entity_store = None
@@ -2317,15 +2326,18 @@ class AsyncMemory(MemoryBase):
         concurrent _delete_memory coroutines each try to read-modify-write
         the same entity rows' linked_memory_ids lists.
         """
-        if self._entity_store is None:
+        try:
+            entity_store = self.entity_store
+        except Exception as e:
+            logger.warning(f"Entity store initialization failed for bulk cleanup: {e}")
             return
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         try:
-            listed = await asyncio.to_thread(self.entity_store.list, filters=search_filters, top_k=10000)
+            listed = await asyncio.to_thread(entity_store.list, filters=search_filters, top_k=10000)
             rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
             for row in rows or []:
                 try:
-                    await asyncio.to_thread(self.entity_store.delete, vector_id=row.id)
+                    await asyncio.to_thread(entity_store.delete, vector_id=row.id)
                 except Exception as e:
                     logger.debug(f"Bulk entity delete failed for id={row.id}: {e}")
         except Exception as e:
@@ -2333,11 +2345,14 @@ class AsyncMemory(MemoryBase):
 
     async def _remove_memory_from_entity_store(self, memory_id, filters):
         """Async variant of `Memory._remove_memory_from_entity_store`."""
-        if self._entity_store is None:
+        try:
+            entity_store = self.entity_store
+        except Exception as e:
+            logger.warning(f"Entity store initialization failed for memory_id={memory_id} (async): {e}")
             return
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         try:
-            listed = await asyncio.to_thread(self.entity_store.list, filters=search_filters, top_k=10000)
+            listed = await asyncio.to_thread(entity_store.list, filters=search_filters, top_k=10000)
             rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
             for row in rows or []:
                 try:
@@ -2348,7 +2363,7 @@ class AsyncMemory(MemoryBase):
                     remaining = [mid for mid in linked if mid != memory_id]
                     if not remaining:
                         try:
-                            await asyncio.to_thread(self.entity_store.delete, vector_id=row.id)
+                            await asyncio.to_thread(entity_store.delete, vector_id=row.id)
                         except Exception as e:
                             logger.debug(f"Entity delete failed for id={row.id} (async): {e}")
                     else:
@@ -2364,7 +2379,7 @@ class AsyncMemory(MemoryBase):
                         new_payload = {**payload, "linked_memory_ids": remaining}
                         try:
                             await asyncio.to_thread(
-                                self.entity_store.update,
+                                entity_store.update,
                                 vector_id=row.id,
                                 vector=vec,
                                 payload=new_payload,
@@ -3593,8 +3608,10 @@ class AsyncMemory(MemoryBase):
             errors.extend(batch_errors)
             deleted_count += len(results) - len(batch_errors)
 
-        if self._entity_store is not None:
-            await self._bulk_clear_entity_store(filters)
+        # Clear entity links unconditionally; _bulk_clear_entity_store routes
+        # through the lazy entity store so a persistent entity collection is
+        # still cleaned up in a fresh process that never called add().
+        await self._bulk_clear_entity_store(filters)
 
         if errors:
             logger.warning("Failed to delete %d memories", len(errors))
@@ -3836,9 +3853,17 @@ class AsyncMemory(MemoryBase):
             self.config.vector_store.provider, self.config.vector_store.config
         )
 
-        if self._entity_store is not None:
+        # Reset the entity store, initializing it if needed so a persistent
+        # entity collection from a prior process is still cleared even when
+        # nothing in this process has touched the lazy entity store yet.
+        try:
+            entity_store = self.entity_store
+        except Exception as e:
+            logger.warning(f"Failed to initialize entity store for reset: {e}")
+            entity_store = None
+        if entity_store is not None:
             try:
-                await asyncio.to_thread(self._entity_store.reset)
+                await asyncio.to_thread(entity_store.reset)
             except Exception as e:
                 logger.warning(f"Failed to reset entity store: {e}")
             self._entity_store = None

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1178,3 +1178,177 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #6863 / #4863:
+# delete/update/reset/delete_all skipped entity cleanup in a fresh process.
+#
+# `entity_store` is a lazy property, but the cleanup paths guarded on the raw
+# `_entity_store` backing field. A fresh process that never called add() always
+# has `_entity_store = None`, so every delete/update/reset silently skipped
+# entity cleanup and left stale `linked_memory_ids` behind. The probe classes
+# below override the lazy property to hand back a dummy store while leaving the
+# backing field at None, so the test only passes if the code routes through the
+# property (the pre-fix early-return never touches it).
+# ---------------------------------------------------------------------------
+
+
+class _EntityStoreProbeMixin:
+    """Route `entity_store` to a supplied dummy while `_entity_store` stays None.
+
+    Simulates a fresh process that has never lazily initialized the entity
+    store, and records every property access so tests can assert the cleanup
+    path went through the lazy property rather than the raw backing field.
+    """
+
+    @property
+    def entity_store(self):
+        self.entity_store_accesses += 1
+        return self._dummy_entity_store
+
+
+class _ProbeMemory(_EntityStoreProbeMixin, Memory):
+    pass
+
+
+class _ProbeAsyncMemory(_EntityStoreProbeMixin, AsyncMemory):
+    pass
+
+
+def _make_probe(cls, dummy_entity_store):
+    memory = cls.__new__(cls)
+    memory._entity_store = None  # fresh-process state: never lazily initialized
+    memory._dummy_entity_store = dummy_entity_store
+    memory.entity_store_accesses = 0
+    memory.vector_store = MagicMock()
+    memory.db = MagicMock()
+    memory.embedding_model = MagicMock()
+    return memory
+
+
+def _existing_memory(memory_id="mem-1"):
+    return SimpleNamespace(
+        payload={
+            "data": "trip to Paris",
+            "created_at": "2026-04-16T00:00:00+00:00",
+            "user_id": "user-1",
+        }
+    )
+
+
+def test_delete_initializes_entity_store_before_cleanup():
+    """Sync delete removes the entity row via the lazy property (delete branch)."""
+    stale_row = SimpleNamespace(id="entity-1", payload={"data": "Paris", "linked_memory_ids": ["mem-1"]})
+    dummy = MagicMock()
+    dummy.list.return_value = [stale_row]
+    memory = _make_probe(_ProbeMemory, dummy)
+
+    memory._delete_memory("mem-1", existing_memory=_existing_memory())
+
+    assert memory.entity_store_accesses > 0, "cleanup returned early instead of using the lazy property"
+    dummy.delete.assert_called_once_with(vector_id="entity-1")
+    dummy.update.assert_not_called()
+
+
+def test_delete_updates_entity_row_when_other_links_remain():
+    """Sync delete trims linked_memory_ids and updates when other ids remain."""
+    stale_row = SimpleNamespace(id="entity-1", payload={"data": "Paris", "linked_memory_ids": ["mem-1", "mem-2"]})
+    dummy = MagicMock()
+    dummy.list.return_value = [stale_row]
+    memory = _make_probe(_ProbeMemory, dummy)
+    memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+
+    memory._delete_memory("mem-1", existing_memory=_existing_memory())
+
+    dummy.delete.assert_not_called()
+    dummy.update.assert_called_once()
+    kwargs = dummy.update.call_args.kwargs
+    assert kwargs["vector_id"] == "entity-1"
+    assert kwargs["payload"]["linked_memory_ids"] == ["mem-2"]
+
+
+@pytest.mark.asyncio
+async def test_async_delete_initializes_entity_store_before_cleanup():
+    """Async delete removes the entity row via the lazy property (delete branch)."""
+    stale_row = SimpleNamespace(id="entity-1", payload={"data": "Paris", "linked_memory_ids": ["mem-1"]})
+    dummy = MagicMock()
+    dummy.list.return_value = [stale_row]
+    memory = _make_probe(_ProbeAsyncMemory, dummy)
+
+    await memory._delete_memory("mem-1", existing_memory=_existing_memory())
+
+    assert memory.entity_store_accesses > 0, "async cleanup returned early instead of using the lazy property"
+    dummy.delete.assert_called_once_with(vector_id="entity-1")
+    dummy.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_delete_updates_entity_row_when_other_links_remain():
+    """Async delete trims linked_memory_ids and updates when other ids remain."""
+    stale_row = SimpleNamespace(id="entity-1", payload={"data": "Paris", "linked_memory_ids": ["mem-1", "mem-2"]})
+    dummy = MagicMock()
+    dummy.list.return_value = [stale_row]
+    memory = _make_probe(_ProbeAsyncMemory, dummy)
+    memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+
+    await memory._delete_memory("mem-1", existing_memory=_existing_memory())
+
+    dummy.delete.assert_not_called()
+    dummy.update.assert_called_once()
+    kwargs = dummy.update.call_args.kwargs
+    assert kwargs["vector_id"] == "entity-1"
+    assert kwargs["payload"]["linked_memory_ids"] == ["mem-2"]
+
+
+def test_reset_initializes_entity_store_in_fresh_process(mocker):
+    """Sync reset clears a persistent entity collection even when never used this process."""
+    mocker.patch("mem0.memory.main.SQLiteManager", MagicMock())
+    mocker.patch("mem0.memory.main.VectorStoreFactory", MagicMock())
+    mocker.patch("mem0.memory.main.capture_event")
+    mocker.patch("mem0.memory.main.display_first_run_notice")
+    dummy = MagicMock()
+    memory = _make_probe(_ProbeMemory, dummy)
+    memory.config = MagicMock()
+
+    memory.reset()
+
+    assert memory.entity_store_accesses > 0, "reset skipped the entity store instead of initializing it"
+    dummy.reset.assert_called_once()
+    assert memory._entity_store is None
+
+
+@pytest.mark.asyncio
+async def test_async_reset_initializes_entity_store_in_fresh_process(mocker):
+    """Async reset clears a persistent entity collection even when never used this process."""
+    mocker.patch("mem0.memory.main.SQLiteManager", MagicMock())
+    mocker.patch("mem0.memory.main.VectorStoreFactory", MagicMock())
+    mocker.patch("mem0.memory.main.capture_event")
+    mocker.patch("mem0.memory.main.display_first_run_notice_async")
+    mocker.patch("mem0.memory.main.gc")
+    dummy = MagicMock()
+    memory = _make_probe(_ProbeAsyncMemory, dummy)
+    memory.config = MagicMock()
+
+    await memory.reset()
+
+    assert memory.entity_store_accesses > 0, "async reset skipped the entity store instead of initializing it"
+    dummy.reset.assert_called_once()
+    assert memory._entity_store is None
+
+
+@pytest.mark.asyncio
+async def test_async_delete_all_clears_entity_store_in_fresh_process(mocker):
+    """Async delete_all bulk-clears entity rows through the lazy property in a fresh process."""
+    mocker.patch("mem0.memory.main.capture_event")
+    entity_row = SimpleNamespace(id="entity-1", payload={"data": "Paris", "linked_memory_ids": ["mem-1"]})
+    dummy = MagicMock()
+    dummy.list.return_value = ([entity_row],)
+    memory = _make_probe(_ProbeAsyncMemory, dummy)
+    mem = SimpleNamespace(id="mem-1", payload={"data": "trip to Paris", "user_id": "user-1"})
+    memory.vector_store.list.side_effect = [([mem],), ([],)]
+
+    await memory.delete_all(user_id="user-1")
+
+    assert memory.entity_store_accesses > 0, "delete_all skipped the entity store instead of initializing it"
+    dummy.delete.assert_called_once_with(vector_id="entity-1")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -113,10 +113,18 @@ def test_collection_name_preserved_after_reset(mock_sqlite, mock_llm_factory, mo
     assert memory.collection_name == test_collection_name
     assert memory.config.vector_store.config.collection_name == test_collection_name
 
-    reset_calls = [call for call in mock_vector_factory.call_args_list if len(mock_vector_factory.call_args_list) > 2]
-    if reset_calls:
-        reset_config = reset_calls[-1][0][1]
-        assert reset_config.collection_name == test_collection_name, f"Reset used wrong collection name: {reset_config.collection_name}"
+    # reset() recreates the main store and (routing through the lazy entity
+    # store) may also create the entity collection ("<name>_entities"). The
+    # main collection name must still be recreated verbatim.
+    created_collection_names = [
+        call.args[1].collection_name
+        for call in mock_vector_factory.call_args_list
+        if len(call.args) > 1 and hasattr(call.args[1], "collection_name")
+    ]
+    if created_collection_names:
+        assert test_collection_name in created_collection_names, (
+            f"Reset did not recreate the main collection '{test_collection_name}'; saw {created_collection_names}"
+        )
 
 
 @patch('mem0.utils.factory.EmbedderFactory.create')


### PR DESCRIPTION
## Linked Issue

Closes #4863

## Description

`Memory._remove_memory_from_entity_store()` and its async variant returned early
whenever the raw `self._entity_store` backing field was `None`. But `entity_store`
is a **lazy property** that only initializes on first use, so a fresh process that
has never called `add()` always has `_entity_store = None`. As a result, delete
and update flows silently skipped entity cleanup and left stale
`linked_memory_ids` pointing at memories that no longer exist — leaving the entity
store inconsistent with the memory store and weakening the delete/erasure
semantics documented by Mem0 (stale entity links can later resurface in
search/entity-boost flows).

The same lazy-vs-raw guard mismatch affected the other entity-cleanup paths, so
this routes **all six** through the lazy `entity_store` property:

- `Memory._remove_memory_from_entity_store` (delete/update)
- `AsyncMemory._remove_memory_from_entity_store` (delete/update)
- `AsyncMemory._bulk_clear_entity_store` (delete_all)
- `Memory.reset` / `AsyncMemory.reset`
- `AsyncMemory.delete_all`

Each property access is wrapped in `try/except` so a misconfigured entity store
still never breaks the primary delete path. A local `entity_store` reference is
cached and used throughout each method to avoid redundant property calls.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added sync + async regression tests in `tests/memory/test_main.py` that simulate a
fresh process (`_entity_store` left as `None`, the lazy `entity_store` property
overridden to hand back a probe store). They cover both cleanup branches — the
delete branch (last link removed) and the update branch (other links remain, row
re-embedded and trimmed) — plus `reset` and `delete_all` in a fresh process. All
seven fail without the fix and pass with it. Updated
`test_collection_name_preserved_after_reset` to remain robust now that `reset()`
also (correctly) recreates the `<name>_entities` collection.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
