### PR TITLE
fix(proxy): copy message dicts to prevent caller mutation and memory …

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -147,9 +147,14 @@ class Completions:
         return response
 
     def _prepare_messages(self, messages: List[dict]) -> List[dict]:
-        if not messages or messages[0]["role"] != "system":
-            return [{"role": "system", "content": MEMORY_ANSWER_PROMPT}] + messages
-        return messages
+        # Always return a fresh list of shallow-copied dicts so that mutations
+        # to prepared_messages (e.g. content enrichment in create()) never
+        # bleed back into the caller-owned `messages` list, and the background
+        # _async_add_to_memory thread always sees the original content.
+        copied = [{**msg} for msg in messages]
+        if not copied or copied[0]["role"] != "system":
+            return [{"role": "system", "content": MEMORY_ANSWER_PROMPT}] + copied
+        return copied
 
     def _async_add_to_memory(self, messages, user_id, agent_id, run_id, metadata, filters):
         def add_task():

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -138,3 +138,99 @@ def test_completions_create_messages_default_does_not_leak_between_calls(mock_me
         f"Completions.create(messages=...) must default to None to avoid the "
         f"B006 shared-default-list bug; got {messages_default!r}."
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: caller-owned message dicts must not be mutated
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_messages_does_not_alias_dicts_without_system_message(mock_memory_client):
+    """_prepare_messages() must return isolated dict copies when the caller has
+    no system message. Mutating the prepared list must NOT touch the originals."""
+    completions = Completions(mock_memory_client)
+
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "original"},
+    ]
+
+    # Temporarily remove the system message to exercise the prepend-system path.
+    user_only = [{"role": "user", "content": "original"}]
+    prepared = completions._prepare_messages(user_only)
+
+    # Mutate the prepared copy.
+    prepared[-1]["content"] = "MUTATED"
+
+    # The caller's dict must be untouched.
+    assert user_only[-1]["content"] == "original", (
+        "_prepare_messages() aliased the caller's dict (no-system-message path)"
+    )
+
+
+def test_prepare_messages_does_not_alias_dicts_with_system_message(mock_memory_client):
+    """_prepare_messages() must return isolated dict copies even when the caller
+    already provides a system message. This is the path that previously returned
+    the original list unchanged, leaving the dicts shared."""
+    completions = Completions(mock_memory_client)
+
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "original"},
+    ]
+
+    prepared = completions._prepare_messages(messages)
+
+    # Mutating the prepared copy must NOT bleed back to the caller's dicts.
+    prepared[-1]["content"] = "MUTATED"
+
+    assert messages[-1]["content"] == "original", (
+        "_prepare_messages() aliased the caller's dict (with-system-message path)"
+    )
+
+
+def test_create_does_not_mutate_caller_messages(mock_memory_client, mock_litellm):
+    """create() must not mutate the caller-owned messages list or any of its
+    nested dicts, even after memory-enrichment replaces the last user content."""
+    completions = Completions(mock_memory_client)
+
+    original_content = "original user question"
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": original_content},
+    ]
+
+    # Capture what _async_add_to_memory receives so we can verify it sees the
+    # original content and not the enriched prompt.
+    captured_add_messages = []
+
+    def fake_add(messages, **kwargs):
+        # Record a snapshot of the content at call time.
+        captured_add_messages.extend([dict(m) for m in messages])
+
+    mock_memory_client.add.side_effect = fake_add
+    mock_memory_client.search.return_value = [{"memory": "some fact"}]
+    mock_litellm.supports_function_calling.return_value = True
+    mock_litellm.completion.return_value = {"choices": [{"message": {"content": "reply"}}]}
+
+    completions.create(
+        model="gpt-4.1-nano-2025-04-14",
+        messages=messages,
+        user_id="test_user",
+    )
+
+    # 1. The caller's list structure must be intact.
+    assert len(messages) == 2
+
+    # 2. The caller's last user dict must NOT have been overwritten.
+    assert messages[-1]["content"] == original_content, (
+        "create() mutated the caller's last user message content"
+    )
+
+    # 3. The memory write must have received the original question, not the
+    #    enriched prompt that contains "Relevant Memories/Facts".
+    # (The background thread runs synchronously via mock side_effect here.)
+    for msg in captured_add_messages:
+        assert "Relevant Memories/Facts" not in msg.get("content", ""), (
+            "_async_add_to_memory received the enriched prompt instead of the original message"
+        )


### PR DESCRIPTION
## Linked Issue

Closes #7024 

## Description

`Completions._prepare_messages()` now creates shallow copies of message dictionaries (`[{**msg} for msg in messages]`). 

Previously, `_prepare_messages()` returned the caller's original list or a new list containing references to the original message dictionaries. Subsequent prompt enrichment in `create()` mutated `prepared_messages[-1]["content"]`, which modified the caller's input dictionary in place.

This change also resolves a race condition where `_async_add_to_memory()` received shared message dictionaries that were overwritten by `create()` before/during the background memory write, causing the enriched facts prompt to be persisted instead of the raw user message.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Ran `pytest tests/test_proxy.py -v` via Hatch (`dev_py_3_11`). All 10 tests passed cleanly, including 3 new regression tests verifying message dictionary isolation and async memory writing.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
