### PR TITLE
fix(vector-store): drop Valkey documents when deleting the index

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -694,14 +694,20 @@ class ValkeyDB(VectorStoreBase):
 
     def _drop_index(self, collection_name, log_level="error"):
         """
-        Drop an index by name using the documented FT.DROPINDEX command.
+        Drop an index by name using the documented FT.DROPINDEX command,
+        including the ``DD`` flag so the underlying documents are deleted too.
+
+        Without ``DD``, ``FT.DROPINDEX`` only removes the index; the hashes
+        remain in the keyspace and are re-adopted the next time an index is
+        created over the same key prefix (e.g. ``reset()`` recreates the index
+        over ``mem0:<collection>``, resurrecting supposedly-cleared memories).
 
         Args:
             collection_name (str): Name of the index to drop.
             log_level (str): Logging level for missing index ("silent", "info", "error").
         """
         try:
-            self.client.execute_command("FT.DROPINDEX", collection_name)
+            self.client.execute_command("FT.DROPINDEX", collection_name, "DD")
             logger.info(f"Successfully deleted index {collection_name}")
             return True
         except ResponseError as e:

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -311,7 +311,11 @@ def test_delete_col(valkey_db, mock_valkey_client):
     assert result is True
 
     # Check that execute_command was called with the correct command
-    mock_valkey_client.execute_command.assert_called_once_with("FT.DROPINDEX", "test_collection")
+    # The DD flag ensures the underlying documents are deleted too, so a
+    # later reset() over the same key prefix doesn't resurrect them.
+    mock_valkey_client.execute_command.assert_called_once_with(
+        "FT.DROPINDEX", "test_collection", "DD"
+    )
 
     # Test error handling - real errors should still raise
     mock_valkey_client.execute_command.side_effect = ResponseError("Error dropping index")


### PR DESCRIPTION
Fixes embedchain/embedchain#6995

## Summary
`ValkeyDB._drop_index` ran bare `FT.DROPINDEX <name>` (no `DD` flag), so `reset()`/`delete_col()` removed the index but left the `mem0:<collection>:*` hashes in the keyspace. Since `reset()` recreates the index over the same key prefix, valkey-search re-adopted and re-indexed those surviving hashes — "cleared" memories reappeared in `search()`/`get_all()`, making `reset()` a no-op on the vector data.

Added the `DD` flag so `FT.DROPINDEX` deletes the documents too, matching the destructive-operation contract every other backend honors (Redis's `index.delete()` removes documents as well).

## Test
- Updated `test_delete_col` to assert the call is `FT.DROPINDEX <name> DD`.
- All 57 `tests/vector_stores/test_valkey.py` tests pass locally.
