### PR TITLE
docs: fix dead links in documentation

### DIFF
--- a/docs/api-reference/memory/add-memories.mdx
+++ b/docs/api-reference/memory/add-memories.mdx
@@ -55,7 +55,7 @@ Provide conversation messages for Mem0 to extract memories from. At least one en
 > \* At least one entity ID (`user_id`, `agent_id`, `app_id`, or `run_id`) is required.
 
 <Tip>
-  Need more details? See [all request parameters](#body-messages) below for complete field descriptions, types, and constraints.
+  Need more details? See [all request parameters](#common-fields) below for complete field descriptions, types, and constraints.
 </Tip>
 
 ## Response

--- a/docs/changelog/sdk.mdx
+++ b/docs/changelog/sdk.mdx
@@ -1502,7 +1502,7 @@ The largest provider release for the TypeScript OSS SDK so far: 17 new vector st
 **Improvements:**
 - **Telemetry:** Sample OSS hot-path events at 10% to reduce PostHog event volume ([#4771](https://github.com/mem0ai/mem0/pull/4771))
 
-See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/ts-v2-to-v3) for upgrade instructions.
+See the [TypeScript SDK migration guide](https://docs.mem0.ai/migration/oss-v2-to-v3) for upgrade instructions.
 
 </Update>
 

--- a/docs/components/llms/models/azure_openai.mdx
+++ b/docs/components/llms/models/azure_openai.mdx
@@ -87,7 +87,7 @@ await memory.add(messages, { userId: "alice", metadata: { category: "movies" } }
 </CodeGroup>
 
 
-We also support the new [OpenAI structured-outputs](https://platform.openai.com/docs/guides/structured-outputs/introduction) model. Typescript SDK does not support the `azure_openai_structured` model yet.
+We also support the new [OpenAI structured-outputs](https://platform.openai.com/docs/guides/structured-outputs) model. Typescript SDK does not support the `azure_openai_structured` model yet.
 
 ```python
 import os

--- a/docs/components/llms/models/openai.mdx
+++ b/docs/components/llms/models/openai.mdx
@@ -74,7 +74,7 @@ await memory.add(messages, { userId: "alice", metadata: { category: "movies" } }
 ```
 </CodeGroup>
 
-We also support the new [OpenAI structured-outputs](https://platform.openai.com/docs/guides/structured-outputs/introduction) model.
+We also support the new [OpenAI structured-outputs](https://platform.openai.com/docs/guides/structured-outputs) model.
 
 ```python
 import os

--- a/docs/components/llms/overview.mdx
+++ b/docs/components/llms/overview.mdx
@@ -49,7 +49,7 @@ Structured outputs are LLMs that align with OpenAI's structured outputs model:
 - **Optimized for:** Returning structured responses (e.g., JSON objects)
 - **Benefits:** Precise, easily parseable data
 - **Ideal for:** Data extraction, form filling, API responses
-- **Learn more:** [OpenAI Structured Outputs Guide](https://platform.openai.com/docs/guides/structured-outputs/introduction)
+- **Learn more:** [OpenAI Structured Outputs Guide](https://platform.openai.com/docs/guides/structured-outputs)
 
 ### Unstructured Outputs
 

--- a/docs/core-concepts/memory-evaluation.mdx
+++ b/docs/core-concepts/memory-evaluation.mdx
@@ -66,7 +66,7 @@ The combined score outperformed every individual signal across every category te
 
 ### LoCoMo
 
-[LoCoMo](https://github.com/snap-stanford/locomo) tests single-hop, multi-hop, open-domain, and temporal memory recall across conversational sessions.
+[LoCoMo](https://github.com/snap-research/locomo) tests single-hop, multi-hop, open-domain, and temporal memory recall across conversational sessions.
 
 | Category | Score |
 |---|---|

--- a/docs/integrations/agentops.mdx
+++ b/docs/integrations/agentops.mdx
@@ -22,7 +22,7 @@ pip install mem0ai agentops python-dotenv
 ```
 
 2. Valid API keys:
-   - [AgentOps API Key](https://app.agentops.ai/dashboard/api-keys)
+   - [AgentOps API Key](https://app.agentops.ai)
    - OpenAI API Key (for LLM operations)
    - <a href="https://app.mem0.ai/dashboard/api-keys?utm_source=oss&utm_medium=integration-agentops" rel="nofollow">Mem0 API Key</a> (optional, for cloud operations)
 


### PR DESCRIPTION
## Linked Issue

N/A — documentation-only change (exempt from the accepted-issue gate per CONTRIBUTING.md).

## Description

Fixes 7 dead links found by sweeping all 247 `.mdx` pages under `docs/` and HTTP-verifying every URL:

| File | Problem | Fix |
|---|---|---|
| `docs/core-concepts/memory-evaluation.mdx` | LoCoMo repo moved orgs: `snap-stanford/locomo` returns 404 | → `snap-research/locomo` (verified 200) |
| `docs/changelog/sdk.mdx` | TS migration guide links to `migration/ts-v2-to-v3`, a page that does not exist in `docs/migration/` | → `migration/oss-v2-to-v3`, which contains the TypeScript OSS and Client SDK sections |
| `docs/components/llms/overview.mdx` | OpenAI structured-outputs guide URL 404s — the `/introduction` path segment was removed upstream | → `.../guides/structured-outputs` (verified 200) |
| `docs/components/llms/models/openai.mdx` | same as above | same fix |
| `docs/components/llms/models/azure_openai.mdx` | same as above | same fix |
| `docs/integrations/agentops.mdx` | deep link `app.agentops.ai/dashboard/api-keys` returns 404; AgentOps docs now reference only the dashboard root | → `https://app.agentops.ai` (verified 200) |
| `docs/api-reference/memory/add-memories.mdx` | Tip block links to a `#body-messages` anchor that does not exist on the page | → `#common-fields`, the heading the parameter table actually lives under |

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Agent used: an LLM coding agent swept the docs for dead links and drafted the diff. What I verified myself before opening this PR:

- Every replacement URL was fetched live and returns HTTP 200 (the AgentOps and LoCoMo replacements were cross-checked against the target sites' current pages).
- The `#common-fields` heading exists in `add-memories.mdx`; the old `#body-messages` anchor matches no heading in that file.
- `python scripts/check-llms-txt-coverage.py` passes on this branch.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

Each change is a single href swap; no code paths are touched.

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual verification: re-ran a link sweep across `docs/**/*.mdx` after the changes — all previously-dead URLs now resolve. `check-llms-txt-coverage.py` exits 0 (no `.mdx` pages added or removed).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
