### PR TITLE
fix(memory): handle empty vector store response in delete_all

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1921,18 +1921,25 @@ class Memory(MemoryBase):
         seen_batches = set()
         while True:
             memories = self.vector_store.list(
-                filters=filters, top_k=DELETE_ALL_BATCH_SIZE
-            )[0]
-            if not memories:
+                filters=filters,
+                top_k=DELETE_ALL_BATCH_SIZE,
+            )
+            batch = memories[0] if memories else []
+
+            if not batch:
                 break
-            batch_ids = tuple(sorted(str(memory.id) for memory in memories))
+
+            batch_ids = tuple(sorted(str(memory.id) for memory in batch))
             if batch_ids in seen_batches:
                 logger.warning("Stopping delete_all after a repeated memory batch")
                 break
+
             seen_batches.add(batch_ids)
-            for memory in memories:
+
+            for memory in batch:
                 self._delete_memory(memory.id)
-            deleted_count += len(memories)
+
+            deleted_count += len(batch)
 
         logger.info(f"Deleted {deleted_count} memories")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -296,6 +296,14 @@ def test_delete_all(memory_instance):
     assert result["message"] == "Memories deleted successfully!"
 
 
+def test_delete_all_handles_empty_outer_list(memory_instance):
+    """delete_all should succeed when the vector store returns an empty list."""
+    memory_instance.vector_store.list = Mock(return_value=[])
+
+    result = memory_instance.delete_all(user_id="test_user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+
 def test_delete_all_paginates_beyond_vector_store_page_size(memory_instance):
     first_batch = [Mock(id=str(index)) for index in range(1000)]
     second_batch = [Mock(id="1000")]


### PR DESCRIPTION
## Summary

Fixes an `IndexError` in `Memory.delete_all()` when a vector store returns an empty outer list (`[]`).

The synchronous implementation previously indexed directly into the response with `[0]`, which caused `IndexError` for adapters returning an empty list when no memories matched. The response is now safely normalized before processing.

## Changes

- Handle an empty outer list returned by `vector_store.list()`
- Add a regression test for the `[]` response shape
- Preserve existing behavior for normal vector-store responses

## Testing

- `python -m pytest tests/test_main.py -k "empty_outer_list" -v`
- `python -m pytest tests/test_main.py -k "delete_all" -v`
- `python -m pytest tests/test_memory.py -k "delete_all" -v`
- `python -m pytest tests/memory/test_decay_usage_notice.py -k "delete_all" -v`
- `pre-commit` checks: Ruff and isort

Closes #7025