### PR TITLE
fix(proxy): stop _prepare_messages from aliasing caller messages

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -140,9 +140,13 @@ class Completions:
         return response
 
     def _prepare_messages(self, messages: List[dict]) -> List[dict]:
-        if not messages or messages[0]["role"] != "system":
-            return [{"role": "system", "content": MEMORY_ANSWER_PROMPT}] + messages
-        return messages
+        # Copy every message: create() rewrites the last one's content and litellm
+        # mutates message dicts in place, while _async_add_to_memory hands the
+        # caller's originals to a background thread.
+        prepared = [dict(message) for message in messages]
+        if not prepared or prepared[0]["role"] != "system":
+            return [{"role": "system", "content": MEMORY_ANSWER_PROMPT}] + prepared
+        return prepared
 
     def _async_add_to_memory(self, messages, user_id, agent_id, run_id, metadata, filters):
         def add_task():

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -104,6 +104,84 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
     assert call_args["messages"][0]["content"] == "You are a helpful assistant."
 
 
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [{"role": "user", "content": "original"}],
+        [{"role": "system", "content": "system"}, {"role": "user", "content": "original"}],
+    ],
+    ids=["no_system_message", "with_system_message"],
+)
+def test_prepare_messages_does_not_alias_caller_messages(mock_memory_client, messages):
+    """`_prepare_messages` must hand back dicts the caller does not own.
+
+    Both branches used to alias: without a system message it built a new outer
+    list out of the caller's dicts, and with one it returned the caller's list
+    itself. Either way, `create()`'s later write to
+    `prepared_messages[-1]["content"]` landed in the caller's own message.
+    """
+    prepared = Completions(mock_memory_client)._prepare_messages(messages)
+
+    prepared[-1]["content"] = "injected"
+
+    assert messages[-1]["content"] == "original"
+
+
+def test_completions_create_does_not_mutate_caller_messages(mock_memory_client, mock_litellm):
+    """Enriching the LLM request must not rewrite the caller's conversation.
+
+    `create()` replaces the last message's content with the retrieved-memories
+    prompt before calling litellm, while `_async_add_to_memory` hands the
+    caller's list to a background thread. When those two shared dicts, the
+    caller saw its input rewritten and — depending on which side of the race
+    the thread landed on — the memory write could persist the generated
+    "Relevant Memories/Facts" block as new user content.
+
+    Asserting the caller's list is untouched after `create()` returns covers the
+    background write too: that thread is given this same list, so if it is never
+    mutated there is no interleaving in which the thread can observe the
+    injected prompt.
+    """
+    completions = Completions(mock_memory_client)
+
+    messages = [{"role": "user", "content": "What should I cook tonight?"}]
+    mock_memory_client.search.return_value = [{"memory": "User is allergic to peanuts"}]
+    mock_litellm.completion.return_value = {"choices": [{"message": {"content": "ok"}}]}
+    mock_litellm.supports_function_calling.return_value = True
+
+    completions.create(model="gpt-4.1-nano-2025-04-14", messages=messages, user_id="test_user")
+
+    assert messages == [{"role": "user", "content": "What should I cook tonight?"}]
+
+    # The enrichment still has to reach the model — this is not a fix that just
+    # stops writing anywhere.
+    sent = mock_litellm.completion.call_args[1]["messages"]
+    assert "User is allergic to peanuts" in sent[-1]["content"]
+    assert "What should I cook tonight?" in sent[-1]["content"]
+
+
+def test_async_add_to_memory_receives_the_unenriched_messages(mock_memory_client, mock_litellm):
+    """The background memory write must see the user's text, not the enriched prompt.
+
+    `create()` hands `_async_add_to_memory` the caller's list and only afterwards
+    writes the retrieved-memories prompt into the prepared copy. Pinning that
+    argument keeps a later refactor from passing `prepared_messages` instead, which
+    would persist the generated "Relevant Memories/Facts" block as new user content.
+    """
+    completions = Completions(mock_memory_client)
+
+    messages = [{"role": "user", "content": "What should I cook tonight?"}]
+    mock_memory_client.search.return_value = [{"memory": "User is allergic to peanuts"}]
+    mock_litellm.completion.return_value = {"choices": [{"message": {"content": "ok"}}]}
+    mock_litellm.supports_function_calling.return_value = True
+
+    with patch.object(Completions, "_async_add_to_memory") as add_to_memory:
+        completions.create(model="gpt-4.1-nano-2025-04-14", messages=messages, user_id="test_user")
+
+    stored_messages = add_to_memory.call_args[0][0]
+    assert stored_messages[-1]["content"] == "What should I cook tonight?"
+
+
 def test_completions_create_messages_default_does_not_leak_between_calls(mock_memory_client, mock_litellm):
     """Regression test for the B006 mutable-default bug in Completions.create.
 


### PR DESCRIPTION
## Linked Issue

Closes #7024

## Description

`Completions._prepare_messages()` handed back the caller's own message dicts. Without a leading system message it built a new outer list from those same dicts; with one it returned the caller's list itself. `create()` then writes the retrieved-memories prompt into `prepared_messages[-1]["content"]`, so that write landed in the caller's input.

Two consequences:

1. **The caller's conversation is rewritten.** Every call, no race. Callers that reuse one list get the scaffold nested on each turn: `- User Question: - Relevant Memories/Facts: … - User Question: …`.
2. **The background memory write can persist the generated prompt.** `_async_add_to_memory` hands the same dicts to a daemon thread. If the main thread's write wins the race, `add()` stores the generated `- Relevant Memories/Facts: … - User Question: …` block as new user content — so retrieved memories are re-ingested as if the user had typed them, and fact extraction sees its own output.

The fix copies each message in `_prepare_messages`, so the enriched request is disjoint from the caller's conversation. Both consequences come from the one aliasing cause, so both close together.

**Why every message and not just the last one.** `litellm.completion()` mutates message dicts in place too — [`main.py`](https://github.com/BerriAI/litellm/blob/main/litellm/main.py) calls `validate_and_fix_openai_messages`, which assigns `message["role"]` on any message lacking one:

```python
caller = [{"content": "hi"}, {"role": "user", "content": "q"}]
validate_and_fix_openai_messages(messages=caller)
# caller is now [{'content': 'hi', 'role': 'assistant'}, {'role': 'user', 'content': 'q'}]
```

So the leak was never limited to the last message. Copying all of them closes that path as well.

**Why shallow (`dict(message)`) and not `copy.deepcopy`.** `create()` only ever *reassigns* `["content"]`; nothing mutates a nested value in place. A deep copy would clone multimodal content lists on every request to defend against a write that does not happen.

**Why inside `_prepare_messages` and not at the call site.** The call-site one-liner (`prepared_messages[-1] = {**prepared_messages[-1], …}`) does not work: in the system-message branch `_prepare_messages` returns the caller's list *object*, so an index assignment would swap an element inside the caller's list. Copying at the source fixes both branches at once.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Written with Claude Code, then reviewed by me. What I checked myself: reproduced the issue's script verbatim on `8d5b7865`; forced the daemon-thread interleaving with a blocking mock `add()` to confirm the background write really does persist the injected block; confirmed all four new tests fail on unfixed `main` and pass after; verified the `litellm` in-place mutation above against the installed version; ran the full `pytest tests/` suite (1869 passed, 75 skipped) and `make lint` locally.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A. One marginal drift worth naming: a malformed non-mapping element in `messages` now raises `ValueError` inside `_prepare_messages` rather than `TypeError` slightly later in `create()`. Both are crashes on input outside the documented `List[dict]`, and no test or caller depends on either.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Four tests in `tests/test_proxy.py`:

- `test_prepare_messages_does_not_alias_caller_messages` — parametrized over both branches (`no_system_message`, `with_system_message`), since they aliased for different reasons and a fix for one would not cover the other.
- `test_completions_create_does_not_mutate_caller_messages` — the user-visible contract, plus an assertion that the memories still reach litellm, so this cannot be "fixed" by simply not writing anywhere.
- `test_async_add_to_memory_receives_the_unenriched_messages` — pins that the background write is handed the originals, so a later refactor passing `prepared_messages` there would fail rather than silently re-persist the injected block.

All four fail on unfixed `main` and pass with the change. Full suite: `1869 passed, 75 skipped`. `make lint` clean.

There is deliberately **no timing test for the race**: forcing the interleaving needs a sleep or an `Event` handshake against a daemon thread, which is flaky in CI. The invariant that kills the race — "the caller's list is never mutated" — is deterministic, and `_async_add_to_memory` is handed exactly that list, so the tests cover the race by covering its cause.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

---

### On the PR gate, and on the three PRs that came before this

I know #7024 is not labelled `accepted` and that the gate will close this within seconds. That is expected, not an accident — I asked for the label [on the issue](https://github.com/mem0ai/mem0/issues/7024) first and am opening this anyway so the diff and its tests are reviewable rather than something you have to take on trust. It reopens by itself if the issue is ever labelled.

#7026, #7035 and #7078 already fix this and were each gate-closed the same way. **#7035's core change is character-for-character identical to mine**, and it is four days older. If you label the issue, please take whichever of those you prefer — I would rather this bug be fixed than be the one who fixes it.

What this one adds, if it is useful: regression tests for *both* aliasing branches and for the background-write argument, the `litellm` in-place-mutation finding above (which is why copying only the last message would be incomplete), and a verified full-suite run.
