### PR TITLE
Handle empty vector-store responses in delete_all

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1920,9 +1920,10 @@ class Memory(MemoryBase):
         deleted_count = 0
         seen_batches = set()
         while True:
-            memories = self.vector_store.list(
+            listed_memories = self.vector_store.list(
                 filters=filters, top_k=DELETE_ALL_BATCH_SIZE
-            )[0]
+            )
+            memories = listed_memories[0] if listed_memories else []
             if not memories:
                 break
             batch_ids = tuple(sorted(str(memory.id) for memory in memories))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -310,6 +310,16 @@ def test_delete_all_paginates_beyond_vector_store_page_size(memory_instance):
     assert memory_instance.vector_store.list.call_count == 3
 
 
+def test_delete_all_stops_when_vector_store_returns_empty_response(memory_instance):
+    memory_instance.vector_store.list = Mock(return_value=[])
+    memory_instance._delete_memory = Mock()
+
+    result = memory_instance.delete_all(user_id="test_user")
+
+    assert result["message"] == "Memories deleted successfully!"
+    memory_instance._delete_memory.assert_not_called()
+
+
 def test_get_all(memory_instance):
     mock_memories = [Mock(id="1", payload={"data": "Memory 1", "user_id": "test_user"})]
     memory_instance.vector_store.list = Mock(return_value=(mock_memories, None))


### PR DESCRIPTION
Closes #7025\n\nSummary:\n- Treat an empty vector-store response as an empty page during delete_all.\n- Add regression coverage to ensure deletion exits cleanly.\n\nTests:\n- Python syntax compilation passed.\n- Pytest could not start because the local checkout is not installed as mem0ai.