### PR TITLE
fix(core): Memory.delete_all() raises IndexError on empty vector_store.list() result

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1922,7 +1922,8 @@ class Memory(MemoryBase):
         while True:
             memories = self.vector_store.list(
                 filters=filters, top_k=DELETE_ALL_BATCH_SIZE
-            )[0]
+            )
+            memories = memories[0] if memories else []
             if not memories:
                 break
             batch_ids = tuple(sorted(str(memory.id) for memory in memories))

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1008,6 +1008,33 @@ async def test_async_delete_all_continues_on_partial_failure(mock_sqlite, mock_l
 @patch('mem0.utils.factory.EmbedderFactory.create')
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.main.SQLiteManager')
+def test_sync_delete_all_empty_vector_store_result(mock_sqlite, mock_llm_factory, mock_vector_factory, mock_embedder_factory):
+    """Regression test: sync delete_all must not raise IndexError when
+    vector_store.list() returns a flat empty list (e.g. LangChain adapter
+    on an empty/no-match collection), matching what AsyncMemory.delete_all
+    already handles via `batch = memories[0] if memories else []`.
+    """
+    mock_embedder_factory.return_value = MagicMock()
+    mock_vector_store = MagicMock()
+    mock_vector_store.list.return_value = []
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory
+    config = MemoryConfig()
+    memory = Memory(config)
+
+    result = memory.delete_all(user_id="test-user")
+
+    assert result == {"message": "Memories deleted successfully!"}
+    assert mock_vector_store.delete.call_count == 0
+
+
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
 @patch('mem0.memory.storage.SQLiteManager')
 class TestProcessMetadataFiltersMerge:
     """Regression tests for issue #3952: multiple operators on the same key must be merged."""


### PR DESCRIPTION
Fixes #7025

Note: I see @pragati243 has an existing PR (#7028) for this same issue.
I'd already independently reproduced and fixed this before seeing it,
and I'm opening mine for visibility — happy to defer entirely to #7028
if a maintainer prefers that implementation.

## Problem
Synchronous Memory.delete_all() unconditionally indexes
self.vector_store.list(...)[0], which raises IndexError when a vector
store adapter (e.g. LangChain) returns a flat [] for an empty result.

## Fix
Mirrors the guard already used in AsyncMemory.delete_all():
batch = memories[0] if memories else [] — check emptiness before
indexing.

## Testing
Added test_sync_delete_all_empty_vector_store_result, a regression
test reproducing the exact empty-list scenario. Verified it fails on
the original code (IndexError) and passes with the fix. Full
tests/test_memory.py suite passes except one pre-existing, unrelated
failure (missing optional langchain-core dependency locally).

## AI Disclosure
Used Claude to help plan this fix and write the test. Verified
myself: reproduced the original IndexError independently, confirmed
the test fails on buggy code and passes on fixed code, ran the full
test suite locally.