### PR TITLE
fix(mongodb): preserve filtered vector search recall

### DIFF
--- a/mem0/vector_stores/mongodb.py
+++ b/mem0/vector_stores/mongodb.py
@@ -193,7 +193,10 @@ class MongoDB(VectorStoreBase):
                 {
                     "$vectorSearch": {
                         "index": self.index_name,
-                        "limit": top_k,
+                        # Fetch extra candidates before applying dynamic payload
+                        # filters; otherwise filtered results can be absent from
+                        # the top_k unfiltered vectors entirely.
+                        "limit": min(top_k * 20, 10000) if filters else top_k,
                         "numCandidates": min(top_k * 20, 10000),
                         "queryVector": vectors,
                         "path": "embedding",
@@ -212,6 +215,7 @@ class MongoDB(VectorStoreBase):
                 if filter_conditions:
                     # Add a $match stage after vector search to apply filters
                     pipeline.insert(1, {"$match": {"$and": filter_conditions}})
+                    pipeline.append({"$limit": top_k})
 
             results = list(collection.aggregate(pipeline))
             logger.info(f"Vector search completed. Found {len(results)} documents.")


### PR DESCRIPTION
Fixes #7072

## Background
MongoDB applied payload filters after $vectorSearch, but the vector stage was limited to 	op_k before filtering. This could return too few or zero results for scoped searches.

## Changes
- Over-fetch candidates for filtered searches, bounded by MongoDB's 10,000 candidate limit.
- Apply a trailing $limit after payload filtering to preserve the public 	op_k contract.
- Leave unfiltered searches unchanged.

## Validation
- python -m py_compile mem0/vector_stores/mongodb.py — passed
- git diff --check — passed
- Full MongoDB tests were not run because pymongo is not installed locally and the partial clone could not restore the existing test file.

## Compatibility
Only filtered MongoDB vector searches inspect a larger candidate pool; this improves recall within MongoDB's existing limit.