### PR TITLE
fix(pgvector-ts): use a Pool so concurrent queries do not share one connection

### DIFF
--- a/mem0-ts/src/oss/src/vector_stores/pgvector.ts
+++ b/mem0-ts/src/oss/src/vector_stores/pgvector.ts
@@ -1,6 +1,6 @@
-import type { Client as ClientType, ClientConfig } from "pg";
+import type { Pool as PoolType, PoolConfig } from "pg";
 import pkg from "pg";
-const { Client, escapeIdentifier } = pkg;
+const { Pool, escapeIdentifier } = pkg;
 import { VectorStore } from "./base";
 import { SearchFilters, VectorStoreConfig, VectorStoreResult } from "../types";
 
@@ -162,7 +162,7 @@ interface PGVectorConfig extends VectorStoreConfig {
   host?: string;
   port?: number;
   connectionString?: string;
-  ssl?: ClientConfig["ssl"];
+  ssl?: PoolConfig["ssl"];
   embeddingModelDims: number;
   diskann?: boolean;
   hnsw?: boolean;
@@ -192,7 +192,7 @@ function validateConnectionConfig(config: PGVectorConfig): void {
 function buildClientConfig(
   config: PGVectorConfig,
   database?: string,
-): ClientConfig {
+): PoolConfig {
   const connectionString = getConnectionString(config);
   if (connectionString) {
     return {
@@ -212,7 +212,12 @@ function buildClientConfig(
 }
 
 export class PGVector implements VectorStore {
-  private client: ClientType;
+  // A single pg.Client cannot serve overlapping query() calls: node-postgres
+  // queues them on the one connection, so the concurrent queries issued by
+  // insert() and list() stall or fail. A Pool hands each concurrent query its
+  // own connection. The Python implementation already uses a ConnectionPool
+  // for the same reason.
+  private client: PoolType;
   private collectionName: string;
   private useDiskann: boolean;
   private useHnsw: boolean;
@@ -235,7 +240,7 @@ export class PGVector implements VectorStore {
       : validateIdentifier(config.dbname || "vector_store", "dbname");
     this.config = config;
 
-    this.client = new Client(
+    this.client = new Pool(
       buildClientConfig(
         config,
         this.useDirectConnection ? undefined : "postgres",
@@ -257,8 +262,6 @@ export class PGVector implements VectorStore {
 
   private async _doInitialize(): Promise<void> {
     try {
-      await this.client.connect();
-
       if (!this.useDirectConnection) {
         const dbExists = await this.checkDatabaseExists(this.dbName);
         if (!dbExists) {
@@ -267,8 +270,7 @@ export class PGVector implements VectorStore {
 
         await this.client.end();
 
-        this.client = new Client(buildClientConfig(this.config, this.dbName));
-        await this.client.connect();
+        this.client = new Pool(buildClientConfig(this.config, this.dbName));
       }
 
       await this.client.query("CREATE EXTENSION IF NOT EXISTS vector");

--- a/mem0-ts/src/oss/tests/pgvector.filters.test.ts
+++ b/mem0-ts/src/oss/tests/pgvector.filters.test.ts
@@ -1,5 +1,5 @@
 jest.mock("pg", () => {
-  const Client = jest.fn().mockImplementation(() => ({
+  const Pool = jest.fn().mockImplementation(() => ({
     connect: jest.fn().mockResolvedValue(undefined),
     end: jest.fn().mockResolvedValue(undefined),
     query: jest.fn().mockResolvedValue({ rows: [] }),
@@ -7,8 +7,8 @@ jest.mock("pg", () => {
   const escapeIdentifier = (str: string) => `"${str.replace(/"/g, '""')}"`;
   return {
     __esModule: true,
-    default: { Client, escapeIdentifier },
-    Client,
+    default: { Pool, escapeIdentifier },
+    Pool,
     escapeIdentifier,
   };
 });

--- a/mem0-ts/src/oss/tests/pgvector.unit.test.ts
+++ b/mem0-ts/src/oss/tests/pgvector.unit.test.ts
@@ -42,10 +42,10 @@ function mockPgQuery(sql: string) {
 }
 
 jest.mock("pg", () => {
-  const clients: any[] = [];
+  const pools: any[] = [];
 
-  const Client = jest.fn().mockImplementation((config: any) => {
-    const client = {
+  const Pool = jest.fn().mockImplementation((config: any) => {
+    const pool = {
       config,
       connect: jest.fn().mockResolvedValue(undefined),
       end: jest.fn().mockResolvedValue(undefined),
@@ -54,36 +54,36 @@ jest.mock("pg", () => {
         .mockImplementation(async (sql: string) => mockPgQuery(sql)),
     };
 
-    clients.push(client);
-    return client;
+    pools.push(pool);
+    return pool;
   });
 
   const escapeIdentifier = (str: string) => `"${str.replace(/"/g, '""')}"`;
 
   return {
     __esModule: true,
-    default: { Client, escapeIdentifier },
-    Client,
+    default: { Pool, escapeIdentifier },
+    Pool,
     escapeIdentifier,
-    __mock: { Client, clients },
+    __mock: { Pool, pools },
   };
 });
 
 import { PGVector } from "../src/vector_stores/pgvector";
 
-function getClientQueries(client: { query: jest.Mock }) {
-  return client.query.mock.calls.map(([sql]) => sql as string);
+function getPoolQueries(pool: { query: jest.Mock }) {
+  return pool.query.mock.calls.map(([sql]) => sql as string);
 }
 
 describe("PGVector", () => {
   beforeEach(() => {
     const pg = require("pg");
     mockState.databaseExists = true;
-    pg.__mock.Client.mockClear();
-    pg.__mock.clients.length = 0;
+    pg.__mock.Pool.mockClear();
+    pg.__mock.pools.length = 0;
   });
 
-  test("uses one direct client for connectionString mode and skips bootstrap database creation", async () => {
+  test("uses one direct Pool for connectionString mode and skips bootstrap database creation", async () => {
     mockState.databaseExists = false;
 
     const ssl = { rejectUnauthorized: false };
@@ -99,15 +99,15 @@ describe("PGVector", () => {
     await store.initialize();
 
     const pg = require("pg");
-    expect(pg.__mock.Client).toHaveBeenCalledTimes(1);
-    expect(pg.__mock.Client).toHaveBeenCalledWith({
+    expect(pg.__mock.Pool).toHaveBeenCalledTimes(1);
+    expect(pg.__mock.Pool).toHaveBeenCalledWith({
       connectionString:
         "postgresql://postgres:postgres@db.example.com:5432/neondb",
       ssl,
     });
 
-    const directClient = pg.__mock.clients[0];
-    const queries = getClientQueries(directClient);
+    const directClient = pg.__mock.pools[0];
+    const queries = getPoolQueries(directClient);
 
     expect(queries).not.toEqual(
       expect.arrayContaining([
@@ -144,8 +144,8 @@ describe("PGVector", () => {
     await store.initialize();
 
     const pg = require("pg");
-    expect(pg.__mock.Client).toHaveBeenCalledTimes(2);
-    expect(pg.__mock.Client).toHaveBeenNthCalledWith(1, {
+    expect(pg.__mock.Pool).toHaveBeenCalledTimes(2);
+    expect(pg.__mock.Pool).toHaveBeenNthCalledWith(1, {
       database: "postgres",
       user: "postgres",
       password: "postgres",
@@ -153,7 +153,7 @@ describe("PGVector", () => {
       port: 5432,
       ssl,
     });
-    expect(pg.__mock.Client).toHaveBeenNthCalledWith(2, {
+    expect(pg.__mock.Pool).toHaveBeenNthCalledWith(2, {
       database: "vector_store",
       user: "postgres",
       password: "postgres",
@@ -162,9 +162,9 @@ describe("PGVector", () => {
       ssl,
     });
 
-    const bootstrapClient = pg.__mock.clients[0];
-    const activeClient = pg.__mock.clients[1];
-    const bootstrapQueries = getClientQueries(bootstrapClient);
+    const bootstrapClient = pg.__mock.pools[0];
+    const activeClient = pg.__mock.pools[1];
+    const bootstrapQueries = getPoolQueries(bootstrapClient);
 
     expect(bootstrapQueries).toEqual(
       expect.arrayContaining([
@@ -173,7 +173,7 @@ describe("PGVector", () => {
       ]),
     );
     expect(bootstrapClient.end).toHaveBeenCalledTimes(1);
-    expect(getClientQueries(activeClient)).toEqual(
+    expect(getPoolQueries(activeClient)).toEqual(
       expect.arrayContaining([
         "CREATE EXTENSION IF NOT EXISTS vector",
         expect.stringContaining("FROM information_schema.tables"),
@@ -233,9 +233,9 @@ describe("PGVector", () => {
     ]);
 
     const pg = require("pg");
-    expect(pg.__mock.Client).toHaveBeenCalledTimes(2);
+    expect(pg.__mock.Pool).toHaveBeenCalledTimes(2);
 
-    const activeClient = pg.__mock.clients[1];
+    const activeClient = pg.__mock.pools[1];
     expect(activeClient.query).toHaveBeenCalledWith(
       expect.stringContaining("vector <=> $1::vector AS distance"),
       ["[1,0,0]", 4],


### PR DESCRIPTION
Closes #6956

`PGVector` opened a single `pg.Client` and reused it for every query. A `Client` is one connection, and node-postgres cannot serve overlapping `query()` calls on it â€” it queues them and warns:

> Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0.

Both hot paths issue concurrent queries against that one client:

```ts
// insert()
await Promise.all(
  values.map((value) =>
    this.client.query(query, [value.id, value.vector, value.payload]),
  ),
);

// list()
const [listResult, countResult] = await Promise.all([
  this.client.query(listQuery, listValues),
  this.client.query(countQuery, filterValues),
]);
```

So `Memory.add()` stalls or drops writes as soon as fact extraction yields more than one memory, exactly as reported.

## Change

Swap `pg.Client` for `pg.Pool`, which gives each concurrent query its own connection from the pool.

This is a small change because the two are API-compatible for how this file uses them: `query()` and `end()` have the same signatures, so all 28 call sites are untouched. `Pool` also connects lazily, so the two explicit `connect()` calls in `_doInitialize` are no longer needed and were removed â€” the first query acquires a connection on its own. The bootstrap-database path still tears down and rebuilds the client when switching from the `postgres` database to the target one, unchanged apart from the constructor.

There's precedent in this repo: the Python implementation already uses a connection pool for the same reason (`mem0/vector_stores/pgvector.py` imports `ConnectionPool` from `psycopg_pool`, or `ThreadedConnectionPool` on psycopg2). This brings the TypeScript store in line with it.

## Tests

`pgvector.unit.test.ts` and `pgvector.filters.test.ts` mock the `pg` module directly, so both mocks were updated to expose `Pool` instead of `Client`. No assertions changed â€” the tests exercise the same query behavior, and they cover the constructor paths (direct `connectionString` vs bootstrap-database) that this change touches.

## Verification

- `jest src/oss/tests/pgvector.unit.test.ts src/oss/tests/pgvector.filters.test.ts`: **33 passed** â€” identical to the 33 passing on unmodified `main`, so no behavior regressions.
- `tsc --noEmit`: **113 errors before and after**, none in `pgvector.ts`. (The existing errors are missing jest type definitions in `src/client/tests/*` and are unrelated.)
- `prettier --check` clean on all three files.

## What I could not verify

I don't have a Postgres/pgvector instance here, so I have not observed the stall disappearing against a real database â€” the fix is verified by unit tests and by the documented `Client` vs `Pool` semantics in node-postgres. @pradeepgudipati or anyone with the original repro can confirm the deprecation warning and the 10s stalls are gone; that would be worth having on the issue before this merges.

