### PR TITLE
fix: tolerate missing Valkey timestamps

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -305,7 +305,7 @@ class ValkeyDB(VectorStoreBase):
                     pass
 
                 # Ensure created_at is present
-                if "created_at" not in payload:
+                if not payload.get("created_at"):
                     payload["created_at"] = datetime.now(pytz.timezone(self.timezone)).isoformat()
 
                 # Prepare the hash data
@@ -505,7 +505,7 @@ class ValkeyDB(VectorStoreBase):
                 pass
 
             # Ensure created_at is present
-            if "created_at" not in payload:
+            if not payload.get("created_at"):
                 payload["created_at"] = datetime.now(pytz.timezone(self.timezone)).isoformat()
 
             # Prepare the hash data
@@ -521,7 +521,7 @@ class ValkeyDB(VectorStoreBase):
                 hash_data["embedding"] = np.array(vector, dtype=np.float32).tobytes()
 
             # Add updated_at if available
-            if "updated_at" in payload:
+            if payload.get("updated_at"):
                 hash_data["updated_at"] = int(datetime.fromisoformat(payload["updated_at"]).timestamp())
 
             # Add optional fields

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -204,6 +204,21 @@ def test_update_handles_missing_created_at(valkey_db, mock_valkey_client):
     assert "created_at" in kwargs["mapping"]  # Should be added automatically
 
 
+def test_update_ignores_none_updated_at(valkey_db, mock_valkey_client):
+    """A missing Valkey timestamp should not fail a metadata update."""
+    payload = {
+        "hash": "test_hash",
+        "data": "updated_data",
+        "created_at": datetime.now(pytz.timezone("UTC")).isoformat(),
+        "updated_at": None,
+    }
+
+    valkey_db.update(vector_id="test_id", vector=None, payload=payload)
+
+    mock_valkey_client.hset.assert_called_once()
+    assert "updated_at" not in mock_valkey_client.hset.call_args.kwargs["mapping"]
+
+
 def test_update_with_none_vector_preserves_embedding(valkey_db, mock_valkey_client):
     """Test that update with vector=None does not corrupt the stored embedding.
 


### PR DESCRIPTION
Closes #6994

Valkey entity updates can receive `None` for timestamps from `list()`. Treat missing `created_at` values as absent and omit `updated_at` when it is `None`, instead of passing it to `datetime.fromisoformat()` and silently dropping the update.

Validation:
- `python3 -m compileall -q mem0 tests/vector_stores/test_valkey.py`
- `git diff --check`
- The targeted pytest could not run locally because `pytz` is not installed.