### PR TITLE
Avoid mutating proxy caller messages

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import threading
 from typing import List, Optional, Union
@@ -140,8 +141,9 @@ class Completions:
         return response
 
     def _prepare_messages(self, messages: List[dict]) -> List[dict]:
+        messages = copy.deepcopy(messages)
         if not messages or messages[0]["role"] != "system":
-            return [{"role": "system", "content": MEMORY_ANSWER_PROMPT}] + messages
+            return [{"role": "system", "content": MEMORY_ANSWER_PROMPT}, *messages]
         return messages
 
     def _async_add_to_memory(self, messages, user_id, agent_id, run_id, metadata, filters):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -143,6 +143,15 @@ def test_completions_create_messages_default_does_not_leak_between_calls(mock_me
     )
 
 
+def test_prepare_messages_does_not_mutate_caller_owned_dicts():
+    messages = [{"role": "user", "content": "original"}]
+
+    prepared = Completions(object())._prepare_messages(messages)
+    prepared[-1]["content"] = "injected"
+
+    assert messages[-1]["content"] == "original"
+
+
 def test_missing_litellm_raises_actionable_import_error(monkeypatch):
     monkeypatch.delitem(sys.modules, "mem0.proxy.main", raising=False)
     monkeypatch.delitem(sys.modules, "litellm", raising=False)


### PR DESCRIPTION
Closes #7024\n\nSummary:\n- Deep-copy proxy messages before prepending the system message.\n- Preserve caller-owned message dictionaries and lists.\n- Add a mutation regression test.\n\nTests:\n- Python syntax compilation passed.