### PR TITLE
docs(embedders): document api_key on the Hugging Face Python config table

### DIFF
--- a/docs/components/embedders/models/huggingface.mdx
+++ b/docs/components/embedders/models/huggingface.mdx
@@ -99,6 +99,7 @@ Here are the parameters available for configuring the Hugging Face embedder:
 | `embedding_dims` | Dimensions of the embedding model | `selected_model_dimensions` |
 | `model_kwargs` | Additional arguments for the model | `None` |
 | `huggingface_base_url` | URL to connect to Text Embeddings Inference (TEI) API | `None` |
+| `api_key` | API key for the endpoint; falls back to the `HUGGINGFACE_API_KEY` env var. Only used on the `huggingface_base_url` path | `"hf"` |
 </Tab>
 <Tab title="TypeScript">
 | Parameter | Description | Default Value |


### PR DESCRIPTION
## Linked Issue

Documentation-only change, so no accepted issue is linked. Follow-up to #6917, which I closed as superseded by #6947.

## Description

The Hugging Face embedder config table documents `apiKey` on the TypeScript tab but has no `api_key` row on the Python tab, even though the Python embedder resolves it the same way after #6947:

```python
api_key = self.config.api_key or os.getenv("HUGGINGFACE_API_KEY") or "hf"
```

This adds the missing row so the two tabs match the behaviour that now exists in both.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

One table row in an `.mdx` file. The behaviour it documents is already covered by the tests #6947 added in `tests/embeddings/test_huggingface_embeddings.py`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
