### PR TITLE
fix(docs): correct relative path to mem0-vercel-ai-sdk SKILL.md

### DIFF
--- a/skills/mem0/references/integration-patterns.md
+++ b/skills/mem0/references/integration-patterns.md
@@ -116,7 +116,7 @@ result = crew.kickoff()
 
 ## Vercel AI SDK
 
-> **Dedicated skill available.** For comprehensive Vercel AI SDK documentation, see the [mem0-vercel-ai-sdk skill](../mem0-vercel-ai-sdk/SKILL.md) ([GitHub](https://github.com/mem0ai/mem0/tree/main/skills/mem0-vercel-ai-sdk)).
+> **Dedicated skill available.** For comprehensive Vercel AI SDK documentation, see the [mem0-vercel-ai-sdk skill](../../mem0-vercel-ai-sdk/SKILL.md) ([GitHub](https://github.com/mem0ai/mem0/tree/main/skills/mem0-vercel-ai-sdk)).
 
 Install: `npm install @mem0/vercel-ai-provider`
 


### PR DESCRIPTION
### Problem
In `skills/mem0/references/integration-patterns.md` (line 119), the link to the dedicated Vercel AI SDK skill is off by one directory level:

```md
see the [mem0-vercel-ai-sdk skill](../mem0-vercel-ai-sdk/SKILL.md)
```

That file lives at `skills/mem0/references/`, so `../mem0-vercel-ai-sdk/SKILL.md` resolves to `skills/mem0/mem0-vercel-ai-sdk/SKILL.md`, which does not exist. The actual skill is at `skills/mem0-vercel-ai-sdk/SKILL.md` (one level higher) — as the GitHub URL in the very same sentence confirms (`.../tree/main/skills/mem0-vercel-ai-sdk`). The link renders as a dead 404 on GitHub and in any docs build.

### Fix
Change `../mem0-vercel-ai-sdk/SKILL.md` → `../../mem0-vercel-ai-sdk/SKILL.md`.

For contrast, the other relative link in the same file (line 395, `[SKILL.md](../SKILL.md)`) is correct: from `references/` it resolves to `skills/mem0/SKILL.md`, which exists — so only this one line needed fixing.

### How to verify
From `skills/mem0/references/`:
- Before: `../mem0-vercel-ai-sdk/SKILL.md` → `skills/mem0/mem0-vercel-ai-sdk/SKILL.md` (missing)
- After:  `../../mem0-vercel-ai-sdk/SKILL.md` → `skills/mem0-vercel-ai-sdk/SKILL.md` (exists ✅)

One-line, docs-only change; no code or behavior affected.