### PR TITLE
fix(docs): balance code fences in cookbook_template.mdx

### DIFF
--- a/docs/templates/cookbook_template.mdx
+++ b/docs/templates/cookbook_template.mdx
@@ -25,7 +25,7 @@ Cookbooks are narrative tutorials. They start with a real problem, show the brok
 ## ✅ COPY THIS: Content Skeleton
 Paste the block below into a new cookbook, then replace all placeholders. Remove any section you don't need **only after** the happy path works.
 
-```mdx
+````mdx
 ---
 title: [Cookbook title: action oriented]
 description: [1 sentence outcome]
@@ -175,7 +175,7 @@ Call out the most common mistake or edge case for this layer.
     href="#next-link"
   />
 </CardGroup>
-```
+````
 
 ---
 
@@ -189,7 +189,6 @@ Call out the most common mistake or edge case for this layer.
 - [ ] Linked related docs (cookbooks, guides, reference) in Next Steps.
 
 Stick to the skeleton above. If you need to deviate, document the rationale in the PR so we can update the template for everyone else.
-```
 
 ## Browse Other Templates
 


### PR DESCRIPTION
## Summary

The ` ```mdx ` fence at line 28 of `docs/templates/cookbook_template.mdx` opens a code block wrapping the whole "Content Skeleton" but is never closed — the inner ` ```python ` / ` ```typescript ` examples break it, leaving the template with an odd number of fences and rendering the Publish Checklist section inside a code block as a side effect.

## Why

`cookbook_template.mdx` is the only one of the 13 templates in `docs/templates/` with unbalanced fences. Contributors copying the skeleton get broken rendering and a confusing template to fill in.

## How verified

- Fence-balance scan over all `docs/templates/*.mdx`: 30 fences, all paired after the fix (a 4-backtick outer block wraps the skeleton so the inner 3-backtick examples no longer collide).
- Docs-only change; no code behavior affected.
