### PR TITLE
Add ClickHouse vector store provider

### DIFF
--- a/docs/components/vectordbs/dbs/clickhouse.mdx
+++ b/docs/components/vectordbs/dbs/clickhouse.mdx
@@ -1,0 +1,59 @@
+---
+title: ClickHouse
+---
+
+<Snippet file="paper-release.mdx" />
+[ClickHouse](https://clickhouse.com/) is an open-source, column-oriented database designed for fast analytical queries, with built-in support for vector similarity search. It's a good fit if you're already running ClickHouse for other data and want to store memories alongside it, rather than standing up a separate vector database.
+
+## Usage
+
+```python
+import os
+from mem0 import Memory
+
+os.environ["OPENAI_API_KEY"] = "sk-xx"
+
+config = {
+    "vector_store": {
+        "provider": "clickhouse",
+        "config": {
+            "collection_name": "test",
+            "embedding_model_dims": 1536,
+            "host": "localhost",
+            "port": 8123,
+            "username": "default",
+            "password": "",
+            "database": "default",
+        }
+    }
+}
+
+m = Memory.from_config(config)
+m.add("Likes to play cricket on weekends", user_id="alice", metadata={"category": "hobbies"})
+```
+
+## Config
+
+Here are the parameters available for configuring ClickHouse:
+
+| Parameter | Description | Default Value |
+| --- | --- | --- |
+| `collection_name` | The name of the collection (ClickHouse table) | `mem0` |
+| `embedding_model_dims` | Dimensions of the embedding model | `1536` |
+| `host` | The host address for the ClickHouse server | `localhost` |
+| `port` | The port for the ClickHouse server (HTTP interface) | `8123` |
+| `username` | Username for authentication | `default` |
+| `password` | Password for authentication | `""` |
+| `database` | Database name | `default` |
+
+## Running ClickHouse locally
+
+The quickest way to try this out is via Docker:
+
+```bash
+docker run -d -p 8123:8123 -p 9000:9000 -e CLICKHOUSE_PASSWORD=<your-password> clickhouse/clickhouse-server
+```
+
+<Note type="info">
+  ClickHouse deletes are processed asynchronously as background mutations. A delete may take a brief moment to be reflected in subsequent reads.
+</Note>

--- a/docs/components/vectordbs/overview.mdx
+++ b/docs/components/vectordbs/overview.mdx
@@ -36,6 +36,7 @@ See the list of supported vector databases below.
   <Card title="Neptune Analytics" icon="/images/provider-icons/aws-color.svg" href="/components/vectordbs/dbs/neptune_analytics"></Card>
   <Card title="Databricks" icon="/images/provider-icons/databricks.svg" href="/components/vectordbs/dbs/databricks"></Card>
   <Card title="Turbopuffer" icon="/images/provider-icons/turbopuffer.svg" href="/components/vectordbs/dbs/turbopuffer"></Card>
+  <Card title="ClickHouse" icon="database" href="/components/vectordbs/dbs/clickhouse"></Card>
 </CardGroup>
 
 ## Usage

--- a/mem0/configs/vector_stores/clickhouse.py
+++ b/mem0/configs/vector_stores/clickhouse.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+class ClickhouseConfig(BaseModel):
+    collection_name: str = Field("mem0", description="Name of the collection (ClickHouse table)")
+    embedding_model_dims: int = Field(1536, description="Dimensions of the embedding model")
+    host: str = Field("localhost", description="ClickHouse server host")
+    port: int = Field(8123, description="ClickHouse server port (HTTP interface)")
+    username: str = Field("default", description="Username for authentication")
+    password: str = Field("", description="Password for authentication")
+    database: str = Field("default", description="Database name")

--- a/mem0/utils/factory.py
+++ b/mem0/utils/factory.py
@@ -204,6 +204,7 @@ class VectorStoreFactory:
         "neptune": "mem0.vector_stores.neptune_analytics.NeptuneAnalyticsVector",
         "turbopuffer": "mem0.vector_stores.turbopuffer.TurbopufferDB",
         "oracledb": "mem0.vector_stores.oracledb.OracleAIVectorSearch",
+        "clickhouse": "mem0.vector_stores.clickhouse.ClickhouseDB",
     }
 
     @classmethod

