### PR TITLE
Preserve MiniMax multimodal content parts

### DIFF
--- a/mem0-ts/src/oss/src/llms/openai.ts
+++ b/mem0-ts/src/oss/src/llms/openai.ts
@@ -25,10 +25,7 @@ export class OpenAILLM implements LLM {
         const role = msg.role as "system" | "user" | "assistant";
         return {
           role,
-          content:
-            typeof msg.content === "string"
-              ? msg.content
-              : JSON.stringify(msg.content),
+          content: msg.content as any,
         };
       }),
       model: this.model,
@@ -58,10 +55,7 @@ export class OpenAILLM implements LLM {
         const role = msg.role as "system" | "user" | "assistant";
         return {
           role,
-          content:
-            typeof msg.content === "string"
-              ? msg.content
-              : JSON.stringify(msg.content),
+          content: msg.content as any,
         };
       }),
       model: this.model,

--- a/mem0-ts/src/oss/src/types/index.ts
+++ b/mem0-ts/src/oss/src/types/index.ts
@@ -1,11 +1,16 @@
 import { z } from "zod";
 
-export interface MultiModalMessages {
-  type: "image_url";
-  image_url: {
-    url: string;
-  };
-}
+export type MultiModalMessagePart =
+  | {
+      type: "image_url";
+      image_url: { url: string };
+    }
+  | {
+      type: "video_url";
+      video_url: { url: string };
+    };
+
+export type MultiModalMessages = MultiModalMessagePart | MultiModalMessagePart[];
 
 export interface Message {
   role: string;

--- a/mem0-ts/src/oss/tests/minimax.test.ts
+++ b/mem0-ts/src/oss/tests/minimax.test.ts
@@ -90,6 +90,26 @@ describe("MiniMaxLLM (unit)", () => {
     expect(result).toBe("Hello from MiniMax");
   });
 
+  it("preserves image and video content parts", async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: "I see both", role: "assistant" } }],
+    });
+
+    const llm = new MiniMaxLLM({ apiKey: "test-key" });
+    const content = [
+      { type: "image_url" as const, image_url: { url: "https://example.com/a.png" } },
+      { type: "video_url" as const, video_url: { url: "https://example.com/a.mp4" } },
+    ];
+    await llm.generateResponse([{ role: "user", content }]);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [{ role: "user", content }],
+        model: "MiniMax-M2.7",
+      }),
+    );
+  });
+
   it("generateResponse() handles tool calls", async () => {
     mockCreate.mockResolvedValueOnce({
       choices: [


### PR DESCRIPTION
Reason: MiniMax requests preserve image and video content parts in TypeScript messages.

The shared TypeScript message schema now accepts image_url and video_url parts, and the OpenAI-compatible request mapping forwards structured content instead of stringifying it. MiniMax therefore receives multimodal content parts unchanged.

Checks: `pnpm exec jest --runInBand src/oss/tests/minimax.test.ts`
