### PR TITLE
fix: scan full FAISS index when filters are applied

### DIFF
--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -400,7 +400,12 @@ class FAISS(VectorStoreBase):
         if self._should_normalize():
             faiss.normalize_L2(query_vectors)
 
-        fetch_k = top_k * 2 if filters else top_k
+        # Filters are applied after the index lookup, so a fixed fetch window
+        # can miss matching vectors ranked below it and silently return fewer
+        # than top_k results. The indexes used here (IndexFlatL2/IndexFlatIP)
+        # are exhaustive, so scan the whole index when filtering; the loop
+        # below still stops as soon as top_k matches are collected.
+        fetch_k = (self.index.ntotal or top_k) if filters else top_k
         scores, indices = self.index.search(query_vectors, fetch_k)
 
         results = self._parse_output(scores[0], indices[0], fetch_k)

--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -185,7 +185,9 @@ def test_search_with_filters_overfetch_not_truncated(faiss_instance, mock_faiss_
     }
     faiss_instance.index_to_id = {0: "id1", 1: "id2", 2: "id3", 3: "id4"}
 
-    # top_k=2 with filters -> fetch_k = 4; the index returns all four candidates.
+    # With filters the search scans the whole index (ntotal = 4) instead of a
+    # fixed multiple of top_k, so the two matching vectors are still surfaced.
+    mock_faiss_index.ntotal = 4
     search_scores = np.array([[0.9, 0.8, 0.7, 0.6]])
     search_indices = np.array([[0, 1, 2, 3]])
     mock_faiss_index.search.return_value = (search_scores, search_indices)
@@ -754,3 +756,74 @@ class TestCosineNormalization:
 
             assert results[0].id == "x"
             assert results[0].score == pytest.approx(1.0, abs=1e-5)
+
+
+class TestFilteredSearchRecall:
+    """Filtered search must surface matches ranked below the fetch window.
+
+    Regression test for the bug where search() fetched only ``top_k * 2``
+    candidates from the index and applied filters afterwards, so a scoped
+    user whose vectors all ranked below that cutoff got silently
+    under-returned (or zero) results even though enough matches existed.
+    """
+
+    @staticmethod
+    def _populated_store(temp_dir):
+        # 15 "bob" memories clustered near the query at the origin, plus 5
+        # "alice" memories much farther away, so every alice vector ranks
+        # below the old top_k*2 fetch window for the [0, 0] query.
+        store = FAISS(
+            collection_name="recall_col",
+            path=os.path.join(temp_dir, "recall"),
+            distance_strategy="euclidean",
+            embedding_model_dims=2,
+        )
+        store.insert(
+            vectors=[[0.01 * (i + 1), 0.0] for i in range(15)],
+            payloads=[{"user_id": "bob"} for _ in range(15)],
+            ids=[f"bob-{i}" for i in range(15)],
+        )
+        store.insert(
+            vectors=[[10.0 + i, 0.0] for i in range(5)],
+            payloads=[{"user_id": "alice"} for _ in range(5)],
+            ids=[f"alice-{i}" for i in range(5)],
+        )
+        return store
+
+    def test_filtered_search_returns_matches_below_overfetch_cutoff(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = self._populated_store(temp_dir)
+
+            results = store.search(query="", vectors=[[0.0, 0.0]], top_k=5, filters={"user_id": "alice"})
+
+            # All 5 alice memories match the filter and must be returned,
+            # even though bob's 15 vectors rank closer to the query.
+            assert [r.id for r in results] == [f"alice-{i}" for i in range(5)]
+            assert all(r.payload["user_id"] == "alice" for r in results)
+
+    def test_filtered_search_respects_top_k(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = self._populated_store(temp_dir)
+
+            results = store.search(query="", vectors=[[0.0, 0.0]], top_k=3, filters={"user_id": "alice"})
+
+            # Ranked by distance: alice-0 (10.0) < alice-1 (10.01) < ...
+            assert [r.id for r in results] == ["alice-0", "alice-1", "alice-2"]
+
+    def test_filtered_search_with_no_matching_vectors_returns_empty(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = self._populated_store(temp_dir)
+
+            results = store.search(query="", vectors=[[0.0, 0.0]], top_k=5, filters={"user_id": "carol"})
+
+            assert results == []
+
+    def test_unfiltered_search_still_returns_nearest(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = self._populated_store(temp_dir)
+
+            results = store.search(query="", vectors=[[0.0, 0.0]], top_k=5)
+
+            # Without filters the fetch window is top_k and bob's memories
+            # nearest the origin win, closest first.
+            assert [r.id for r in results] == [f"bob-{i}" for i in range(5)]


### PR DESCRIPTION
## Problem

Closes #6998

`FAISS.search()` applied payload filters *after* the index lookup but only fetched `top_k * 2` candidates first. Any vector matching the filter but ranking below that window was never considered, so in multi-user collections a scoped user could be silently under-returned — often zero results — even with plenty of matching memories.

Reproduced on `main` with the scenario from the issue: 15 memories for user `bob` clustered near the query, 5 for `alice` farther away; `search(top_k=5, filters={"user_id": "alice"})` returned `[]`.

## Fix

The indexes used by this store (`IndexFlatL2` / `IndexFlatIP`) are exhaustive, so when filters are present the search now scans the whole index instead of a fixed multiple of `top_k`:

```python
fetch_k = (self.index.ntotal or top_k) if filters else top_k
```

The existing post-filter loop already stops as soon as `top_k` matches are collected, so this only widens the candidate set; unfiltered searches keep fetching exactly `top_k`.

## Testing

- New `TestFilteredSearchRecall` regression class in `tests/vector_stores/test_faiss.py` (real index, the issue's scenario):
  - filtered search returns all matches ranked below the old `top_k*2` cutoff (**fails on unmodified `main`**, passes with this fix)
  - filtered search still respects `top_k` and ranking order
  - filter with no matching vectors returns `[]`
  - unfiltered search behavior unchanged (nearest `top_k` returned)
- Updated `test_search_with_filters_overfetch_not_truncated` (mock-based): the mock index now reports `ntotal` so it models the full-index scan.
- Ran the FAISS-dependent suites (`test_faiss.py`, `test_e2e_threshold.py`, `test_score_normalization.py`): identical results before/after this change apart from the new regression tests. `ruff check` clean; new code is `ruff format` clean.

## AI assistance disclosure

This fix was prepared with AI assistance. I reproduced the bug manually, verified the regression tests fail on unmodified `main`, reviewed and understand every line of the diff, and ran the test and lint suites myself.