### PR TITLE
fix(ts-oss): stop the entity store from sharing the memory store's table

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -323,10 +323,14 @@ export class Memory {
         ...this.config.vectorStore.config,
         collectionName: entityCollectionName,
       };
-      // For file-based stores (memory/SQLite), always use a separate DB for entities
+      // For file-based stores (memory/SQLite), always use a separate DB for entities.
+      // The suffix swap only fires on a .db path, so anything else needs appending
+      // or both stores open the same file and the same table.
       if (entityProvider === "memory") {
         const basePath = entityConfig.dbPath || getDefaultVectorStoreDbPath();
-        entityConfig.dbPath = basePath.replace(/\.db$/, "_entities.db");
+        entityConfig.dbPath = basePath.endsWith(".db")
+          ? basePath.replace(/\.db$/, "_entities.db")
+          : `${basePath}_entities`;
       }
       // Some stores name their physical storage with tableName or indexName and
       // never read collectionName, so renaming the collection alone would leave

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -328,9 +328,11 @@ export class Memory {
       // or both stores open the same file and the same table.
       if (entityProvider === "memory") {
         const basePath = entityConfig.dbPath || getDefaultVectorStoreDbPath();
-        entityConfig.dbPath = basePath.endsWith(".db")
-          ? basePath.replace(/\.db$/, "_entities.db")
-          : `${basePath}_entities`;
+        if (basePath !== ":memory:") {
+          entityConfig.dbPath = basePath.endsWith(".db")
+            ? basePath.replace(/\.db$/, "_entities.db")
+            : `${basePath}_entities`;
+        }
       }
       // Some stores name their physical storage with tableName or indexName and
       // never read collectionName, so renaming the collection alone would leave

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -328,10 +328,16 @@ export class Memory {
         const basePath = entityConfig.dbPath || getDefaultVectorStoreDbPath();
         entityConfig.dbPath = basePath.replace(/\.db$/, "_entities.db");
       }
-      if (entityProvider === "databricks") {
-        entityConfig.tableName = entityConfig.tableName
-          ? `${entityConfig.tableName}_entities`
-          : entityCollectionName;
+      // Some stores name their physical storage with tableName or indexName and
+      // never read collectionName, so renaming the collection alone would leave
+      // the entity store pointing at the memory store's own table.
+      if (entityConfig.tableName) {
+        entityConfig.tableName = `${entityConfig.tableName}_entities`;
+      } else if (entityProvider === "databricks") {
+        entityConfig.tableName = entityCollectionName;
+      }
+      if (entityConfig.indexName) {
+        entityConfig.indexName = `${entityConfig.indexName}_entities`;
       }
       this._entityStore = VectorStoreFactory.create(
         entityProvider,

--- a/mem0-ts/src/oss/tests/memory.entity-store-isolation.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-store-isolation.test.ts
@@ -41,6 +41,9 @@ jest.mock("../src/vector_stores/vectorize", () => ({
 jest.mock("../src/vector_stores/databricks", () => ({
   DatabricksVectorStore: jest.fn().mockImplementation(mockStoreStub),
 }));
+jest.mock("../src/vector_stores/memory", () => ({
+  MemoryVectorStore: jest.fn().mockImplementation(mockStoreStub),
+}));
 jest.mock("../src/utils/telemetry", () => ({
   captureClientEvent: jest.fn(),
   captureEvent: jest.fn(),
@@ -94,6 +97,23 @@ describe("entity store does not share storage with the memory store", () => {
     });
     expect(memoryCfg.indexName).toBe("memories");
     expect(entityCfg.indexName).toBe("memories_entities");
+  });
+
+  it("memory: entity db is separate even when dbPath does not end in .db", async () => {
+    const [memoryCfg, entityCfg] = await configsFor("memory", {
+      collectionName: "memories",
+      dbPath: "/tmp/mem0-isolation/store.sqlite",
+    });
+    expect(memoryCfg.dbPath).toBe("/tmp/mem0-isolation/store.sqlite");
+    expect(entityCfg.dbPath).not.toBe(memoryCfg.dbPath);
+  });
+
+  it("memory: existing .db naming is unchanged", async () => {
+    const [, entityCfg] = await configsFor("memory", {
+      collectionName: "memories",
+      dbPath: "/tmp/mem0-isolation/store.db",
+    });
+    expect(entityCfg.dbPath).toBe("/tmp/mem0-isolation/store_entities.db");
   });
 
   it("databricks: existing naming is unchanged", async () => {

--- a/mem0-ts/src/oss/tests/memory.entity-store-isolation.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-store-isolation.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The entity store must never resolve to the memory store's own storage.
+ *
+ * getEntityStore() renames only `collectionName`. Supabase and Baidu name their
+ * table with `tableName`, Vectorize names its index with `indexName`, and none
+ * of the three read `collectionName`, so the entity store used to open the exact
+ * table the memories live in. Every extracted entity was then written into the
+ * user's memory collection and came back out of search() and getAll().
+ */
+/// <reference types="jest" />
+
+const mockCreatedConfigs: any[] = [];
+
+const mockStoreStub = (config: any) => {
+  mockCreatedConfigs.push(config);
+  return {
+    initialize: jest.fn().mockResolvedValue(undefined),
+    insert: jest.fn().mockResolvedValue(undefined),
+    search: jest.fn().mockResolvedValue([]),
+    list: jest.fn().mockResolvedValue([[], 0]),
+    get: jest.fn().mockResolvedValue(null),
+    update: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+    deleteCol: jest.fn().mockResolvedValue(undefined),
+    getUserId: jest.fn().mockResolvedValue("u"),
+    setUserId: jest.fn().mockResolvedValue(undefined),
+    initializeUserId: jest.fn().mockResolvedValue(undefined),
+    keywordSearch: jest.fn().mockResolvedValue(null),
+  };
+};
+
+jest.mock("../src/vector_stores/supabase", () => ({
+  SupabaseDB: jest.fn().mockImplementation(mockStoreStub),
+}));
+jest.mock("../src/vector_stores/baidu", () => ({
+  BaiduDB: jest.fn().mockImplementation(mockStoreStub),
+}));
+jest.mock("../src/vector_stores/vectorize", () => ({
+  VectorizeDB: jest.fn().mockImplementation(mockStoreStub),
+}));
+jest.mock("../src/vector_stores/databricks", () => ({
+  DatabricksVectorStore: jest.fn().mockImplementation(mockStoreStub),
+}));
+jest.mock("../src/utils/telemetry", () => ({
+  captureClientEvent: jest.fn(),
+  captureEvent: jest.fn(),
+  isTelemetryEnabled: () => false,
+  telemetry: { captureEvent: jest.fn() },
+}));
+
+import { Memory } from "../src/memory";
+
+async function configsFor(provider: string, storeConfig: any) {
+  mockCreatedConfigs.length = 0;
+  const m: any = new Memory({
+    vectorStore: { provider, config: { dimension: 8, ...storeConfig } },
+    historyDbPath: ":memory:",
+  } as any);
+  await m._ensureInitialized();
+  await m.getEntityStore();
+  return mockCreatedConfigs;
+}
+
+describe("entity store does not share storage with the memory store", () => {
+  it("supabase: entity table is separate from the memory table", async () => {
+    const [memoryCfg, entityCfg] = await configsFor("supabase", {
+      collectionName: "memories",
+      tableName: "memories",
+      supabaseUrl: "https://x.supabase.co",
+      supabaseKey: "k",
+    });
+    expect(memoryCfg.tableName).toBe("memories");
+    expect(entityCfg.tableName).toBe("memories_entities");
+  });
+
+  it("baidu: entity table is separate from the memory table", async () => {
+    const [memoryCfg, entityCfg] = await configsFor("baidu", {
+      collectionName: "memories",
+      tableName: "memories",
+      endpoint: "e",
+      account: "a",
+      apiKey: "k",
+    });
+    expect(memoryCfg.tableName).toBe("memories");
+    expect(entityCfg.tableName).toBe("memories_entities");
+  });
+
+  it("vectorize: entity index is separate from the memory index", async () => {
+    const [memoryCfg, entityCfg] = await configsFor("vectorize", {
+      collectionName: "memories",
+      indexName: "memories",
+      accountId: "a",
+      apiKey: "k",
+    });
+    expect(memoryCfg.indexName).toBe("memories");
+    expect(entityCfg.indexName).toBe("memories_entities");
+  });
+
+  it("databricks: existing naming is unchanged", async () => {
+    const [, withTable] = await configsFor("databricks", {
+      collectionName: "memories",
+      tableName: "memories",
+      workspaceUrl: "w",
+      token: "t",
+      endpointName: "e",
+    });
+    expect(withTable.tableName).toBe("memories_entities");
+
+    const [, withoutTable] = await configsFor("databricks", {
+      collectionName: "memories",
+      workspaceUrl: "w",
+      token: "t",
+      endpointName: "e",
+    });
+    expect(withoutTable.tableName).toBe("memories_entities");
+  });
+});

--- a/mem0-ts/src/oss/tests/memory.entity-store-isolation.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-store-isolation.test.ts
@@ -108,6 +108,14 @@ describe("entity store does not share storage with the memory store", () => {
     expect(entityCfg.dbPath).not.toBe(memoryCfg.dbPath);
   });
 
+  it("memory: :memory: is left alone so it stays in memory", async () => {
+    const [, entityCfg] = await configsFor("memory", {
+      collectionName: "memories",
+      dbPath: ":memory:",
+    });
+    expect(entityCfg.dbPath).toBe(":memory:");
+  });
+
   it("memory: existing .db naming is unchanged", async () => {
     const [, entityCfg] = await configsFor("memory", {
       collectionName: "memories",


### PR DESCRIPTION
## Linked Issue

Superseded by #7005, which carries the same branch and the same commits. Closing keyword removed on purpose so this one stays closed and does not reopen alongside it. Tracking issue is #7003.

This one was marked ready for review before #7003 had `accepted`, which fired the PR Gate and closed it. That was the gate working correctly. The work continues in #7005.

## Description

`getEntityStore()` derived the entity store by cloning the vector store config and renaming `collectionName`, with special-cases for `memory` (dbPath) and `databricks` (tableName). Four providers end up sharing storage with the memory store, because none of them resolve their location from `collectionName`:

| provider | key that names the storage |
|---|---|
| supabase | `config.tableName` (`vector_stores/supabase.ts:99`) |
| baidu | `config.tableName` (`vector_stores/baidu.ts:120`) |
| vectorize | `config.indexName` (`vector_stores/vectorize.ts:30`) |
| memory | `config.dbPath` (`vector_stores/memory.ts:42`), fixed `vectors` table |

So `collectionName` became `memories_entities`, which nothing reads, and `tableName` stayed `memories`, which is what actually gets opened. The entity store and the memory store were the same table.

Every entity extracted in Phase 7 of `addToVectorStore` was inserted into the user's memory collection with a populated `data` field, so those rows passed every downstream filter and came back out of `search()` and `getAll()` as memories. They also fed back into the extraction prompt through Phase 1, and `_existingEntitiesByText()` could match a real memory as an entity and overwrite its embedding through `entityStore.update()`.

`docs/components/vectordbs/dbs/supabase.mdx:43-51` ships `{ collectionName: "memories", tableName: "memories" }`, so this was the documented path rather than an unusual config.

The `memory` provider is affected too, by a different route. Its separation depends on `basePath.replace(/\.db$/, "_entities.db")`, which silently returns the path unchanged for anything not ending in `.db`. Since `MemoryVectorStore` keys only on `dbPath` and always uses the `vectors` table, a `dbPath` like `/data/store.sqlite` puts both stores in the same file and the same table. The default path ends in `.db`, which is why local runs and the whole test suite never showed it.

The `databricks` branch already handled the table case for one provider. This generalises it: namespace `tableName` and `indexName` whenever the config carries them, and append `_entities` to a non-`.db` `dbPath`. `:memory:` is left alone, since appending to SQLite's in-memory magic value would turn it into a real file, and two connections to `:memory:` already get separate private databases. Databricks keeps its exact current naming and so do `.db` paths, so no existing entity store is orphaned. The tests pin both.

Python is unaffected. Its Supabase store keys off `collection_name`, which `_entity_collection_name()` already renames.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [x] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [ ] AI-generated (an agent wrote most or all of this diff)

I used Claude to sweep the vector store implementations for which config key each one reads, which is what surfaced the mismatch. The diff and the tests I wrote and ran myself.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

Existing supabase, baidu and vectorize deployments will start writing entities to `<table>_entities` instead of the memory table, and a `memory` deployment on a non-`.db` path will start writing to `<path>_entities`. New entity rows go to the new location and the memory table stops growing with them. Rows already written into the memory table stay there, and they are identifiable by an `entityType` field in the payload. Happy to add a note to the docs or a cleanup snippet if you want one.

Nothing changes for databricks or for a `.db` path, so no entity store that is currently separated gets orphaned.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

`mem0-ts/src/oss/tests/memory.entity-store-isolation.test.ts`, seven tests. Four cover the affected providers. Three are controls pinning databricks naming, `.db` naming, and `:memory:`, so nothing that works today changes.

The store modules are mocked and the test records the config each instance is built with, so it needs no network and no provider SDK.

- With the fix: 7 passed.
- Against a pristine `origin/main` copy of the file, same tests: 4 failed, 3 passed. The three that pass are the controls.
- Full suite: 1542 passed. The two suites that fail (`memory.embedding-action`, `memory.prototype-key-embedding`) fail identically on a pristine `origin/main`, and they fail on timeouts, which is the telemetry issue in #6798.
- `prettier --check` clean. `tsc --noEmit` reports the same 30 pre-existing errors before and after, none in the files this touches.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

