### PR TITLE
feat(vector-stores): add Polign vector store backend

### DIFF
--- a/docs/components/vectordbs/dbs/polign.mdx
+++ b/docs/components/vectordbs/dbs/polign.mdx
@@ -70,5 +70,5 @@ config = {
 ```
 
 <Note>
-Polign metadata is string-to-string. Mem0 stores each memory's full payload JSON-encoded and additionally promotes scalar fields (like `user_id`, `agent_id`, `run_id`) to plain metadata keys, so session filters are applied server-side. Numeric range filters compare string forms literally.
+Mem0 stores each memory's full payload JSON-encoded and additionally promotes scalar fields (like `user_id`, `agent_id`, `run_id`, and any numeric or boolean metadata) to typed Polign metadata keys, so session and range filters are applied server-side with the right comparison semantics (numbers compare numerically). Requires a Polign server 0.3.0 or newer.
 </Note>

--- a/docs/components/vectordbs/dbs/polign.mdx
+++ b/docs/components/vectordbs/dbs/polign.mdx
@@ -1,0 +1,74 @@
+---
+title: "Polign"
+description: "Use Polign as a vector database in Mem0 — a single-binary vector store built for agent memory, with your data in your own object-storage bucket."
+---
+[Polign](https://polign.com) is a vector database built for agent memory. It runs as a single binary with no external dependencies, stores data in object storage you own, and serves vector, BM25, and hybrid search over HTTP or gRPC.
+
+### Usage
+
+```python Python
+import os
+from mem0 import Memory
+
+os.environ["OPENAI_API_KEY"] = "sk-xx"
+
+config = {
+    "vector_store": {
+        "provider": "polign",
+        "config": {
+            "collection_name": "movie_preferences",
+            "embedding_model_dims": 1536,
+            "url": "http://localhost:23000",
+        }
+    }
+}
+
+m = Memory.from_config(config)
+
+messages = [
+    {"role": "user", "content": "I'm planning to watch a movie tonight. Any recommendations?"},
+    {"role": "assistant", "content": "How about thriller movies? They can be quite engaging."},
+    {"role": "user", "content": "I'm not a big fan of thrillers but I love sci-fi."},
+    {"role": "assistant", "content": "Got it! I'll suggest sci-fi movies instead."}
+]
+
+m.add(messages, user_id="alice", metadata={"category": "movies"})
+
+# Search memories
+results = m.search(query="sci-fi recommendations", filters={"user_id": "alice"})
+```
+
+Collections are created automatically on first write, so no schema setup is needed.
+
+### Config
+
+Here are the parameters available for configuring Polign:
+
+| Parameter | Description | Default Value |
+| --- | --- | --- |
+| `collection_name` | Name of the collection | `mem0` |
+| `embedding_model_dims` | Dimensions of the embedding model (must match your chosen embedding model) | `1536` |
+| `url` | Base URL of the polign server's HTTP listener | `http://localhost:23000` |
+| `api_key` | API key (`plgn_<key_id>_<secret>`); optional — servers started without `-auth-stores` need none | Environment variable: `POLIGN_API_KEY` |
+| `ef` | HNSW beam width override for searches (`0` = server default) | `0` |
+| `batch_size` | Vectors per bulk-insert request (server max 5000) | `1000` |
+
+### Config Example
+
+```python Python
+config = {
+    "vector_store": {
+        "provider": "polign",
+        "config": {
+            "collection_name": "my_memories",
+            "embedding_model_dims": 1536,
+            "url": "https://db.example.com:23000",
+            "api_key": "plgn_xxxxxxxx_xxxxxxxx",
+        }
+    }
+}
+```
+
+<Note>
+Polign metadata is string-to-string. Mem0 stores each memory's full payload JSON-encoded and additionally promotes scalar fields (like `user_id`, `agent_id`, `run_id`) to plain metadata keys, so session filters are applied server-side. Numeric range filters compare string forms literally.
+</Note>

--- a/docs/components/vectordbs/overview.mdx
+++ b/docs/components/vectordbs/overview.mdx
@@ -36,6 +36,7 @@ See the list of supported vector databases below.
   <Card title="Neptune Analytics" icon="/images/provider-icons/aws-color.svg" href="/components/vectordbs/dbs/neptune_analytics"></Card>
   <Card title="Databricks" icon="/images/provider-icons/databricks.svg" href="/components/vectordbs/dbs/databricks"></Card>
   <Card title="Turbopuffer" icon="/images/provider-icons/turbopuffer.svg" href="/components/vectordbs/dbs/turbopuffer"></Card>
+  <Card title="Polign" icon="/images/provider-icons/polign.svg" href="/components/vectordbs/dbs/polign"></Card>
 </CardGroup>
 
 ## Usage

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -228,7 +228,8 @@
                               "components/vectordbs/dbs/databricks",
                               "components/vectordbs/dbs/neon",
                               "components/vectordbs/dbs/neptune_analytics",
-                              "components/vectordbs/dbs/turbopuffer"
+                              "components/vectordbs/dbs/turbopuffer",
+                              "components/vectordbs/dbs/polign"
                             ]
                           }
                         ]

