### PR TITLE
fix(valkey): guard against None timestamps in update()

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -521,7 +521,7 @@ class ValkeyDB(VectorStoreBase):
                 hash_data["embedding"] = np.array(vector, dtype=np.float32).tobytes()
 
             # Add updated_at if available
-            if "updated_at" in payload:
+            if payload.get("updated_at") is not None:
                 hash_data["updated_at"] = int(datetime.fromisoformat(payload["updated_at"]).timestamp())
 
             # Add optional fields


### PR DESCRIPTION
## Summary

Fixes #6994

`list()` injects `updated_at=None` when the key is absent from the Valkey hash (via `.get("updated_at")`). `update()` then checks `if "updated_at" in payload:` which is `True` for `None` values, causing `datetime.fromisoformat(None)` to raise `TypeError`.

This silently drops entity updates on the Valkey backend, degrading entity-boost ranking. Qdrant and other backends are unaffected.

## Fix

Change the guard in `update()` from key-presence check to truthiness check:

```python
# Before:
if "updated_at" in payload:

# After:
if payload.get("updated_at") is not None:
```

## Testing

The issue provides a reproduction script using `infer=True` with two adds mentioning the same entity. After this fix, both adds complete without the `TypeError` warning, and the entity's `linked_memory_ids` is updated correctly.