### PR TITLE
fix(vector_stores/neptune_analytics): convert distance to similarity …

### DIFF
--- a/mem0/vector_stores/neptune_analytics.py
+++ b/mem0/vector_stores/neptune_analytics.py
@@ -34,7 +34,7 @@ def _escape_cypher(value: str) -> str:
 
 class OutputData(BaseModel):
     id: Optional[str]  # memory id
-    score: Optional[float]  # distance
+    score: Optional[float]  # similarity (higher = more similar); see _parse_query_responses
     payload: Optional[Dict]  # metadata
 
 
@@ -432,7 +432,14 @@ class NeptuneAnalyticsVector(VectorStoreBase):
             properties = item[self._FIELD_N][self._FIELD_PROP]
             properties.pop("label", None)
             if with_score:
-                score = item[self._FIELD_SCORE]
+                # Neptune Analytics' topK.byEmbedding returns the squared Euclidean
+                # DISTANCE (lower = more similar). VectorStoreBase.search requires a
+                # similarity score (higher = more similar), so convert with the L2
+                # formula documented there: score = 1 / (1 + distance). Without this,
+                # mem0's score_and_rank sorts farthest-first and its threshold drops
+                # the nearest matches (distance ~0 -> score ~0).
+                raw_distance = item[self._FIELD_SCORE]
+                score = 1.0 / (1.0 + raw_distance) if raw_distance is not None else None
             else:
                 score = None
             result.append(OutputData(

--- a/tests/vector_stores/test_neptune_analytics.py
+++ b/tests/vector_stores/test_neptune_analytics.py
@@ -283,6 +283,59 @@ class TestNeptuneAnalyticsVectorInitValidation:
             )
 
 
+class _FakeNeptuneSearchGraph:
+    """Returns a canned topK.byEmbedding response so search()'s score handling can be
+    exercised without a real Neptune Analytics endpoint. Neptune returns the squared
+    Euclidean DISTANCE as `score` (lower = more similar); the sample below mirrors the
+    AWS docs where the nearest (identical) node scores 0.0 and farther nodes score higher."""
+
+    # (node_id, squared_euclidean_distance) ordered nearest -> farthest
+    _RESULTS = [("A", 0.0), ("B", 24.0), ("C", 25.0)]
+
+    def query(self, query_string, params=None):
+        if "topKByEmbedding" in query_string or "topK.byEmbedding" in query_string:
+            return [
+                {"n": {"~id": nid, "~properties": {"data": nid, "label": "MEM0_VECTOR_scores"}}, "score": dist}
+                for nid, dist in self._RESULTS
+            ]
+        return []
+
+
+class TestNeptuneAnalyticsScoreContract:
+    """search() must satisfy the VectorStoreBase.search contract: higher score = more
+    similar. Neptune returns a raw distance, so without conversion the nearest match
+    (distance ~0) scores ~0 and is dropped/ranked last."""
+
+    def _make_vec(self, monkeypatch):
+        monkeypatch.setattr(
+            "mem0.vector_stores.neptune_analytics.NeptuneAnalyticsGraph", lambda *args, **kwargs: None
+        )
+        vec = NeptuneAnalyticsVector(endpoint="neptune-graph://test", collection_name="scores")
+        vec.graph = _FakeNeptuneSearchGraph()
+        return vec
+
+    def test_nearest_neighbour_has_highest_score(self, monkeypatch):
+        vec = self._make_vec(monkeypatch)
+        results = vec.search(query="", vectors=[0.1, 0.2], top_k=3)
+
+        by_id = {r.id: r.score for r in results}
+        # Contract: the nearest neighbour (distance 0.0) must score highest.
+        assert by_id["A"] > by_id["B"] > by_id["C"], f"nearest match should score highest, got {by_id}"
+        # And it must not collapse to a raw distance that the default threshold drops.
+        assert by_id["A"] >= 0.1
+
+    def test_ranking_not_inverted_end_to_end(self, monkeypatch):
+        from mem0.utils.scoring import score_and_rank
+
+        vec = self._make_vec(monkeypatch)
+        out = vec.search(query="", vectors=[0.1, 0.2], top_k=3)
+        cands = [{"id": o.id, "score": o.score, "payload": o.payload} for o in out]
+        ranked = score_and_rank(cands, {}, {}, threshold=0.1, top_k=3)
+
+        assert ranked, "nearest match must not be dropped by the threshold"
+        assert ranked[0]["id"] == "A", f"nearest match should rank first, got {[r['id'] for r in ranked]}"
+
+
 class _FakeNeptuneGraph:
     """Minimal stand-in for `NeptuneAnalyticsGraph.query()` so update()'s compensation
     path can be exercised without a real Neptune Analytics endpoint."""


### PR DESCRIPTION
…so search ranking isn't inverted

Neptune Analytics' `topK.byEmbedding` (used by `search()` via `topKByEmbeddingWithFiltering`) returns the squared Euclidean DISTANCE as its `score` — lower means more similar, and the nearest/identical node scores 0.0 (confirmed in the AWS docs' sample output). `_parse_query_responses` passed that value straight through as the similarity score.

`VectorStoreBase.search` requires the opposite: higher = more similar. So mem0's `score_and_rank` (default `threshold=0.1`, sorts descending):
- drops the nearest matches, whose distance ~0 becomes a score ~0 < threshold;
- ranks the farthest candidates first.

Net effect: on a Neptune-backed `Memory`, `search()` returns results roughly farthest-first and silently discards the closest matches.

Convert with the L2 formula the base class documents: `score = 1 / (1 + distance)` (monotonic, maps [0, inf) -> (0, 1], nearest -> highest). This is the same class of fix already applied for pgvector, Baidu, Chroma, Milvus and the LangChain wrapper.

Adds a regression test using a fake graph that returns the AWS sample distances: the nearest match now scores highest, survives the threshold, and ranks first (all fail without the conversion).

Closes #7068

## Linked Issue

Closes #<!-- issue number -->

## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

<!-- This is about the code, not this description. Writing the description with AI is fine. -->

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [ ] AI-generated (an agent wrote most or all of this diff)

<!-- If you ticked either AI box, name the tool and what you checked yourself. -->

- [ ] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
