### PR TITLE
Feat/dynamodb vector store

### DIFF
--- a/docs/components/vectordbs/dbs/dynamodb.mdx
+++ b/docs/components/vectordbs/dbs/dynamodb.mdx
@@ -1,0 +1,62 @@
+---
+title: Amazon DynamoDB
+description: "Use Amazon DynamoDB as a serverless vector store in Mem0, keeping memories next to your operational data."
+---
+
+[Amazon DynamoDB](https://aws.amazon.com/dynamodb/) is a serverless, fully managed NoSQL database. DynamoDB vector indexes store embeddings as an attribute on the item and query them with the `SearchVectors` API, so memories live in the same table infrastructure as your application data with no separate vector cluster to manage.
+
+### Installation
+
+DynamoDB vector search requires boto3 1.43.64 or newer:
+
+```bash Python
+pip install "boto3>=1.43.64"
+```
+
+### Usage
+
+To use Amazon DynamoDB with Mem0, you need an AWS account and IAM permissions for `dynamodb:CreateTable`, `dynamodb:DescribeTable`, `dynamodb:PutItem`, `dynamodb:GetItem`, `dynamodb:UpdateItem`, `dynamodb:DeleteItem`, `dynamodb:BatchWriteItem`, `dynamodb:Scan`, `dynamodb:SearchVectors`, `dynamodb:ListTables`, and `dynamodb:DeleteTable`. Ensure your environment is configured with AWS credentials (e.g., via `~/.aws/credentials` or environment variables).
+
+```python Python
+import os
+from mem0 import Memory
+
+# Ensure your AWS credentials are configured in your environment
+# e.g., by setting AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_DEFAULT_REGION
+
+config = {
+    "vector_store": {
+        "provider": "dynamodb",
+        "config": {
+            "collection_name": "mem0-memories",
+            "embedding_model_dims": 1536,
+            "distance_metric": "cosine",
+            "region_name": "us-east-1"
+        }
+    }
+}
+
+m = Memory.from_config(config)
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about a thriller movie? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thrillers, but I love sci-fi movies."},
+]
+m.add(messages, user_id="alice", metadata={"category": "movies"})
+```
+
+### Configuration parameters
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `collection_name` | Name of the DynamoDB table | `mem0` |
+| `embedding_model_dims` | Dimension of the embedding vector | `1536` |
+| `distance_metric` | `cosine` or `euclidean` | `cosine` |
+| `region_name` | AWS region for the DynamoDB client | `None` |
+| `endpoint_url` | Optional endpoint override, e.g. a local DynamoDB-compatible server | `None` |
+
+### Notes
+
+- The table is created on first use with on-demand billing and a vector index over the `vector` attribute. `user_id`, `agent_id`, and `run_id` filters are applied server-side during the vector search; other metadata filters are applied to the returned results.
+- DynamoDB vector index maintenance is asynchronous: memories become searchable shortly after they are written rather than in the same instant.
+- Search scores follow the Mem0 convention (higher is more similar); the store converts DynamoDB's distance values.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -224,6 +224,7 @@
                               "components/vectordbs/dbs/langchain",
                               "components/vectordbs/dbs/baidu",
                               "components/vectordbs/dbs/cassandra",
+                              "components/vectordbs/dbs/dynamodb",
                               "components/vectordbs/dbs/s3_vectors",
                               "components/vectordbs/dbs/databricks",
                               "components/vectordbs/dbs/neon",

--- a/mem0/configs/vector_stores/dynamodb.py
+++ b/mem0/configs/vector_stores/dynamodb.py
@@ -1,0 +1,30 @@
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class DynamoDBConfig(BaseModel):
+    collection_name: str = Field("mem0", description="Name of the DynamoDB table")
+    embedding_model_dims: int = Field(1536, description="Dimension of the embedding vector")
+    distance_metric: str = Field(
+        "cosine",
+        description="Distance metric for similarity search. Options: 'cosine', 'euclidean'",
+    )
+    region_name: Optional[str] = Field(None, description="AWS region for the DynamoDB client")
+    endpoint_url: Optional[str] = Field(
+        None, description="Optional endpoint override, e.g. a local DynamoDB-compatible server"
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_extra_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        allowed_fields = set(cls.model_fields.keys())
+        input_fields = set(values.keys())
+        extra_fields = input_fields - allowed_fields
+        if extra_fields:
+            raise ValueError(
+                f"Extra fields not allowed: {', '.join(extra_fields)}. Please input only the following fields: {', '.join(allowed_fields)}"
+            )
+        return values
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -199,6 +199,7 @@ class VectorStoreFactory:
         "faiss": "mem0.vector_stores.faiss.FAISS",
         "langchain": "mem0.vector_stores.langchain.Langchain",
         "s3_vectors": "mem0.vector_stores.s3_vectors.S3Vectors",
+        "dynamodb": "mem0.vector_stores.dynamodb.DynamoDB",
         "baidu": "mem0.vector_stores.baidu.BaiduDB",
         "cassandra": "mem0.vector_stores.cassandra.CassandraDB",
         "neptune": "mem0.vector_stores.neptune_analytics.NeptuneAnalyticsVector",

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -34,6 +34,7 @@ class VectorStoreConfig(BaseModel):
         "faiss": "FAISSConfig",
         "langchain": "LangchainConfig",
         "s3_vectors": "S3VectorsConfig",
+        "dynamodb": "DynamoDBConfig",
         "turbopuffer": "TurbopufferConfig",
         "oracledb": "OracleAIVectorSearchConfig",
     }

--- a/mem0/vector_stores/dynamodb.py
+++ b/mem0/vector_stores/dynamodb.py
@@ -1,7 +1,6 @@
 import json
 import logging
-import time
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 from pydantic import BaseModel
 
@@ -159,9 +158,7 @@ class DynamoDB(VectorStoreBase):
         response = self.client.search_vectors(**params)
         results = [self._parse_item(r["Item"], r.get("Score")) for r in response.get("SearchResults", [])]
         if remainder:
-            results = [
-                r for r in results if r.payload and all(r.payload.get(k) == v for k, v in remainder.items())
-            ]
+            results = [r for r in results if r.payload and all(r.payload.get(k) == v for k, v in remainder.items())]
         return results
 
     def delete(self, vector_id):
@@ -227,9 +224,7 @@ class DynamoDB(VectorStoreBase):
             items.extend(page.get("Items", []))
         results = [self._parse_item(item) for item in items]
         if remainder:
-            results = [
-                r for r in results if r.payload and all(r.payload.get(k) == v for k, v in remainder.items())
-            ]
+            results = [r for r in results if r.payload and all(r.payload.get(k) == v for k, v in remainder.items())]
         if top_k:
             results = results[:top_k]
         return [results]

--- a/mem0/vector_stores/dynamodb.py
+++ b/mem0/vector_stores/dynamodb.py
@@ -1,0 +1,240 @@
+import json
+import logging
+import time
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+from mem0.vector_stores.base import VectorStoreBase
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:
+    raise ImportError("The 'boto3' library is required. Please install it using 'pip install boto3'.")
+
+logger = logging.getLogger(__name__)
+
+# Attributes mem0 filters on; declared as inline filters in the vector index
+# search schema so SearchVectors can constrain on them server-side.
+FILTERABLE_ATTRIBUTES = ("user_id", "agent_id", "run_id")
+
+VECTOR_INDEX_NAME = "mem0-vector-index"
+
+DISTANCE_FUNCTIONS = {
+    "cosine": "COSINE",
+    "euclidean": "EUCLIDEAN",
+}
+
+
+class OutputData(BaseModel):
+    id: Optional[str]
+    score: Optional[float]
+    payload: Optional[Dict]
+
+
+class DynamoDB(VectorStoreBase):
+    def __init__(
+        self,
+        collection_name: str,
+        embedding_model_dims: int,
+        distance_metric: str = "cosine",
+        region_name: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
+    ):
+        self.client = boto3.client("dynamodb", region_name=region_name, endpoint_url=endpoint_url)
+        if not hasattr(self.client, "search_vectors"):
+            raise RuntimeError(
+                "This botocore release does not support DynamoDB vector search. "
+                "Upgrade with 'pip install \"boto3>=1.43.64\"'."
+            )
+        self.collection_name = collection_name
+        self.embedding_model_dims = embedding_model_dims
+        self.distance_metric = distance_metric
+
+        self.create_col(self.collection_name, self.embedding_model_dims, self.distance_metric)
+
+    def _table_exists(self, name) -> bool:
+        try:
+            self.client.describe_table(TableName=name)
+            return True
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ResourceNotFoundException":
+                return False
+            raise
+
+    def create_col(self, name, vector_size, distance="cosine"):
+        if distance not in DISTANCE_FUNCTIONS:
+            raise ValueError(f"Unsupported distance metric '{distance}'. Options: {sorted(DISTANCE_FUNCTIONS)}")
+        if self._table_exists(name):
+            logger.info(f"Table '{name}' already exists.")
+            return
+        logger.info(f"Creating table '{name}' with vector index.")
+        # Attributes referenced by the search schema must be declared in
+        # AttributeDefinitions, in addition to the key attribute.
+        attribute_definitions = [{"AttributeName": "id", "AttributeType": "S"}] + [
+            {"AttributeName": attr, "AttributeType": "S"} for attr in FILTERABLE_ATTRIBUTES
+        ]
+        self.client.create_table(
+            TableName=name,
+            KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+            AttributeDefinitions=attribute_definitions,
+            BillingMode="PAY_PER_REQUEST",
+            VectorIndexes=[
+                {
+                    "IndexName": VECTOR_INDEX_NAME,
+                    "VectorAttribute": {"AttributeName": "vector"},
+                    "SearchSchema": [
+                        {"AttributeName": attr, "SearchSchemaElementType": "INLINE_FILTER"}
+                        for attr in FILTERABLE_ATTRIBUTES
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                    "Dimensions": vector_size,
+                    "DistanceFunction": DISTANCE_FUNCTIONS[distance],
+                }
+            ],
+        )
+        self.client.get_waiter("table_exists").wait(TableName=name)
+
+    def _to_item(self, vector_id, vector, payload) -> Dict:
+        payload = payload or {}
+        item = {
+            "id": {"S": str(vector_id)},
+            "vector": {"L": [{"N": str(x)} for x in vector]},
+            "payload": {"S": json.dumps(payload)},
+        }
+        for attr in FILTERABLE_ATTRIBUTES:
+            value = payload.get(attr)
+            if value is not None:
+                item[attr] = {"S": str(value)}
+        return item
+
+    def _parse_item(self, item: Dict, distance: Optional[float] = None) -> OutputData:
+        payload = json.loads(item.get("payload", {}).get("S", "{}"))
+        score = None
+        if distance is not None:
+            if self.distance_metric == "cosine":
+                score = max(0.0, 1.0 - distance)
+            else:  # euclidean
+                score = 1.0 / (1.0 + distance)
+        return OutputData(id=item["id"]["S"], score=score, payload=payload)
+
+    def insert(self, vectors, payloads=None, ids=None):
+        requests = [
+            {"PutRequest": {"Item": self._to_item(ids[i], vec, payloads[i] if payloads else {})}}
+            for i, vec in enumerate(vectors)
+        ]
+        for start in range(0, len(requests), 25):
+            response = self.client.batch_write_item(RequestItems={self.collection_name: requests[start : start + 25]})
+            while response.get("UnprocessedItems"):
+                response = self.client.batch_write_item(RequestItems=response["UnprocessedItems"])
+
+    def _build_condition(self, filters: Optional[Dict]):
+        """Split filters into a server-side search condition and a client-side remainder."""
+        if not filters:
+            return None, {}
+        server = {k: v for k, v in filters.items() if k in FILTERABLE_ATTRIBUTES and v is not None}
+        remainder = {k: v for k, v in filters.items() if k not in server}
+        if not server:
+            return None, remainder
+        names = {f"#f{i}": k for i, k in enumerate(server)}
+        values = {f":v{i}": {"S": str(v)} for i, v in enumerate(server.values())}
+        expression = " AND ".join(f"#f{i} = :v{i}" for i in range(len(server)))
+        return {
+            "SearchConditionExpression": expression,
+            "ExpressionAttributeNames": names,
+            "ExpressionAttributeValues": values,
+        }, remainder
+
+    def search(self, query, vectors, top_k=5, filters=None):
+        condition, remainder = self._build_condition(filters)
+        params = {
+            "TableName": self.collection_name,
+            "IndexName": VECTOR_INDEX_NAME,
+            "SearchVector": [{"N": str(x)} for x in vectors],
+            "TopK": top_k,
+        }
+        if condition:
+            params.update(condition)
+        response = self.client.search_vectors(**params)
+        results = [self._parse_item(r["Item"], r.get("Score")) for r in response.get("SearchResults", [])]
+        if remainder:
+            results = [
+                r for r in results if r.payload and all(r.payload.get(k) == v for k, v in remainder.items())
+            ]
+        return results
+
+    def delete(self, vector_id):
+        self.client.delete_item(TableName=self.collection_name, Key={"id": {"S": str(vector_id)}})
+
+    def update(self, vector_id, vector=None, payload=None):
+        sets, names, values = [], {}, {}
+        if vector is not None:
+            sets.append("#vec = :vec")
+            names["#vec"] = "vector"
+            values[":vec"] = {"L": [{"N": str(x)} for x in vector]}
+        if payload is not None:
+            sets.append("#pl = :pl")
+            names["#pl"] = "payload"
+            values[":pl"] = {"S": json.dumps(payload)}
+            for i, attr in enumerate(FILTERABLE_ATTRIBUTES):
+                value = payload.get(attr)
+                if value is not None:
+                    sets.append(f"#a{i} = :a{i}")
+                    names[f"#a{i}"] = attr
+                    values[f":a{i}"] = {"S": str(value)}
+        if not sets:
+            return
+        self.client.update_item(
+            TableName=self.collection_name,
+            Key={"id": {"S": str(vector_id)}},
+            UpdateExpression="SET " + ", ".join(sets),
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+        )
+
+    def get(self, vector_id) -> Optional[OutputData]:
+        response = self.client.get_item(TableName=self.collection_name, Key={"id": {"S": str(vector_id)}})
+        item = response.get("Item")
+        if not item:
+            return None
+        return self._parse_item(item)
+
+    def list_cols(self):
+        tables = []
+        paginator = self.client.get_paginator("list_tables")
+        for page in paginator.paginate():
+            tables.extend(page.get("TableNames", []))
+        return tables
+
+    def delete_col(self):
+        self.client.delete_table(TableName=self.collection_name)
+        self.client.get_waiter("table_not_exists").wait(TableName=self.collection_name)
+
+    def col_info(self):
+        return self.client.describe_table(TableName=self.collection_name)["Table"]
+
+    def list(self, filters=None, top_k=None):
+        params = {"TableName": self.collection_name}
+        condition, remainder = self._build_condition(filters)
+        if condition:
+            params["FilterExpression"] = condition["SearchConditionExpression"]
+            params["ExpressionAttributeNames"] = condition["ExpressionAttributeNames"]
+            params["ExpressionAttributeValues"] = condition["ExpressionAttributeValues"]
+        items = []
+        paginator = self.client.get_paginator("scan")
+        for page in paginator.paginate(**params):
+            items.extend(page.get("Items", []))
+        results = [self._parse_item(item) for item in items]
+        if remainder:
+            results = [
+                r for r in results if r.payload and all(r.payload.get(k) == v for k, v in remainder.items())
+            ]
+        if top_k:
+            results = results[:top_k]
+        return [results]
+
+    def reset(self):
+        logger.warning(f"Resetting table {self.collection_name}...")
+        self.delete_col()
+        self.create_col(self.collection_name, self.embedding_model_dims, self.distance_metric)

--- a/tests/vector_stores/test_dynamodb.py
+++ b/tests/vector_stores/test_dynamodb.py
@@ -1,0 +1,143 @@
+import json
+
+import pytest
+
+from mem0.configs.vector_stores.dynamodb import DynamoDBConfig
+from mem0.vector_stores.dynamodb import DynamoDB
+
+TABLE_NAME = "test-memories"
+EMBEDDING_DIMS = 1536
+REGION = "us-east-1"
+
+
+@pytest.fixture
+def mock_boto_client(mocker):
+    """Fixture to mock the boto3 DynamoDB client."""
+    mock_client = mocker.MagicMock()
+    mocker.patch("boto3.client", return_value=mock_client)
+    # Table does not exist yet -> create path
+    mock_client.describe_table.side_effect = _resource_not_found
+    return mock_client
+
+
+def _resource_not_found(*args, **kwargs):
+    from botocore.exceptions import ClientError
+
+    raise ClientError({"Error": {"Code": "ResourceNotFoundException"}}, "DescribeTable")
+
+
+@pytest.fixture
+def store(mock_boto_client):
+    s = DynamoDB(collection_name=TABLE_NAME, embedding_model_dims=EMBEDDING_DIMS, region_name=REGION)
+    mock_boto_client.describe_table.side_effect = None
+    return s
+
+
+def test_initialization_creates_table_with_vector_index(mock_boto_client, store):
+    call = mock_boto_client.create_table.call_args.kwargs
+    assert call["TableName"] == TABLE_NAME
+    vi = call["VectorIndexes"][0]
+    assert vi["VectorAttribute"] == {"AttributeName": "vector"}
+    assert vi["Dimensions"] == EMBEDDING_DIMS
+    assert vi["DistanceFunction"] == "COSINE"
+    # Search schema attributes must also be declared in AttributeDefinitions
+    schema_attrs = {e["AttributeName"] for e in vi["SearchSchema"]}
+    defined_attrs = {d["AttributeName"] for d in call["AttributeDefinitions"]}
+    assert schema_attrs == {"user_id", "agent_id", "run_id"}
+    assert schema_attrs <= defined_attrs
+
+
+def test_unsupported_distance_metric_rejected(mock_boto_client):
+    with pytest.raises(ValueError, match="Unsupported distance metric"):
+        DynamoDB(
+            collection_name=TABLE_NAME,
+            embedding_model_dims=EMBEDDING_DIMS,
+            distance_metric="hamming",
+            region_name=REGION,
+        )
+
+
+def test_insert_serializes_vector_and_payload(mock_boto_client, store):
+    mock_boto_client.batch_write_item.return_value = {}
+    store.insert(vectors=[[0.1, 0.2]], payloads=[{"data": "alpha", "user_id": "u1"}], ids=["m1"])
+    request = mock_boto_client.batch_write_item.call_args.kwargs["RequestItems"][TABLE_NAME][0]
+    item = request["PutRequest"]["Item"]
+    assert item["id"] == {"S": "m1"}
+    assert item["vector"] == {"L": [{"N": "0.1"}, {"N": "0.2"}]}
+    assert json.loads(item["payload"]["S"]) == {"data": "alpha", "user_id": "u1"}
+    assert item["user_id"] == {"S": "u1"}  # promoted for server-side filtering
+
+
+def test_insert_retries_unprocessed_items(mock_boto_client, store):
+    retry_batch = {TABLE_NAME: [{"PutRequest": {"Item": {"id": {"S": "m1"}}}}]}
+    mock_boto_client.batch_write_item.side_effect = [{"UnprocessedItems": retry_batch}, {}]
+    store.insert(vectors=[[0.1]], payloads=[{}], ids=["m1"])
+    assert mock_boto_client.batch_write_item.call_count == 2
+    assert mock_boto_client.batch_write_item.call_args.kwargs["RequestItems"] == retry_batch
+
+
+def test_search_converts_distance_to_similarity(mock_boto_client, store):
+    mock_boto_client.search_vectors.return_value = {
+        "SearchResults": [
+            {"Item": {"id": {"S": "m1"}, "payload": {"S": "{}"}}, "Score": 0.0},
+            {"Item": {"id": {"S": "m2"}, "payload": {"S": "{}"}}, "Score": 1.0},
+        ]
+    }
+    results = store.search("q", [0.1] * EMBEDDING_DIMS, top_k=2)
+    # Base contract: higher score = more similar. Cosine distance 0.0 -> 1.0
+    assert results[0].score == 1.0
+    assert results[1].score == 0.0
+
+
+def test_search_builds_server_side_condition(mock_boto_client, store):
+    mock_boto_client.search_vectors.return_value = {"SearchResults": []}
+    store.search("q", [0.1], top_k=5, filters={"user_id": "u1", "agent_id": "a1"})
+    call = mock_boto_client.search_vectors.call_args.kwargs
+    assert "SearchConditionExpression" in call
+    assert set(call["ExpressionAttributeNames"].values()) == {"user_id", "agent_id"}
+    assert {v["S"] for v in call["ExpressionAttributeValues"].values()} == {"u1", "a1"}
+
+
+def test_search_applies_remainder_filter_client_side(mock_boto_client, store):
+    mock_boto_client.search_vectors.return_value = {
+        "SearchResults": [
+            {"Item": {"id": {"S": "m1"}, "payload": {"S": json.dumps({"topic": "x"})}}, "Score": 0.0},
+            {"Item": {"id": {"S": "m2"}, "payload": {"S": json.dumps({"topic": "y"})}}, "Score": 0.1},
+        ]
+    }
+    results = store.search("q", [0.1], top_k=5, filters={"topic": "x"})
+    assert [r.id for r in results] == ["m1"]
+    # Non-schema filter must not reach the service
+    assert "SearchConditionExpression" not in mock_boto_client.search_vectors.call_args.kwargs
+
+
+def test_get_returns_none_for_missing(mock_boto_client, store):
+    mock_boto_client.get_item.return_value = {}
+    assert store.get("missing") is None
+
+
+def test_update_payload_promotes_filterable_attributes(mock_boto_client, store):
+    store.update("m1", payload={"data": "new", "user_id": "u9"})
+    call = mock_boto_client.update_item.call_args.kwargs
+    assert "user_id" in call["ExpressionAttributeNames"].values()
+    assert {"S": "u9"} in call["ExpressionAttributeValues"].values()
+
+
+def test_reset_deletes_and_recreates(mock_boto_client, store):
+    mock_boto_client.describe_table.side_effect = _resource_not_found
+    store.reset()
+    mock_boto_client.delete_table.assert_called_once_with(TableName=TABLE_NAME)
+    assert mock_boto_client.create_table.call_count == 2  # init + reset
+
+
+def test_config_rejects_extra_fields():
+    with pytest.raises(ValueError, match="Extra fields not allowed"):
+        DynamoDBConfig(collection_name="x", not_a_field=1)
+
+
+def test_config_defaults():
+    config = DynamoDBConfig()
+    assert config.collection_name == "mem0"
+    assert config.embedding_model_dims == 1536
+    assert config.distance_metric == "cosine"
+    assert config.endpoint_url is None


### PR DESCRIPTION
## Linked Issue

Closes #7064

## Description

Adds Amazon DynamoDB as a vector store provider. DynamoDB vector indexes store embeddings as an item attribute and query them with the `SearchVectors` API, so memories live in the same serverless table infrastructure as application data, with no separate vector cluster to manage.

The provider creates the table on first use with a vector index over the `vector` attribute, applies `user_id`/`agent_id`/`run_id` filters server-side via the index search schema, applies remaining metadata filters client-side, and converts DynamoDB distance scores to Mem0 similarity scores (higher = more similar, per the `VectorStoreBase` contract).

Follows the existing provider conventions (modeled on the `s3_vectors` provider): one provider file, one config class, registrations in `VectorStoreConfig` and `VectorStoreFactory`, unit tests, and a docs page. Requires `boto3>=1.43.64` (first release with `SearchVectors`); the provider raises a clear error on older versions.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [X] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [ ] AI-generated (an agent wrote most or all of this diff)

An AI coding agent wrote the initial implementation under my direction. I designed the approach (table schema, search schema filter split, score conversion) and verified the behavior myself: every `VectorStoreBase` method was exercised against the live DynamoDB service (search ordering, similarity conversion, server-side and client-side filtering, vector and payload updates with re-indexing, scan-backed list, and the full collection lifecycle), plus the unit tests below.

- [X] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

12 unit tests in `tests/vector_stores/test_dynamodb.py` following the mocked-boto3 pattern used by the other AWS provider tests: table/index creation (including the search schema / `AttributeDefinitions` coupling), vector serialization, `UnprocessedItems` retry, distance-to-similarity conversion, server-side condition building, client-side remainder filtering, updates, reset, and config validation. Manually: every provider method was run against the live DynamoDB service with a 4-dimension index: exact-match returns similarity 1.0, orthogonal returns 0.0, tenant filters exclude near-identical vectors from other tenants, and updates to the indexed attribute are re-indexed and searchable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

`ruff check` and `ruff format --check` pass at the project line length. New tests 12/12; pre-existing errors in `tests/vector_stores/test_score_normalization.py` are missing optional local deps (chromadb/faiss) and occur identically without this change. Docs: `docs/components/vectordbs/dbs/dynamodb.mdx` plus the navigation entry in `docs/docs.json`.
