### PR TITLE
fix(memory): serialize AsyncMemory store writes on embedded backends

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import contextlib
 import gc
 import hashlib
 import json
@@ -2188,6 +2189,18 @@ class AsyncMemory(MemoryBase):
         self.custom_instructions = self.config.custom_instructions
         self._entity_store = None
 
+        # Embedded vector stores (Qdrant with `path=...`) keep their data in a
+        # process-local database that is not safe to write from several threads
+        # at once. Every store write here goes through asyncio.to_thread, so
+        # concurrent callers produce genuinely parallel writes and a share of
+        # them fail. Serialize writes for those backends only; server-backed
+        # stores handle their own concurrency and keep writing in parallel.
+        #
+        # This lock coordinates coroutines within a single process. Deployments
+        # running multiple workers or containers against one embedded database
+        # need server-mode Qdrant instead.
+        self._write_lock = asyncio.Lock() if getattr(self.vector_store, "is_local", False) else None
+
         # Initialize reranker if configured
         self.reranker = None
         if config.reranker:
@@ -2215,6 +2228,17 @@ class AsyncMemory(MemoryBase):
             )
 
         capture_event("mem0.init", self, {"sync_type": "async"})
+
+    async def _store_write(self, fn, *args, **kwargs):
+        """Run a blocking vector/entity store write in a worker thread.
+
+        Identical to `asyncio.to_thread(fn, ...)` except that the call is
+        serialized against other store writes when the backend cannot take
+        concurrent ones. Reads, embeddings and LLM calls stay parallel.
+        """
+        guard = self._write_lock if self._write_lock is not None else contextlib.nullcontext()
+        async with guard:
+            return await asyncio.to_thread(fn, *args, **kwargs)
 
     @property
     def project(self):
@@ -2293,7 +2317,7 @@ class AsyncMemory(MemoryBase):
                 if memory_id not in linked_ids:
                     linked_ids.append(memory_id)
                     payload["linked_memory_ids"] = linked_ids
-                    await asyncio.to_thread(
+                    await self._store_write(
                         self.entity_store.update,
                         vector_id=match.id,
                         vector=None,
@@ -2307,7 +2331,7 @@ class AsyncMemory(MemoryBase):
                     "linked_memory_ids": [memory_id],
                     **{k: v for k, v in search_filters.items()},
                 }
-                await asyncio.to_thread(
+                await self._store_write(
                     self.entity_store.insert,
                     vectors=[entity_embedding],
                     ids=[entity_id],
@@ -2331,7 +2355,7 @@ class AsyncMemory(MemoryBase):
             rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
             for row in rows or []:
                 try:
-                    await asyncio.to_thread(self.entity_store.delete, vector_id=row.id)
+                    await self._store_write(self.entity_store.delete, vector_id=row.id)
                 except Exception as e:
                     logger.debug(f"Bulk entity delete failed for id={row.id}: {e}")
         except Exception as e:
@@ -2354,7 +2378,7 @@ class AsyncMemory(MemoryBase):
                     remaining = [mid for mid in linked if mid != memory_id]
                     if not remaining:
                         try:
-                            await asyncio.to_thread(self.entity_store.delete, vector_id=row.id)
+                            await self._store_write(self.entity_store.delete, vector_id=row.id)
                         except Exception as e:
                             logger.debug(f"Entity delete failed for id={row.id} (async): {e}")
                     else:
@@ -2369,7 +2393,7 @@ class AsyncMemory(MemoryBase):
                             continue
                         new_payload = {**payload, "linked_memory_ids": remaining}
                         try:
-                            await asyncio.to_thread(
+                            await self._store_write(
                                 self.entity_store.update,
                                 vector_id=row.id,
                                 vector=vec,
@@ -2706,7 +2730,7 @@ class AsyncMemory(MemoryBase):
         all_payloads = [r[3] for r in records]
 
         try:
-            await asyncio.to_thread(
+            await self._store_write(
                 self.vector_store.insert,
                 vectors=all_vectors,
                 ids=all_ids,
@@ -2715,7 +2739,7 @@ class AsyncMemory(MemoryBase):
         except Exception:
             for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
                 try:
-                    await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
+                    await self._store_write(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid} (async): {e}")
 
@@ -2815,7 +2839,7 @@ class AsyncMemory(MemoryBase):
                             linked |= memory_ids
                             payload["linked_memory_ids"] = sorted(linked)
                             try:
-                                await asyncio.to_thread(
+                                await self._store_write(
                                     self.entity_store.update,
                                     vector_id=match.id,
                                     vector=None,
@@ -2836,7 +2860,7 @@ class AsyncMemory(MemoryBase):
                     # 7e: Batch insert new entities
                     if to_insert_vectors:
                         try:
-                            await asyncio.to_thread(
+                            await self._store_write(
                                 self.entity_store.insert,
                                 vectors=to_insert_vectors,
                                 ids=to_insert_ids,
@@ -3647,7 +3671,7 @@ class AsyncMemory(MemoryBase):
         new_metadata["updated_at"] = new_metadata["created_at"]
         new_metadata["text_lemmatized"] = lemmatize_for_bm25(data)
 
-        await asyncio.to_thread(
+        await self._store_write(
             self.vector_store.insert,
             vectors=[embeddings],
             ids=[memory_id],
@@ -3765,7 +3789,7 @@ class AsyncMemory(MemoryBase):
         else:
             embeddings = await asyncio.to_thread(self.embedding_model.embed, data, "update")
 
-        await asyncio.to_thread(
+        await self._store_write(
             self.vector_store.update,
             vector_id=memory_id,
             vector=embeddings,
@@ -3806,7 +3830,7 @@ class AsyncMemory(MemoryBase):
         payload = existing_memory.payload or {}
         session_filters = {k: payload[k] for k in ("user_id", "agent_id", "run_id") if payload.get(k)}
 
-        await asyncio.to_thread(self.vector_store.delete, vector_id=memory_id)
+        await self._store_write(self.vector_store.delete, vector_id=memory_id)
         await asyncio.to_thread(
             self.db.add_history,
             memory_id,

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import time
 from datetime import datetime, timezone
@@ -1178,3 +1179,105 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+class TestAsyncEmbeddedWriteSerialization:
+    """Concurrent AsyncMemory writes against an embedded vector store (#4892).
+
+    AsyncMemory dispatches every store write through `asyncio.to_thread`, so
+    concurrent callers write to the embedded database in genuine parallel.
+    Embedded Qdrant keeps its data in a process-local database that does not
+    tolerate that, and a share of the writes fail.
+    """
+
+    @staticmethod
+    def _async_memory_on_embedded_qdrant(mocker, path):
+        mock_embedder = mocker.MagicMock()
+        mock_embedder.return_value.embed.return_value = [0.1] * 8
+        mocker.patch("mem0.utils.factory.EmbedderFactory.create", mock_embedder)
+        mocker.patch("mem0.utils.factory.LlmFactory.create", mocker.MagicMock())
+        mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+
+        from mem0.configs.base import MemoryConfig
+
+        config = MemoryConfig()
+        config.vector_store.provider = "qdrant"
+        config.vector_store.config.collection_name = "concurrency_test"
+        config.vector_store.config.embedding_model_dims = 8
+        config.vector_store.config.path = str(path)
+        config.vector_store.config.on_disk = False
+        return AsyncMemory(config)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_creates_against_embedded_qdrant_all_persist(self, mocker, tmp_path):
+        """Real embedded Qdrant, no mocked store: every concurrent write must land."""
+        memory = self._async_memory_on_embedded_qdrant(mocker, tmp_path / "qdrant")
+        assert memory._write_lock is not None, "embedded backend should serialize writes"
+
+        writers = 50
+        results = await asyncio.gather(
+            *[
+                memory._create_memory(f"memory {i}", {f"memory {i}": [0.1] * 8}, {"user_id": "u1"})
+                for i in range(writers)
+            ],
+            return_exceptions=True,
+        )
+
+        failures = [r for r in results if isinstance(r, BaseException)]
+        assert not failures, f"{len(failures)}/{writers} concurrent writes failed: {failures[:3]}"
+
+        stored = memory.vector_store.list(filters={"user_id": "u1"}, top_k=writers * 2)[0]
+        assert len(stored) == writers, f"expected {writers} memories persisted, found {len(stored)}"
+
+    @pytest.mark.asyncio
+    async def test_write_lock_serializes_insert_update_and_delete(self, mocker, tmp_path):
+        """The three write verbs must never overlap while the lock is engaged."""
+        memory = self._async_memory_on_embedded_qdrant(mocker, tmp_path / "qdrant")
+
+        in_flight = 0
+        max_in_flight = 0
+
+        def tracked(*args, **kwargs):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            time.sleep(0.01)
+            in_flight -= 1
+
+        store = mocker.MagicMock()
+        store.insert.side_effect = tracked
+        store.update.side_effect = tracked
+        store.delete.side_effect = tracked
+        store.get.return_value = SimpleNamespace(
+            id="m-1", payload={"data": "old", "user_id": "u1", "created_at": "2026-04-19T00:00:00+00:00"}
+        )
+        memory.vector_store = store
+        memory.db = MagicMock()
+
+        await asyncio.gather(
+            *[memory._create_memory(f"m{i}", {f"m{i}": [0.1] * 8}, {"user_id": "u1"}) for i in range(6)],
+            *[memory._update_memory(f"m{i}", "new", {"new": [0.1] * 8}, {"user_id": "u1"}) for i in range(6)],
+            *[memory._delete_memory(f"m{i}", skip_entity_cleanup=True) for i in range(6)],
+        )
+
+        assert max_in_flight == 1, f"writes overlapped: {max_in_flight} concurrent store calls"
+
+    @pytest.mark.parametrize(
+        "store, expect_lock",
+        [
+            (SimpleNamespace(is_local=True), True),
+            (SimpleNamespace(is_local=False), False),
+            (SimpleNamespace(), False),
+        ],
+        ids=["embedded", "server-mode", "backend-without-the-attribute"],
+    )
+    def test_lock_is_created_only_for_embedded_backends(self, mocker, store, expect_lock):
+        """Scoping check: server-backed stores keep writing in parallel."""
+        mocker.patch("mem0.utils.factory.EmbedderFactory.create", mocker.MagicMock())
+        mocker.patch("mem0.utils.factory.VectorStoreFactory.create", return_value=store)
+        mocker.patch("mem0.utils.factory.LlmFactory.create", mocker.MagicMock())
+        mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+
+        memory = AsyncMemory()
+
+        assert (memory._write_lock is not None) is expect_lock


### PR DESCRIPTION
## Linked Issue

Closes #4892

## Description

`AsyncMemory` dispatches every vector-store and entity-store write through `asyncio.to_thread`, which puts them on the thread pool with nothing serializing them. Embedded Qdrant (`path=...`) keeps its data in a process-local database that cannot take concurrent writes, so a share of them fail outright.

This adds a per-instance `asyncio.Lock`, created only when the backend reports `is_local`, and routes the twelve async store writes through a `_store_write` helper that holds it. Reads, embeddings and LLM calls stay parallel.

This builds directly on #4893 by @MattGyver, which diagnosed the root cause and established the lock design. That PR was closed in the August backlog sweep rather than on merit, and the five review points left on it are addressed below.

## On the reported symptom

The issue reports `IndexError: index N is out of bounds for axis 0 with size M` from HNSW graph corruption. I could not reproduce that specific error on `qdrant-client` 1.19.0, and I would rather say so than imply I had.

What concurrent writes actually produce on 1.19.0 is a set of storage-layer errors:

```
SystemError: error return without exception set
InterfaceError: bad parameter or other API misuse
OperationalError: cannot commit - no transaction is active
DatabaseError
```

Same trigger, same fix, and arguably worse than the reported symptom: these are lost writes, not a degraded index. The reported `IndexError` is plausibly the same race surfacing through an older client version. Anyone who can still reproduce the `IndexError` shape on a specific `qdrant-client` version, please say so on the issue and I will fold it into the test.

## Verification

Real embedded Qdrant, no mocked store, driven through `AsyncMemory._create_memory` with 50 concurrent writers.

Against `main`, ten consecutive runs:

```
run  1: 6/50 concurrent writes failed
run  2: 4/50 concurrent writes failed
run  3: 6/50 concurrent writes failed
run  4: 6/50 concurrent writes failed
run  5: 11/50 concurrent writes failed
run  6: 3/50 concurrent writes failed
run  7: 6/50 concurrent writes failed
run  8: 6/50 concurrent writes failed
run  9: 3/50 concurrent writes failed
run 10: 3/50 concurrent writes failed
```

With this branch, ten consecutive runs of the same suite:

```
run  1: 5 passed    run  6: 5 passed
run  2: 5 passed    run  7: 5 passed
run  3: 5 passed    run  8: 5 passed
run  4: 5 passed    run  9: 5 passed
run  5: 5 passed    run 10: 5 passed
```

Ten runs each way because a single green run on a race proves nothing.

Full suite before and after, same ignore list on both sides (the ignores are provider SDKs not installed locally, none reachable from this diff): identical failure sets, no regressions. 965 passed.

## The five review points from #4893

**1. Lock layer and scope.** The lock is now created only when `getattr(self.vector_store, "is_local", False)` is true, so pgvector, Pinecone, Chroma and Milvus keep writing in parallel and pay nothing. Qdrant already exposes `is_local`, so this needs no change to `vector_stores/base.py` and no new capability plumbing. A backend that wants serialization opts in by exposing the same attribute. Covered by a parametrized test over embedded, server-mode, and a backend without the attribute at all.

**2. `delete_all` serialization cliff.** Addressed by locking at the leaf rather than around aggregates. `delete_all` still gathers its `_delete_memory` coroutines, and their reads, history writes and entity extraction still overlap; only the individual store writes serialize, which is the minimum the fix requires. Acquiring the lock once around the whole gather would serialize the reads too, and holding it across `_delete_memory` would deadlock against the entity-cleanup writes inside it, since `asyncio.Lock` is not reentrant. I think leaf-level locking is the better answer here, but happy to be told otherwise.

**3. Entity-store path.** Covered. All seven async entity-store writes go through the same helper. They target a second collection on the same client, so they share the lock rather than needing their own. Worth noting that the entity store reports `is_local = False` even in embedded mode, because `Qdrant.__init__` hardcodes that in its `if client:` branch. Deciding the lock from the main store is what keeps those writes protected.

**4. Multi-process scope.** Stated in the comment at the lock, pointing at server-mode Qdrant for multi-worker and multi-container deployments.

**5. The test proves the lock, not the fix.** There are now both kinds. `test_concurrent_creates_against_embedded_qdrant_all_persist` runs against a real embedded Qdrant and reproduces the actual failure, which is the transcript above. `test_write_lock_serializes_insert_update_and_delete` covers the insert, update and delete sites together and asserts no two overlap. `qdrant-client` is a base dependency, so the real one runs in CI rather than being skipped.

## Not covered

`reset()` calls `delete_col` outside the lock. It is a teardown path rather than part of the concurrent-write scenario, and folding it in would widen this diff past its point. Happy to take it in a follow-up if you want it closed too.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Claude Code wrote the diff and the tests. I did not accept it on trust. I had the diff explained line by line before approving it, including why the lock is decided from the main vector store rather than the entity store's own `is_local`, and why it is taken around `vector_store.delete` rather than around `_delete_memory`, since `asyncio.Lock` is not reentrant. The issue's root cause was not taken on faith either: the concurrency workload was run against a real embedded Qdrant before any code was written, which is how the `IndexError` discrepancy above surfaced. The reproduction was run ten times against `main` and ten times against the branch rather than trusting one pass, and the full-suite failure sets were diffed on both sides rather than reading a summary line.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Five tests in `TestAsyncEmbeddedWriteSerialization`: the real-Qdrant concurrency reproduction, the insert/update/delete serialization assertion, and three parametrized scoping cases. Manual testing is the ten-run transcript above.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

