### PR TITLE
fix(vector-store): delete Valkey documents on collection delete

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -723,9 +723,23 @@ class ValkeyDB(VectorStoreBase):
 
     def delete_col(self):
         """
-        Delete the current collection (index).
+        Delete the current collection (index) and its documents.
+
+        Valkey's ``FT.DROPINDEX`` only removes the index — the underlying
+        ``mem0:<collection>:*`` hashes survive and are re-adopted the next
+        time an index is created over the same key prefix (e.g. ``reset()``
+        recreates the index over the same prefix, resurrecting supposedly
+        cleared memories). Delete the keys explicitly so a reset is actually
+        destructive.
         """
-        return self._drop_index(self.collection_name, log_level="info")
+        dropped = self._drop_index(self.collection_name, log_level="info")
+
+        # Delete the document hashes under this collection's key prefix.
+        keys = list(self.client.scan_iter(match=f"{self.prefix}:*"))
+        if keys:
+            self.client.delete(*keys)
+
+        return dropped
 
     def col_info(self, name=None):
         """

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -21,6 +21,7 @@ def mock_valkey_client():
         mock_client.return_value.hset = MagicMock()
         mock_client.return_value.hgetall = MagicMock()
         mock_client.return_value.delete = MagicMock()
+        mock_client.return_value.scan_iter = MagicMock(return_value=[])
         yield mock_client.return_value
 
 
@@ -305,6 +306,8 @@ def test_delete_col(valkey_db, mock_valkey_client):
     """Test deleting a collection."""
     # Reset the mock to clear previous calls
     mock_valkey_client.execute_command.reset_mock()
+    mock_valkey_client.scan_iter.reset_mock()
+    mock_valkey_client.delete.reset_mock()
 
     # Test successful deletion
     result = valkey_db.delete_col()
@@ -312,6 +315,20 @@ def test_delete_col(valkey_db, mock_valkey_client):
 
     # Check that execute_command was called with the correct command
     mock_valkey_client.execute_command.assert_called_once_with("FT.DROPINDEX", "test_collection")
+
+    # Valkey's FT.DROPINDEX does not support DD, so the document hashes must be
+    # deleted explicitly: scan the collection prefix and delete the keys.
+    mock_valkey_client.scan_iter.assert_called_once_with(match="mem0:test_collection:*")
+
+    # With no keys, delete is not called
+    mock_valkey_client.delete.assert_not_called()
+
+    # When hashes exist under the prefix, they are deleted
+    mock_valkey_client.scan_iter.return_value = ["mem0:test_collection:abc", "mem0:test_collection:def"]
+    valkey_db.delete_col()
+    mock_valkey_client.delete.assert_called_once_with(
+        "mem0:test_collection:abc", "mem0:test_collection:def"
+    )
 
     # Test error handling - real errors should still raise
     mock_valkey_client.execute_command.side_effect = ResponseError("Error dropping index")


### PR DESCRIPTION
Fixes mem0ai/mem0#6995

## Summary
`ValkeyDB.delete_col()` (and `reset()`, which calls it) dropped only the search index via `FT.DROPINDEX`, leaving the `mem0:<collection>:*` hashes in the keyspace. Since `reset()` recreates the index over the same key prefix, valkey-search re-adopted and re-indexed those surviving hashes — "cleared" memories reappeared in `search()`/`get_all()`, making `reset()` a no-op on the vector data.

Valkey's `FT.DROPINDEX` does **not** support Redis Stack's `DD` flag (signature is `FT.DROPINDEX <index-name>` only — [valkey.io docs](https://valkey.io/commands/ft.dropindex/)), so the documents must be deleted explicitly. `delete_col()` now scans the collection's key prefix (`mem0:<collection>:*`) and `DEL`s the hashes after dropping the index.

## Test
- `test_delete_col` now asserts the prefix scan (`scan_iter(match="mem0:test_collection:*")`) and that discovered hashes are deleted; empty prefix → no `DEL`.
- All 57 `tests/vector_stores/test_valkey.py` tests pass locally.