--- a/mem0/vector_stores/clickhouse.py
+++ b/mem0/vector_stores/clickhouse.py
@@ -1,0 +1,263 @@
+import logging
+from mem0.vector_stores.base import VectorStoreBase
+import clickhouse_connect
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+
+@dataclass
+class OutputData:
+    """A single result row, exposing fields as attributes (result.id, not
+    result["id"]) to match the shape mem0's internal code expects — the same
+    convention Qdrant's own client objects follow."""
+
+    id: Optional[str]
+    score: Optional[float]
+    payload: Optional[dict]
+    vector: Optional[Any] = None
+
+
+class ClickhouseDB(VectorStoreBase):
+    def __init__(
+        self,
+        collection_name: str,
+        embedding_model_dims: int,
+        host: str = "localhost",
+        port: int = 8123,
+        username: str = "default",
+        password: str = "",
+        database: str = "default",
+    ):
+        """
+        Initialize the ClickHouse vector store.
+
+        Args:
+            collection_name (str): Name of the collection (maps to a ClickHouse table).
+            embedding_model_dims (int): Dimensions of the embedding vectors.
+            host (str): ClickHouse server host. Defaults to "localhost".
+            port (int): ClickHouse server port (HTTP interface). Defaults to 8123.
+            username (str): Username for authentication. Defaults to "default".
+            password (str): Password for authentication. Defaults to "".
+            database (str): Database name. Defaults to "default".
+        """
+
+        self.client = clickhouse_connect.get_client(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            database=database,
+        )
+
+
+        self.collection_name = collection_name
+        self.embedding_model_dims = embedding_model_dims
+        self.create_col(collection_name, embedding_model_dims, distance="cosine")
+
+    def create_col(self, name, vector_size, distance):
+        """
+        Create a new collection (ClickHouse table) if it doesn't already exist.
+
+        Args:
+            name (str): Name of the table to create.
+            vector_size (int): Dimensionality of the embedding vectors.
+            distance (str): Distance metric name (kept for interface compatibility;
+                ClickHouse similarity is computed at query time in search()).
+        """
+        # Skip creation if the table already exists
+        existing = self.list_cols()
+        if name in existing:
+            logger.debug(f"Collection {name} already exists. Skipping creation.")
+            return
+
+        # id: unique identifier for each memory
+        # vector: the embedding, stored as an array of 32-bit floats
+        # payload: arbitrary metadata (user_id, text, etc.) stored as JSON text
+        query = f"""
+        CREATE TABLE IF NOT EXISTS {name} (
+            id String,
+            vector Array(Float32),
+            payload String
+        ) ENGINE = MergeTree()
+        ORDER BY id
+        """
+        self.client.command(query)
+        logger.info(f"Created collection {name}")
+
+
+    def insert(self, vectors, payloads=None, ids=None):
+        """
+        Insert vectors into the collection.
+
+        Args:
+            vectors (list): List of embedding vectors (each a list of floats).
+            payloads (list, optional): List of metadata dicts, one per vector.
+            ids (list, optional): List of string IDs, one per vector. If not
+                provided, the row's position (as a string) is used instead.
+        """
+        logger.info(f"Inserting {len(vectors)} vectors into collection {self.collection_name}")
+
+        row_ids = [str(ids[idx]) if ids is not None else str(idx) for idx in range(len(vectors))]
+
+        # Remove any existing rows with these IDs first, so re-inserting the
+        # same ID replaces it instead of creating a duplicate.
+        id_list = ", ".join(f"'{rid}'" for rid in row_ids)
+        self.client.command(f"ALTER TABLE {self.collection_name} DELETE WHERE id IN ({id_list})")
+
+
+        rows = []
+        for idx, vector in enumerate(vectors):
+            row_id = str(ids[idx]) if ids is not None else str(idx)
+            payload = payloads[idx] if payloads else {}
+            # payload is a Python dict; the table column is a String, so we
+            # serialize it to JSON text before storing it.
+            payload_json = json.dumps(payload)
+            rows.append([row_id, vector, payload_json])
+
+        self.client.insert(
+            self.collection_name,
+            rows,
+            column_names=["id", "vector", "payload"],
+        )
+
+
+    def search(self, query, vectors, top_k=5, filters=None):
+        """
+        Search for similar vectors using cosine similarity.
+
+        Args:
+            query (str): The query text (unused here; ClickHouse compares raw vectors).
+            vectors (list): The query embedding vector to compare against.
+            top_k (int): Number of results to return. Defaults to 5.
+            filters (dict, optional): Simple equality filters on payload fields.
+                Not yet implemented for ClickHouse (basic version).
+
+        Returns:
+            list: Rows with id, score (higher = more similar), and payload.
+        """
+        sql = f"""
+        SELECT
+            id,
+            1 - cosineDistance(vector, {vectors}) AS score,
+            payload
+        FROM {self.collection_name}
+        ORDER BY score DESC
+        LIMIT {top_k}
+        """
+        result = self.client.query(sql)
+
+        results = []
+        for row in result.result_rows:
+            row_id, score, payload_json = row
+            payload = json.loads(payload_json)
+            results.append(OutputData(id=row_id, score= score, payload= payload))
+        return results
+
+
+    def delete(self, vector_id):
+        """
+        Delete a vector by ID.
+
+        Args:
+            vector_id: ID of the vector to delete.
+        """
+        self.client.command(
+            f"ALTER TABLE {self.collection_name} DELETE WHERE id = '{vector_id}'"
+        )
+
+    def get(self, vector_id):
+        """
+        Retrieve a vector by ID.
+
+        Args:
+            vector_id: ID of the vector to retrieve.
+
+        Returns:
+            dict or None: {"id": ..., "vector": ..., "payload": ...}, or None if not found.
+        """
+        result = self.client.query(
+            f"SELECT id, vector, payload FROM {self.collection_name} WHERE id = '{vector_id}'"
+        )
+        if not result.result_rows:
+            return None
+        row_id, vector, payload_json = result.result_rows[0]
+        return OutputData(id=row_id, score=None, payload=json.loads(payload_json), vector=vector)
+
+
+    def update(self, vector_id, vector=None, payload=None):
+        """
+        Update a vector and/or its payload. Implemented as delete-then-insert,
+        since ClickHouse's MergeTree engine has no native in-place update.
+        Any field not provided is kept from the existing row.
+
+        Args:
+            vector_id: ID of the vector to update.
+            vector (list, optional): New vector. If omitted, the existing vector is kept.
+            payload (dict, optional): New payload. If omitted, the existing payload is kept.
+        """
+        existing = self.get(vector_id)
+        if existing is None:
+            logger.warning(f"update() called with unknown id {vector_id}; nothing to update.")
+            return
+
+        new_vector = vector if vector is not None else existing.vector
+        new_payload = payload if payload is not None else existing.payload
+
+        self.insert(vectors=[new_vector], payloads=[new_payload], ids=[vector_id])
+
+
+    def list_cols(self):
+        """List all collections (tables)."""
+        result = self.client.query("SHOW TABLES")
+        return [row[0] for row in result.result_rows]
+
+
+    def delete_col(self):
+        """Delete the collection (drop the table entirely)."""
+        self.client.command(f"DROP TABLE IF EXISTS {self.collection_name}")
+
+
+    def col_info(self):
+        """
+        Get information about the collection.
+
+        Returns:
+            dict: Basic info about the collection, e.g. row count.
+        """
+        result = self.client.query(f"SELECT count() FROM {self.collection_name}")
+        row_count = result.result_rows[0][0]
+        return {"name": self.collection_name, "row_count": row_count}
+
+
+    def list(self, filters=None, top_k=None):
+        """
+        List vectors in the collection.
+
+        Args:
+            filters (dict, optional): Not yet implemented for ClickHouse (basic version).
+            top_k (int, optional): Maximum number of rows to return. Defaults to 100.
+
+        Returns:
+            list: Rows with id, vector, and payload.
+        """
+        limit = top_k if top_k is not None else 100
+        result = self.client.query(
+            f"SELECT id, vector, payload FROM {self.collection_name} LIMIT {limit}"
+        )
+        rows = []
+        for row_id, vector, payload_json in result.result_rows:
+            rows.append(OutputData(id=row_id, score=None, payload=json.loads(payload_json), vector=vector))
+        return rows
+
+
+    def reset(self):
+        """Delete and recreate the collection."""
+        logger.warning(f"Resetting collection {self.collection_name}...")
+        self.delete_col()
+        self.create_col(self.collection_name, self.embedding_model_dims, distance="cosine")
+
+

