### PR TITLE
fix(vector_stores/mongodb): over-fetch before filtering so scoped searches don't lose results

### DIFF
--- a/mem0/vector_stores/mongodb.py
+++ b/mem0/vector_stores/mongodb.py
@@ -189,12 +189,23 @@ class MongoDB(VectorStoreBase):
         results = []
         try:
             collection = self.client[self.db_name][self.collection_name]
+
+            # $vectorSearch applies its `limit` BEFORE the payload filter can run.
+            # mem0's dynamic metadata filters aren't indexed as `filter`-type fields,
+            # so they can't move into $vectorSearch itself and must be applied as a
+            # later $match. Fetching only `top_k` candidates first then filtering
+            # silently drops scoped results whose vectors rank below other scopes'
+            # (e.g. a user_id whose memories aren't the query's global nearest) --
+            # frequently returning fewer than top_k, or zero. Over-fetch a larger
+            # candidate pool when filtering, then re-limit to top_k. (10000 is the
+            # MongoDB numCandidates ceiling.)
+            fetch_k = min(max(top_k * 20, 1000), 10000) if filters else top_k
             pipeline = [
                 {
                     "$vectorSearch": {
                         "index": self.index_name,
-                        "limit": top_k,
-                        "numCandidates": min(top_k * 20, 10000),
+                        "limit": fetch_k,
+                        "numCandidates": min(fetch_k * 20, 10000),
                         "queryVector": vectors,
                         "path": "embedding",
                     }
@@ -210,8 +221,9 @@ class MongoDB(VectorStoreBase):
                     filter_conditions.append({"payload." + key: value})
 
                 if filter_conditions:
-                    # Add a $match stage after vector search to apply filters
+                    # $match filters the over-fetched pool, then $limit restores top_k.
                     pipeline.insert(1, {"$match": {"$and": filter_conditions}})
+                    pipeline.append({"$limit": top_k})
 
             results = list(collection.aggregate(pipeline))
             logger.info(f"Vector search completed. Found {len(results)} documents.")

--- a/tests/vector_stores/test_mongodb.py
+++ b/tests/vector_stores/test_mongodb.py
@@ -129,8 +129,13 @@ def test_search_with_filters(mongo_vector_fixture):
     pipeline = mock_collection.aggregate.call_args[0][0]
     
     # Check that the pipeline has the expected stages
-    assert len(pipeline) == 4  # vectorSearch, match, set, project
-    
+    assert len(pipeline) == 5  # vectorSearch, match, set, project, limit
+
+    # $vectorSearch must over-fetch (its limit runs before the payload filter),
+    # and a trailing $limit restores top_k after filtering.
+    assert pipeline[0]["$vectorSearch"]["limit"] > 2
+    assert pipeline[-1] == {"$limit": 2}
+
     # Check that the match stage is present with the correct filters
     match_stage = pipeline[1]
     assert "$match" in match_stage
@@ -139,7 +144,7 @@ def test_search_with_filters(mongo_vector_fixture):
         {"payload.agent_id": "agent1"},
         {"payload.run_id": "run1"}
     ]
-    
+
     assert len(results) == 1
     assert results[0].payload["user_id"] == "alice"
     assert results[0].payload["agent_id"] == "agent1"
@@ -427,3 +432,63 @@ def test_search_allows_scalar_filter_values(mongo_vector_fixture):
     mock_collection.list_search_indexes.return_value = ["test_collection_vector_index"]
 
     mongo_vector.search("q", [0.1] * 1536, top_k=2, filters={"user_id": "alice", "count": 5})
+
+
+def _fake_vector_search_aggregate(dataset):
+    """Interpret the mem0 search pipeline the way MongoDB would, so recall behaviour
+    can be exercised without a live Atlas cluster. Supports the stages mem0 emits:
+    $vectorSearch (source + limit, ranked by |embedding - queryVector| on 1-D vectors),
+    $match (payload equality), and $limit."""
+
+    def _get(doc, dotted):
+        cur = doc
+        for part in dotted.split("."):
+            cur = cur.get(part, {})
+        return cur
+
+    def _aggregate(pipeline):
+        vs = pipeline[0]["$vectorSearch"]
+        qv = vs["queryVector"][0]
+        docs = sorted(dataset, key=lambda d: abs(d["embedding"] - qv))[: vs["limit"]]
+        docs = [{"_id": d["_id"], "score": 1.0 / (1.0 + abs(d["embedding"] - qv)), "payload": d["payload"]} for d in docs]
+        for stage in pipeline[1:]:
+            if "$match" in stage:
+                conds = stage["$match"]["$and"]
+                docs = [d for d in docs if all(_get(d, k) == v for c in conds for k, v in c.items())]
+            elif "$limit" in stage:
+                docs = docs[: stage["$limit"]]
+        return docs
+
+    return _aggregate
+
+
+def test_filtered_search_recalls_matches_ranked_beyond_top_k(mongo_vector_fixture):
+    """A scoped search must not lose results whose vectors rank below other scopes'.
+    Here alice's memories are all farther from the query than bob's, so the old
+    pipeline ($vectorSearch limit=top_k, then $match) returned zero for alice."""
+    mongo_vector, mock_collection, _ = mongo_vector_fixture
+    mock_collection.list_search_indexes.return_value = ["test_collection_vector_index"]
+
+    # 12 bob docs nearest the query (emb ~0), 5 alice docs far away (emb >= 10).
+    dataset = [{"_id": f"bob-{i}", "embedding": 0.01 * (i + 1), "payload": {"user_id": "bob"}} for i in range(12)]
+    dataset += [{"_id": f"alice-{i}", "embedding": 10.0 + i, "payload": {"user_id": "alice"}} for i in range(5)]
+    mock_collection.aggregate.side_effect = _fake_vector_search_aggregate(dataset)
+
+    results = mongo_vector.search("q", [0.0] * 1536, top_k=5, filters={"user_id": "alice"})
+
+    assert len(results) == 5, f"expected alice's 5 memories, got {len(results)}"
+    assert all(r.payload["user_id"] == "alice" for r in results)
+
+
+def test_filtered_search_still_respects_top_k(mongo_vector_fixture):
+    """Over-fetching must not return more than top_k after filtering."""
+    mongo_vector, mock_collection, _ = mongo_vector_fixture
+    mock_collection.list_search_indexes.return_value = ["test_collection_vector_index"]
+
+    dataset = [{"_id": f"alice-{i}", "embedding": 0.1 * i, "payload": {"user_id": "alice"}} for i in range(10)]
+    mock_collection.aggregate.side_effect = _fake_vector_search_aggregate(dataset)
+
+    results = mongo_vector.search("q", [0.0] * 1536, top_k=3, filters={"user_id": "alice"})
+
+    assert len(results) == 3
+    assert all(r.payload["user_id"] == "alice" for r in results)


### PR DESCRIPTION
## Linked Issue

Closes #7072

## Description

`MongoDB.search()` applied the payload filter as a `$match` stage placed **after** `$vectorSearch`, which fetched only `top_k` candidates first:

```python
{"$vectorSearch": {..., "limit": top_k, "numCandidates": min(top_k * 20, 10000)}}
{"$match": {"$and": [...]}}   # runs on those top_k only
```

`$vectorSearch` applies its `limit` before any later stage, so any vector matching the filter but ranked below the global `top_k` was never fetched. A scope (typically a `user_id`) whose vectors sit farther from the query than other scopes' vectors was silently under-returned — **frequently zero results** despite having plenty of matching memories. If the `top_k` nearest vectors all belong to `bob`, then `search(top_k=5, filters={"user_id": "alice"})` returns 0 even when alice has many relevant memories.

mem0's dynamic metadata filters aren't indexed as `filter`-type fields, so they can't move into `$vectorSearch` itself. Instead this over-fetches a larger candidate pool when a filter is present (bounded by MongoDB's 10000 `numCandidates` ceiling), then re-limits to `top_k` with a trailing `$limit`. **Non-filtered search is unchanged** (`fetch_k = top_k`, no `$limit` added).

This is the same class of recall bug already fixed for FAISS (#6998) and Cassandra (#6867).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A — filtered searches now return results they previously dropped; unfiltered search is byte-for-byte the same pipeline.

## Test Coverage

- [x] I added/updated unit tests

Added `test_filtered_search_recalls_matches_ranked_beyond_top_k` and `test_filtered_search_still_respects_top_k`, driven by a fake `aggregate` that models MongoDB's stage semantics (rank by distance, apply `$vectorSearch.limit`, then `$match`, then `$limit`). The recall test returns 0 without the fix and alice's 5 memories with it. Also updated `test_search_with_filters` to assert the corrected pipeline (over-fetched `$vectorSearch.limit` + trailing `$limit == top_k`). Full `tests/vector_stores/test_mongodb.py` passes (23 tests); `ruff check` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (n/a — internal query behavior)
