### PR TITLE
fix(claude-code-plugin): honor auto_save=false in auto-import

### DIFF
--- a/integrations/mem0-plugin/scripts/on_session_start.sh
+++ b/integrations/mem0-plugin/scripts/on_session_start.sh
@@ -180,8 +180,12 @@ if [ "$SOURCE" = "startup" ]; then
     echo "Native MEMORY.md detected at ${_MEMORY_MD}. Add autoMemoryEnabled:false to settings.json or run /mem0:import."
   fi
 
-  MEM0_CWD="$MEM0_CWD_RESOLVED" \
-    python3 "$SCRIPT_DIR/auto_import.py" 2>/dev/null &
+  # Honor auto_save=false in ~/.mem0/settings.json -- auto-import writes
+  # memories, so it belongs behind the same guard as every other writer.
+  if [ "${MEM0_AUTO_SAVE:-true}" != "false" ]; then
+    MEM0_CWD="$MEM0_CWD_RESOLVED" \
+      python3 "$SCRIPT_DIR/auto_import.py" 2>/dev/null &
+  fi
 
   # Configure the coding-category taxonomy in the background (idempotent, never blocks).
   # Prefer the venv python since this path needs the mem0ai SDK.

--- a/integrations/mem0-plugin/tests/test_auto_save_gate.py
+++ b/integrations/mem0-plugin/tests/test_auto_save_gate.py
@@ -1,0 +1,103 @@
+"""Tests that auto_save=false actually suppresses the session-start auto-import.
+
+auto_import.py writes memories, so it belongs behind the same MEM0_AUTO_SAVE
+guard as every other writer in the plugin. It was previously launched
+unconditionally, which made `auto_save: false` in ~/.mem0/settings.json a no-op
+for that path: every session start still imported CLAUDE.md and friends.
+
+These drive the real hook rather than importing Python, because the bug lives in
+the shell wiring and is invisible from the module level.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+
+import pytest
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+HOOK = os.path.join(SCRIPTS_DIR, "on_session_start.sh")
+
+
+def _python_stub(tmp_path, log_path):
+    """A python3 that records auto_import.py invocations, then delegates.
+
+    Delegation matters: _identity.sh shells out to python3 to parse
+    ~/.mem0/settings.json, so a stub that does not exec the real interpreter
+    would break the very setting under test.
+    """
+    stub_dir = tmp_path / "stub"
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    stub = stub_dir / "python3"
+    stub.write_text(
+        "#!/bin/sh\n"
+        'for a in "$@"; do\n'
+        "  case \"$a\" in\n"
+        f'    *auto_import.py) echo ran >> "{log_path}" ;;\n'
+        "  esac\n"
+        "done\n"
+        f'exec "{os.path.realpath(__import__("sys").executable)}" "$@"\n'
+    )
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return stub_dir
+
+
+def _run_hook(tmp_path, home, auto_save):
+    """Run the session-start hook with auto_save set, return True if it imported."""
+    mem0_dir = home / ".mem0"
+    mem0_dir.mkdir(parents=True, exist_ok=True)
+    # _identity.sh re-exports MEM0_AUTO_SAVE from this file, so the file is
+    # authoritative -- passing the env var alone would not exercise the path.
+    (mem0_dir / "settings.json").write_text('{"auto_save": %s}\n' % ("true" if auto_save else "false"))
+
+    log_path = tmp_path / f"import-{auto_save}.log"
+    stub_dir = _python_stub(tmp_path / f"case-{auto_save}", log_path)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_dir}{os.pathsep}{env['PATH']}"
+    env["HOME"] = str(home)
+    # A key must be present or the hook exits early with a setup message. It is
+    # never used: no CLAUDE.md exists in cwd, so auto_import returns immediately.
+    env["MEM0_API_KEY"] = "m0-test-key-not-real"
+    env.pop("MEM0_PROJECT_ID", None)
+
+    subprocess.run(
+        ["sh", HOOK],
+        input='{"session_id":"t","cwd":"%s","source":"startup"}' % tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    # The hook backgrounds auto_import, so give it a moment to land.
+    for _ in range(50):
+        if log_path.exists() and log_path.stat().st_size:
+            return True
+        subprocess.run(["sleep", "0.1"], check=False)
+    return False
+
+
+@pytest.mark.parametrize("auto_save,expected", [(True, True), (False, False)])
+def test_session_start_import_respects_auto_save(tmp_path, monkeypatch, auto_save, expected):
+    """auto-import runs iff auto_save is not false."""
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HOME", str(home))
+    assert _run_hook(tmp_path, home, auto_save) is expected
+
+
+def test_auto_import_is_guarded_in_the_hook_source():
+    """The launch is inside a MEM0_AUTO_SAVE guard, not merely near one.
+
+    on_session_start.sh already contains an unrelated MEM0_AUTO_SAVE check in
+    the `compact` branch, so grepping for the variable is not enough -- this
+    pins the guard to the auto_import call itself.
+    """
+    lines = open(HOOK, encoding="utf-8").read().splitlines()
+    call = next(i for i, ln in enumerate(lines) if "auto_import.py" in ln)
+    preceding = "\n".join(lines[max(0, call - 6) : call])
+    assert "MEM0_AUTO_SAVE" in preceding, (
+        "auto_import.py is launched without a MEM0_AUTO_SAVE guard above it"
+    )


### PR DESCRIPTION
## Linked Issue

Closes #7056

## Description

`auto_import.py` writes memories, but `on_session_start.sh` launches it unconditionally, so setting `auto_save: false` in `~/.mem0/settings.json` does not stop it.

Every session start still imports `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.windsurfrules` and `mem0.md`, split per `##` heading into one memory per chunk. Because `_delete_stale_chunks()` deletes and re-posts whenever a file's content hash changes, this repeats on every edit to any of those files rather than importing once.

There is currently no way to opt out. `auto_import.py` never references `auto_save`, and the only environment variables it reads in the entire file are `MEM0_DEBUG` and `MEM0_CWD`, so no env var or setting disables it.

In practice this fills a project's scope with copies of its own instruction files. In one repo of ours, 11 of the 22 memories in scope are chunks of that repo's own `CLAUDE.md`, competing with real memories for the default `top_k` of 10.

**This is #5449 with a fourth writer.** That issue fixed `auto_save` for the three writers it enumerated — `capture_session_summary.py`, `auto_capture.py`, and `capture_compact_summary.py` — and shipped in #5450. `auto_import.py` writes memories too, but it is an *import* path rather than a *capture* path, so it fell outside that issue's framing and kept running. The guard #5450 added to `on_session_start.sh:200` is in the `elif [ "$SOURCE" = "compact" ]` branch, sixteen lines below the unguarded call at line 184 in the `startup` branch.

That adjacency is probably why this survived: grepping `on_session_start.sh` for `MEM0_AUTO_SAVE` finds the line-200 guard and looks like coverage. It is also why the second test below pins the guard to the call site rather than to the file.

See also #6065, open, for the sibling case: `auto_search: false` is likewise dead for hook-driven searches.

**The plumbing is already correct and complete:** `scripts/_identity.sh` reads `auto_save` from `~/.mem0/settings.json` and exports `MEM0_AUTO_SAVE`, and `scripts/on_session_start.sh` sources it on line 9, so the variable is in scope at the call site. The plugin's three other writers already gate on it — `scripts/on_stop.sh:36`, `scripts/on_user_prompt.sh:204`, and `scripts/on_session_start.sh:200` for the `compact` branch.

The fix guards the call with the same idiom as its neighbours. No behaviour change when `auto_save` is unset or true.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Tool: Claude Code. The agent located the unguarded call site, confirmed `MEM0_AUTO_SAVE` was already in scope via the `_identity.sh` source on line 9, checked the three existing guarded writers for the house idiom, and ran the before/after verification below.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A for anyone who has not set `auto_save: false`.

For those who have, this stops the imports they had already asked to stop. One consequence worth a changelog line: once imports stop, `_delete_stale_chunks()` no longer refreshes previously imported chunks, so they persist as-is. That is correct for someone who asked for writes to be off, but they may want to clean up existing `source: auto-import` memories if they want the scope empty.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `tests/test_auto_save_gate.py`, which drives `on_session_start.sh` for real rather than importing Python. The existing `auto_import` tests exercise `post_memory()` directly, which is only reached once the hook has already decided to launch the script, so the bug was invisible from the module level.

Two details that bit me and may bite a reviewer reproducing it:

- `_identity.sh` **re-exports** `MEM0_AUTO_SAVE` from `~/.mem0/settings.json`, so the file is authoritative and setting the env var alone does not exercise the path. My first harness gave a false pass for exactly this reason.
- The stubbed `python3` must delegate to the real interpreter, because `_identity.sh` shells out to `python3` to parse that settings file.

The second test pins the guard to the call site rather than to the file: `on_session_start.sh` already contains an unrelated `MEM0_AUTO_SAVE` check in the `compact` branch, so a plain grep would pass even with the bug present.

**Confirmed to fail without the fix.** Against the unpatched hook, the `auto_save=false` case and the source-guard check both fail while the `auto_save=true` case stays green.

| | `auto_save: true` | `auto_save: false` |
|---|---|---|
| before | ran | **ran** |
| after | ran | did not run |

Full plugin suite: **189 passed** (186 before this branch, plus the 3 added here). I also ran the other two steps from `mem0-plugin-checks.yml`: hook entry points are all executable, and all six JSON manifests validate.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
