### PR TITLE
docs: redirect five dead api-reference paths to their real pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1279,6 +1279,26 @@
     {
       "source": "/v0x/integrations/llama-index",
       "destination": "/integrations/llama-index"
+    },
+    {
+      "source": "/api-reference/event/get-event",
+      "destination": "/api-reference/events/get-event"
+    },
+    {
+      "source": "/api-reference/webhook/get-webhooks",
+      "destination": "/api-reference/webhook/get-webhook"
+    },
+    {
+      "source": "/api-reference/organization/update-organization-members",
+      "destination": "/api-reference/organization/update-org-member"
+    },
+    {
+      "source": "/api-reference/organization/delete-project",
+      "destination": "/api-reference/project/delete-project"
+    },
+    {
+      "source": "/api-reference/entities/get-entities",
+      "destination": "/api-reference/entities/get-users"
     }
   ]
 }


### PR DESCRIPTION
## Linked Issue

None. This is a documentation-only change, which is exempt from the accepted-issue gate. Follow-up to #7053.

## Description

Five `api-reference` URLs 404 because the page was renamed or moved to a different section. This adds five permanent redirects to `docs/docs.json` so they land on the live page instead:

| From | To |
|---|---|
| `/api-reference/event/get-event` | `/api-reference/events/get-event` |
| `/api-reference/webhook/get-webhooks` | `/api-reference/webhook/get-webhook` |
| `/api-reference/organization/update-organization-members` | `/api-reference/organization/update-org-member` |
| `/api-reference/organization/delete-project` | `/api-reference/project/delete-project` |
| `/api-reference/entities/get-entities` | `/api-reference/entities/get-users` |

Every destination page was verified to exist under `docs/api-reference/` (`events/get-event.mdx`, `webhook/get-webhook.mdx`, `organization/update-org-member.mdx`, `project/delete-project.mdx`, `entities/get-users.mdx`) and every source path was verified to 404.

No `permanent` key is set on the new entries: Mintlify redirects default to permanent (308), and no existing entry in `docs/docs.json` uses that flag, so this keeps the file's existing style consistent.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

This diff was written by Claude Code (Opus 5) under kartik-mem0's direction.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

This is a static `redirects` array in `docs/docs.json` (Mintlify config). Verified with `python3 -c "import json; json.load(open('docs/docs.json'))"` that the file still parses, confirmed the redirect count increased by exactly 5, and confirmed no duplicate `source` values exist in the array.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
