### PR TITLE
fix(memory): handle empty outer list response in sync delete_all

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1920,9 +1920,10 @@ class Memory(MemoryBase):
         deleted_count = 0
         seen_batches = set()
         while True:
-            memories = self.vector_store.list(
+            memories_list = self.vector_store.list(
                 filters=filters, top_k=DELETE_ALL_BATCH_SIZE
-            )[0]
+            )
+            memories = memories_list[0] if memories_list else []
             if not memories:
                 break
             batch_ids = tuple(sorted(str(memory.id) for memory in memories))

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1574,3 +1574,18 @@ async def test_async_procedural_memory_default_path_without_langchain(mock_llm_f
 
     assert result["results"][0]["event"] == "ADD"
     memory.llm.generate_response.assert_called_once()
+
+
+def test_sync_delete_all_empty_outer_list():
+    import mem0.memory.main as mm
+
+    with patch("mem0.memory.main.capture_event"):
+        memory = mm.Memory.__new__(mm.Memory)
+        memory.vector_store = MagicMock()
+        memory.vector_store.list.return_value = []
+        memory.db = MagicMock()
+        memory.graph = MagicMock()
+
+        result = memory.delete_all(user_id="u1")
+        assert result == {"message": "Memories deleted successfully!"}
+        memory.vector_store.list.assert_called_once()


### PR DESCRIPTION
### Description

Closes #7025

### Summary
Synchronous `Memory.delete_all()` raised `IndexError: list index out of range` when the underlying vector store returned an empty list `[]` (e.g. LangChain vector store adapter when no records match). The async implementation already handled empty lists safely.

### Changes
- Updated sync `Memory.delete_all()` in `mem0/memory/main.py` to safely extract the first batch (`memories = memories_list[0] if memories_list else []`).
- Added unit test `test_sync_delete_all_empty_outer_list` in `tests/test_memory.py`.
