### PR TITLE
Skip reasoning blocks when parsing LLM responses

### DIFF
--- a/mem0/llms/aws_bedrock.py
+++ b/mem0/llms/aws_bedrock.py
@@ -396,7 +396,10 @@ class AWSBedrockLLM(LLMBase):
 
             # Provider-specific response parsing
             if self.provider == "anthropic":
-                return response_json.get("content", [{"text": ""}])[0].get("text", "")
+                return next(
+                    (item["text"] for item in response_json.get("content", []) if "text" in item),
+                    "",
+                )
             elif self.provider == "amazon":
                 # Handle both Nova and legacy Amazon models
                 if "nova" in self.config.model.lower():
@@ -581,9 +584,12 @@ class AWSBedrockLLM(LLMBase):
 
             # Parse Converse API response
             if hasattr(response, 'output') and hasattr(response.output, 'message'):
-                return response.output.message.content[0].text
+                return next((block.text for block in response.output.message.content if hasattr(block, 'text')), '')
             elif 'output' in response and 'message' in response['output']:
-                return response['output']['message']['content'][0]['text']
+                return next(
+                    (block['text'] for block in response['output']['message']['content'] if 'text' in block),
+                    '',
+                )
             else:
                 return str(response)
 

--- a/mem0/llms/gemini.py
+++ b/mem0/llms/gemini.py
@@ -66,7 +66,7 @@ class GeminiLLM(LLMBase):
             if parts:
                 # Extract content from the first candidate
                 for part in parts:
-                    if hasattr(part, "text") and part.text:
+                    if hasattr(part, "text") and part.text and not getattr(part, "thought", False):
                         processed_response["content"] = part.text
                         break
 
@@ -85,7 +85,7 @@ class GeminiLLM(LLMBase):
         else:
             if parts:
                 for part in parts:
-                    if hasattr(part, "text") and part.text:
+                    if hasattr(part, "text") and part.text and not getattr(part, "thought", False):
                         return part.text
             return ""
 


### PR DESCRIPTION
Closes #7040\n\nSummary:\n- Ignore Gemini thought parts when extracting text.\n- Select text blocks rather than assuming the first Bedrock content block is text.\n\nTests:\n- Python syntax compilation passed.\n- Pytest could not start because the local checkout is not installed as mem0ai.