### PR TITLE
Fix/cli clear validation timeout

### DIFF
--- a/cli/node/src/index.ts
+++ b/cli/node/src/index.ts
@@ -53,7 +53,10 @@ async function getBackendAndConfig(
 
 	// Validate the API key upfront with a fast timeout
 	try {
-		const pingData = (await withTimeout(backend.ping(), 5000)) as Record<string, unknown>;
+		const pingData = (await withTimeout(backend.ping(), 5000)) as Record<
+			string,
+			unknown
+		>;
 
 		const email = pingData?.user_email as string | undefined;
 		if (email) {

--- a/cli/node/src/index.ts
+++ b/cli/node/src/index.ts
@@ -22,6 +22,7 @@ import {
 } from "./state.js";
 import { captureEvent } from "./telemetry.js";
 import { CLI_VERSION } from "./version.js";
+import { withTimeout } from "./with-timeout.js";
 
 const program = new Command();
 
@@ -52,12 +53,7 @@ async function getBackendAndConfig(
 
 	// Validate the API key upfront with a fast timeout
 	try {
-		const pingData = (await Promise.race([
-			backend.ping(),
-			new Promise<never>((_, reject) =>
-				setTimeout(() => reject(new Error("timeout")), 5000),
-			),
-		])) as Record<string, unknown>;
+		const pingData = (await withTimeout(backend.ping(), 5000)) as Record<string, unknown>;
 
 		const email = pingData?.user_email as string | undefined;
 		if (email) {

--- a/cli/node/src/with-timeout.ts
+++ b/cli/node/src/with-timeout.ts
@@ -1,0 +1,17 @@
+/**
+ * Race a promise against a timeout without leaving the losing timer alive.
+ */
+export async function withTimeout<T>(promise: Promise<T>, milliseconds: number): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error("timeout")), milliseconds);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}

--- a/cli/node/src/with-timeout.ts
+++ b/cli/node/src/with-timeout.ts
@@ -1,7 +1,10 @@
 /**
  * Race a promise against a timeout without leaving the losing timer alive.
  */
-export async function withTimeout<T>(promise: Promise<T>, milliseconds: number): Promise<T> {
+export async function withTimeout<T>(
+	promise: Promise<T>,
+	milliseconds: number,
+): Promise<T> {
 	let timer: ReturnType<typeof setTimeout> | undefined;
 
 	try {

--- a/cli/node/tests/with-timeout.test.ts
+++ b/cli/node/tests/with-timeout.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withTimeout } from "../src/with-timeout.js";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("withTimeout", () => {
+	it("clears the losing timer when the promise resolves", async () => {
+		vi.useFakeTimers();
+
+		await expect(withTimeout(Promise.resolve("ok"), 5000)).resolves.toBe("ok");
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("clears the timer after a timeout rejection", async () => {
+		vi.useFakeTimers();
+		const result = withTimeout(new Promise(() => {}), 5000);
+
+		await vi.advanceTimersByTimeAsync(5000);
+		await expect(result).rejects.toThrow("timeout");
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});

--- a/cli/node/tests/with-timeout.test.ts
+++ b/cli/node/tests/with-timeout.test.ts
@@ -16,9 +16,10 @@ describe("withTimeout", () => {
 	it("clears the timer after a timeout rejection", async () => {
 		vi.useFakeTimers();
 		const result = withTimeout(new Promise(() => {}), 5000);
+		const rejection = expect(result).rejects.toThrow("timeout");
 
 		await vi.advanceTimersByTimeAsync(5000);
-		await expect(result).rejects.toThrow("timeout");
+		await rejection;
 		expect(vi.getTimerCount()).toBe(0);
 	});
 });


### PR DESCRIPTION
## Linked Issue

Closes #7052

## Description

The Node CLI validates its API key by racing `backend.ping()` against a five-second timer. When the ping finishes first, the old inline `Promise.race` leaves that timer alive and can delay process shutdown.

This change adds a reusable `withTimeout` helper that clears the timer in `finally`, then uses it for API validation. Regression tests cover both the resolved-promise and timeout-rejection paths.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Codex produced and reviewed the change, rebased it onto current `main`, and ran the checks listed below.

- [ ] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Verified locally on Node.js 22.23.2:

- Vitest: 11 files, 152 tests passed
- TypeScript: `tsc --noEmit` passed
- Biome: `biome check src/ tests/with-timeout.test.ts` passed
- Build: `tsup` passed
- Manual timing repro: old race `6.11s`; cleared timer `0.02s`

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have performed a self-review of the code and tests
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (not needed for this internal cleanup)