### PR TITLE
fix(memory): rescue entity-linked search candidates

### DIFF
--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -100,10 +100,7 @@ function matchesSimpleRescueFilters(
       key === "$not" ||
       key === "OR" ||
       key === "AND" ||
-      key === "NOT" ||
-      key === "or" ||
-      key === "and" ||
-      key === "not"
+      key === "NOT"
     )
       return false;
     if (
@@ -112,7 +109,10 @@ function matchesSimpleRescueFilters(
       (expected !== null && typeof expected === "object")
     )
       return false;
-    return payload[key] === expected;
+    return (
+      Object.prototype.hasOwnProperty.call(payload, key) &&
+      payload[key] === expected
+    );
   });
 }
 

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -1588,6 +1588,7 @@ export class Memory {
       id: string;
       score?: number;
       payload: Record<string, any>;
+      isEntityRescue?: boolean;
     }> = [];
     const candidateIds = new Set<string>();
     for (const mem of semanticResults) {

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -80,55 +80,7 @@ import { logger } from "../utils/logger";
 import { normalizeExpirationDate, payloadIsExpired } from "../utils/expiration";
 import { getOrCreateMem0UserId } from "../../../client/config";
 
-function filterValueMatches(actual: any, expected: any): boolean {
-  if (expected === "*") return actual !== undefined && actual !== null;
-  if (!expected || typeof expected !== "object" || Array.isArray(expected)) {
-    return Array.isArray(expected)
-      ? expected.includes(actual)
-      : actual === expected;
-  }
-  if (actual === undefined || actual === null) return false;
-
-  try {
-    return Object.entries(expected as Record<string, any>).every(
-      ([operator, operand]) => {
-        switch (operator) {
-          case "eq":
-            return actual === operand;
-          case "ne":
-            return actual !== operand;
-          case "gt":
-            return actual > operand;
-          case "gte":
-            return actual >= operand;
-          case "lt":
-            return actual < operand;
-          case "lte":
-            return actual <= operand;
-          case "in":
-            return Array.isArray(operand) && operand.includes(actual);
-          case "nin":
-            return Array.isArray(operand) && !operand.includes(actual);
-          case "contains":
-            return (
-              typeof actual === "string" && actual.includes(String(operand))
-            );
-          case "icontains":
-            return (
-              typeof actual === "string" &&
-              actual.toLowerCase().includes(String(operand).toLowerCase())
-            );
-          default:
-            return false;
-        }
-      },
-    );
-  } catch {
-    return false;
-  }
-}
-
-function payloadMatchesFilters(
+function matchesSimpleRescueFilters(
   payload: Record<string, any>,
   filters: Record<string, any>,
 ): boolean {
@@ -142,25 +94,25 @@ function payloadMatchesFilters(
   }
 
   return Object.entries(filters).every(([key, expected]) => {
-    if (key === "$or" || key === "OR" || key === "or") {
-      return (
-        Array.isArray(expected) &&
-        expected.some((branch) => payloadMatchesFilters(payload, branch))
-      );
-    }
-    if (key === "$and" || key === "AND" || key === "and") {
-      return (
-        Array.isArray(expected) &&
-        expected.every((branch) => payloadMatchesFilters(payload, branch))
-      );
-    }
-    if (key === "$not" || key === "NOT" || key === "not") {
-      return (
-        Array.isArray(expected) &&
-        expected.every((branch) => !payloadMatchesFilters(payload, branch))
-      );
-    }
-    return filterValueMatches(payload[key], expected);
+    if (
+      key === "$or" ||
+      key === "$and" ||
+      key === "$not" ||
+      key === "OR" ||
+      key === "AND" ||
+      key === "NOT" ||
+      key === "or" ||
+      key === "and" ||
+      key === "not"
+    )
+      return false;
+    if (
+      expected === "*" ||
+      Array.isArray(expected) ||
+      (expected !== null && typeof expected === "object")
+    )
+      return false;
+    return payload[key] === expected;
   });
 }
 
@@ -1659,7 +1611,7 @@ export class Memory {
       .sort(([leftId, leftBoost], [rightId, rightBoost]) => {
         return rightBoost - leftBoost || leftId.localeCompare(rightId);
       })
-      .slice(0, internalLimit)
+      .slice(0, Math.min(internalLimit, 60))
       .map(([id]) => id);
 
     for (const memoryId of rescueIds) {
@@ -1680,13 +1632,18 @@ export class Memory {
         typeof payload !== "object" ||
         typeof payload.data !== "string" ||
         !payload.data ||
-        !payloadMatchesFilters(payload, effectiveFilters) ||
+        !matchesSimpleRescueFilters(payload, effectiveFilters) ||
         (!showExpired && payloadIsExpired(payload))
       ) {
         continue;
       }
 
-      candidates.push({ id: memoryId, score: undefined, payload });
+      candidates.push({
+        id: memoryId,
+        score: undefined,
+        payload,
+        isEntityRescue: true,
+      });
       candidateIds.add(memoryId);
     }
 

--- a/mem0-ts/src/oss/src/memory/index.ts
+++ b/mem0-ts/src/oss/src/memory/index.ts
@@ -80,6 +80,90 @@ import { logger } from "../utils/logger";
 import { normalizeExpirationDate, payloadIsExpired } from "../utils/expiration";
 import { getOrCreateMem0UserId } from "../../../client/config";
 
+function filterValueMatches(actual: any, expected: any): boolean {
+  if (expected === "*") return actual !== undefined && actual !== null;
+  if (!expected || typeof expected !== "object" || Array.isArray(expected)) {
+    return Array.isArray(expected)
+      ? expected.includes(actual)
+      : actual === expected;
+  }
+  if (actual === undefined || actual === null) return false;
+
+  try {
+    return Object.entries(expected as Record<string, any>).every(
+      ([operator, operand]) => {
+        switch (operator) {
+          case "eq":
+            return actual === operand;
+          case "ne":
+            return actual !== operand;
+          case "gt":
+            return actual > operand;
+          case "gte":
+            return actual >= operand;
+          case "lt":
+            return actual < operand;
+          case "lte":
+            return actual <= operand;
+          case "in":
+            return Array.isArray(operand) && operand.includes(actual);
+          case "nin":
+            return Array.isArray(operand) && !operand.includes(actual);
+          case "contains":
+            return (
+              typeof actual === "string" && actual.includes(String(operand))
+            );
+          case "icontains":
+            return (
+              typeof actual === "string" &&
+              actual.toLowerCase().includes(String(operand).toLowerCase())
+            );
+          default:
+            return false;
+        }
+      },
+    );
+  } catch {
+    return false;
+  }
+}
+
+function payloadMatchesFilters(
+  payload: Record<string, any>,
+  filters: Record<string, any>,
+): boolean {
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    !filters ||
+    typeof filters !== "object"
+  ) {
+    return false;
+  }
+
+  return Object.entries(filters).every(([key, expected]) => {
+    if (key === "$or" || key === "OR" || key === "or") {
+      return (
+        Array.isArray(expected) &&
+        expected.some((branch) => payloadMatchesFilters(payload, branch))
+      );
+    }
+    if (key === "$and" || key === "AND" || key === "and") {
+      return (
+        Array.isArray(expected) &&
+        expected.every((branch) => payloadMatchesFilters(payload, branch))
+      );
+    }
+    if (key === "$not" || key === "NOT" || key === "not") {
+      return (
+        Array.isArray(expected) &&
+        expected.every((branch) => !payloadMatchesFilters(payload, branch))
+      );
+    }
+    return filterValueMatches(payload[key], expected);
+  });
+}
+
 export class LLMError extends Error {
   readonly cause?: unknown;
 
@@ -1548,13 +1632,63 @@ export class Memory {
     }
 
     // Step 7: Build candidate set from semantic results
-    const candidates = semanticResults
-      .filter((mem) => showExpired || !payloadIsExpired(mem.payload))
-      .map((mem) => ({
-        id: String(mem.id),
-        score: mem.score ?? 0,
+    const candidates: Array<{
+      id: string;
+      score?: number;
+      payload: Record<string, any>;
+    }> = [];
+    const candidateIds = new Set<string>();
+    for (const mem of semanticResults) {
+      const id = String(mem.id);
+      if (
+        candidateIds.has(id) ||
+        (!showExpired && payloadIsExpired(mem.payload))
+      ) {
+        continue;
+      }
+      candidateIds.add(id);
+      candidates.push({
+        id,
+        score: mem.score,
         payload: mem.payload || {},
-      }));
+      });
+    }
+
+    const rescueIds = Object.entries(entityBoosts)
+      .filter(([id, boost]) => boost > 0 && !candidateIds.has(id))
+      .sort(([leftId, leftBoost], [rightId, rightBoost]) => {
+        return rightBoost - leftBoost || leftId.localeCompare(rightId);
+      })
+      .slice(0, internalLimit)
+      .map(([id]) => id);
+
+    for (const memoryId of rescueIds) {
+      let fetched;
+      try {
+        fetched = await this.vectorStore.get(memoryId);
+      } catch (error) {
+        console.warn(
+          `Entity-linked point fetch failed for ${memoryId}:`,
+          error,
+        );
+        continue;
+      }
+
+      const payload = fetched?.payload;
+      if (
+        !payload ||
+        typeof payload !== "object" ||
+        typeof payload.data !== "string" ||
+        !payload.data ||
+        !payloadMatchesFilters(payload, effectiveFilters) ||
+        (!showExpired && payloadIsExpired(payload))
+      ) {
+        continue;
+      }
+
+      candidates.push({ id: memoryId, score: undefined, payload });
+      candidateIds.add(memoryId);
+    }
 
     // Step 8: Score and rank
     const scoredResults = scoreAndRank(

--- a/mem0-ts/src/oss/src/utils/scoring.ts
+++ b/mem0-ts/src/oss/src/utils/scoring.ts
@@ -79,8 +79,8 @@ export interface ScoredResult {
  * For each candidate:
  *   combined = (semantic + bm25 + entity_boost) / max_possible
  *
- * Threshold gates the semantic score BEFORE combining -- candidates
- * below the threshold are excluded even if BM25/entity would boost them.
+ * Threshold gates numeric semantic scores before combining. Candidates with
+ * no semantic score require a positive entity boost to enter this scorer.
  *
  * The divisor adapts based on which signals are active:
  *   - Semantic only: max_possible = 1.0
@@ -99,7 +99,7 @@ export interface ScoredResult {
 export function scoreAndRank(
   semanticResults: Array<{
     id: string;
-    score: number;
+    score?: number;
     payload: Record<string, any>;
   }>,
   bm25Scores: Record<string, number>,
@@ -127,14 +127,17 @@ export function scoreAndRank(
       continue;
     }
 
-    const semanticScore = result.score ?? 0.0;
-    if (semanticScore < threshold) {
-      continue;
-    }
-
     const memIdStr = String(memId);
     const bm25Score = bm25Scores[memIdStr] ?? 0.0;
     const entityBoost = entityBoosts[memIdStr] ?? 0.0;
+    const rawSemanticScore = result.score;
+    const semanticScore = rawSemanticScore ?? 0.0;
+    if (rawSemanticScore == null && entityBoost <= 0) {
+      continue;
+    }
+    if (rawSemanticScore != null && semanticScore < threshold) {
+      continue;
+    }
 
     const rawCombined = semanticScore + bm25Score + entityBoost;
     const combined = Math.min(rawCombined / maxPossible, 1.0);

--- a/mem0-ts/src/oss/src/utils/scoring.ts
+++ b/mem0-ts/src/oss/src/utils/scoring.ts
@@ -134,10 +134,14 @@ export function scoreAndRank(
     const rawSemanticScore = result.score;
     const semanticScore = rawSemanticScore ?? 0.0;
     const isEntityRescue = result.isEntityRescue === true;
-    if (rawSemanticScore == null && entityBoost <= 0) {
-      continue;
-    }
-    if (!isEntityRescue && semanticScore < threshold) {
+    if (isEntityRescue) {
+      if (
+        entityBoost <= 0 ||
+        (rawSemanticScore != null && semanticScore < threshold)
+      ) {
+        continue;
+      }
+    } else if (semanticScore < threshold) {
       continue;
     }
 

--- a/mem0-ts/src/oss/src/utils/scoring.ts
+++ b/mem0-ts/src/oss/src/utils/scoring.ts
@@ -101,6 +101,7 @@ export function scoreAndRank(
     id: string;
     score?: number;
     payload: Record<string, any>;
+    isEntityRescue?: boolean;
   }>,
   bm25Scores: Record<string, number>,
   entityBoosts: Record<string, number>,
@@ -132,10 +133,11 @@ export function scoreAndRank(
     const entityBoost = entityBoosts[memIdStr] ?? 0.0;
     const rawSemanticScore = result.score;
     const semanticScore = rawSemanticScore ?? 0.0;
+    const isEntityRescue = result.isEntityRescue === true;
     if (rawSemanticScore == null && entityBoost <= 0) {
       continue;
     }
-    if (rawSemanticScore != null && semanticScore < threshold) {
+    if (!isEntityRescue && semanticScore < threshold) {
       continue;
     }
 

--- a/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
@@ -272,7 +272,12 @@ describe("Entity boost parallelism (#5214)", () => {
     m.vectorStore.get = jest.fn().mockImplementation(async (id: string) => {
       if (id === "mem-throws") throw new Error("point fetch failed");
       const payloads: Record<string, Record<string, any> | null> = {
-        "mem-rescued": { data: "rescued", user_id: "u1", topic: "keep" },
+        "mem-rescued": {
+          data: "rescued",
+          user_id: "u1",
+          topic: "keep",
+          memory_type: "procedural_memory",
+        },
         "mem-wrong-scope": { data: "wrong", user_id: "u2", topic: "keep" },
         "mem-wrong-filter": { data: "wrong", user_id: "u1", topic: "drop" },
         "mem-expired": {
@@ -306,12 +311,19 @@ describe("Entity boost parallelism (#5214)", () => {
     expect(resultIds).not.toContain("mem-throws");
     expect(m.vectorStore.get).not.toHaveBeenCalledWith("mem-primary");
 
-    const advancedResult = await m.search("Alice Smith", {
-      filters: { user_id: "u1", topic: { eq: "keep" } },
-    });
-    expect(
-      advancedResult.results.map((item: { id: string }) => item.id),
-    ).not.toContain("mem-rescued");
+    for (const advancedValue of [
+      { eq: "keep" },
+      ["keep"],
+      { $or: [{ topic: "keep" }] },
+      "*",
+    ]) {
+      const advancedResult = await m.search("Alice Smith", {
+        filters: { user_id: "u1", topic: advancedValue },
+      });
+      expect(
+        advancedResult.results.map((item: { id: string }) => item.id),
+      ).not.toContain("mem-rescued");
+    }
   });
 
   it("should call entity searches concurrently, not sequentially", async () => {

--- a/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
@@ -277,6 +277,8 @@ describe("Entity boost parallelism (#5214)", () => {
           user_id: "u1",
           topic: "keep",
           memory_type: "procedural_memory",
+          not: "keep",
+          rank: true,
         },
         "mem-wrong-scope": { data: "wrong", user_id: "u2", topic: "keep" },
         "mem-wrong-filter": { data: "wrong", user_id: "u1", topic: "drop" },
@@ -303,6 +305,11 @@ describe("Entity boost parallelism (#5214)", () => {
     expect(resultIds.filter((id: string) => id === "mem-primary")).toHaveLength(
       1,
     );
+    const rescued = result.results.find(
+      (item: { id: string; metadata?: Record<string, any> }) =>
+        item.id === "mem-rescued",
+    );
+    expect(rescued?.metadata?.memory_type).toBe("procedural_memory");
     expect(resultIds).not.toContain("mem-wrong-scope");
     expect(resultIds).not.toContain("mem-wrong-filter");
     expect(resultIds).not.toContain("mem-expired");
@@ -324,6 +331,60 @@ describe("Entity boost parallelism (#5214)", () => {
         advancedResult.results.map((item: { id: string }) => item.id),
       ).not.toContain("mem-rescued");
     }
+
+    const metadataKeyResult = await m.search("Alice Smith", {
+      filters: { user_id: "u1", not: "keep" },
+    });
+    expect(
+      metadataKeyResult.results.map((item: { id: string }) => item.id),
+    ).toContain("mem-rescued");
+    const typeMismatchResult = await m.search("Alice Smith", {
+      filters: { user_id: "u1", rank: 1 },
+    });
+    expect(
+      typeMismatchResult.results.map((item: { id: string }) => item.id),
+    ).not.toContain("mem-rescued");
+  });
+
+  it("bounds rescue point fetches independently of topK", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+    const linkedIds = Array.from(
+      { length: 75 },
+      (_, index) => `rescued-${index}`,
+    );
+    m._entityStore = {
+      search: jest
+        .fn()
+        .mockResolvedValue([makeMatch("e-alice", 0.9, linkedIds)]),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m.embedder = {
+      embed: jest.fn().mockResolvedValue(mockEmbedding),
+      embedBatch: jest
+        .fn()
+        .mockImplementation((texts: string[]) =>
+          Promise.resolve(texts.map(() => mockEmbedding)),
+        ),
+    };
+    m.vectorStore.search = jest
+      .fn()
+      .mockResolvedValue([
+        {
+          id: "mem-primary",
+          score: 0.8,
+          payload: { data: "primary", user_id: "u1" },
+        },
+      ]);
+    m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
+    m.vectorStore.get = jest.fn().mockImplementation(async (id: string) => ({
+      id,
+      payload: { data: id, user_id: "u1" },
+    }));
+
+    await m.search("Alice Smith", { filters: { user_id: "u1" }, topK: 100 });
+
+    expect(m.vectorStore.get).toHaveBeenCalledTimes(60);
   });
 
   it("should call entity searches concurrently, not sequentially", async () => {

--- a/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
@@ -226,6 +226,91 @@ describe("Entity boost parallelism (#5214)", () => {
     warnSpy.mockRestore();
   });
 
+  it("should rescue linked points outside the semantic pool and fail closed", async () => {
+    const m = memory as any;
+    await m._ensureInitialized();
+
+    m._entityStore = {
+      search: jest
+        .fn()
+        .mockResolvedValue([
+          makeMatch("e-alice", 0.9, [
+            "mem-primary",
+            "mem-rescued",
+            "mem-rescued",
+            "mem-wrong-scope",
+            "mem-wrong-filter",
+            "mem-expired",
+            "mem-malformed",
+            "mem-missing",
+            "mem-throws",
+          ]),
+        ]),
+      initialize: jest.fn().mockResolvedValue(undefined),
+    };
+    m.embedder = {
+      embed: jest.fn().mockResolvedValue(mockEmbedding),
+      embedBatch: jest
+        .fn()
+        .mockImplementation((texts: string[]) =>
+          Promise.resolve(texts.map(() => mockEmbedding)),
+        ),
+    };
+    m.vectorStore.search = jest.fn().mockResolvedValue([
+      {
+        id: "mem-primary",
+        score: 0.8,
+        payload: { data: "primary", user_id: "u1", topic: "keep" },
+      },
+      {
+        id: "mem-primary",
+        score: 0.8,
+        payload: { data: "primary", user_id: "u1", topic: "keep" },
+      },
+    ]);
+    m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
+    m.vectorStore.get = jest.fn().mockImplementation(async (id: string) => {
+      if (id === "mem-throws") throw new Error("point fetch failed");
+      const payloads: Record<string, Record<string, any> | null> = {
+        "mem-rescued": { data: "rescued", user_id: "u1", topic: "keep" },
+        "mem-wrong-scope": { data: "wrong", user_id: "u2", topic: "keep" },
+        "mem-wrong-filter": { data: "wrong", user_id: "u1", topic: "drop" },
+        "mem-expired": {
+          data: "expired",
+          user_id: "u1",
+          topic: "keep",
+          expiration_date: "2000-01-01",
+        },
+        "mem-malformed": null,
+      };
+      const payload = payloads[id];
+      return payload === undefined ? null : { id, payload };
+    });
+
+    const result = await m.search("Alice Smith", {
+      filters: { user_id: "u1", topic: { eq: "keep" } },
+    });
+    const resultIds = result.results.map((item: { id: string }) => item.id);
+
+    expect(resultIds.filter((id: string) => id === "mem-rescued")).toHaveLength(
+      1,
+    );
+    expect(resultIds.filter((id: string) => id === "mem-primary")).toHaveLength(
+      1,
+    );
+    expect(resultIds).not.toEqual(
+      expect.arrayContaining([
+        "mem-wrong-scope",
+        "mem-wrong-filter",
+        "mem-expired",
+        "mem-malformed",
+        "mem-missing",
+        "mem-throws",
+      ]),
+    );
+    expect(m.vectorStore.get).not.toHaveBeenCalledWith("mem-primary");
+  });
+
   it("should call entity searches concurrently, not sequentially", async () => {
     const m = memory as any;
     await m._ensureInitialized();

--- a/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
@@ -288,7 +288,7 @@ describe("Entity boost parallelism (#5214)", () => {
     });
 
     const result = await m.search("Alice Smith", {
-      filters: { user_id: "u1", topic: { eq: "keep" } },
+      filters: { user_id: "u1", topic: "keep" },
     });
     const resultIds = result.results.map((item: { id: string }) => item.id);
 
@@ -298,17 +298,20 @@ describe("Entity boost parallelism (#5214)", () => {
     expect(resultIds.filter((id: string) => id === "mem-primary")).toHaveLength(
       1,
     );
-    expect(resultIds).not.toEqual(
-      expect.arrayContaining([
-        "mem-wrong-scope",
-        "mem-wrong-filter",
-        "mem-expired",
-        "mem-malformed",
-        "mem-missing",
-        "mem-throws",
-      ]),
-    );
+    expect(resultIds).not.toContain("mem-wrong-scope");
+    expect(resultIds).not.toContain("mem-wrong-filter");
+    expect(resultIds).not.toContain("mem-expired");
+    expect(resultIds).not.toContain("mem-malformed");
+    expect(resultIds).not.toContain("mem-missing");
+    expect(resultIds).not.toContain("mem-throws");
     expect(m.vectorStore.get).not.toHaveBeenCalledWith("mem-primary");
+
+    const advancedResult = await m.search("Alice Smith", {
+      filters: { user_id: "u1", topic: { eq: "keep" } },
+    });
+    expect(
+      advancedResult.results.map((item: { id: string }) => item.id),
+    ).not.toContain("mem-rescued");
   });
 
   it("should call entity searches concurrently, not sequentially", async () => {

--- a/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
+++ b/mem0-ts/src/oss/tests/memory.entity-boost.test.ts
@@ -344,6 +344,12 @@ describe("Entity boost parallelism (#5214)", () => {
     expect(
       typeMismatchResult.results.map((item: { id: string }) => item.id),
     ).not.toContain("mem-rescued");
+    const missingFieldResult = await m.search("Alice Smith", {
+      filters: { user_id: "u1", missing: "value" },
+    });
+    expect(
+      missingFieldResult.results.map((item: { id: string }) => item.id),
+    ).not.toContain("mem-rescued");
   });
 
   it("bounds rescue point fetches independently of topK", async () => {
@@ -367,15 +373,13 @@ describe("Entity boost parallelism (#5214)", () => {
           Promise.resolve(texts.map(() => mockEmbedding)),
         ),
     };
-    m.vectorStore.search = jest
-      .fn()
-      .mockResolvedValue([
-        {
-          id: "mem-primary",
-          score: 0.8,
-          payload: { data: "primary", user_id: "u1" },
-        },
-      ]);
+    m.vectorStore.search = jest.fn().mockResolvedValue([
+      {
+        id: "mem-primary",
+        score: 0.8,
+        payload: { data: "primary", user_id: "u1" },
+      },
+    ]);
     m.vectorStore.keywordSearch = jest.fn().mockResolvedValue(null);
     m.vectorStore.get = jest.fn().mockImplementation(async (id: string) => ({
       id,
@@ -384,6 +388,9 @@ describe("Entity boost parallelism (#5214)", () => {
 
     await m.search("Alice Smith", { filters: { user_id: "u1" }, topK: 100 });
 
+    expect(m.vectorStore.get).toHaveBeenCalledTimes(60);
+    m.vectorStore.get.mockClear();
+    await m.search("Alice Smith", { filters: { user_id: "u1" }, topK: 1 });
     expect(m.vectorStore.get).toHaveBeenCalledTimes(60);
   });
 

--- a/mem0-ts/src/oss/tests/scoring.test.ts
+++ b/mem0-ts/src/oss/tests/scoring.test.ts
@@ -46,4 +46,42 @@ describe("scoreAndRank", () => {
     expect(details.maxPossibleScore).toBe(1.0);
     expect(details.finalScore).toBe(0.8);
   });
+
+  it("admits an absent semantic score only with an active entity signal", () => {
+    const scored = scoreAndRank(
+      [{ id: "entity", score: undefined, payload: { data: "entity memory" } }],
+      {},
+      { entity: 0.3 },
+      0.1,
+      10,
+    );
+
+    expect(scored).toHaveLength(1);
+    expect(scored[0].id).toBe("entity");
+    expect(scored[0].score).toBeCloseTo(0.2);
+  });
+
+  it("rejects an absent semantic score without an active entity signal", () => {
+    const scored = scoreAndRank(
+      [{ id: "unscored", score: undefined, payload: { data: "memory" } }],
+      {},
+      {},
+      0.1,
+      10,
+    );
+
+    expect(scored).toHaveLength(0);
+  });
+
+  it("does not rescue a numeric below-threshold semantic score with entity boost", () => {
+    const scored = scoreAndRank(
+      [{ id: "weak", score: 0.05, payload: { data: "weak semantic" } }],
+      {},
+      { weak: 0.5 },
+      0.1,
+      10,
+    );
+
+    expect(scored).toHaveLength(0);
+  });
 });

--- a/mem0-ts/src/oss/tests/scoring.test.ts
+++ b/mem0-ts/src/oss/tests/scoring.test.ts
@@ -49,7 +49,14 @@ describe("scoreAndRank", () => {
 
   it("admits an absent semantic score only with an active entity signal", () => {
     const scored = scoreAndRank(
-      [{ id: "entity", score: undefined, payload: { data: "entity memory" } }],
+      [
+        {
+          id: "entity",
+          score: undefined,
+          payload: { data: "entity memory" },
+          isEntityRescue: true,
+        },
+      ],
       {},
       { entity: 0.3 },
       0.1,

--- a/mem0-ts/src/oss/tests/scoring.test.ts
+++ b/mem0-ts/src/oss/tests/scoring.test.ts
@@ -80,9 +80,28 @@ describe("scoreAndRank", () => {
     expect(scored).toHaveLength(0);
   });
 
+  it("preserves an ordinary unscored candidate at zero threshold", () => {
+    const scored = scoreAndRank(
+      [{ id: "ordinary", score: undefined, payload: { data: "memory" } }],
+      {},
+      {},
+      0,
+      10,
+    );
+
+    expect(scored.map((item) => item.id)).toEqual(["ordinary"]);
+  });
+
   it("does not rescue a numeric below-threshold semantic score with entity boost", () => {
     const scored = scoreAndRank(
-      [{ id: "weak", score: 0.05, payload: { data: "weak semantic" } }],
+      [
+        {
+          id: "weak",
+          score: 0.05,
+          payload: { data: "weak semantic" },
+          isEntityRescue: true,
+        },
+      ],
       {},
       { weak: 0.5 },
       0.1,

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -451,17 +451,27 @@ def _payload_is_expired(payload: Optional[Dict[str, Any]]) -> bool:
         return False
 
 
+def _simple_filter_values_equal(actual: Any, expected: Any) -> bool:
+    if actual is None or expected is None:
+        return actual is None and expected is None
+    if isinstance(actual, bool) or isinstance(expected, bool):
+        return isinstance(actual, bool) and isinstance(expected, bool) and actual == expected
+    if isinstance(actual, (int, float)) and isinstance(expected, (int, float)):
+        return actual == expected
+    return type(actual) is type(expected) and actual == expected
+
+
 def _matches_simple_rescue_filters(payload: Any, filters: Dict[str, Any]) -> bool:
     """Recheck scalar equality filters without reproducing backend semantics."""
     if not isinstance(payload, dict) or not isinstance(filters, dict):
         return False
 
     for key, expected in filters.items():
-        if key in {"$or", "$and", "$not", "OR", "AND", "NOT", "or", "and", "not"}:
+        if key in {"$or", "$and", "$not", "OR", "AND", "NOT"}:
             return False
         if expected == "*" or isinstance(expected, (dict, list)):
             return False
-        if payload.get(key) != expected:
+        if key not in payload or not _simple_filter_values_equal(payload[key], expected):
             return False
     return True
 

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -451,77 +451,17 @@ def _payload_is_expired(payload: Optional[Dict[str, Any]]) -> bool:
         return False
 
 
-def _filter_value_matches(actual: Any, expected: Any) -> bool:
-    if expected == "*":
-        return actual is not None
-    if not isinstance(expected, dict):
-        if isinstance(expected, list):
-            return actual in expected
-        return actual == expected
-    if actual is None:
-        return False
-
-    try:
-        for operator, operand in expected.items():
-            if operator == "eq" and actual != operand:
-                return False
-            if operator == "ne" and actual == operand:
-                return False
-            if operator == "gt" and not actual > operand:
-                return False
-            if operator == "gte" and not actual >= operand:
-                return False
-            if operator == "lt" and not actual < operand:
-                return False
-            if operator == "lte" and not actual <= operand:
-                return False
-            if operator == "in" and actual not in operand:
-                return False
-            if operator == "nin" and actual in operand:
-                return False
-            if operator == "contains" and (not isinstance(actual, str) or operand not in actual):
-                return False
-            if operator == "icontains" and (
-                not isinstance(actual, str) or str(operand).lower() not in actual.lower()
-            ):
-                return False
-            if operator not in {
-                "eq",
-                "ne",
-                "gt",
-                "gte",
-                "lt",
-                "lte",
-                "in",
-                "nin",
-                "contains",
-                "icontains",
-            }:
-                return False
-        return True
-    except (TypeError, ValueError):
-        return False
-
-
-def _payload_matches_filters(payload: Any, filters: Dict[str, Any]) -> bool:
+def _matches_simple_rescue_filters(payload: Any, filters: Dict[str, Any]) -> bool:
+    """Recheck scalar equality filters without reproducing backend semantics."""
     if not isinstance(payload, dict) or not isinstance(filters, dict):
         return False
 
     for key, expected in filters.items():
-        if key in ("$or", "OR", "or"):
-            if not isinstance(expected, list) or not any(
-                _payload_matches_filters(payload, branch) for branch in expected
-            ):
-                return False
-        elif key in ("$and", "AND", "and"):
-            if not isinstance(expected, list) or not all(
-                _payload_matches_filters(payload, branch) for branch in expected
-            ):
-                return False
-        elif key in ("$not", "NOT", "not"):
-            if not isinstance(expected, list) or any(_payload_matches_filters(payload, branch) for branch in expected):
-                return False
-        elif not _filter_value_matches(payload.get(key), expected):
+        if key in {"$or", "$and", "$not", "OR", "AND", "NOT", "or", "and", "not"}:
+            return False
+        if expected == "*" or isinstance(expected, (dict, list)):
+            return False
+        if payload.get(key) != expected:
             return False
     return True
 
@@ -536,6 +476,9 @@ def _entity_rescue_ids(
         )
         if boost > 0 and memory_id not in candidate_ids
     ][:limit]
+
+
+_MAX_ENTITY_RESCUE_FETCHES = 60
 
 
 setup_config()
@@ -1767,7 +1710,8 @@ class Memory(MemoryBase):
                 "payload": payload,
             })
 
-        for memory_id in _entity_rescue_ids(entity_boosts, candidate_ids, internal_limit):
+        rescue_limit = min(internal_limit, _MAX_ENTITY_RESCUE_FETCHES)
+        for memory_id in _entity_rescue_ids(entity_boosts, candidate_ids, rescue_limit):
             try:
                 fetched = self.vector_store.get(vector_id=memory_id)
             except Exception as e:
@@ -1784,12 +1728,14 @@ class Memory(MemoryBase):
                 not isinstance(payload, dict)
                 or not isinstance(payload.get("data"), str)
                 or not payload["data"]
-                or not _payload_matches_filters(payload, filters)
+                or not _matches_simple_rescue_filters(payload, filters)
                 or (not show_expired and _payload_is_expired(payload))
             ):
                 continue
 
-            candidates.append({"id": memory_id, "score": None, "payload": payload})
+            candidates.append(
+                {"id": memory_id, "score": None, "payload": payload, "is_entity_rescue": True}
+            )
             candidate_ids.add(memory_id)
 
         # Step 8: Score and rank
@@ -3460,7 +3406,8 @@ class AsyncMemory(MemoryBase):
                 "payload": payload,
             })
 
-        for memory_id in _entity_rescue_ids(entity_boosts, candidate_ids, internal_limit):
+        rescue_limit = min(internal_limit, _MAX_ENTITY_RESCUE_FETCHES)
+        for memory_id in _entity_rescue_ids(entity_boosts, candidate_ids, rescue_limit):
             try:
                 fetched = await asyncio.to_thread(self.vector_store.get, vector_id=memory_id)
             except Exception as e:
@@ -3477,12 +3424,14 @@ class AsyncMemory(MemoryBase):
                 not isinstance(payload, dict)
                 or not isinstance(payload.get("data"), str)
                 or not payload["data"]
-                or not _payload_matches_filters(payload, filters)
+                or not _matches_simple_rescue_filters(payload, filters)
                 or (not show_expired and _payload_is_expired(payload))
             ):
                 continue
 
-            candidates.append({"id": memory_id, "score": None, "payload": payload})
+            candidates.append(
+                {"id": memory_id, "score": None, "payload": payload, "is_entity_rescue": True}
+            )
             candidate_ids.add(memory_id)
 
         # Step 8: Score and rank

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -451,6 +451,93 @@ def _payload_is_expired(payload: Optional[Dict[str, Any]]) -> bool:
         return False
 
 
+def _filter_value_matches(actual: Any, expected: Any) -> bool:
+    if expected == "*":
+        return actual is not None
+    if not isinstance(expected, dict):
+        if isinstance(expected, list):
+            return actual in expected
+        return actual == expected
+    if actual is None:
+        return False
+
+    try:
+        for operator, operand in expected.items():
+            if operator == "eq" and actual != operand:
+                return False
+            if operator == "ne" and actual == operand:
+                return False
+            if operator == "gt" and not actual > operand:
+                return False
+            if operator == "gte" and not actual >= operand:
+                return False
+            if operator == "lt" and not actual < operand:
+                return False
+            if operator == "lte" and not actual <= operand:
+                return False
+            if operator == "in" and actual not in operand:
+                return False
+            if operator == "nin" and actual in operand:
+                return False
+            if operator == "contains" and (not isinstance(actual, str) or operand not in actual):
+                return False
+            if operator == "icontains" and (
+                not isinstance(actual, str) or str(operand).lower() not in actual.lower()
+            ):
+                return False
+            if operator not in {
+                "eq",
+                "ne",
+                "gt",
+                "gte",
+                "lt",
+                "lte",
+                "in",
+                "nin",
+                "contains",
+                "icontains",
+            }:
+                return False
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def _payload_matches_filters(payload: Any, filters: Dict[str, Any]) -> bool:
+    if not isinstance(payload, dict) or not isinstance(filters, dict):
+        return False
+
+    for key, expected in filters.items():
+        if key in ("$or", "OR", "or"):
+            if not isinstance(expected, list) or not any(
+                _payload_matches_filters(payload, branch) for branch in expected
+            ):
+                return False
+        elif key in ("$and", "AND", "and"):
+            if not isinstance(expected, list) or not all(
+                _payload_matches_filters(payload, branch) for branch in expected
+            ):
+                return False
+        elif key in ("$not", "NOT", "not"):
+            if not isinstance(expected, list) or any(_payload_matches_filters(payload, branch) for branch in expected):
+                return False
+        elif not _filter_value_matches(payload.get(key), expected):
+            return False
+    return True
+
+
+def _entity_rescue_ids(
+    entity_boosts: Dict[str, float], candidate_ids: set, limit: int
+) -> list[str]:
+    return [
+        memory_id
+        for memory_id, boost in sorted(
+            entity_boosts.items(), key=lambda item: (-item[1], item[0])
+        )
+        if boost > 0 and memory_id not in candidate_ids
+    ][:limit]
+
+
 setup_config()
 logger = logging.getLogger(__name__)
 
@@ -1665,16 +1752,45 @@ class Memory(MemoryBase):
 
         # Step 7: Build candidate set from semantic results
         candidates = []
+        candidate_ids = set()
         for mem in semantic_results:
             payload = mem.payload if hasattr(mem, 'payload') else {}
             if not show_expired and _payload_is_expired(payload):
                 continue
             mem_id = str(mem.id)
+            if not mem_id or mem_id in candidate_ids:
+                continue
+            candidate_ids.add(mem_id)
             candidates.append({
                 "id": mem_id,
                 "score": mem.score,
                 "payload": payload,
             })
+
+        for memory_id in _entity_rescue_ids(entity_boosts, candidate_ids, internal_limit):
+            try:
+                fetched = self.vector_store.get(vector_id=memory_id)
+            except Exception as e:
+                logger.warning("Entity-linked point fetch failed for %s: %s", memory_id, e)
+                continue
+
+            if hasattr(fetched, "payload"):
+                payload = fetched.payload
+            elif isinstance(fetched, dict):
+                payload = fetched.get("payload")
+            else:
+                payload = None
+            if (
+                not isinstance(payload, dict)
+                or not isinstance(payload.get("data"), str)
+                or not payload["data"]
+                or not _payload_matches_filters(payload, filters)
+                or (not show_expired and _payload_is_expired(payload))
+            ):
+                continue
+
+            candidates.append({"id": memory_id, "score": None, "payload": payload})
+            candidate_ids.add(memory_id)
 
         # Step 8: Score and rank
         scored_results = score_and_rank(
@@ -3329,16 +3445,45 @@ class AsyncMemory(MemoryBase):
 
         # Step 7: Build candidate set from semantic results
         candidates = []
+        candidate_ids = set()
         for mem in semantic_results:
             payload = mem.payload if hasattr(mem, 'payload') else {}
             if not show_expired and _payload_is_expired(payload):
                 continue
             mem_id = str(mem.id)
+            if not mem_id or mem_id in candidate_ids:
+                continue
+            candidate_ids.add(mem_id)
             candidates.append({
                 "id": mem_id,
                 "score": mem.score,
                 "payload": payload,
             })
+
+        for memory_id in _entity_rescue_ids(entity_boosts, candidate_ids, internal_limit):
+            try:
+                fetched = await asyncio.to_thread(self.vector_store.get, vector_id=memory_id)
+            except Exception as e:
+                logger.warning("Entity-linked point fetch failed for %s: %s", memory_id, e)
+                continue
+
+            if hasattr(fetched, "payload"):
+                payload = fetched.payload
+            elif isinstance(fetched, dict):
+                payload = fetched.get("payload")
+            else:
+                payload = None
+            if (
+                not isinstance(payload, dict)
+                or not isinstance(payload.get("data"), str)
+                or not payload["data"]
+                or not _payload_matches_filters(payload, filters)
+                or (not show_expired and _payload_is_expired(payload))
+            ):
+                continue
+
+            candidates.append({"id": memory_id, "score": None, "payload": payload})
+            candidate_ids.add(memory_id)
 
         # Step 8: Score and rank
         scored_results = score_and_rank(

--- a/mem0/utils/scoring.py
+++ b/mem0/utils/scoring.py
@@ -112,10 +112,11 @@ def score_and_rank(
         bm25_score = bm25_scores.get(mem_id_str, 0.0)
         entity_boost = entity_boosts.get(mem_id_str, 0.0)
         is_entity_rescue = result.get("is_entity_rescue") is True
-        if raw_semantic_score is None and entity_boost <= 0:
-            continue
         semantic_score = raw_semantic_score or 0.0
-        if not is_entity_rescue and semantic_score < threshold:
+        if is_entity_rescue:
+            if entity_boost <= 0 or (raw_semantic_score is not None and semantic_score < threshold):
+                continue
+        elif semantic_score < threshold:
             continue
 
         raw_combined = semantic_score + bm25_score + entity_boost

--- a/mem0/utils/scoring.py
+++ b/mem0/utils/scoring.py
@@ -111,10 +111,11 @@ def score_and_rank(
         mem_id_str = str(mem_id)
         bm25_score = bm25_scores.get(mem_id_str, 0.0)
         entity_boost = entity_boosts.get(mem_id_str, 0.0)
+        is_entity_rescue = result.get("is_entity_rescue") is True
         if raw_semantic_score is None and entity_boost <= 0:
             continue
         semantic_score = raw_semantic_score or 0.0
-        if raw_semantic_score is not None and semantic_score < threshold:
+        if not is_entity_rescue and semantic_score < threshold:
             continue
 
         raw_combined = semantic_score + bm25_score + entity_boost

--- a/mem0/utils/scoring.py
+++ b/mem0/utils/scoring.py
@@ -71,8 +71,8 @@ def score_and_rank(
         semantic_score is taken from the result's score field.
         combined = (semantic + bm25 + entity_boost) / max_possible
 
-    Threshold gates the semantic score BEFORE combining -- candidates
-    below the threshold are excluded even if BM25/entity would boost them.
+    Threshold gates numeric semantic scores BEFORE combining. Candidates with
+    no semantic score require a positive entity boost to enter this scorer.
 
     The divisor adapts based on which signals are active:
         - Semantic only: max_possible = 1.0
@@ -107,13 +107,15 @@ def score_and_rank(
         if mem_id is None:
             continue
 
-        semantic_score = result.get("score") or 0.0
-        if semantic_score < threshold:
-            continue
-
+        raw_semantic_score = result.get("score")
         mem_id_str = str(mem_id)
         bm25_score = bm25_scores.get(mem_id_str, 0.0)
         entity_boost = entity_boosts.get(mem_id_str, 0.0)
+        if raw_semantic_score is None and entity_boost <= 0:
+            continue
+        semantic_score = raw_semantic_score or 0.0
+        if raw_semantic_score is not None and semantic_score < threshold:
+            continue
 
         raw_combined = semantic_score + bm25_score + entity_boost
         combined = min(raw_combined / max_possible, 1.0)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -343,7 +343,7 @@ def test_search_rescues_entity_linked_candidates_with_fail_closed_filters(
 
     mock_vector_store.get.side_effect = get_memory
 
-    result = memory.search("Alice", filters={"user_id": "u1", "topic": {"eq": "keep"}}, top_k=10)
+    result = memory.search("Alice", filters={"user_id": "u1", "topic": "keep"}, top_k=10)
     result_ids = [item["id"] for item in result["results"]]
 
     assert result_ids.count("rescued") == 1
@@ -357,6 +357,9 @@ def test_search_rescues_entity_linked_candidates_with_fail_closed_filters(
     assert not any(
         call.kwargs.get("vector_id") == "primary" for call in mock_vector_store.get.call_args_list
     )
+
+    advanced_result = memory.search("Alice", filters={"user_id": "u1", "topic": {"eq": "keep"}}, top_k=10)
+    assert "rescued" not in [item["id"] for item in advanced_result["results"]]
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -286,7 +286,13 @@ def test_search_rescues_entity_linked_candidates_with_fail_closed_filters(
         "primary", {"data": "primary", "user_id": "u1", "topic": "keep"}, score=0.8
     )
     rescued = MockVectorMemory(
-        "rescued", {"data": "rescued", "user_id": "u1", "topic": "keep"}
+        "rescued",
+        {
+            "data": "rescued",
+            "user_id": "u1",
+            "topic": "keep",
+            "memory_type": "procedural_memory",
+        },
     )
     wrong_scope = MockVectorMemory(
         "wrong-scope", {"data": "wrong", "user_id": "u2", "topic": "keep"}
@@ -358,8 +364,16 @@ def test_search_rescues_entity_linked_candidates_with_fail_closed_filters(
         call.kwargs.get("vector_id") == "primary" for call in mock_vector_store.get.call_args_list
     )
 
-    advanced_result = memory.search("Alice", filters={"user_id": "u1", "topic": {"eq": "keep"}}, top_k=10)
-    assert "rescued" not in [item["id"] for item in advanced_result["results"]]
+    for advanced_filters in (
+        {"eq": "keep"},
+        ["keep"],
+        {"$or": [{"topic": "keep"}]},
+        "*",
+    ):
+        advanced_result = memory.search(
+            "Alice", filters={"user_id": "u1", "topic": advanced_filters}, top_k=10
+        )
+        assert "rescued" not in [item["id"] for item in advanced_result["results"]]
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -240,6 +240,166 @@ def test_search_explain_includes_score_details(
     assert details["threshold"] == 0.1
 
 
+def _configure_entity_rescue_memory(
+    mock_vector_factory,
+    mock_llm_factory,
+    mock_embedder_factory,
+    mock_sqlite,
+    memory_class=None,
+):
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+    mock_embedder_factory.return_value = mock_embedder
+
+    mock_vector_store = MagicMock()
+    mock_vector_factory.return_value = mock_vector_store
+    mock_llm_factory.return_value = MagicMock()
+    mock_sqlite.return_value = MagicMock()
+
+    from mem0.memory.main import Memory as MemoryClass
+
+    if memory_class is not None:
+        MemoryClass = memory_class
+
+    memory = MemoryClass(MemoryConfig())
+    memory.embedding_model = mock_embedder
+    return memory, mock_vector_store
+
+
+@patch('mem0.memory.main.extract_entities', return_value=[("person", "Alice")])
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_search_rescues_entity_linked_candidates_with_fail_closed_filters(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    _mock_extract_entities,
+):
+    memory, mock_vector_store = _configure_entity_rescue_memory(
+        mock_vector_factory, mock_llm_factory, mock_embedder_factory, mock_sqlite
+    )
+    primary = MockVectorMemory(
+        "primary", {"data": "primary", "user_id": "u1", "topic": "keep"}, score=0.8
+    )
+    rescued = MockVectorMemory(
+        "rescued", {"data": "rescued", "user_id": "u1", "topic": "keep"}
+    )
+    wrong_scope = MockVectorMemory(
+        "wrong-scope", {"data": "wrong", "user_id": "u2", "topic": "keep"}
+    )
+    wrong_filter = MockVectorMemory(
+        "wrong-filter", {"data": "wrong", "user_id": "u1", "topic": "drop"}
+    )
+    expired = MockVectorMemory(
+        "expired",
+        {
+            "data": "expired",
+            "user_id": "u1",
+            "topic": "keep",
+            "expiration_date": "2000-01-01",
+        },
+    )
+    malformed = MockVectorMemory("malformed", None)
+
+    mock_vector_store.search.return_value = [primary, primary]
+    mock_vector_store.keyword_search.return_value = []
+    memory._entity_store = MagicMock()
+    memory._entity_store.search.return_value = [
+        MockVectorMemory(
+            "alice",
+            {
+                "linked_memory_ids": [
+                    "primary",
+                    "rescued",
+                    "rescued",
+                    "wrong-scope",
+                    "wrong-filter",
+                    "expired",
+                    "malformed",
+                    "missing",
+                    "raises",
+                ]
+            },
+            score=0.9,
+        )
+    ]
+
+    fetched = {
+        "rescued": {"id": "rescued", "payload": rescued.payload},
+        "wrong-scope": wrong_scope,
+        "wrong-filter": wrong_filter,
+        "expired": expired,
+        "malformed": malformed,
+    }
+
+    def get_memory(vector_id):
+        if vector_id == "raises":
+            raise RuntimeError("point fetch failed")
+        return fetched.get(vector_id)
+
+    mock_vector_store.get.side_effect = get_memory
+
+    result = memory.search("Alice", filters={"user_id": "u1", "topic": {"eq": "keep"}}, top_k=10)
+    result_ids = [item["id"] for item in result["results"]]
+
+    assert result_ids.count("rescued") == 1
+    assert result_ids.count("primary") == 1
+    assert "wrong-scope" not in result_ids
+    assert "wrong-filter" not in result_ids
+    assert "expired" not in result_ids
+    assert "malformed" not in result_ids
+    assert "missing" not in result_ids
+    assert "raises" not in result_ids
+    assert not any(
+        call.kwargs.get("vector_id") == "primary" for call in mock_vector_store.get.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch('mem0.memory.main.extract_entities', return_value=[("person", "Alice")])
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+async def test_async_search_rescues_entity_linked_candidate_and_survives_point_fetch_failure(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    _mock_extract_entities,
+):
+    from mem0.memory.main import AsyncMemory
+
+    memory, mock_vector_store = _configure_entity_rescue_memory(
+        mock_vector_factory, mock_llm_factory, mock_embedder_factory, mock_sqlite, AsyncMemory
+    )
+    mock_vector_store.search.return_value = [
+        MockVectorMemory("primary", {"data": "primary", "user_id": "u1"}, score=0.8)
+    ]
+    mock_vector_store.keyword_search.return_value = []
+    memory._entity_store = MagicMock()
+    memory._entity_store.search.return_value = [
+        MockVectorMemory(
+            "alice", {"linked_memory_ids": ["rescued", "rescued", "raises"]}, score=0.9
+        )
+    ]
+    mock_vector_store.get.side_effect = lambda vector_id: (
+        (_ for _ in ()).throw(RuntimeError("point fetch failed"))
+        if vector_id == "raises"
+        else MockVectorMemory("rescued", {"data": "rescued", "user_id": "u1"})
+    )
+
+    result = await memory.search("Alice", filters={"user_id": "u1"}, top_k=10)
+    result_ids = [item["id"] for item in result["results"]]
+
+    assert result_ids.count("rescued") == 1
+    assert result_ids.count("primary") == 1
+
+
 @patch('mem0.utils.factory.EmbedderFactory.create')
 @patch('mem0.utils.factory.VectorStoreFactory.create')
 @patch('mem0.utils.factory.LlmFactory.create')

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -292,6 +292,8 @@ def test_search_rescues_entity_linked_candidates_with_fail_closed_filters(
             "user_id": "u1",
             "topic": "keep",
             "memory_type": "procedural_memory",
+            "not": "keep",
+            "rank": True,
         },
     )
     wrong_scope = MockVectorMemory(
@@ -354,6 +356,8 @@ def test_search_rescues_entity_linked_candidates_with_fail_closed_filters(
 
     assert result_ids.count("rescued") == 1
     assert result_ids.count("primary") == 1
+    rescued_result = next(item for item in result["results"] if item["id"] == "rescued")
+    assert rescued_result["metadata"]["memory_type"] == "procedural_memory"
     assert "wrong-scope" not in result_ids
     assert "wrong-filter" not in result_ids
     assert "expired" not in result_ids
@@ -374,6 +378,48 @@ def test_search_rescues_entity_linked_candidates_with_fail_closed_filters(
             "Alice", filters={"user_id": "u1", "topic": advanced_filters}, top_k=10
         )
         assert "rescued" not in [item["id"] for item in advanced_result["results"]]
+
+    metadata_key_result = memory.search(
+        "Alice", filters={"user_id": "u1", "not": "keep"}, top_k=10
+    )
+    assert "rescued" in [item["id"] for item in metadata_key_result["results"]]
+    type_mismatch_result = memory.search(
+        "Alice", filters={"user_id": "u1", "rank": 1}, top_k=10
+    )
+    assert "rescued" not in [item["id"] for item in type_mismatch_result["results"]]
+
+
+@patch('mem0.memory.main.extract_entities', return_value=[("person", "Alice")])
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+def test_entity_rescue_fetches_are_bounded_independently_of_top_k(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    _mock_extract_entities,
+):
+    memory, mock_vector_store = _configure_entity_rescue_memory(
+        mock_vector_factory, mock_llm_factory, mock_embedder_factory, mock_sqlite
+    )
+    linked_ids = [f"rescued-{index}" for index in range(75)]
+    mock_vector_store.search.return_value = [
+        MockVectorMemory("primary", {"data": "primary", "user_id": "u1"}, score=0.8)
+    ]
+    mock_vector_store.keyword_search.return_value = []
+    memory._entity_store = MagicMock()
+    memory._entity_store.search.return_value = [
+        MockVectorMemory("alice", {"linked_memory_ids": linked_ids}, score=0.9)
+    ]
+    mock_vector_store.get.side_effect = lambda vector_id: MockVectorMemory(
+        vector_id, {"data": vector_id, "user_id": "u1"}
+    )
+
+    memory.search("Alice", filters={"user_id": "u1"}, top_k=100)
+
+    assert mock_vector_store.get.call_count == 60
 
 
 @pytest.mark.asyncio
@@ -415,6 +461,42 @@ async def test_async_search_rescues_entity_linked_candidate_and_survives_point_f
 
     assert result_ids.count("rescued") == 1
     assert result_ids.count("primary") == 1
+
+
+@pytest.mark.asyncio
+@patch('mem0.memory.main.extract_entities', return_value=[("person", "Alice")])
+@patch('mem0.utils.factory.EmbedderFactory.create')
+@patch('mem0.utils.factory.VectorStoreFactory.create')
+@patch('mem0.utils.factory.LlmFactory.create')
+@patch('mem0.memory.storage.SQLiteManager')
+async def test_async_entity_rescue_fetches_are_bounded_independently_of_top_k(
+    mock_sqlite,
+    mock_llm_factory,
+    mock_vector_factory,
+    mock_embedder_factory,
+    _mock_extract_entities,
+):
+    from mem0.memory.main import AsyncMemory
+
+    memory, mock_vector_store = _configure_entity_rescue_memory(
+        mock_vector_factory, mock_llm_factory, mock_embedder_factory, mock_sqlite, AsyncMemory
+    )
+    linked_ids = [f"rescued-{index}" for index in range(75)]
+    mock_vector_store.search.return_value = [
+        MockVectorMemory("primary", {"data": "primary", "user_id": "u1"}, score=0.8)
+    ]
+    mock_vector_store.keyword_search.return_value = []
+    memory._entity_store = MagicMock()
+    memory._entity_store.search.return_value = [
+        MockVectorMemory("alice", {"linked_memory_ids": linked_ids}, score=0.9)
+    ]
+    mock_vector_store.get.side_effect = lambda vector_id: MockVectorMemory(
+        vector_id, {"data": vector_id, "user_id": "u1"}
+    )
+
+    await memory.search("Alice", filters={"user_id": "u1"}, top_k=100)
+
+    assert mock_vector_store.get.call_count == 60
 
 
 @patch('mem0.utils.factory.EmbedderFactory.create')

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -387,6 +387,10 @@ def test_search_rescues_entity_linked_candidates_with_fail_closed_filters(
         "Alice", filters={"user_id": "u1", "rank": 1}, top_k=10
     )
     assert "rescued" not in [item["id"] for item in type_mismatch_result["results"]]
+    missing_field_result = memory.search(
+        "Alice", filters={"user_id": "u1", "missing": "value"}, top_k=10
+    )
+    assert "rescued" not in [item["id"] for item in missing_field_result["results"]]
 
 
 @patch('mem0.memory.main.extract_entities', return_value=[("person", "Alice")])
@@ -419,6 +423,9 @@ def test_entity_rescue_fetches_are_bounded_independently_of_top_k(
 
     memory.search("Alice", filters={"user_id": "u1"}, top_k=100)
 
+    assert mock_vector_store.get.call_count == 60
+    mock_vector_store.get.reset_mock()
+    memory.search("Alice", filters={"user_id": "u1"}, top_k=1)
     assert mock_vector_store.get.call_count == 60
 
 
@@ -496,6 +503,9 @@ async def test_async_entity_rescue_fetches_are_bounded_independently_of_top_k(
 
     await memory.search("Alice", filters={"user_id": "u1"}, top_k=100)
 
+    assert mock_vector_store.get.call_count == 60
+    mock_vector_store.get.reset_mock()
+    await memory.search("Alice", filters={"user_id": "u1"}, top_k=1)
     assert mock_vector_store.get.call_count == 60
 
 

--- a/tests/utils/test_scoring.py
+++ b/tests/utils/test_scoring.py
@@ -97,7 +97,7 @@ class TestScoreAndRank:
         assert scored[0]["id"] == "b"
 
     def test_active_entity_signal_admits_absent_semantic_score(self):
-        results = [{"id": "a", "score": None, "payload": {"data": "entity memory"}}]
+        results = [{"id": "a", "score": None, "payload": {"data": "entity memory"}, "is_entity_rescue": True}]
         scored = score_and_rank(results, {}, {"a": 0.3}, threshold=0.1, top_k=10)
 
         assert len(scored) == 1

--- a/tests/utils/test_scoring.py
+++ b/tests/utils/test_scoring.py
@@ -96,6 +96,26 @@ class TestScoreAndRank:
         assert len(scored) == 1
         assert scored[0]["id"] == "b"
 
+    def test_active_entity_signal_admits_absent_semantic_score(self):
+        results = [{"id": "a", "score": None, "payload": {"data": "entity memory"}}]
+        scored = score_and_rank(results, {}, {"a": 0.3}, threshold=0.1, top_k=10)
+
+        assert len(scored) == 1
+        assert scored[0]["id"] == "a"
+        assert scored[0]["score"] == pytest.approx(0.2)
+
+    def test_absent_semantic_score_without_active_signal_is_excluded(self):
+        results = [{"id": "a", "score": None, "payload": {"data": "unscored"}}]
+        scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
+
+        assert scored == []
+
+    def test_numeric_weak_semantic_score_is_not_rescued_by_entity(self):
+        results = [{"id": "a", "score": 0.05, "payload": {"data": "weak semantic"}}]
+        scored = score_and_rank(results, {}, {"a": 0.5}, threshold=0.1, top_k=10)
+
+        assert scored == []
+
     def test_top_k_limit(self):
         results = [{"id": str(i), "score": 0.5, "payload": {}} for i in range(20)]
         scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=5)

--- a/tests/utils/test_scoring.py
+++ b/tests/utils/test_scoring.py
@@ -104,6 +104,12 @@ class TestScoreAndRank:
         assert scored[0]["id"] == "a"
         assert scored[0]["score"] == pytest.approx(0.2)
 
+    def test_unscored_ordinary_candidate_remains_admitted_at_zero_threshold(self):
+        results = [{"id": "a", "score": None, "payload": {"data": "ordinary"}}]
+        scored = score_and_rank(results, {}, {}, threshold=0.0, top_k=10)
+
+        assert [item["id"] for item in scored] == ["a"]
+
     def test_absent_semantic_score_without_active_signal_is_excluded(self):
         results = [{"id": "a", "score": None, "payload": {"data": "unscored"}}]
         scored = score_and_rank(results, {}, {}, threshold=0.1, top_k=10)
@@ -111,7 +117,14 @@ class TestScoreAndRank:
         assert scored == []
 
     def test_numeric_weak_semantic_score_is_not_rescued_by_entity(self):
-        results = [{"id": "a", "score": 0.05, "payload": {"data": "weak semantic"}}]
+        results = [
+            {
+                "id": "a",
+                "score": 0.05,
+                "payload": {"data": "weak semantic"},
+                "is_entity_rescue": True,
+            }
+        ]
         scored = score_and_rank(results, {}, {"a": 0.5}, threshold=0.1, top_k=10)
 
         assert scored == []


### PR DESCRIPTION
## Linked Issue

Closes #5742

## Description

Hybrid search now keeps entity-linked memories in the candidate pool when semantic retrieval misses them. The change admits only candidates with an active rescue signal, preserves the existing semantic threshold for ordinary results, and applies scope and expiry checks to point-fetched memories.

## Root cause

The sync, async, and TypeScript OSS search paths built Step 7 candidates exclusively from semantic results. Entity boosts were calculated separately, so an entity-linked memory could never reach scoring when it was absent from semantic top-k.

## Scope

This PR covers entity rescue only. Keyword-only candidate union remains in PR #6378. Simple equality filters and expiry are rechecked after point fetch; complex filter expressions fail closed for rescue and continue through the existing vector-store path. Hosted API search, graph-memory ranking, and vector-store adapter contracts are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed

Verification:
- [x] Focused Python sync/async search and scoring tests
- [x] Focused TypeScript OSS search and scoring tests
- [ ] Relevant package suites

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed

The entity-rescue boundary follows the current hybrid-search contract and preserves the existing scoring, filtering, expiry, and result-shape behavior. PR #5743 is closed prior art; PR #6378 remains the separate keyword-only slice.

Focused validation passed: Python `91 passed` across `tests/test_memory.py` and `tests/utils/test_scoring.py`, Ruff check, two focused TypeScript Jest suites with `14` tests, and targeted Prettier.
