### PR TITLE
fix(vector_stores/valkey): guard against None timestamps in insert and update

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -304,8 +304,9 @@ class ValkeyDB(VectorStoreBase):
                     # Silently use default value for missing 'data' field
                     pass
 
-                # Ensure created_at is present
-                if "created_at" not in payload:
+                # Ensure created_at is present (treat None like missing —
+                # list() read-back supplies created_at=None for records stored without it)
+                if not payload.get("created_at"):
                     payload["created_at"] = datetime.now(pytz.timezone(self.timezone)).isoformat()
 
                 # Prepare the hash data
@@ -504,8 +505,9 @@ class ValkeyDB(VectorStoreBase):
                 # Silently use default value for missing 'data' field
                 pass
 
-            # Ensure created_at is present
-            if "created_at" not in payload:
+            # Ensure created_at is present (treat None like missing —
+            # list() read-back supplies created_at=None for records stored without it)
+            if not payload.get("created_at"):
                 payload["created_at"] = datetime.now(pytz.timezone(self.timezone)).isoformat()
 
             # Prepare the hash data
@@ -520,8 +522,9 @@ class ValkeyDB(VectorStoreBase):
             if vector is not None:
                 hash_data["embedding"] = np.array(vector, dtype=np.float32).tobytes()
 
-            # Add updated_at if available
-            if "updated_at" in payload:
+            # Add updated_at if available (treat None like missing — entity payloads
+            # read back via list() carry updated_at=None because insert() never writes it)
+            if payload.get("updated_at"):
                 hash_data["updated_at"] = int(datetime.fromisoformat(payload["updated_at"]).timestamp())
 
             # Add optional fields

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -158,6 +158,26 @@ def test_insert_handles_missing_created_at(valkey_db, mock_valkey_client):
     assert "created_at" in kwargs["mapping"]  # Should be added automatically
 
 
+def test_insert_handles_none_created_at(valkey_db, mock_valkey_client):
+    """Test inserting vectors whose payload carries created_at=None.
+
+    Regression test for #6994: list() read-back supplies created_at=None for
+    records stored without it, and datetime.fromisoformat(None) raises
+    TypeError inside insert().
+    """
+    # Prepare test data
+    vectors = [np.random.rand(1536).tolist()]
+    payloads = [{"hash": "test_hash", "data": "test_data", "created_at": None}]
+    ids = ["test_id"]
+
+    # Call insert — must not raise, and must store a real timestamp
+    valkey_db.insert(vectors=vectors, payloads=payloads, ids=ids)
+
+    mock_valkey_client.hset.assert_called_once()
+    args, kwargs = mock_valkey_client.hset.call_args
+    assert isinstance(kwargs["mapping"]["created_at"], int)
+
+
 def test_delete(valkey_db, mock_valkey_client):
     """Test deleting a vector."""
     # Call delete
@@ -202,6 +222,49 @@ def test_update_handles_missing_created_at(valkey_db, mock_valkey_client):
     mock_valkey_client.hset.assert_called_once()
     args, kwargs = mock_valkey_client.hset.call_args
     assert "created_at" in kwargs["mapping"]  # Should be added automatically
+
+
+def test_update_handles_none_timestamps(valkey_db, mock_valkey_client):
+    """Test updating a vector whose payload carries created_at=None and updated_at=None.
+
+    Regression test for #6994: entity payloads read back via list() contain
+    updated_at=None (insert() never writes updated_at), and update() used to
+    call datetime.fromisoformat(None) → TypeError, silently dropping entity
+    link updates during consolidation.
+    """
+    # Prepare test data — mirrors the read-back payload shape from list()
+    vector = np.random.rand(1536).tolist()
+    payload = {
+        "hash": "test_hash",
+        "data": "updated_data",
+        "created_at": None,
+        "updated_at": None,
+        "user_id": "test_user",
+    }
+
+    # Call update — must not raise
+    valkey_db.update(vector_id="test_id", vector=vector, payload=payload)
+
+    mock_valkey_client.hset.assert_called_once()
+    args, kwargs = mock_valkey_client.hset.call_args
+    # created_at=None falls back to a fresh timestamp, like the missing case
+    assert isinstance(kwargs["mapping"]["created_at"], int)
+    # updated_at=None means "not set" — omitted so the stored value is preserved
+    assert "updated_at" not in kwargs["mapping"]
+
+
+def test_update_with_real_updated_at_still_written(valkey_db, mock_valkey_client):
+    """A genuine updated_at string must still be written (guards the new None
+    check against over-matching)."""
+    ts = datetime.now(pytz.timezone("UTC")).isoformat()
+    vector = np.random.rand(1536).tolist()
+    payload = {"hash": "test_hash", "data": "updated_data", "updated_at": ts}
+
+    valkey_db.update(vector_id="test_id", vector=vector, payload=payload)
+
+    mock_valkey_client.hset.assert_called_once()
+    args, kwargs = mock_valkey_client.hset.call_args
+    assert kwargs["mapping"]["updated_at"] == int(datetime.fromisoformat(ts).timestamp())
 
 
 def test_update_with_none_vector_preserves_embedding(valkey_db, mock_valkey_client):


### PR DESCRIPTION
## Linked Issue

Closes #6994

## Description

`ValkeyDB.insert()`/`update()` call `datetime.fromisoformat()` on `created_at`/`updated_at` unconditionally, guarded only by key *presence* checks. When `infer=True`, entity records read back via `list()` carry `updated_at=None` (because `insert()` never writes `updated_at`, and `list()` returns it via `.get()`), and `_upsert_entity` feeds that payload straight into `update()`. `fromisoformat(None)` raises `TypeError`, which consolidation swallows as a warning — so the entity link update is silently dropped on Valkey only (Qdrant and other backends run the same flow cleanly).

Fix: treat `None` timestamps like missing ones, matching each site's existing semantics for absent fields:

- `insert()`/`update()` `created_at`: `if "created_at" not in payload` → `if not payload.get("created_at")` — `None` falls back to `now()` (same default the missing case already uses)
- `update()` `updated_at`: `if "updated_at" in payload` → `if payload.get("updated_at")` — `None` omits the field, so the partial HSET preserves the stored value

This mirrors the falsy-check pattern already used in the Redis provider (`redis.py` `if created_at_str else 0`). Behavior for every previously-valid input is unchanged; only `None` values take the pre-existing "missing" path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Tool: ZCode coding agent. What I checked myself: reproduced the failure against unmodified main (`001c2352`) with the regression tests before applying the fix; confirmed both new tests fail on main with `TypeError: fromisoformat: argument must be str` and pass after; read every remaining `fromisoformat`/timestamp site in `valkey.py` and the call path in `memory/main.py` to confirm no other unguarded entry point; ran the full `tests/vector_stores/test_valkey.py` suite (60/60) and `ruff check` locally.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added three tests in `tests/vector_stores/test_valkey.py` following the file's existing mocked-client pattern:

- `test_insert_handles_none_created_at` — insert with `created_at=None` stores a real int timestamp instead of raising
- `test_update_handles_none_timestamps` — update with `created_at=None`/`updated_at=None` (the exact `list()` read-back shape from the issue) completes, writes a fresh `created_at`, and omits `updated_at` so the stored value is preserved
- `test_update_with_real_updated_at_still_written` — control: a genuine `updated_at` string is still written, guarding against over-matching

The first two fail on unmodified main with the issue's exact error; all 60 tests in `test_valkey.py` pass with the fix. `ruff check` clean. (The pre-existing `ruff format` complaint in this test file's `#5006` tests exists on unmodified main too and is deliberately left untouched.)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (internal bug fix — no docs change needed)
