### PR TITLE
docs: fix broken relative link to mem0-vercel-ai-sdk skill

### DIFF
--- a/skills/mem0/references/integration-patterns.md
+++ b/skills/mem0/references/integration-patterns.md
@@ -116,7 +116,7 @@ result = crew.kickoff()
 
 ## Vercel AI SDK
 
-> **Dedicated skill available.** For comprehensive Vercel AI SDK documentation, see the [mem0-vercel-ai-sdk skill](../mem0-vercel-ai-sdk/SKILL.md) ([GitHub](https://github.com/mem0ai/mem0/tree/main/skills/mem0-vercel-ai-sdk)).
+> **Dedicated skill available.** For comprehensive Vercel AI SDK documentation, see the [mem0-vercel-ai-sdk skill](../../mem0-vercel-ai-sdk/SKILL.md) ([GitHub](https://github.com/mem0ai/mem0/tree/main/skills/mem0-vercel-ai-sdk)).
 
 Install: `npm install @mem0/vercel-ai-provider`
 


### PR DESCRIPTION
`skills/mem0/references/integration-patterns.md` links to `../mem0-vercel-ai-sdk/SKILL.md`, which resolves to `skills/mem0/mem0-vercel-ai-sdk/SKILL.md` and does not exist. The skill actually lives at `skills/mem0-vercel-ai-sdk/SKILL.md`, one level up, so the link needs `../../`.

The adjacent GitHub URL in the same sentence already points at `skills/mem0-vercel-ai-sdk`, confirming the intended target.