### PR TITLE
fix(llms): skip thought and reasoning blocks when parsing Gemini and Bedrock responses

### DIFF
--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -394,9 +394,19 @@ class AWSBedrockLLM(LLMBase):
             response_body = response.get("body").read().decode()
             response_json = json.loads(response_body)
 
-            # Provider-specific response parsing
             if self.provider == "anthropic":
-                return response_json.get("content", [{"text": ""}])[0].get("text", "")
+                content_blocks = response_json.get("content", [])
+                if isinstance(content_blocks, list):
+                    for block in content_blocks:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            return block.get("text", "")
+                        elif isinstance(block, dict) and "text" in block:
+                            return block.get("text", "")
+                    return ""
+                elif isinstance(content_blocks, str):
+                    return content_blocks
+                return str(content_blocks)
+
             elif self.provider == "amazon":
                 # Handle both Nova and legacy Amazon models
                 if "nova" in self.config.model.lower():
@@ -580,12 +590,23 @@ class AWSBedrockLLM(LLMBase):
             response = self.client.converse(**converse_params)
 
             # Parse Converse API response
-            if hasattr(response, 'output') and hasattr(response.output, 'message'):
-                return response.output.message.content[0].text
-            elif 'output' in response and 'message' in response['output']:
-                return response['output']['message']['content'][0]['text']
+            if hasattr(response, "output") and hasattr(response.output, "message"):
+                for block in response.output.message.content:
+                    if hasattr(block, "text") and block.text:
+                        return block.text
+                    elif isinstance(block, dict) and "text" in block:
+                        return block["text"]
+                return ""
+            elif "output" in response and "message" in response["output"]:
+                for block in response["output"]["message"]["content"]:
+                    if isinstance(block, dict) and "text" in block:
+                        return block["text"]
+                    elif hasattr(block, "text") and block.text:
+                        return block.text
+                return ""
             else:
                 return str(response)
+
 
         elif self.provider == "minimax":
             # MiniMax models (e.g. minimax.minimax-m2.5) use the Bedrock Converse API.

--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -64,11 +64,18 @@ class GeminiLLM(LLMBase):
             }
 
             if parts:
-                # Extract content from the first candidate
+                # Extract content from candidate (prefer non-thought text parts)
                 for part in parts:
-                    if hasattr(part, "text") and part.text:
+                    if hasattr(part, "text") and part.text and not getattr(part, "thought", False):
                         processed_response["content"] = part.text
                         break
+
+                # Fallback to any text part if only thought parts were present
+                if processed_response["content"] is None:
+                    for part in parts:
+                        if hasattr(part, "text") and part.text:
+                            processed_response["content"] = part.text
+                            break
 
                 # Extract function calls
                 for part in parts:
@@ -84,10 +91,16 @@ class GeminiLLM(LLMBase):
             return processed_response
         else:
             if parts:
+                # Prefer non-thought text parts (answer output) over internal reasoning parts
+                for part in parts:
+                    if hasattr(part, "text") and part.text and not getattr(part, "thought", False):
+                        return part.text
+                # Fallback to any text part if only thought parts were present
                 for part in parts:
                     if hasattr(part, "text") and part.text:
                         return part.text
             return ""
