### PR TITLE
fix(vector_stores/langchain): dispatch add_embeddings on actual signature 

### DIFF
--- a/mem0/vector_stores/langchain.py
+++ b/mem0/vector_stores/langchain.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 from typing import Dict, List, Optional
 
@@ -92,13 +93,24 @@ class Langchain(VectorStoreBase):
         """
         Insert vectors into the LangChain vectorstore.
         """
-        # Check if client has add_embeddings method
+        texts = [payload.get("data", "") for payload in payloads] if payloads else [""] * len(vectors)
+
         if hasattr(self.client, "add_embeddings"):
-            # Some LangChain vectorstores have a direct add_embeddings method
-            self.client.add_embeddings(embeddings=vectors, metadatas=payloads, ids=ids)
+            try:
+                params = set(inspect.signature(self.client.add_embeddings).parameters)
+            except (ValueError, TypeError):
+                params = set()
+
+            if "text_embeddings" in params:
+                # FAISS, AzureSearch, ElasticsearchStore, OpenSearchVectorSearch, ScaNN
+                text_embeddings = list(zip(texts, vectors))
+                self.client.add_embeddings(text_embeddings=text_embeddings, metadatas=payloads, ids=ids)
+            elif "texts" in params and "embeddings" in params:
+                # PGVector, Neo4jVector, Lantern, Hologres, Kinetica, PGEmbedding, TimescaleVector
+                self.client.add_embeddings(texts=texts, embeddings=vectors, metadatas=payloads, ids=ids)
+            else:
+                self.client.add_texts(texts=texts, metadatas=payloads, ids=ids)
         else:
-            # Fallback to add_texts method
-            texts = [payload.get("data", "") for payload in payloads] if payloads else [""] * len(vectors)
             self.client.add_texts(texts=texts, metadatas=payloads, ids=ids)
 
     def search(self, query: str, vectors: List[List[float]], top_k: int = 5, filters: Optional[Dict] = None):
@@ -151,7 +163,11 @@ class Langchain(VectorStoreBase):
         Update a vector and its payload.
         """
         self.delete(vector_id)
-        self.insert([vector], [payload], [vector_id])
+        if vector is not None:
+            self.insert([vector], [payload], [vector_id])
+        else:
+            texts = [payload.get("data", "")] if payload else [""]
+            self.client.add_texts(texts=texts, metadatas=[payload] if payload else None, ids=[vector_id])
 
     def get(self, vector_id):
         """

--- a/tests/vector_stores/test_langchain_vector_store.py
+++ b/tests/vector_stores/test_langchain_vector_store.py
@@ -1,9 +1,17 @@
+import inspect
 from unittest.mock import Mock, patch
 
 import pytest
 from langchain_community.vectorstores import VectorStore
 
 from mem0.vector_stores.langchain import Langchain
+
+
+def _mock_with_sig(func):
+    """Create a Mock whose inspect.signature matches *func*."""
+    m = Mock()
+    m.__signature__ = inspect.signature(func)
+    return m
 
 
 @pytest.fixture
@@ -18,24 +26,50 @@ def langchain_instance(mock_langchain_client):
     return Langchain(client=mock_client, collection_name="test_collection")
 
 
-def test_insert_vectors(langchain_instance):
-    # Test data
+def test_insert_faiss_style(langchain_instance):
+    """FAISS/AzureSearch/ScaNN: add_embeddings(text_embeddings=..., metadatas=..., ids=...)."""
     vectors = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
     payloads = [{"data": "text1", "name": "vector1"}, {"data": "text2", "name": "vector2"}]
     ids = ["id1", "id2"]
 
-    # Test with add_embeddings method
-    langchain_instance.client.add_embeddings = Mock()
-    langchain_instance.insert(vectors=vectors, payloads=payloads, ids=ids)
-    langchain_instance.client.add_embeddings.assert_called_once_with(embeddings=vectors, metadatas=payloads, ids=ids)
+    def _faiss_sig(self, text_embeddings, metadatas=None, ids=None): ...
 
-    # Test with add_texts method
-    delattr(langchain_instance.client, "add_embeddings")  # Remove attribute completely
+    langchain_instance.client.add_embeddings = _mock_with_sig(_faiss_sig)
+    langchain_instance.insert(vectors=vectors, payloads=payloads, ids=ids)
+    langchain_instance.client.add_embeddings.assert_called_once_with(
+        text_embeddings=[("text1", [0.1, 0.2, 0.3]), ("text2", [0.4, 0.5, 0.6])],
+        metadatas=payloads,
+        ids=ids,
+    )
+
+
+def test_insert_pgvector_style(langchain_instance):
+    """PGVector/Neo4j: add_embeddings(texts=..., embeddings=..., metadatas=..., ids=...)."""
+    vectors = [[0.1, 0.2, 0.3]]
+    payloads = [{"data": "hello"}]
+    ids = ["id1"]
+
+    def _pgvector_sig(self, texts, embeddings, metadatas=None, ids=None): ...
+
+    langchain_instance.client.add_embeddings = _mock_with_sig(_pgvector_sig)
+    langchain_instance.insert(vectors=vectors, payloads=payloads, ids=ids)
+    langchain_instance.client.add_embeddings.assert_called_once_with(
+        texts=["hello"], embeddings=vectors, metadatas=payloads, ids=ids,
+    )
+
+
+def test_insert_falls_back_to_add_texts(langchain_instance):
+    """No add_embeddings → fall back to add_texts."""
+    vectors = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    payloads = [{"data": "text1", "name": "vector1"}, {"data": "text2", "name": "vector2"}]
+    ids = ["id1", "id2"]
+
+    delattr(langchain_instance.client, "add_embeddings")
     langchain_instance.client.add_texts = Mock()
     langchain_instance.insert(vectors=vectors, payloads=payloads, ids=ids)
     langchain_instance.client.add_texts.assert_called_once_with(texts=["text1", "text2"], metadatas=payloads, ids=ids)
 
-    # Test with empty payloads
+    # Empty payloads
     langchain_instance.client.add_texts.reset_mock()
     langchain_instance.insert(vectors=vectors, payloads=None, ids=ids)
     langchain_instance.client.add_texts.assert_called_once_with(texts=["", ""], metadatas=None, ids=ids)
@@ -279,14 +313,13 @@ def test_search_falls_back_when_scored_method_raises_not_implemented(langchain_i
     assert results[0].score == 1.0
 
 
-def test_update_wraps_vector_and_payload_in_lists(langchain_instance):
-    """Regression test for Langchain update() type mismatch.
-
-    update() must wrap vector and payload in lists before calling insert(),
-    which expects List[List[float]] and List[Dict] respectively.
-    """
+def test_update_with_vector(langchain_instance):
+    """update() with a vector delegates to insert()."""
     langchain_instance.client.delete = Mock()
-    langchain_instance.client.add_embeddings = Mock()
+
+    def _faiss_sig(self, text_embeddings, metadatas=None, ids=None): ...
+
+    langchain_instance.client.add_embeddings = _mock_with_sig(_faiss_sig)
 
     vector = [0.1, 0.2, 0.3]
     payload = {"data": "updated text", "name": "updated"}
@@ -295,6 +328,20 @@ def test_update_wraps_vector_and_payload_in_lists(langchain_instance):
     langchain_instance.update(vector_id=vector_id, vector=vector, payload=payload)
 
     langchain_instance.client.delete.assert_called_once_with(ids=[vector_id])
-    langchain_instance.client.add_embeddings.assert_called_once_with(
-        embeddings=[vector], metadatas=[payload], ids=[vector_id]
+    langchain_instance.client.add_embeddings.assert_called_once()
+
+
+def test_update_without_vector_uses_add_texts(langchain_instance):
+    """update(vector=None) must not pass None as an embedding; use add_texts instead."""
+    langchain_instance.client.delete = Mock()
+    langchain_instance.client.add_texts = Mock()
+
+    payload = {"data": "updated text", "name": "updated"}
+    vector_id = "id1"
+
+    langchain_instance.update(vector_id=vector_id, vector=None, payload=payload)
+
+    langchain_instance.client.delete.assert_called_once_with(ids=[vector_id])
+    langchain_instance.client.add_texts.assert_called_once_with(
+        texts=["updated text"], metadatas=[payload], ids=[vector_id]
     )


### PR DESCRIPTION


## Linked Issue

Closes #6657

## Description

`Langchain.insert()` called `add_embeddings(embeddings=...)` which no LangChain store accepts — FAISS expects `text_embeddings` (list of (text, vector) pairs), PGVector expects separate `texts` + `embeddings` args. Every store that defines `add_embeddings` hit `TypeError` on insert.

Used `inspect.signature` to check the method's actual parameter names and dispatch accordingly. Falls back to `add_texts` when the signature doesn't match either known shape.

Also fixed `update(vector=None)`: the old code did `delete()` then `insert([None], ...)`, which failed on the broken `add_embeddings` path and left the row gone. Now routes payload-only updates through `add_texts` so the store re-embeds the text itself.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## AI Assistance

- [x] No AI assistance

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

Replaced the old `test_insert_vectors` (which used bare `Mock()` — accepts any keyword, hiding the signature mismatch) with three tests that set `__signature__` on the mock to match the real FAISS and PGVector method signatures. Added `test_update_without_vector_uses_add_texts` for the `vector=None` path. All 17 tests pass locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed