### PR TITLE
fix(docs): redirect the eight 404 paths and repair dead wildcard rules

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -952,24 +952,20 @@
       "destination": "/platform/features/memory-export"
     },
     {
-      "source": "/v0x/components/:a/:b/:c",
-      "destination": "/components/:a/:b/:c"
+      "source": "/v0x/components/:slug*",
+      "destination": "/components/:slug*"
     },
     {
-      "source": "/v0x/components/:a/:b",
-      "destination": "/components/:a/:b"
+      "source": "/v0x/core-concepts/:slug*",
+      "destination": "/core-concepts/:slug*"
     },
     {
-      "source": "/v0x/core-concepts/:a/:b",
-      "destination": "/core-concepts/:a/:b"
+      "source": "/v0x/integrations/:slug*",
+      "destination": "/integrations/:slug*"
     },
     {
-      "source": "/v0x/integrations/:slug",
-      "destination": "/integrations/:slug"
-    },
-    {
-      "source": "/v0x/open-source/:slug",
-      "destination": "/open-source/:slug"
+      "source": "/v0x/open-source/:slug*",
+      "destination": "/open-source/:slug*"
     },
     {
       "source": "/v0x/introduction",
@@ -1044,8 +1040,8 @@
       "destination": "/platform/features/graph-memory"
     },
     {
-      "source": "/features/:slug",
-      "destination": "/platform/features/:slug"
+      "source": "/features/:slug*",
+      "destination": "/platform/features/:slug*"
     },
     {
       "source": "/platform/features/online-memory",
@@ -1172,7 +1168,7 @@
       "destination": "/open-source/overview"
     },
     {
-      "source": "/self-hosting/:slug",
+      "source": "/self-hosting/:slug*",
       "destination": "/open-source/overview"
     },
     {
@@ -1180,7 +1176,7 @@
       "destination": "/open-source/overview"
     },
     {
-      "source": "/self-hosted/:slug",
+      "source": "/self-hosted/:slug*",
       "destination": "/open-source/overview"
     },
     {
@@ -1188,7 +1184,7 @@
       "destination": "/platform/quickstart"
     },
     {
-      "source": "/getting-started/:slug",
+      "source": "/getting-started/:slug*",
       "destination": "/platform/quickstart"
     },
     {
@@ -1196,7 +1192,7 @@
       "destination": "/open-source/setup"
     },
     {
-      "source": "/deployment/:slug",
+      "source": "/deployment/:slug*",
       "destination": "/open-source/setup"
     },
     {
@@ -1208,12 +1204,12 @@
       "destination": "/open-source/overview"
     },
     {
-      "source": "/oss/:slug",
+      "source": "/oss/:slug*",
       "destination": "/open-source/overview"
     },
     {
-      "source": "/concepts/:slug",
-      "destination": "/core-concepts/:slug"
+      "source": "/concepts/:slug*",
+      "destination": "/core-concepts/:slug*"
     },
     {
       "source": "/pricing",
@@ -1254,6 +1250,34 @@
     {
       "source": "/cookbooks/essentials/controlling-memory-ingestion",
       "destination": "/platform/features/custom-instructions"
+    },
+    {
+      "source": "/open-source/quickstart",
+      "destination": "/open-source/overview"
+    },
+    {
+      "source": "/open-source/graph-memory/overview",
+      "destination": "/open-source/overview"
+    },
+    {
+      "source": "/what-is-mem0",
+      "destination": "https://mem0.ai/"
+    },
+    {
+      "source": "/platform-vs-oss",
+      "destination": "/platform/platform-vs-oss"
+    },
+    {
+      "source": "/components/overview",
+      "destination": "/components/llms/overview"
+    },
+    {
+      "source": "/v0x/core-concepts/memory-operations/add",
+      "destination": "/core-concepts/memory-operations/add"
+    },
+    {
+      "source": "/v0x/integrations/llama-index",
+      "destination": "/integrations/llama-index"
     }
   ]
 }


### PR DESCRIPTION
## Linked Issue

N/A - documentation-only change, exempt from the accepted-issue gate ([`pr-gate.yml`](https://github.com/mem0ai/mem0/blob/main/.github/workflows/pr-gate.yml#L55-L60)).

## Description

Cloudflare logs flagged eight `docs.mem0.ai` paths returning 404 while still receiving referral and search traffic. I checked every one against the live site before touching anything:

| # | Path | Before | Rule in `docs.json`? |
|---|------|--------|----------------------|
| 1 | `/open-source/quickstart` | 404 | none |
| 2 | `/open-source/graph-memory/overview` | 404 | none |
| 3 | `/what-is-mem0` | 404 | none |
| 4 | `/platform-vs-oss` | 404 | none |
| 5 | `/components/overview` | 404 | none |
| 6 | `/v0x/core-concepts/memory-operations/add` | 404 | yes, but dead |
| 7 | `/v0x/integrations/llama-index` | 404 | yes, but dead |
| 8 | `/features/graph-memory` | 308 already | exact rule |

### Root cause for 6 and 7

Rows 6 and 7 were already covered by `/v0x/core-concepts/:a/:b` and `/v0x/integrations/:slug`, and both still 404'd. Every `:param` wildcard in `docs.json` was silently doing nothing, while every exact rule worked:

```
404  /oss/anything                    (rule: /oss/:slug)
404  /concepts/memory-types           (rule: /concepts/:slug)
404  /self-hosting/foo                (rule: /self-hosting/:slug)
404  /v0x/open-source/overview        (rule: /v0x/open-source/:slug)
308  /quickstart -> /platform/quickstart          (exact rule)
308  /v0x/examples/mem0-demo -> /cookbooks/...    (exact rule)
```

[Mintlify's redirect syntax](https://mintlify.com/docs/create/redirects) requires a trailing `*` on the capture (`/beta/:slug*` -> `/v2/:slug*`). The eleven rules written as `/:slug` or `/:a/:b` matched nothing, so `/oss/*`, `/concepts/*`, `/self-hosting/*`, `/self-hosted/*`, `/getting-started/*`, `/deployment/*`, `/features/*` and the whole `/v0x/*` group were dead.

### Changes

1. Exact redirects for the five uncovered paths (rows 1-5).
2. The eleven broken wildcards rewritten to `:slug*`, with the two `/v0x/components/...` rules collapsed into one.
3. Exact rules for rows 6 and 7 as well, so the two SEO-tracked URLs land on the proven-working exact-match path rather than depending on the wildcard fix alone.

No `permanent` field added anywhere: Mintlify already serves redirects as **308**, which passes SEO ranking exactly as a 301 does. The Notion doc asks for 301; 308 is the platform default and what the working redirects already emit.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Claude Code wrote the `docs.json` edit. I verified the live 404/308 status of every affected path with `curl` before and confirmed the resolution table below after, checked the wildcard syntax against Mintlify's redirect docs, and reviewed the full diff.

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Before** (live `curl -o /dev/null -w "%{http_code}"` against `docs.mem0.ai`): rows 1-7 all `404`, row 8 `308`.

**After** (resolving the eight sources through the new rule set, then confirming each destination exists):

```
OK  /open-source/quickstart                   -> /open-source/overview
OK  /open-source/graph-memory/overview        -> /open-source/overview
OK  /what-is-mem0                             -> https://mem0.ai/
OK  /platform-vs-oss                          -> /platform/platform-vs-oss
OK  /components/overview                      -> /components/llms/overview
OK  /v0x/core-concepts/memory-operations/add  -> /core-concepts/memory-operations/add
OK  /v0x/integrations/llama-index             -> /integrations/llama-index
OK  /features/graph-memory                    -> /platform/features/graph-memory
```

Also checked across all 167 rules: no duplicate sources, no redirect loops, and every relative destination resolves to an existing `.mdx` page. Each of the eight destination pages returns 200 live today.

**One thing to confirm after deploy:** `/what-is-mem0` points off-domain to `https://mem0.ai/`. Mintlify's redirect docs only document relative destinations, so if it does not take, that row needs a Cloudflare rule instead. Worst case it stays a 404, which is where it is today.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

https://claude.ai/code/session_018dFFSMLs5ci68X25Rux42c