+
 
     def _reformat_messages(self, messages: List[Dict[str, str]]):
         """

--- a/tests/llms/test_aws_bedrock.py
+++ b/tests/llms/test_aws_bedrock.py
@@ -506,3 +506,48 @@ class TestParseResponseLegacy:
         response = {"body": body}
         result = llm._parse_response(response, tools=None)
         assert result == "hello from ai21"
+
+    def test_anthropic_invoke_model_with_reasoning_blocks(self, mock_boto3):
+        """When Anthropic invoke_model response contains thinking/reasoning blocks before text block."""
+        llm = _make_llm("anthropic.claude-3-7-sonnet-20250219-v1:0", mock_boto3)
+        import io
+        import json
+        body = io.BytesIO(json.dumps({
+            "content": [
+                {"type": "thinking", "thinking": "Internal thinking process..."},
+                {"type": "text", "text": "Extracted memory payload."}
+            ]
+        }).encode())
+        response = {"body": body}
+        result = llm._parse_response(response, tools=None)
+        assert result == "Extracted memory payload."
+
+
+class TestAnthropicConverseReasoning:
+    def test_anthropic_converse_with_reasoning_content_block(self, mock_boto3):
+        """Converse API returns reasoningContent as block 0 on thinking models (e.g. Claude 3.7 Sonnet)."""
+        mock_response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "reasoningContent": {
+                                "reasoningText": {"text": "Step-by-step thinking process..."}
+                            }
+                        },
+                        {
+                            "text": '{"memory": [{"text": "User likes Python", "event": "ADD"}]}'
+                        }
+                    ]
+                }
+            }
+        }
+        mock_boto3.converse.return_value = mock_response
+        llm = _make_llm("anthropic.claude-3-7-sonnet-20250219-v1:0", mock_boto3)
+
+        messages = [{"role": "user", "content": "Extract memories"}]
+        response = llm.generate_response(messages)
+
+        assert response == '{"memory": [{"text": "User likes Python", "event": "ADD"}]}'
+

--- a/tests/llms/test_gemini.py
+++ b/tests/llms/test_gemini.py
@@ -298,3 +298,62 @@ def test_init_base_config_respects_vertexai_env(monkeypatch):
     with patch("mem0.llms.gemini.genai.Client") as mock_client_class:
         GeminiLLM(BaseLlmConfig(model="gemini-2.0-flash", api_key="ignored-key"))
     mock_client_class.assert_called_once_with(vertexai=True, project="env-project", location="us-west1")
+
+
+def test_parse_response_skips_thought_parts_without_tools(mock_gemini_client: Mock):
+    """Reasoning/thinking models (e.g. Gemini 2.0 Flash Thinking) return scratchpad thoughts as thought=True parts.
+    _parse_response must skip thought parts and return the actual answer text."""
+    config = BaseLlmConfig(model="gemini-2.0-flash-thinking-exp")
+    llm = GeminiLLM(config)
+
+    mock_thought_part = Mock()
+    mock_thought_part.text = "Thinking process: user mentions they work at Acme Corp."
+    mock_thought_part.thought = True
+
+    mock_answer_part = Mock()
+    mock_answer_part.text = '{"memory": [{"text": "Works at Acme Corp", "event": "ADD"}]}'
+    mock_answer_part.thought = False
+
+    mock_content = Mock(parts=[mock_thought_part, mock_answer_part])
+    mock_candidate = Mock(content=mock_content)
+    mock_response = Mock(candidates=[mock_candidate])
+
+    result = llm._parse_response(mock_response, tools=None)
+    assert result == '{"memory": [{"text": "Works at Acme Corp", "event": "ADD"}]}'
+    assert "Thinking process" not in result
+
+
+def test_parse_response_skips_thought_parts_with_tools(mock_gemini_client: Mock):
+    """Reasoning models with tools return thought parts alongside function calls. Content should be answer text."""
+    config = BaseLlmConfig(model="gemini-2.0-flash-thinking-exp")
+    llm = GeminiLLM(config)
+
+    mock_thought_part = Mock()
+    mock_thought_part.text = "Thinking process: deciding which tool to call..."
+    mock_thought_part.thought = True
+    mock_thought_part.function_call = None
+
+    mock_answer_part = Mock()
+    mock_answer_part.text = "Adding memory for you."
+    mock_answer_part.thought = False
+    mock_answer_part.function_call = None
+
+    mock_tool_call = Mock()
+    mock_tool_call.name = "add_memory"
+    mock_tool_call.args = {"data": "Works at Acme Corp"}
+
+    mock_func_part = Mock()
+    mock_func_part.text = None
+    mock_func_part.function_call = mock_tool_call
+    mock_func_part.thought = False
+
+    mock_content = Mock(parts=[mock_thought_part, mock_answer_part, mock_func_part])
+    mock_candidate = Mock(content=mock_content)
+    mock_response = Mock(candidates=[mock_candidate])
+
+    result = llm._parse_response(mock_response, tools=[{"function": {"name": "add_memory"}}])
+    assert result["content"] == "Adding memory for you."
+    assert "Thinking process" not in result["content"]
+    assert len(result["tool_calls"]) == 1
+    assert result["tool_calls"][0]["name"] == "add_memory"
+


### PR DESCRIPTION
Closes #7040

## Summary
When using reasoning/thinking models (such as `gemini-2.0-flash-thinking-exp`, Gemini 2.5, or Claude 3.7 Sonnet thinking mode on AWS Bedrock), responses return internal scratchpad thoughts as separate parts/blocks before the actual output text.

Previously:
1. **Gemini** (`mem0/llms/gemini.py`): `_parse_response` picked the first text part (`parts[0].text`), which on thinking models is the internal thought process (`thought=True`). This returned scratchpad reasoning text instead of the structured JSON memory output, corrupting memory extraction or failing `json.loads`.
2. **AWS Bedrock** (`mem0/llms/aws_bedrock.py`): `_generate_standard` and `_parse_response` hardcoded `content[0]["text"]` for Anthropic models. When thinking mode is enabled, `content[0]` is a `reasoningContent` block, raising `KeyError: 'text'`.

## Changes
- **`mem0/llms/gemini.py`**: Updated `_parse_response` (both standard and tool-calling paths) to prioritize non-thought parts (`not getattr(part, "thought", False)`), falling back gracefully if only thought parts are present.
- **`mem0/llms/aws_bedrock.py`**: Updated Anthropic Converse and InvokeModel response parsers to iterate over `content` blocks to extract the `"text"` block when reasoning blocks are present (aligning with MiniMax handling).
- **Unit Tests**: Added test cases in `tests/llms/test_gemini.py` and `tests/llms/test_aws_bedrock.py` verifying response extraction with and without tools when thinking/reasoning blocks precede answer text.

## Verification
- `pytest tests/llms/test_gemini.py tests/llms/test_aws_bedrock.py` (73 passed in 2.85s)
- `pytest tests/llms/test_openai.py tests/llms/test_ollama.py tests/llms/test_groq.py` (107 passed)