### PR TITLE
Fix: ensure full index candidate recall on filtered searches

### DIFF
--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -400,7 +400,8 @@ class FAISS(VectorStoreBase):
         if self._should_normalize():
             faiss.normalize_L2(query_vectors)
 
-        fetch_k = top_k * 2 if filters else top_k
+        total_count = max(getattr(self.index, "ntotal", 0), len(self.index_to_id))
+        fetch_k = max(total_count, top_k) if filters else top_k
         scores, indices = self.index.search(query_vectors, fetch_k)
 
         results = self._parse_output(scores[0], indices[0], fetch_k)

--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -190,9 +190,7 @@ def test_search_with_filters_overfetch_not_truncated(faiss_instance, mock_faiss_
     search_indices = np.array([[0, 1, 2, 3]])
     mock_faiss_index.search.return_value = (search_scores, search_indices)
 
-    results = faiss_instance.search(
-        query="test query", vectors=query_vector, top_k=2, filters={"category": "A"}
-    )
+    results = faiss_instance.search(query="test query", vectors=query_vector, top_k=2, filters={"category": "A"})
 
     # Two matching vectors exist among the over-fetched set, so we must get top_k of them.
     assert len(results) == 2
@@ -754,3 +752,35 @@ class TestCosineNormalization:
 
             assert results[0].id == "x"
             assert results[0].score == pytest.approx(1.0, abs=1e-5)
+
+    def test_search_with_filters_scoped_recall_beyond_top_k_multiplier(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = FAISS(
+                collection_name="filtered_col",
+                path=os.path.join(temp_dir, "filtered"),
+                distance_strategy="euclidean",
+                embedding_model_dims=3,
+            )
+            # 10 vectors for user "bob" positioned close to [0, 0, 0]
+            bob_vectors = [[0.01 * i, 0.0, 0.0] for i in range(10)]
+            bob_payloads = [{"user_id": "bob", "text": f"bob {i}"} for i in range(10)]
+            bob_ids = [f"bob_{i}" for i in range(10)]
+            store.insert(bob_vectors, bob_payloads, bob_ids)
+
+            # 5 vectors for user "alice" positioned further from [0, 0, 0]
+            alice_vectors = [[0.5 + 0.01 * i, 0.0, 0.0] for i in range(5)]
+            alice_payloads = [{"user_id": "alice", "text": f"alice {i}"} for i in range(5)]
+            alice_ids = [f"alice_{i}" for i in range(5)]
+            store.insert(alice_vectors, alice_payloads, alice_ids)
+
+            # Query with filters={"user_id": "alice"} and top_k=5
+            results = store.search(
+                query="",
+                vectors=[0.0, 0.0, 0.0],
+                top_k=5,
+                filters={"user_id": "alice"},
+            )
+
+            assert len(results) == 5
+            assert [r.id for r in results] == [f"alice_{i}" for i in range(5)]
+            assert all(r.payload["user_id"] == "alice" for r in results)


### PR DESCRIPTION
## Linked Issue

Closes #6998

## Description

Fixes an under-fetching bug in `FAISS.search()` where filtered searches previously limited candidate retrieval to `top_k * 2` vectors globally before applying post-hoc metadata filters (`_apply_filters`).

In multi-user or scoped environments (e.g. `filters={"user_id": "alice"}`), if other users in the index had `2 * top_k` vectors closer in distance to the query vector, the target user's vectors were
excluded from the ANN candidate set, resulting in 0 results even when exact matching memories existed.

This change adjusts `fetch_k` during filtered searches to evaluate across the available index vectors (`max(total_count, top_k)`), ensuring full candidate recall before applying post-hoc filters.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [x] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [ ] AI-generated (an agent wrote most or all of this diff)

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Manual Test / Verification**:
- Added unit regression test `test_search_with_filters_scoped_recall_beyond_top_k_multiplier` in `tests/vector_stores/test_faiss.py` with multi-user noise vectors.
- Verified with reproduction script inserting 10 vectors for `user_id="bob"` close to origin and 5 for `user_id="alice"`; query for Alice now returns all 5 memories (previously returned 0).
- Ran full test suite: `pytest tests/vector_stores/test_faiss.py` (34/34 passed) and `pytest tests/test_memory.py` (59/59 passed).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed