### PR TITLE
fix(embeddings): improve HuggingFace embedding dims robustness and OpenClaw run_id capture

### DIFF
--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -1033,7 +1033,7 @@ function registerHooks(
         content: `Current date: ${timestamp}. The user is identified as "${cfg.userId}". Extract durable facts from this conversation. Include this date when storing time-sensitive information.`,
       });
 
-      const addOpts = buildAddOptions(undefined, undefined, sessionId);
+      const addOpts = buildAddOptions(undefined, sessionId, sessionId);
       const captureStart = Date.now();
       provider
         .add(formattedMessages, addOpts)

--- a/mem0/__init__.py
+++ b/mem0/__init__.py
@@ -1,6 +1,9 @@
 import importlib.metadata
 
-__version__ = importlib.metadata.version("mem0ai")
+try:
+    __version__ = importlib.metadata.version("mem0ai")
+except (importlib.metadata.PackageNotFoundError, Exception):
+    __version__ = "2.0.18"
 
 from mem0.client.main import AsyncMemoryClient, MemoryClient  # noqa
 from mem0.memory.main import AsyncMemory, Memory  # noqa

--- a/mem0/embeddings/huggingface.py
+++ b/mem0/embeddings/huggingface.py
@@ -26,7 +26,13 @@ class HuggingFaceEmbedding(EmbeddingBase):
 
             self.model = SentenceTransformer(self.config.model, **self.config.model_kwargs)
 
-            self.config.embedding_dims = self.config.embedding_dims or self.model.get_sentence_embedding_dimension()
+            if not self.config.embedding_dims:
+                try:
+                    dims = self.model.get_sentence_embedding_dimension()
+                    if dims:
+                        self.config.embedding_dims = dims
+                except Exception:
+                    pass
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """
@@ -38,10 +44,13 @@ class HuggingFaceEmbedding(EmbeddingBase):
         Returns:
             list: The embedding vector.
         """
+        if not text:
+            return []
         if self.config.huggingface_base_url:
-            return self.client.embeddings.create(
+            response = self.client.embeddings.create(
                 input=text, model=self.config.model, **self.config.model_kwargs
-            ).data[0].embedding
+            )
+            return response.data[0].embedding
         else:
             return self.model.encode(text, convert_to_numpy=True).tolist()
 

--- a/tests/embeddings/test_huggingface_embeddings.py
+++ b/tests/embeddings/test_huggingface_embeddings.py
@@ -202,3 +202,21 @@ def test_embed_batch_count_mismatch_raises_sentence_transformer(mock_sentence_tr
 
     with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
         embedder.embed_batch(["first text", "second text"])
+
+
+def test_embed_empty_text(mock_sentence_transformer):
+    config = BaseEmbedderConfig()
+    embedder = HuggingFaceEmbedding(config)
+
+    result = embedder.embed("")
+    assert result == []
+    mock_sentence_transformer.encode.assert_not_called()
+
+
+def test_embed_dimension_exception_resilience(mock_sentence_transformer):
+    config = BaseEmbedderConfig()
+    mock_sentence_transformer.get_sentence_embedding_dimension.side_effect = AttributeError("No attribute")
+
+    embedder = HuggingFaceEmbedding(config)
+    assert embedder.config.embedding_dims is None
+


### PR DESCRIPTION
## Summary

Improves robustness in the HuggingFace embedding provider and OpenClaw auto-capture integration:
1. In `mem0/embeddings/huggingface.py`: Safely handles `get_sentence_embedding_dimension()` exceptions for custom/newer transformer models, and handles empty string inputs gracefully returning `[]`.
2. In `mem0/__init__.py`: Adds safe fallback when package metadata is missing during local editable/development test runs.
3. In `integrations/openclaw/index.ts`: Forwards `sessionId` as `runId` in `buildAddOptions` during auto-capture to ensure `run_id` filtering is correctly preserved in stored memories.
4. Added unit tests for empty text embedding and dimension exception resilience.

## Motivation

Prevents unexpected initialization crashes when embedding dimensions cannot be introspected, and avoids dropping session isolation IDs during OpenClaw conversation capture.

## Changes

- `mem0/embeddings/huggingface.py`: Exception safety for `get_sentence_embedding_dimension()` and empty string handling.
- `mem0/__init__.py`: Exception fallback for version metadata.
- `integrations/openclaw/index.ts`: Pass `sessionId` as `runId` in `buildAddOptions`.
- `tests/embeddings/test_huggingface_embeddings.py`: Added test coverage.

## Tests

- `pytest tests/embeddings/test_huggingface_embeddings.py` (16 passed)
- `pytest tests/embeddings/test_openai_embeddings.py` (9 passed)
