### PR TITLE
fix(proxy): prevent input messages mutation and memory injection race (#7024)

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -147,9 +147,10 @@ class Completions:
         return response
 
     def _prepare_messages(self, messages: List[dict]) -> List[dict]:
-        if not messages or messages[0]["role"] != "system":
-            return [{"role": "system", "content": MEMORY_ANSWER_PROMPT}] + messages
-        return messages
+        prepared = [dict(m) for m in messages]
+        if not prepared or prepared[0]["role"] != "system":
+            return [{"role": "system", "content": MEMORY_ANSWER_PROMPT}] + prepared
+        return prepared
 
     def _async_add_to_memory(self, messages, user_id, agent_id, run_id, metadata, filters):
         def add_task():
@@ -188,4 +189,13 @@ class Completions:
                 entities = [entity for entity in relevant_memories["relations"]]
         elif isinstance(self.mem0_client, mem0.client.main.MemoryClient):
             memories_text = "\n".join(memory["memory"] for memory in relevant_memories)
+        else:
+            if isinstance(relevant_memories, dict) and "results" in relevant_memories:
+                memories_text = "\n".join(memory.get("memory", str(memory)) for memory in relevant_memories["results"])
+                if relevant_memories.get("relations"):
+                    entities = [entity for entity in relevant_memories["relations"]]
+            elif isinstance(relevant_memories, list):
+                memories_text = "\n".join(memory.get("memory", str(memory)) if isinstance(memory, dict) else str(memory) for memory in relevant_memories)
+            else:
+                memories_text = str(relevant_memories)
         return f"- Relevant Memories/Facts: {memories_text}\n\n- Entities: {entities}\n\n- User Question: {messages[-1]['content']}"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -138,3 +138,35 @@ def test_completions_create_messages_default_does_not_leak_between_calls(mock_me
         f"Completions.create(messages=...) must default to None to avoid the "
         f"B006 shared-default-list bug; got {messages_default!r}."
     )
+
+
+def test_prepare_messages_does_not_alias_input_dictionaries(mock_memory_client):
+    """Test that _prepare_messages clones dictionaries to prevent callers or downstreams mutating original objects."""
+    completions = Completions(mock_memory_client)
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "original question"},
+    ]
+
+    prepared = completions._prepare_messages(messages)
+    prepared[-1]["content"] = "injected content"
+
+    assert messages[-1]["content"] == "original question", "Original input messages must not be mutated"
+
+
+def test_completions_create_does_not_mutate_caller_messages(mock_memory_client, mock_litellm):
+    """Test that Completions.create does not mutate caller's messages when injecting retrieved memories."""
+    completions = Completions(mock_memory_client)
+    mock_litellm.supports_function_calling.return_value = True
+    mock_litellm.completion.return_value = {"choices": [{"message": {"content": "ok"}}]}
+    mock_memory_client.search.return_value = [{"memory": "User likes Python"}]
+
+    messages = [{"role": "user", "content": "What is my favorite language?"}]
+    completions.create(
+        model="gpt-4.1-nano-2025-04-14",
+        messages=messages,
+        user_id="test_user",
+    )
+
+    assert messages[0]["content"] == "What is my favorite language?", "Completions.create must not mutate input messages in-place"
+


### PR DESCRIPTION
## Description
Fixes #7024

`Completions._prepare_messages()` previously returned the original message dictionary references when preparing requests for LiteLLM. When the proxy formatted retrieved memories into `prepared_messages[-1]["content"]`, it mutated the caller-owned input dictionaries in-place.

Because `_async_add_to_memory()` runs on a daemon background thread sharing the same message objects, this in-place mutation could race with the background memory write, causing prompt-injected memories (`- Relevant Memories/Facts:...`) to be persisted into the vector store as user conversation content.

### Changes:
1. Cloned message dictionaries (`[dict(m) for m in messages]`) in `Completions._prepare_messages()` so caller-owned input is never mutated.
2. Added safe memory text formatting fallback in `_format_query_with_memories()` when custom/mock client instances are used.
3. Added unit tests in `tests/test_proxy.py` to verify caller messages and input dictionaries remain unmutated.

## Testing
- Ran unit tests in `tests/test_proxy.py` (9/9 passed).