--- a/docs/images/provider-icons/polign.svg
+++ b/docs/images/provider-icons/polign.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0B0F14"/>
+      <stop offset="1" stop-color="#1C2530"/>
+    </linearGradient>
+    <mask id="notch">
+      <rect width="32" height="32" fill="#fff"/>
+      <rect x="18.6" y="2.6" width="8.4" height="8.4" fill="#000"/>
+    </mask>
+  </defs>
+  <path mask="url(#notch)" fill="url(#g)" fill-rule="evenodd"
+    d="M9.5 27.5V4.5h9a9 9 0 0 1 0 18H14v5zM14 17.5h4.3a4 4 0 0 0 0-8H14z"/>
+  <rect x="21" y="3.6" width="5.2" height="5.2" rx="1.6" fill="#72F1B8"/>
+</svg>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -495,6 +495,7 @@ Everything below is OSS-only provider configuration. Skip this entire section wh
 - [Databricks](https://docs.mem0.ai/components/vectordbs/dbs/databricks) [OSS]: Use when the user is on Databricks with Delta Lake.
 - [Neptune Analytics](https://docs.mem0.ai/components/vectordbs/dbs/neptune_analytics) [OSS]: Use when the user is on AWS Neptune Analytics (graph + vector).
 - [Turbopuffer](https://docs.mem0.ai/components/vectordbs/dbs/turbopuffer) [OSS]: Use when the user is on Turbopuffer serverless.
+- [Polign](https://docs.mem0.ai/components/vectordbs/dbs/polign) [OSS]: Use when the user is on Polign (single-binary, bring-your-own-bucket agent memory store).
 
 ### Rerankers [OSS]
 - [Reranker Overview](https://docs.mem0.ai/components/rerankers/overview) [OSS]: Use when the user wants to improve OSS search result quality.

--- a/mem0/configs/vector_stores/polign.py
+++ b/mem0/configs/vector_stores/polign.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class PolignConfig(BaseModel):
+    collection_name: str = Field("mem0", description="Name of the collection")
+    embedding_model_dims: int = Field(1536, description="Dimensions of the embedding model")
+    url: str = Field("http://localhost:23000", description="Base URL of the polign server's HTTP listener")
+    api_key: Optional[str] = Field(
+        None,
+        description="API key ('plgn_<key_id>_<secret>'). Optional — servers started without -auth-stores need none. "
+        "Falls back to the POLIGN_API_KEY environment variable.",
+    )
+    ef: int = Field(0, description="HNSW beam width override for searches (0 = server default)")
+    batch_size: int = Field(1000, description="Vectors per put_many request (server max 5000)")
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_extra_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        allowed_fields = set(cls.model_fields.keys())
+        input_fields = set(values.keys())
+        extra_fields = input_fields - allowed_fields
+        if extra_fields:
+            raise ValueError(
+                f"Extra fields not allowed: {', '.join(extra_fields)}. "
+                f"Please input only the following fields: {', '.join(allowed_fields)}"
+            )
+        return values
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -204,6 +204,7 @@ class VectorStoreFactory:
         "neptune": "mem0.vector_stores.neptune_analytics.NeptuneAnalyticsVector",
         "turbopuffer": "mem0.vector_stores.turbopuffer.TurbopufferDB",
         "oracledb": "mem0.vector_stores.oracledb.OracleAIVectorSearch",
+        "polign": "mem0.vector_stores.polign.PolignDB",
     }
 
     @classmethod

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -36,6 +36,7 @@ class VectorStoreConfig(BaseModel):
         "s3_vectors": "S3VectorsConfig",
         "turbopuffer": "TurbopufferConfig",
         "oracledb": "OracleAIVectorSearchConfig",
+        "polign": "PolignConfig",
     }
 
     @model_validator(mode="after")

--- a/mem0/vector_stores/polign.py
+++ b/mem0/vector_stores/polign.py
@@ -151,72 +151,6 @@ class PolignDB(VectorStoreBase):
                 raise ValueError(f"Unsupported filter operator '{op}' for field '{key}' in Polign")
         return {key: ops} if ops else None
 
-    def _matches(self, payload: Dict, filters: Optional[Dict]) -> bool:
-        """Client-side filter evaluation (list() has no server-side filter)."""
-        if not filters:
-            return True
-
-        key_map = {"$or": "OR", "$not": "NOT", "$and": "AND"}
-        for key, value in filters.items():
-            key = key_map.get(key, key)
-            if key == "AND":
-                if not all(self._matches(payload, sub) for sub in value):
-                    return False
-            elif key == "OR":
-                if not any(self._matches(payload, sub) for sub in value):
-                    return False
-            elif key == "NOT":
-                if any(self._matches(payload, sub) for sub in value):
-                    return False
-            elif not self._matches_field(payload, key, value):
-                return False
-        return True
-
-    def _matches_field(self, payload: Dict, key: str, value: Any) -> bool:
-        present = key in payload
-        stored = _scalar_str(payload[key]) if present and payload[key] is not None else None
-        if not isinstance(value, dict):
-            if value == "*":
-                return present
-            if isinstance(value, list):
-                return stored in [_scalar_str(v) for v in value]
-            return stored == _scalar_str(value)
-
-        def _compare(a: str, b: str) -> int:
-            try:
-                fa, fb = float(a), float(b)
-                return (fa > fb) - (fa < fb)
-            except (TypeError, ValueError):
-                return (a > b) - (a < b)
-
-        for op, operand in value.items():
-            if op == "eq":
-                if stored != _scalar_str(operand):
-                    return False
-            elif op == "ne":
-                if stored == _scalar_str(operand):
-                    return False
-            elif op == "in":
-                if stored not in [_scalar_str(v) for v in operand]:
-                    return False
-            elif op == "nin":
-                if stored in [_scalar_str(v) for v in operand]:
-                    return False
-            elif op in ("gt", "gte", "lt", "lte"):
-                if stored is None:
-                    return False
-                cmp = _compare(stored, _scalar_str(operand))
-                if (
-                    (op == "gt" and cmp <= 0)
-                    or (op == "gte" and cmp < 0)
-                    or (op == "lt" and cmp >= 0)
-                    or (op == "lte" and cmp > 0)
-                ):
-                    return False
-            else:
-                raise ValueError(f"Unsupported filter operator '{op}' for field '{key}' in Polign")
-        return True
-
     # ── VectorStoreBase ─────────────────────────────────────────────
 
     def create_col(self, name=None, vector_size=None, distance=None):
@@ -403,8 +337,9 @@ class PolignDB(VectorStoreBase):
         """
         List vectors with optional filtering.
 
-        Polign's list endpoint has no filter parameter, so pages are filtered
-        client-side.
+        Filters run server-side (polign's list takes the same filter language
+        as search); offset and the page total count matching vectors only, so
+        pagination works unchanged under a filter.
 
         Args:
             filters (dict, optional): Filters to apply.
@@ -413,19 +348,19 @@ class PolignDB(VectorStoreBase):
         Returns:
             list: Wrapped list of OutputData objects ([[results]]).
         """
+        translated = self._translate_filters(filters)
         results: List[OutputData] = []
         offset = 0
         try:
             while top_k is None or len(results) < top_k:
-                page = self.client.list(self.collection_name, limit=self.batch_size, offset=offset)
+                limit = self.batch_size if top_k is None else min(self.batch_size, top_k - len(results))
+                page = self.client.list(self.collection_name, limit=limit, offset=offset, filter=translated)
                 if not page.vectors:
                     break
                 for vector in page.vectors:
-                    payload = self._decode_payload(vector.metadata)
-                    if self._matches(payload, filters):
-                        results.append(OutputData(id=vector.id, score=None, payload=payload))
-                        if top_k is not None and len(results) >= top_k:
-                            break
+                    results.append(OutputData(id=vector.id, score=None, payload=self._decode_payload(vector.metadata)))
+                    if top_k is not None and len(results) >= top_k:
+                        break
                 offset += len(page.vectors)
                 if offset >= page.total:
                     break

--- a/mem0/vector_stores/polign.py
+++ b/mem0/vector_stores/polign.py
@@ -1,0 +1,450 @@
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional, Union
+
+try:
+    from polign import Client as PolignClient
+    from polign import NotFoundError, PolignError
+    from polign import Vector as PolignVector
+except ImportError:
+    raise ImportError("Polign requires extra dependencies. Install with `pip install polign`") from None
+
+from pydantic import BaseModel
+
+from mem0.vector_stores.base import VectorStoreBase
+
+logger = logging.getLogger(__name__)
+
+# Polign metadata is string-to-string. The full mem0 payload is stored
+# JSON-encoded under this reserved key; scalar payload fields are also
+# promoted to plain string keys so filters run server-side.
+PAYLOAD_KEY = "_payload"
+
+
+class OutputData(BaseModel):
+    id: Optional[str]
+    score: Optional[float]
+    payload: Optional[Dict]
+
+
+def _scalar_str(value: Any) -> str:
+    """Canonical string form for a scalar, shared by storage and filters."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return value if isinstance(value, str) else str(value)
+
+
+class PolignDB(VectorStoreBase):
+    def __init__(
+        self,
+        collection_name: str,
+        embedding_model_dims: int,
+        url: str = "http://localhost:23000",
+        api_key: Optional[str] = None,
+        ef: int = 0,
+        batch_size: int = 1000,
+    ):
+        """
+        Initialize the Polign vector store.
+
+        Args:
+            collection_name (str): Name of the collection.
+            embedding_model_dims (int): Dimensions of the embedding model.
+            url (str, optional): Base URL of the polign server's HTTP listener.
+                Defaults to "http://localhost:23000".
+            api_key (str, optional): API key. Optional — servers started without
+                -auth-stores need none. Falls back to POLIGN_API_KEY.
+            ef (int, optional): HNSW beam width override (0 = server default).
+            batch_size (int, optional): Vectors per put_many request. Defaults to 1000.
+        """
+        api_key = api_key or os.environ.get("POLIGN_API_KEY")
+
+        self.client = PolignClient(url, api_key=api_key)
+        self.collection_name = collection_name
+        self.embedding_model_dims = embedding_model_dims
+        self.ef = ef
+        self.batch_size = min(batch_size, 5000)
+
+    # ── payload <-> metadata ────────────────────────────────────────
+
+    def _encode_payload(self, payload: Optional[Dict]) -> Dict[str, str]:
+        payload = payload or {}
+        metadata = {
+            key: _scalar_str(value)
+            for key, value in payload.items()
+            if isinstance(value, (str, int, float, bool)) and not key.startswith("_")
+        }
+        metadata[PAYLOAD_KEY] = json.dumps(payload)
+        return metadata
+
+    def _decode_payload(self, metadata: Optional[Dict[str, str]]) -> Dict:
+        metadata = metadata or {}
+        raw = metadata.get(PAYLOAD_KEY)
+        if raw is not None:
+            try:
+                return json.loads(raw)
+            except (TypeError, ValueError):
+                logger.warning("Malformed %s metadata in collection %s", PAYLOAD_KEY, self.collection_name)
+        return {k: v for k, v in metadata.items() if k != PAYLOAD_KEY}
+
+    # ── filters ─────────────────────────────────────────────────────
+
+    def _translate_filters(self, filters: Optional[Dict]) -> Optional[Dict]:
+        """
+        Translate mem0's filter syntax (scalars, lists, eq/ne/gt/gte/lt/lte/
+        in/nin operator dicts, AND/OR/NOT) to polign's filter language
+        ($eq/$ne/$gt/$gte/$lt/$lte/$in/$exists, $and/$or/$not).
+        """
+        if not filters:
+            return None
+
+        key_map = {"$or": "OR", "$not": "NOT", "$and": "AND"}
+        normalized = {}
+        for key, value in filters.items():
+            norm_key = key_map.get(key, key)
+            if norm_key not in normalized:
+                normalized[norm_key] = value
+
+        conditions: List[Dict] = []
+        for key, value in normalized.items():
+            if key in ("AND", "OR", "NOT"):
+                if not isinstance(value, list):
+                    raise ValueError(f"{key} filter value must be a list of filter dicts, got {type(value).__name__}")
+                subs = [s for s in (self._translate_filters(item) for item in value) if s]
+                if not subs:
+                    continue
+                if key == "AND":
+                    conditions.append(subs[0] if len(subs) == 1 else {"$and": subs})
+                elif key == "OR":
+                    conditions.append(subs[0] if len(subs) == 1 else {"$or": subs})
+                else:  # NOT
+                    conditions.append({"$not": subs[0] if len(subs) == 1 else {"$and": subs}})
+            else:
+                condition = self._translate_field(key, value)
+                if condition is not None:
+                    conditions.append(condition)
+
+        if not conditions:
+            return None
+        if len(conditions) == 1:
+            return conditions[0]
+        return {"$and": conditions}
+
+    def _translate_field(self, key: str, value: Any) -> Optional[Dict]:
+        if not isinstance(value, dict):
+            if value == "*":
+                return {key: {"$exists": True}}
+            if isinstance(value, list):
+                return {key: {"$in": [_scalar_str(v) for v in value]}}
+            return {key: _scalar_str(value)}
+
+        ops = {}
+        for op, operand in value.items():
+            if op in ("eq", "ne", "gt", "gte", "lt", "lte"):
+                ops[f"${op}"] = _scalar_str(operand)
+            elif op == "in":
+                ops["$in"] = [_scalar_str(v) for v in operand]
+            elif op == "nin":
+                return {"$not": {key: {"$in": [_scalar_str(v) for v in operand]}}}
+            else:
+                raise ValueError(f"Unsupported filter operator '{op}' for field '{key}' in Polign")
+        return {key: ops} if ops else None
+
+    def _matches(self, payload: Dict, filters: Optional[Dict]) -> bool:
+        """Client-side filter evaluation (list() has no server-side filter)."""
+        if not filters:
+            return True
+
+        key_map = {"$or": "OR", "$not": "NOT", "$and": "AND"}
+        for key, value in filters.items():
+            key = key_map.get(key, key)
+            if key == "AND":
+                if not all(self._matches(payload, sub) for sub in value):
+                    return False
+            elif key == "OR":
+                if not any(self._matches(payload, sub) for sub in value):
+                    return False
+            elif key == "NOT":
+                if any(self._matches(payload, sub) for sub in value):
+                    return False
+            elif not self._matches_field(payload, key, value):
+                return False
+        return True
+
+    def _matches_field(self, payload: Dict, key: str, value: Any) -> bool:
+        present = key in payload
+        stored = _scalar_str(payload[key]) if present and payload[key] is not None else None
+        if not isinstance(value, dict):
+            if value == "*":
+                return present
+            if isinstance(value, list):
+                return stored in [_scalar_str(v) for v in value]
+            return stored == _scalar_str(value)
+
+        def _compare(a: str, b: str) -> int:
+            try:
+                fa, fb = float(a), float(b)
+                return (fa > fb) - (fa < fb)
+            except (TypeError, ValueError):
+                return (a > b) - (a < b)
+
+        for op, operand in value.items():
+            if op == "eq":
+                if stored != _scalar_str(operand):
+                    return False
+            elif op == "ne":
+                if stored == _scalar_str(operand):
+                    return False
+            elif op == "in":
+                if stored not in [_scalar_str(v) for v in operand]:
+                    return False
+            elif op == "nin":
+                if stored in [_scalar_str(v) for v in operand]:
+                    return False
+            elif op in ("gt", "gte", "lt", "lte"):
+                if stored is None:
+                    return False
+                cmp = _compare(stored, _scalar_str(operand))
+                if (
+                    (op == "gt" and cmp <= 0)
+                    or (op == "gte" and cmp < 0)
+                    or (op == "lt" and cmp >= 0)
+                    or (op == "lte" and cmp > 0)
+                ):
+                    return False
+            else:
+                raise ValueError(f"Unsupported filter operator '{op}' for field '{key}' in Polign")
+        return True
+
+    # ── VectorStoreBase ─────────────────────────────────────────────
+
+    def create_col(self, name=None, vector_size=None, distance=None):
+        """
+        Create a new collection.
+        Collections are auto-created on first put, so this is a no-op.
+        """
+        pass
+
+    def insert(
+        self,
+        vectors: List[List[float]],
+        payloads: Optional[List[Dict]] = None,
+        ids: Optional[List[Union[str, int]]] = None,
+    ):
+        """
+        Insert vectors into the collection.
+
+        Args:
+            vectors (list): List of vectors to insert.
+            payloads (list, optional): List of payloads corresponding to vectors.
+            ids (list, optional): List of IDs corresponding to vectors.
+        """
+        logger.info(f"Inserting {len(vectors)} vectors into collection {self.collection_name}")
+
+        if ids is None:
+            ids = [str(i) for i in range(len(vectors))]
+
+        rows = [
+            PolignVector(
+                id=str(ids[i]),
+                values=vectors[i],
+                metadata=self._encode_payload(payloads[i] if payloads else None),
+            )
+            for i in range(len(vectors))
+        ]
+        for i in range(0, len(rows), self.batch_size):
+            self.client.put_many(self.collection_name, rows[i : i + self.batch_size])
+
+    def search(
+        self, query: str, vectors: List[float], top_k: int = 5, filters: Optional[Dict] = None
+    ) -> List[OutputData]:
+        """
+        Search for similar vectors.
+
+        Args:
+            query (str): Query text (unused in vector search, kept for interface consistency).
+            vectors (list): Query vector to search with.
+            top_k (int, optional): Number of results to return. Defaults to 5.
+            filters (dict, optional): Filters to apply to the search.
+
+        Returns:
+            list: Search results.
+        """
+        try:
+            hits = self.client.search(
+                self.collection_name,
+                values=vectors,
+                k=top_k,
+                ef=self.ef,
+                filter=self._translate_filters(filters),
+            )
+        except NotFoundError:
+            return []
+        # Auto-created collections use the L2 metric: similarity = 1 / (1 + distance).
+        return [
+            OutputData(
+                id=hit.id,
+                score=1.0 / (1.0 + hit.distance),
+                payload=self._decode_payload(hit.metadata),
+            )
+            for hit in hits
+        ]
+
+    def keyword_search(self, query: str, top_k: int = 5, filters: Optional[Dict] = None) -> Optional[List[OutputData]]:
+        """
+        BM25 full-text search (requires a segment index server-side).
+
+        Returns None if the server cannot serve a text search.
+        """
+        try:
+            hits = self.client.search(
+                self.collection_name,
+                text=query,
+                k=top_k,
+                filter=self._translate_filters(filters),
+            )
+        except PolignError as e:
+            logger.debug(f"Polign keyword search unavailable: {e}")
+            return None
+        return [OutputData(id=hit.id, score=hit.score, payload=self._decode_payload(hit.metadata)) for hit in hits]
+
+    def delete(self, vector_id: Union[str, int]):
+        """
+        Delete a vector by ID.
+
+        Args:
+            vector_id (Union[str, int]): ID of the vector to delete.
+        """
+        self.client.delete(self.collection_name, str(vector_id))
+
+    def update(
+        self,
+        vector_id: Union[str, int],
+        vector: Optional[List[float]] = None,
+        payload: Optional[Dict] = None,
+    ):
+        """
+        Update a vector and its payload.
+
+        Args:
+            vector_id (Union[str, int]): ID of the vector to update.
+            vector (list, optional): Updated vector.
+            payload (dict, optional): Updated payload.
+        """
+        existing = self.client.get(self.collection_name, str(vector_id))
+        self.client.put(
+            self.collection_name,
+            str(vector_id),
+            vector if vector is not None else existing.values,
+            metadata=self._encode_payload(payload) if payload is not None else existing.metadata,
+        )
+
+    def get(self, vector_id: Union[str, int]) -> Optional[OutputData]:
+        """
+        Retrieve a vector by ID.
+
+        Args:
+            vector_id (Union[str, int]): ID of the vector to retrieve.
+
+        Returns:
+            OutputData: Retrieved vector data, or None if not found.
+        """
+        try:
+            vector = self.client.get(self.collection_name, str(vector_id))
+        except NotFoundError:
+            return None
+        return OutputData(id=vector.id, score=None, payload=self._decode_payload(vector.metadata))
+
+    def list_cols(self) -> List[str]:
+        """
+        List all collections.
+
+        Returns:
+            list: List of collection names.
+        """
+        try:
+            return [c.name for c in self.client.list_collections()]
+        except PolignError as e:
+            logger.debug(f"Error listing collections: {e}")
+            return []
+
+    def delete_col(self):
+        """Delete the collection (falls back to deleting every vector)."""
+        try:
+            self.client.delete_collection(self.collection_name)
+            return
+        except PolignError as e:
+            logger.debug(f"delete_collection unavailable, deleting vectors instead: {e}")
+        try:
+            while True:
+                page = self.client.list(self.collection_name, limit=self.batch_size)
+                if not page.vectors:
+                    break
+                for vector in page.vectors:
+                    self.client.delete(self.collection_name, vector.id)
+        except NotFoundError:
+            pass
+
+    def col_info(self) -> Dict:
+        """
+        Get information about the collection.
+
+        Returns:
+            dict: Collection name and vector count.
+        """
+        try:
+            page = self.client.list(self.collection_name, limit=1)
+            return {"name": self.collection_name, "count": page.total}
+        except PolignError:
+            return {"name": self.collection_name}
+
+    def list(self, filters: Optional[Dict] = None, top_k: Optional[int] = 100) -> List[List[OutputData]]:
+        """
+        List vectors with optional filtering.
+
+        Polign's list endpoint has no filter parameter, so pages are filtered
+        client-side.
+
+        Args:
+            filters (dict, optional): Filters to apply.
+            top_k (int, optional): Number of vectors to return. Defaults to 100.
+
+        Returns:
+            list: Wrapped list of OutputData objects ([[results]]).
+        """
+        results: List[OutputData] = []
+        offset = 0
+        try:
+            while top_k is None or len(results) < top_k:
+                page = self.client.list(self.collection_name, limit=self.batch_size, offset=offset)
+                if not page.vectors:
+                    break
+                for vector in page.vectors:
+                    payload = self._decode_payload(vector.metadata)
+                    if self._matches(payload, filters):
+                        results.append(OutputData(id=vector.id, score=None, payload=payload))
+                        if top_k is not None and len(results) >= top_k:
+                            break
+                offset += len(page.vectors)
+                if offset >= page.total:
+                    break
+        except NotFoundError:
+            pass
+        return [results]
+
+    def count(self) -> int:
+        """
+        Get the live vector count of the collection.
+
+        Returns:
+            int: Number of vectors.
+        """
+        try:
+            return self.client.list(self.collection_name, limit=1).total
+        except PolignError:
+            return 0
+
+    def reset(self):
+        """Reset the collection by deleting all vectors (recreated on next insert)."""
+        self.delete_col()

--- a/mem0/vector_stores/polign.py
+++ b/mem0/vector_stores/polign.py
@@ -16,9 +16,10 @@ from mem0.vector_stores.base import VectorStoreBase
 
 logger = logging.getLogger(__name__)
 
-# Polign metadata is string-to-string. The full mem0 payload is stored
-# JSON-encoded under this reserved key; scalar payload fields are also
-# promoted to plain string keys so filters run server-side.
+# Polign metadata holds typed scalars (strings, numbers, booleans). The full
+# mem0 payload is stored JSON-encoded under this reserved key; scalar payload
+# fields are also promoted to plain metadata keys so filters run server-side
+# with the right comparison semantics (numbers compare numerically).
 PAYLOAD_KEY = "_payload"
 
 
@@ -28,11 +29,17 @@ class OutputData(BaseModel):
     payload: Optional[Dict]
 
 
-def _scalar_str(value: Any) -> str:
-    """Canonical string form for a scalar, shared by storage and filters."""
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    return value if isinstance(value, str) else str(value)
+def _is_scalar(value: Any) -> bool:
+    return isinstance(value, (str, int, float, bool))
+
+
+def _scalar(value: Any) -> Any:
+    """Metadata form of a scalar, shared by storage and filters.
+
+    Strings, ints, floats, and bools pass through typed so the server
+    compares them by type. Anything else falls back to its string form.
+    """
+    return value if _is_scalar(value) else str(value)
 
 
 class PolignDB(VectorStoreBase):
@@ -68,17 +75,13 @@ class PolignDB(VectorStoreBase):
 
     # ── payload <-> metadata ────────────────────────────────────────
 
-    def _encode_payload(self, payload: Optional[Dict]) -> Dict[str, str]:
+    def _encode_payload(self, payload: Optional[Dict]) -> Dict[str, Any]:
         payload = payload or {}
-        metadata = {
-            key: _scalar_str(value)
-            for key, value in payload.items()
-            if isinstance(value, (str, int, float, bool)) and not key.startswith("_")
-        }
+        metadata = {key: value for key, value in payload.items() if _is_scalar(value) and not key.startswith("_")}
         metadata[PAYLOAD_KEY] = json.dumps(payload)
         return metadata
 
-    def _decode_payload(self, metadata: Optional[Dict[str, str]]) -> Dict:
+    def _decode_payload(self, metadata: Optional[Dict[str, Any]]) -> Dict:
         metadata = metadata or {}
         raw = metadata.get(PAYLOAD_KEY)
         if raw is not None:
@@ -136,17 +139,17 @@ class PolignDB(VectorStoreBase):
             if value == "*":
                 return {key: {"$exists": True}}
             if isinstance(value, list):
-                return {key: {"$in": [_scalar_str(v) for v in value]}}
-            return {key: _scalar_str(value)}
+                return {key: {"$in": [_scalar(v) for v in value]}}
+            return {key: _scalar(value)}
 
         ops = {}
         for op, operand in value.items():
             if op in ("eq", "ne", "gt", "gte", "lt", "lte"):
-                ops[f"${op}"] = _scalar_str(operand)
+                ops[f"${op}"] = _scalar(operand)
             elif op == "in":
-                ops["$in"] = [_scalar_str(v) for v in operand]
+                ops["$in"] = [_scalar(v) for v in operand]
             elif op == "nin":
-                return {"$not": {key: {"$in": [_scalar_str(v) for v in operand]}}}
+                return {"$not": {key: {"$in": [_scalar(v) for v in operand]}}}
             else:
                 raise ValueError(f"Unsupported filter operator '{op}' for field '{key}' in Polign")
         return {key: ops} if ops else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ vector-stores = [
     "pymilvus>=2.4.0,<2.6.0",
     "langchain-aws>=0.2.23,<0.3.0",
     "oracledb>=2.2.0",
-    "polign>=0.2.0",
+    "polign>=0.3.0",
 ]
 llms = [
     "groq>=0.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ vector-stores = [
     "pymilvus>=2.4.0,<2.6.0",
     "langchain-aws>=0.2.23,<0.3.0",
     "oracledb>=2.2.0",
-    "polign>=0.1.0",
+    "polign>=0.2.0",
 ]
 llms = [
     "groq>=0.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ vector-stores = [
     "pymilvus>=2.4.0,<2.6.0",
     "langchain-aws>=0.2.23,<0.3.0",
     "oracledb>=2.2.0",
+    "polign>=0.1.0",
 ]
 llms = [
     "groq>=0.3.0",

--- a/tests/vector_stores/test_polign.py
+++ b/tests/vector_stores/test_polign.py
@@ -1,0 +1,324 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("polign", reason="polign not installed")
+
+from polign import Hit, NotFoundError, Vector, VectorPage
+
+from mem0.vector_stores.polign import PAYLOAD_KEY, OutputData, PolignDB
+
+
+def _encoded(payload):
+    """Metadata dict as PolignDB stores it for the given payload."""
+    metadata = {
+        k: ("true" if v is True else "false" if v is False else v if isinstance(v, str) else str(v))
+        for k, v in payload.items()
+        if isinstance(v, (str, int, float, bool)) and not k.startswith("_")
+    }
+    metadata[PAYLOAD_KEY] = json.dumps(payload)
+    return metadata
+
+
+@pytest.fixture
+def mock_client():
+    with patch("mem0.vector_stores.polign.PolignClient") as MockClient:
+        client_instance = MagicMock()
+        MockClient.return_value = client_instance
+        yield client_instance
+
+
+@pytest.fixture
+def db(mock_client):
+    return PolignDB(
+        collection_name="test_col",
+        embedding_model_dims=4,
+        url="http://localhost:23000",
+        batch_size=2,
+    )
+
+
+# ── Initialization ──────────────────────────────────────────────────
+
+
+class TestInit:
+    def test_init_defaults(self, mock_client):
+        with patch("mem0.vector_stores.polign.PolignClient") as MockClient:
+            db = PolignDB(collection_name="my_col", embedding_model_dims=128)
+            MockClient.assert_called_once_with("http://localhost:23000", api_key=None)
+        assert db.collection_name == "my_col"
+        assert db.embedding_model_dims == 128
+        assert db.batch_size == 1000
+
+    def test_init_with_auth(self):
+        with patch("mem0.vector_stores.polign.PolignClient") as MockClient:
+            PolignDB(
+                collection_name="c",
+                embedding_model_dims=4,
+                url="https://db.example.com:23000",
+                api_key="plgn_id_secret",
+            )
+            MockClient.assert_called_once_with("https://db.example.com:23000", api_key="plgn_id_secret")
+
+    def test_init_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("POLIGN_API_KEY", "plgn_env_key")
+        with patch("mem0.vector_stores.polign.PolignClient") as MockClient:
+            PolignDB(collection_name="c", embedding_model_dims=4)
+            assert MockClient.call_args.kwargs["api_key"] == "plgn_env_key"
+
+    def test_batch_size_capped_at_server_max(self, mock_client):
+        db = PolignDB(collection_name="c", embedding_model_dims=4, batch_size=9000)
+        assert db.batch_size == 5000
+
+
+# ── Payload encoding ────────────────────────────────────────────────
+
+
+class TestPayloadCodec:
+    def test_encode_promotes_scalars_and_keeps_json(self, db):
+        payload = {"data": "hello", "user_id": "alice", "count": 3, "flag": True, "nested": {"a": 1}}
+        metadata = db._encode_payload(payload)
+        assert metadata["data"] == "hello"
+        assert metadata["user_id"] == "alice"
+        assert metadata["count"] == "3"
+        assert metadata["flag"] == "true"
+        assert "nested" not in metadata  # non-scalar: only inside the JSON blob
+        assert json.loads(metadata[PAYLOAD_KEY]) == payload
+
+    def test_decode_roundtrip(self, db):
+        payload = {"data": "hi", "user_id": "u", "score": 0.5, "nested": {"a": [1, 2]}}
+        assert db._decode_payload(db._encode_payload(payload)) == payload
+
+    def test_decode_without_payload_key_falls_back_to_raw(self, db):
+        assert db._decode_payload({"user_id": "u"}) == {"user_id": "u"}
+
+    def test_decode_malformed_payload_key(self, db):
+        assert db._decode_payload({PAYLOAD_KEY: "{not json", "user_id": "u"}) == {"user_id": "u"}
+
+
+# ── Filter translation ──────────────────────────────────────────────
+
+
+class TestFilterTranslation:
+    def test_none_and_empty(self, db):
+        assert db._translate_filters(None) is None
+        assert db._translate_filters({}) is None
+
+    def test_equality_and_coercion(self, db):
+        assert db._translate_filters({"user_id": "alice"}) == {"user_id": "alice"}
+        assert db._translate_filters({"count": 3}) == {"count": "3"}
+        assert db._translate_filters({"flag": True}) == {"flag": "true"}
+
+    def test_multiple_keys_anded(self, db):
+        result = db._translate_filters({"user_id": "alice", "agent_id": "a1"})
+        assert result == {"$and": [{"user_id": "alice"}, {"agent_id": "a1"}]}
+
+    def test_wildcard_maps_to_exists(self, db):
+        assert db._translate_filters({"user_id": "*"}) == {"user_id": {"$exists": True}}
+
+    def test_list_shorthand_maps_to_in(self, db):
+        assert db._translate_filters({"lang": ["en", "fr"]}) == {"lang": {"$in": ["en", "fr"]}}
+
+    def test_comparison_operators(self, db):
+        assert db._translate_filters({"score": {"gte": 0.5}}) == {"score": {"$gte": "0.5"}}
+        assert db._translate_filters({"a": {"ne": "x"}}) == {"a": {"$ne": "x"}}
+        assert db._translate_filters({"a": {"in": ["x", "y"]}}) == {"a": {"$in": ["x", "y"]}}
+
+    def test_nin_uses_not_in(self, db):
+        assert db._translate_filters({"a": {"nin": ["x"]}}) == {"$not": {"a": {"$in": ["x"]}}}
+
+    def test_logical_operators(self, db):
+        result = db._translate_filters({"OR": [{"a": "1"}, {"b": "2"}]})
+        assert result == {"$or": [{"a": "1"}, {"b": "2"}]}
+        result = db._translate_filters({"$or": [{"a": "1"}, {"b": "2"}]})
+        assert result == {"$or": [{"a": "1"}, {"b": "2"}]}
+        result = db._translate_filters({"NOT": [{"a": "1"}]})
+        assert result == {"$not": {"a": "1"}}
+        result = db._translate_filters({"AND": [{"a": "1"}, {"b": "2"}]})
+        assert result == {"$and": [{"a": "1"}, {"b": "2"}]}
+
+    def test_unsupported_operator_raises(self, db):
+        with pytest.raises(ValueError, match="Unsupported filter operator"):
+            db._translate_filters({"a": {"icontains": "x"}})
+
+
+# ── Insert ──────────────────────────────────────────────────────────
+
+
+class TestInsert:
+    def test_insert_batches(self, db, mock_client):
+        vectors = [[0.1] * 4, [0.2] * 4, [0.3] * 4]
+        payloads = [{"data": f"m{i}", "user_id": "u"} for i in range(3)]
+        ids = ["id0", "id1", "id2"]
+
+        db.insert(vectors, payloads=payloads, ids=ids)
+
+        assert mock_client.put_many.call_count == 2  # batch_size=2 → 2+1
+        first_batch = mock_client.put_many.call_args_list[0].args[1]
+        assert [v.id for v in first_batch] == ["id0", "id1"]
+        assert first_batch[0].values == vectors[0]
+        assert first_batch[0].metadata["user_id"] == "u"
+        assert json.loads(first_batch[0].metadata[PAYLOAD_KEY]) == payloads[0]
+
+    def test_insert_without_ids_or_payloads(self, db, mock_client):
+        db.insert([[0.1] * 4])
+        batch = mock_client.put_many.call_args.args[1]
+        assert batch[0].id == "0"
+        assert json.loads(batch[0].metadata[PAYLOAD_KEY]) == {}
+
+
+# ── Search ──────────────────────────────────────────────────────────
+
+
+class TestSearch:
+    def test_search_converts_distance_to_score(self, db, mock_client):
+        payload = {"data": "hello", "user_id": "alice"}
+        mock_client.search.return_value = [Hit(id="m1", distance=1.0, metadata=_encoded(payload))]
+
+        results = db.search("q", [0.1] * 4, top_k=5, filters={"user_id": "alice"})
+
+        mock_client.search.assert_called_once_with("test_col", values=[0.1] * 4, k=5, ef=0, filter={"user_id": "alice"})
+        assert len(results) == 1
+        assert results[0].id == "m1"
+        assert results[0].score == pytest.approx(0.5)  # 1 / (1 + 1.0)
+        assert results[0].payload == payload
+
+    def test_search_missing_collection_returns_empty(self, db, mock_client):
+        mock_client.search.side_effect = NotFoundError("no such collection")
+        assert db.search("q", [0.1] * 4) == []
+
+    def test_keyword_search(self, db, mock_client):
+        payload = {"data": "quick brown fox"}
+        mock_client.search.return_value = [Hit(id="m1", distance=0.0, score=7.3, metadata=_encoded(payload))]
+
+        results = db.keyword_search("fox", top_k=3)
+
+        mock_client.search.assert_called_once_with("test_col", text="fox", k=3, filter=None)
+        assert results[0].score == pytest.approx(7.3)
+
+    def test_keyword_search_unavailable_returns_none(self, db, mock_client):
+        mock_client.search.side_effect = NotFoundError("no segment index")
+        assert db.keyword_search("fox") is None
+
+
+# ── Get / delete / update ───────────────────────────────────────────
+
+
+class TestCrud:
+    def test_get(self, db, mock_client):
+        payload = {"data": "hello"}
+        mock_client.get.return_value = Vector(id="m1", values=[0.1] * 4, metadata=_encoded(payload))
+        result = db.get("m1")
+        mock_client.get.assert_called_once_with("test_col", "m1")
+        assert result.id == "m1"
+        assert result.payload == payload
+
+    def test_get_missing_returns_none(self, db, mock_client):
+        mock_client.get.side_effect = NotFoundError("nope")
+        assert db.get("missing") is None
+
+    def test_delete(self, db, mock_client):
+        db.delete("m1")
+        mock_client.delete.assert_called_once_with("test_col", "m1")
+
+    def test_update_payload_only_keeps_vector(self, db, mock_client):
+        mock_client.get.return_value = Vector(id="m1", values=[0.5] * 4, metadata=_encoded({"data": "old"}))
+        db.update("m1", payload={"data": "new"})
+        args = mock_client.put.call_args
+        assert args.args == ("test_col", "m1", [0.5] * 4)
+        assert json.loads(args.kwargs["metadata"][PAYLOAD_KEY]) == {"data": "new"}
+
+    def test_update_vector_only_keeps_payload(self, db, mock_client):
+        old_metadata = _encoded({"data": "old"})
+        mock_client.get.return_value = Vector(id="m1", values=[0.5] * 4, metadata=old_metadata)
+        db.update("m1", vector=[0.9] * 4)
+        args = mock_client.put.call_args
+        assert args.args == ("test_col", "m1", [0.9] * 4)
+        assert args.kwargs["metadata"] == old_metadata
+
+
+# ── List ────────────────────────────────────────────────────────────
+
+
+class TestList:
+    def _page(self, payloads, ids=None, total=None):
+        vectors = [
+            Vector(id=ids[i] if ids else f"id{i}", values=[0.1], metadata=_encoded(p)) for i, p in enumerate(payloads)
+        ]
+        return VectorPage(vectors=vectors, total=total if total is not None else len(vectors))
+
+    def test_list_filters_client_side(self, db, mock_client):
+        mock_client.list.return_value = self._page([{"data": "a", "user_id": "alice"}, {"data": "b", "user_id": "bob"}])
+        [results] = db.list(filters={"user_id": "alice"})
+        assert [r.payload["data"] for r in results] == ["a"]
+
+    def test_list_paginates_until_total(self, db, mock_client):
+        page1 = self._page([{"data": "a"}, {"data": "b"}], ids=["a", "b"], total=3)
+        page2 = self._page([{"data": "c"}], ids=["c"], total=3)
+        mock_client.list.side_effect = [page1, page2]
+        [results] = db.list(top_k=100)
+        assert [r.id for r in results] == ["a", "b", "c"]
+        assert mock_client.list.call_count == 2
+        assert mock_client.list.call_args_list[1].kwargs["offset"] == 2
+
+    def test_list_respects_top_k(self, db, mock_client):
+        mock_client.list.return_value = self._page([{"data": "a"}, {"data": "b"}])
+        [results] = db.list(top_k=1)
+        assert len(results) == 1
+
+    def test_list_missing_collection_returns_empty(self, db, mock_client):
+        mock_client.list.side_effect = NotFoundError("nope")
+        assert db.list() == [[]]
+
+    def test_client_side_operator_matching(self, db):
+        payload = {"user_id": "alice", "score": 0.7}
+        assert db._matches(payload, {"score": {"gte": 0.5}})
+        assert not db._matches(payload, {"score": {"lt": 0.5}})
+        assert db._matches(payload, {"user_id": "*"})
+        assert db._matches(payload, {"user_id": ["alice", "bob"]})
+        assert db._matches(payload, {"OR": [{"user_id": "bob"}, {"score": 0.7}]})
+        assert not db._matches(payload, {"NOT": [{"user_id": "alice"}]})
+        assert db._matches(payload, {"missing": {"nin": ["x"]}})
+
+
+# ── Collection ops ──────────────────────────────────────────────────
+
+
+class TestCollectionOps:
+    def test_list_cols(self, db, mock_client):
+        col = MagicMock()
+        col.name = "test_col"
+        mock_client.list_collections.return_value = [col]
+        assert db.list_cols() == ["test_col"]
+
+    def test_col_info_and_count(self, db, mock_client):
+        mock_client.list.return_value = VectorPage(vectors=[], total=42)
+        assert db.col_info() == {"name": "test_col", "count": 42}
+        assert db.count() == 42
+
+    def test_delete_col_prefers_collection_delete(self, db, mock_client):
+        db.delete_col()
+        mock_client.delete_collection.assert_called_once_with("test_col")
+        mock_client.list.assert_not_called()
+
+    def test_delete_col_falls_back_to_vector_deletes(self, db, mock_client):
+        from polign import PolignError
+
+        mock_client.delete_collection.side_effect = PolignError("registry not enabled")
+        page = VectorPage(vectors=[Vector(id="a", values=[0.1]), Vector(id="b", values=[0.1])], total=2)
+        empty = VectorPage(vectors=[], total=0)
+        mock_client.list.side_effect = [page, empty]
+
+        db.reset()
+
+        deleted = [c.args[1] for c in mock_client.delete.call_args_list]
+        assert deleted == ["a", "b"]
+
+
+# ── Output shape ────────────────────────────────────────────────────
+
+
+def test_output_data_model():
+    out = OutputData(id="x", score=0.9, payload={"data": "hi"})
+    assert out.id == "x" and out.score == 0.9 and out.payload == {"data": "hi"}

--- a/tests/vector_stores/test_polign.py
+++ b/tests/vector_stores/test_polign.py
@@ -248,10 +248,16 @@ class TestList:
         ]
         return VectorPage(vectors=vectors, total=total if total is not None else len(vectors))
 
-    def test_list_filters_client_side(self, db, mock_client):
-        mock_client.list.return_value = self._page([{"data": "a", "user_id": "alice"}, {"data": "b", "user_id": "bob"}])
+    def test_list_passes_translated_filter_server_side(self, db, mock_client):
+        mock_client.list.return_value = self._page([{"data": "a", "user_id": "alice"}])
         [results] = db.list(filters={"user_id": "alice"})
+        assert mock_client.list.call_args.kwargs["filter"] == {"user_id": "alice"}
         assert [r.payload["data"] for r in results] == ["a"]
+
+    def test_list_without_filters_sends_none(self, db, mock_client):
+        mock_client.list.return_value = self._page([{"data": "a"}])
+        db.list()
+        assert mock_client.list.call_args.kwargs["filter"] is None
 
     def test_list_paginates_until_total(self, db, mock_client):
         page1 = self._page([{"data": "a"}, {"data": "b"}], ids=["a", "b"], total=3)
@@ -270,16 +276,6 @@ class TestList:
     def test_list_missing_collection_returns_empty(self, db, mock_client):
         mock_client.list.side_effect = NotFoundError("nope")
         assert db.list() == [[]]
-
-    def test_client_side_operator_matching(self, db):
-        payload = {"user_id": "alice", "score": 0.7}
-        assert db._matches(payload, {"score": {"gte": 0.5}})
-        assert not db._matches(payload, {"score": {"lt": 0.5}})
-        assert db._matches(payload, {"user_id": "*"})
-        assert db._matches(payload, {"user_id": ["alice", "bob"]})
-        assert db._matches(payload, {"OR": [{"user_id": "bob"}, {"score": 0.7}]})
-        assert not db._matches(payload, {"NOT": [{"user_id": "alice"}]})
-        assert db._matches(payload, {"missing": {"nin": ["x"]}})
 
 
 # ── Collection ops ──────────────────────────────────────────────────

--- a/tests/vector_stores/test_polign.py
+++ b/tests/vector_stores/test_polign.py
@@ -12,11 +12,7 @@ from mem0.vector_stores.polign import PAYLOAD_KEY, OutputData, PolignDB
 
 def _encoded(payload):
     """Metadata dict as PolignDB stores it for the given payload."""
-    metadata = {
-        k: ("true" if v is True else "false" if v is False else v if isinstance(v, str) else str(v))
-        for k, v in payload.items()
-        if isinstance(v, (str, int, float, bool)) and not k.startswith("_")
-    }
+    metadata = {k: v for k, v in payload.items() if isinstance(v, (str, int, float, bool)) and not k.startswith("_")}
     metadata[PAYLOAD_KEY] = json.dumps(payload)
     return metadata
 
@@ -81,8 +77,8 @@ class TestPayloadCodec:
         metadata = db._encode_payload(payload)
         assert metadata["data"] == "hello"
         assert metadata["user_id"] == "alice"
-        assert metadata["count"] == "3"
-        assert metadata["flag"] == "true"
+        assert metadata["count"] == 3  # typed: numbers compare numerically server-side
+        assert metadata["flag"] is True
         assert "nested" not in metadata  # non-scalar: only inside the JSON blob
         assert json.loads(metadata[PAYLOAD_KEY]) == payload
 
@@ -107,8 +103,8 @@ class TestFilterTranslation:
 
     def test_equality_and_coercion(self, db):
         assert db._translate_filters({"user_id": "alice"}) == {"user_id": "alice"}
-        assert db._translate_filters({"count": 3}) == {"count": "3"}
-        assert db._translate_filters({"flag": True}) == {"flag": "true"}
+        assert db._translate_filters({"count": 3}) == {"count": 3}
+        assert db._translate_filters({"flag": True}) == {"flag": True}
 
     def test_multiple_keys_anded(self, db):
         result = db._translate_filters({"user_id": "alice", "agent_id": "a1"})
@@ -121,7 +117,7 @@ class TestFilterTranslation:
         assert db._translate_filters({"lang": ["en", "fr"]}) == {"lang": {"$in": ["en", "fr"]}}
 
     def test_comparison_operators(self, db):
-        assert db._translate_filters({"score": {"gte": 0.5}}) == {"score": {"$gte": "0.5"}}
+        assert db._translate_filters({"score": {"gte": 0.5}}) == {"score": {"$gte": 0.5}}
         assert db._translate_filters({"a": {"ne": "x"}}) == {"a": {"$ne": "x"}}
         assert db._translate_filters({"a": {"in": ["x", "y"]}}) == {"a": {"$in": ["x", "y"]}}
 


### PR DESCRIPTION
## Linked Issue

Closes #6930

## Description

Adds [Polign](https://polign.com) as a vector store backend for the Python SDK. Polign  serves vector + BM25 search over the user's own object storage (S3, GCS, or filesystem), so memory data stays in the user's 
account with no cluster to operate. Approach as proposed in #6930.

What's in the diff:

- `mem0/vector_stores/polign.py`: `PolignDB(VectorStoreBase)` implementing `create_col`, `insert`, `search`, `delete`, `u
pdate`, `get`, `list_cols`, `delete_col`, `col_info`, `list` (filters run server-side), `count`, `reset`, and the optiona
l `keyword_search` via Polign's BM25 (returns `None` when the server has no segment index yet, which `Memory` already han
dles).
- Payloads are stored JSON-encoded under a reserved `_payload` metadata key and scalar fields 
- Vector search scores follow the `VectorStoreBase` contract: `1 / (1 + distance)` for the L2 metric.
- `mem0/configs/vector_stores/polign.py` config class plus registration in `mem0/vector_stores/configs.py` and `mem0/util
s/factory.py`.
- Docs page `docs/components/vectordbs/dbs/polign.mdx`, nav entry in `docs/docs.json`, `docs/llms.txt` entry, overview ca
rd and icon.
- `tests/vector_stores/test_polign.py` (38 tests, mocked client).

Disclosure: I'm the founder of Polign and will maintain this backend.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [x ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [] AI-generated (an agent wrote most or all of this diff)

Tool: Claude Code.

- [x ] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes
N/A

## Test Coverage

- [x ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x ] I tested manually (describe below)
- [ ] No tests needed (explain why)

- `pytest tests/vector_stores/test_polign.py`: 38 passed. 
- Live run against a Polign 0.3.0 server 
- Full `Memory` stack over Polign with a stubbed LLM and embedder
- `ruff check`, `ruff format --check`, `isort --check-only` clean on touched files
- 
## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