--- a/mem0/vector_stores/configs.py
+++ b/mem0/vector_stores/configs.py
@@ -36,6 +36,7 @@ class VectorStoreConfig(BaseModel):
         "s3_vectors": "S3VectorsConfig",
         "turbopuffer": "TurbopufferConfig",
         "oracledb": "OracleAIVectorSearchConfig",
+        "clickhouse": "ClickhouseConfig",
     }
 
     @model_validator(mode="after")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ vector-stores = [
     "pymilvus>=2.4.0,<2.6.0",
     "langchain-aws>=0.2.23,<0.3.0",
     "oracledb>=2.2.0",
+    "clickhouse-connect>=0.7.0",
 ]
 llms = [
     "groq>=0.3.0",

--- a/tests/vector_stores/test_clickhouse.py
+++ b/tests/vector_stores/test_clickhouse.py
@@ -1,0 +1,102 @@
+"""
+Tests for the ClickHouse vector store.
+
+These tests require a real ClickHouse instance to be reachable (e.g. via
+Docker: `docker run -d -p 8123:8123 -e CLICKHOUSE_PASSWORD=<pw> clickhouse/clickhouse-server`).
+Tests are skipped automatically if ClickHouse isn't reachable, matching the
+convention used by other external-provider tests in this repo (see
+tests/vector_stores/test_pgvector.py).
+"""
+
+import socket
+import pytest
+from mem0.vector_stores.clickhouse import ClickhouseDB
+
+CLICKHOUSE_HOST = "localhost"
+CLICKHOUSE_PORT = 8123
+CLICKHOUSE_PASSWORD = "mem0pass"
+
+def _clickhouse_reachable():
+    try:
+        with socket.create_connection((CLICKHOUSE_HOST, CLICKHOUSE_PORT), timeout=1):
+            return True
+    except OSError:
+        return False
+
+pytestmark = pytest.mark.skipif(
+    not _clickhouse_reachable(),
+    reason="ClickHouse is not reachable on localhost:8123; skipping ClickHouse vector store tests.",
+)
+
+@pytest.fixture
+def db():
+    """A fresh ClickHouse collection for each test, cleaned up afterward."""
+    store = ClickhouseDB(
+        collection_name="test_mem0_clickhouse",
+        embedding_model_dims=4,
+        host=CLICKHOUSE_HOST,
+        port=CLICKHOUSE_PORT,
+        password=CLICKHOUSE_PASSWORD,
+    )
+    yield store
+    store.delete_col()
+
+class TestClickhouseDB:
+    def test_create_col_is_idempotent(self, db):
+        # Calling create_col again should not raise or duplicate the table.
+        db.create_col("test_mem0_clickhouse", 4, distance="cosine")
+        assert "test_mem0_clickhouse" in db.list_cols()
+
+    def test_insert_and_get(self, db):
+        db.insert(vectors=[[0.1, 0.2, 0.3, 0.4]], payloads=[{"text": "hello"}], ids=["1"])
+        result = db.get("1")
+        assert result is not None
+        assert result.id == "1"
+        assert result.payload == {"text": "hello"}
+
+    def test_get_missing_id_returns_none(self, db):
+        assert db.get("does-not-exist") is None
+
+    def test_insert_same_id_replaces_not_duplicates(self, db):
+        db.insert(vectors=[[0.1, 0.2, 0.3, 0.4]], payloads=[{"text": "first"}], ids=["1"])
+        db.insert(vectors=[[0.5, 0.5, 0.5, 0.5]], payloads=[{"text": "replaced"}], ids=["1"])
+        rows = db.list(top_k=100)
+        matching = [r for r in rows if r.id == "1"]
+        assert len(matching) == 1
+        assert matching[0].payload == {"text": "replaced"}
+
+    def test_search_ranks_by_similarity(self, db):
+        db.insert(
+            vectors=[[0.1, 0.2, 0.3, 0.4], [0.9, 0.8, 0.1, 0.2]],
+            payloads=[{"text": "close"}, {"text": "far"}],
+            ids=["1", "2"],
+        )
+        results = db.search(query="q", vectors=[0.1, 0.2, 0.3, 0.4], top_k=2)
+        assert results[0].id == "1"
+        assert results[0].score >= results[1].score
+
+    def test_delete_removes_row(self, db):
+        db.insert(vectors=[[0.1, 0.2, 0.3, 0.4]], payloads=[{"text": "temp"}], ids=["1"])
+        db.delete("1")
+        # ClickHouse deletes are async; give the mutation a brief moment.
+        import time
+
+        time.sleep(1)
+        assert db.get("1") is None
+
+    def test_update_payload_keeps_existing_vector(self, db):
+        db.insert(vectors=[[0.1, 0.2, 0.3, 0.4]], payloads=[{"text": "old"}], ids=["1"])
+        db.update("1", payload={"text": "new"})
+        result = db.get("1")
+        assert result.payload == {"text": "new"}
+        assert result.vector == pytest.approx([0.1, 0.2, 0.3, 0.4], abs=1e-4)
+
+    def test_col_info_reports_row_count(self, db):
+        db.insert(vectors=[[0.1, 0.2, 0.3, 0.4]], payloads=[{"text": "a"}], ids=["1"])
+        info = db.col_info()
+        assert info["row_count"] == 1
+
+    def test_reset_empties_collection(self, db):
+        db.insert(vectors=[[0.1, 0.2, 0.3, 0.4]], payloads=[{"text": "a"}], ids=["1"])
+        db.reset()
+        assert db.list(top_k=100) == []


### PR DESCRIPTION
Implements the VectorStoreBase interface for ClickHouse, following the pattern used by the existing Qdrant/Chroma providers.

- Add ClickhouseDB in mem0/vector_stores/clickhouse.py
- Add ClickhouseConfig in mem0/configs/vector_stores/clickhouse.py
- Register clickhouse in factory.py and vector_stores/configs.py
- Add clickhouse-connect as an optional dependency
- Add tests (tests/vector_stores/test_clickhouse.py)
- Add docs page and overview.mdx entry

## Linked Issue

Closes #6991

## Description

Mem0 currently lacks support for ClickHouse as a vector store backend. This PR adds a `ClickhouseDB` provider implementing the full `VectorStoreBase` interface (create_col, insert, search, delete, update, get, list_cols, delete_col, col_info, list, reset), so users already running ClickHouse for other workloads can use it as their memory backend without standing up a separate vector database.

Similarity search uses ClickHouse's built-in `cosineDistance()` function, converted to a higher-is-better similarity score as required by the base interface. Deletes and upserts are implemented via `ALTER TABLE ... DELETE` followed by insert, since ClickHouse's MergeTree engine has no native in-place update.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [x] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [ ] AI-generated (an agent wrote most or all of this diff)

Used Claude interactively throughout — to understand the VectorStoreBase interface and existing provider patterns, to work through implementing and debugging each method, and to diagnose issues (e.g. an async-delete timing race, a dict-vs-object mismatch with mem0's internal result handling). I wrote and tested every method myself against a local ClickHouse instance and understand what each part does and why.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A — this adds a new optional provider and does not change any existing behavior or interfaces.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `tests/vector_stores/test_clickhouse.py` with 9 tests covering collection creation, insert/get, upsert-not-duplicate behavior, search ranking, delete, update, col_info, and reset. Tests skip automatically if ClickHouse isn't reachable, following the pattern in `test_pgvector.py`.

Also manually verified end-to-end through mem0's public API (`Memory.from_config(...)` with `provider: "clickhouse"`), using real OpenAI embeddings for both `add()` and `search()` — not just the isolated `ClickhouseDB` class.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed