### PR TITLE
fix(valkey): add trailing colon to FT.CREATE prefix so entity keys are not indexed

### DIFF
--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -169,7 +169,13 @@ class ValkeyDB(VectorStoreBase):
             "HASH",
             "PREFIX",
             "1",
-            prefix,
+            # Memory hashes are stored under "{prefix}:{id}" while the entity
+            # store uses the sibling collection "{collection}_entities" with keys
+            # "{prefix}_entities:{id}". Valkey matches FT.CREATE PREFIX as a plain
+            # string prefix, so without the trailing colon here the memory index
+            # also indexes entity documents and they leak into search results.
+            # See #5680.
+            prefix + ":",
             "SCHEMA",
             "memory_id",
             "TAG",

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -1043,6 +1043,33 @@ def test_build_index_schema_indexes_memory_as_text(valkey_db):
     assert ["memory", "TAG"] != cmd[memory_idx : memory_idx + 2]
 
 
+def test_build_index_schema_prefix_has_trailing_colon(valkey_db):
+    """The FT.CREATE PREFIX token must carry a trailing colon.
+
+    Memory hashes are stored at "{prefix}:{id}" while the entity store's keys
+    live at "{prefix}_entities:{id}". Valkey matches PREFIX as a plain string
+    prefix, so a bare "mem0:col" also matches entity keys and their documents
+    leak into search results.
+
+    Regression test for #5680.
+    """
+    cmd = valkey_db._build_index_schema(
+        collection_name="test_collection",
+        embedding_dims=1536,
+        distance_metric="COSINE",
+        prefix="mem0:test_collection",
+    )
+
+    prefix_idx = cmd.index("PREFIX")
+    assert cmd[prefix_idx + 1] == "1", "PREFIX count must be 1"
+    indexed_prefix = cmd[prefix_idx + 2]
+    assert indexed_prefix == "mem0:test_collection:", (
+        f"FT.CREATE PREFIX must end with a colon, got {indexed_prefix!r}"
+    )
+    # Entity collection keys must not fall inside the indexed prefix.
+    assert not "mem0:test_collection_entities:123".startswith(indexed_prefix)
+
+
 def test_escape_tag_value_wildcards(valkey_db):
     """Wildcard characters in filter values must be escaped to prevent query injection."""
     assert "\\*" in valkey_db._escape_tag_value("*")


### PR DESCRIPTION
## Linked Issue

Closes #5680

## Description

`_build_index_schema()` emits `FT.CREATE ... PREFIX 1 mem0:{collection}` without a trailing colon, while memory hashes are stored at `{prefix}:{id}`. Valkey matches the PREFIX argument as a plain string prefix, so the memory index also matches the entity store's sibling collection (`{collection}_entities`, see `_entity_collection_name()` in `mem0/memory/main.py`), whose keys are `{prefix}_entities:{id}`. Entity documents therefore get indexed by the memories index and their fragments leak into `mem.search()` results.

The fix appends `:` to the PREFIX token so only keys of the memories collection are indexed. The sibling `redis.py` store is unaffected because it delegates index creation to the `redisvl` library, which handles the key separator itself.

Coordination note: #5681 was an earlier attempt on this issue that has been inactive since July 7; the original author (@adarshprabhu03) kindly handed this off in https://github.com/mem0ai/mem0/issues/5680#issuecomment-5391691397.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Agent used: an LLM coding agent traced the prefix-collision mechanism and drafted the diff. What I verified myself before opening this PR:

- The key layout on main: `self.prefix = f"mem0:{collection_name}"` (`valkey.py:86`), hashes written as `f"{self.prefix}:{id}"` (`valkey.py:300`), and the entity collection named `{collection}_entities` via `_entity_collection_name()` — so `mem0:col` is a strict string-prefix of `mem0:col_entities:*`.
- Both call sites of `_build_index_schema()` pass the bare prefix, which is why the colon append lives inside the builder.
- Red/green on the regression test: it fails against unmodified `main` and passes with this fix; the full suite runs 1866 passed / 75 skipped locally.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

The change is one expression (`prefix + ":"`) inside the FT.CREATE command builder plus a comment; the test asserts the emitted command tokens.

## Breaking Changes

None for new collections. One behavioral nuance worth flagging for review: existing deployments whose index was created by a pre-fix version have an index over the broad prefix; after upgrading they will keep using that existing index until it is recreated (e.g., after dropping the collection/index), since `_create_index` exits early when the index already exists. New/clean installs get the correct narrow prefix immediately.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed

Added `test_build_index_schema_prefix_has_trailing_colon` in `tests/vector_stores/test_valkey.py`: asserts the FT.CREATE command carries `PREFIX 1 mem0:test_collection:` and that an entity-collection key (`mem0:test_collection_entities:123`) does not fall under the indexed prefix. Verified red against unmodified `main` and green with the fix; full valkey suite passes (1866 passed, 75 skipped).

## Checklist

- [x] My code follows the project's style guidelines (ruff + isort + pre-commit pass)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed (no docs changes required; behavior now matches what redis.py users already get)
