### PR TITLE
fix: preserve LF endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
## Linked Issue

Closes #7038

## Description

Preserve LF line endings for shell scripts when the repository is checked out on Windows with `core.autocrlf=true`.

Without this attribute, Docker containers can fail with a misleading error such as:

`exec /home/nextjs/entrypoint.sh: no such file or directory`

The script exists, but CRLF changes its shebang so Linux attempts to resolve an interpreter path containing `\r`.

This adds a root `.gitattributes` rule:

```gitattributes
*.sh text eol=lf
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

Closes #7038

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Tested on Windows with Git `core.autocrlf=true`:

1. Verified `server/init-db.sh` and `server/dashboard/entrypoint.sh` check out with LF via `git ls-files --eol`.
2. Ran `docker compose up -d --build` from `server/`.
3. Confirmed PostgreSQL initialized and remained healthy.
4. Confirmed the Mem0 API started on port 8888.
5. Confirmed the dashboard health endpoint returned HTTP 200 on port 3000.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed