### PR TITLE
docs(skills): fix dead links in skills READMEs

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,6 @@
 # Mem0 Skills for AI Coding Assistants
 
-Mem0 ships structured skill definitions for Claude Code, Codex, Cursor, OpenCode, OpenClaw, and any assistant that supports the [skills standard](https://github.com/anthropic-experimental/skills). Skills teach the assistant how to work with Mem0 — either by loading SDK knowledge into context, or by executing an end-to-end workflow on demand.
+Mem0 ships structured skill definitions for Claude Code, Codex, Cursor, OpenCode, OpenClaw, and any assistant that supports the [skills standard](https://github.com/anthropics/skills). Skills teach the assistant how to work with Mem0 — either by loading SDK knowledge into context, or by executing an end-to-end workflow on demand.
 
 ## Two Categories
 

--- a/skills/mem0-cli/README.md
+++ b/skills/mem0-cli/README.md
@@ -1,6 +1,6 @@
 # Mem0 CLI Skill for Claude
 
-Manage memories from the terminal using the [Mem0 CLI](https://docs.mem0.ai/cli). This skill teaches Claude how to use every `mem0` command, flag, and output mode -- for both the Node.js and Python implementations.
+Manage memories from the terminal using the [Mem0 CLI](https://docs.mem0.ai/platform/cli). This skill teaches Claude how to use every `mem0` command, flag, and output mode -- for both the Node.js and Python implementations.
 
 ## What This Skill Does
 
@@ -84,7 +84,7 @@ skills/mem0-cli/
 
 - [Mem0 Platform Dashboard](https://app.mem0.ai?utm_source=oss&utm_medium=skill-mem0-cli-readme)
 - [Mem0 Documentation](https://docs.mem0.ai)
-- [Mem0 CLI Docs](https://docs.mem0.ai/cli)
+- [Mem0 CLI Docs](https://docs.mem0.ai/platform/cli)
 - [Mem0 GitHub](https://github.com/mem0ai/mem0)
 
 ## Skill Graph


### PR DESCRIPTION
## Linked Issue

Closes #7091

## Description

Fixes two dead external links in the `skills/` READMEs, both verified with live HTTP checks:

| File | Problem | Fix |
|---|---|---|
| `skills/README.md` | Skills-standard link points to `github.com/anthropic-experimental/skills`, which returns 404 — the repo moved to the `anthropics` org | → `https://github.com/anthropics/skills` (verified 200) |
| `skills/mem0-cli/README.md` | "Mem0 CLI" links (2 places) point to `https://docs.mem0.ai/cli`, a page that does not exist on docs.mem0.ai (404) | → `https://docs.mem0.ai/platform/cli`, where the CLI reference actually lives (verified 200) |

Note: this PR is outside `docs/**`, so I understand it does not qualify for the docs-only gate exemption — hence the linked issue. Happy to wait for the `accepted` label; from what I understand the PR reopens automatically once the issue is labeled.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Agent used: an LLM coding agent swept repo markdown files for dead URLs and drafted the diff. What I checked myself: fetched all four URLs live (two 404s confirmed, two replacements return 200), and cross-checked the Anthropic skills repo's current location.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

Three one-line href swaps; no code paths touched.

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual verification: all four affected URLs were fetched before and after; the docs site's own llms.txt coverage check (`python scripts/check-llms-txt-coverage.py`) passes since no pages under `docs/**` changed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
