### PR TITLE
Normalize Neptune Analytics distance scores

### DIFF
--- a/mem0/vector_stores/neptune_analytics.py
+++ b/mem0/vector_stores/neptune_analytics.py
@@ -38,6 +38,13 @@ class OutputData(BaseModel):
     payload: Optional[Dict]  # metadata
 
 
+def _distance_to_similarity(distance: Optional[float]) -> Optional[float]:
+    """Convert Neptune's squared-Euclidean distance to Mem0's similarity score."""
+    if distance is None:
+        return None
+    return 1.0 / (1.0 + max(distance, 0.0))
+
+
 class NeptuneAnalyticsVector(VectorStoreBase):
     """
     Neptune Analytics vector store implementation for Mem0.
@@ -432,7 +439,7 @@ class NeptuneAnalyticsVector(VectorStoreBase):
             properties = item[self._FIELD_N][self._FIELD_PROP]
             properties.pop("label", None)
             if with_score:
-                score = item[self._FIELD_SCORE]
+                score = _distance_to_similarity(item[self._FIELD_SCORE])
             else:
                 score = None
             result.append(OutputData(

--- a/tests/vector_stores/test_neptune_analytics.py
+++ b/tests/vector_stores/test_neptune_analytics.py
@@ -11,6 +11,7 @@ from mem0.utils.factory import VectorStoreFactory
 from mem0.vector_stores.neptune_analytics import (
     NeptuneAnalyticsVector,
     _escape_cypher,
+    _distance_to_similarity,
     _validate_filter,
 )
 
@@ -33,6 +34,12 @@ EMBEDDING_MODEL_DIMS = 1024
 VECTOR_1 = [-0.1] * EMBEDDING_MODEL_DIMS
 VECTOR_2 = [-0.2] * EMBEDDING_MODEL_DIMS
 VECTOR_3 = [-0.3] * EMBEDDING_MODEL_DIMS
+
+
+def test_neptune_distance_is_normalized_to_similarity():
+    assert _distance_to_similarity(0.0) == pytest.approx(1.0)
+    assert _distance_to_similarity(3.0) == pytest.approx(0.25)
+    assert _distance_to_similarity(None) is None
 
 SAMPLE_PAYLOADS = [
     {"test_text": "text_value", "another_field": "field_2_value"},


### PR DESCRIPTION
Closes #7068\n\nSummary:\n- Convert Neptune Analytics distance values into bounded similarity scores.\n- Add focused score conversion coverage.\n\nTests:\n- Python syntax compilation passed.\n- Pytest could not start because the local checkout is not installed as mem0ai.