### PR TITLE
fix(vector_stores/neptune_analytics): convert distance to similarity so search ranking isn't inverted

### DIFF
--- a/mem0/vector_stores/neptune_analytics.py
+++ b/mem0/vector_stores/neptune_analytics.py
@@ -34,7 +34,7 @@ def _escape_cypher(value: str) -> str:
 
 class OutputData(BaseModel):
     id: Optional[str]  # memory id
-    score: Optional[float]  # distance
+    score: Optional[float]  # similarity (higher = more similar); see _parse_query_responses
     payload: Optional[Dict]  # metadata
 
 
@@ -432,7 +432,14 @@ class NeptuneAnalyticsVector(VectorStoreBase):
             properties = item[self._FIELD_N][self._FIELD_PROP]
             properties.pop("label", None)
             if with_score:
-                score = item[self._FIELD_SCORE]
+                # Neptune Analytics' topK.byEmbedding returns the squared Euclidean
+                # DISTANCE (lower = more similar). VectorStoreBase.search requires a
+                # similarity score (higher = more similar), so convert with the L2
+                # formula documented there: score = 1 / (1 + distance). Without this,
+                # mem0's score_and_rank sorts farthest-first and its threshold drops
+                # the nearest matches (distance ~0 -> score ~0).
+                raw_distance = item[self._FIELD_SCORE]
+                score = 1.0 / (1.0 + raw_distance) if raw_distance is not None else None
             else:
                 score = None
             result.append(OutputData(

--- a/tests/vector_stores/test_neptune_analytics.py
+++ b/tests/vector_stores/test_neptune_analytics.py
@@ -283,6 +283,59 @@ class TestNeptuneAnalyticsVectorInitValidation:
             )
 
 
+class _FakeNeptuneSearchGraph:
+    """Returns a canned topK.byEmbedding response so search()'s score handling can be
+    exercised without a real Neptune Analytics endpoint. Neptune returns the squared
+    Euclidean DISTANCE as `score` (lower = more similar); the sample below mirrors the
+    AWS docs where the nearest (identical) node scores 0.0 and farther nodes score higher."""
+
+    # (node_id, squared_euclidean_distance) ordered nearest -> farthest
+    _RESULTS = [("A", 0.0), ("B", 24.0), ("C", 25.0)]
+
+    def query(self, query_string, params=None):
+        if "topKByEmbedding" in query_string or "topK.byEmbedding" in query_string:
+            return [
+                {"n": {"~id": nid, "~properties": {"data": nid, "label": "MEM0_VECTOR_scores"}}, "score": dist}
+                for nid, dist in self._RESULTS
+            ]
+        return []
+
+
+class TestNeptuneAnalyticsScoreContract:
+    """search() must satisfy the VectorStoreBase.search contract: higher score = more
+    similar. Neptune returns a raw distance, so without conversion the nearest match
+    (distance ~0) scores ~0 and is dropped/ranked last."""
+
+    def _make_vec(self, monkeypatch):
+        monkeypatch.setattr(
+            "mem0.vector_stores.neptune_analytics.NeptuneAnalyticsGraph", lambda *args, **kwargs: None
+        )
+        vec = NeptuneAnalyticsVector(endpoint="neptune-graph://test", collection_name="scores")
+        vec.graph = _FakeNeptuneSearchGraph()
+        return vec
+
+    def test_nearest_neighbour_has_highest_score(self, monkeypatch):
+        vec = self._make_vec(monkeypatch)
+        results = vec.search(query="", vectors=[0.1, 0.2], top_k=3)
+
+        by_id = {r.id: r.score for r in results}
+        # Contract: the nearest neighbour (distance 0.0) must score highest.
+        assert by_id["A"] > by_id["B"] > by_id["C"], f"nearest match should score highest, got {by_id}"
+        # And it must not collapse to a raw distance that the default threshold drops.
+        assert by_id["A"] >= 0.1
+
+    def test_ranking_not_inverted_end_to_end(self, monkeypatch):
+        from mem0.utils.scoring import score_and_rank
+
+        vec = self._make_vec(monkeypatch)
+        out = vec.search(query="", vectors=[0.1, 0.2], top_k=3)
+        cands = [{"id": o.id, "score": o.score, "payload": o.payload} for o in out]
+        ranked = score_and_rank(cands, {}, {}, threshold=0.1, top_k=3)
+
+        assert ranked, "nearest match must not be dropped by the threshold"
+        assert ranked[0]["id"] == "A", f"nearest match should rank first, got {[r['id'] for r in ranked]}"
+
+
 class _FakeNeptuneGraph:
     """Minimal stand-in for `NeptuneAnalyticsGraph.query()` so update()'s compensation
     path can be exercised without a real Neptune Analytics endpoint."""


### PR DESCRIPTION
## Linked Issue

Closes #7068

## Description

Neptune Analytics' `topK.byEmbedding` (called by `search()` via `topKByEmbeddingWithFiltering`) returns the **squared Euclidean distance** as its `score` — lower means more similar, and the nearest/identical node scores `0.0`. This is documented by AWS, whose sample output shows the nearest node at `score: 0.0` and farther nodes at `24.0` / `25.0`:
https://docs.aws.amazon.com/neptune-analytics/latest/userguide/vectors.topK.byEmbedding.html

`_parse_query_responses` passed that value straight through as the similarity score, violating the `VectorStoreBase.search` contract (higher = more similar). As a result mem0's `score_and_rank` (default `threshold=0.1`, sorts descending):

- **drops the nearest matches** — distance ~0 becomes a score ~0, below the threshold;
- **ranks the farthest candidates first**.

So on a Neptune-backed `Memory`, `search()` returns results roughly farthest-first and silently discards the closest matches.

The fix converts the distance to similarity using the L2 formula the base class documents: `score = 1.0 / (1.0 + distance)` (monotonic, maps `[0, inf) -> (0, 1]`, nearest → highest). `get`/`list` (which return `score=None`) are unchanged.

This is the same class of fix already applied for pgvector (#6883), Milvus (#6933), the LangChain wrapper (#6884), Baidu (#6434) and Chroma. Unlike the euclidean-only cases (S3 Vectors #6546, Turbopuffer #6557), Neptune returns the distance **unconditionally** (no cosine path), so ranking is always inverted.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — scores were previously unusable (raw distances). Callers relying on mem0's documented similarity contract now get correct ranking.

## Test Coverage

- [x] I added/updated unit tests

Added `TestNeptuneAnalyticsScoreContract`, which drives `search()` through a fake graph returning the AWS sample distances (`0.0`, `24.0`, `25.0`) and asserts the nearest match scores highest, clears the default `0.1` threshold, and ranks first end-to-end through `score_and_rank`. All three assertions fail without the conversion (nearest is dropped and ranking inverts to `['B', 'C']`). Full `tests/vector_stores/test_neptune_analytics.py` passes (31 passed, 9 live-only skipped); `ruff check` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (n/a — internal scoring behavior)
