### PR TITLE
fix(memory): handle empty list returned by vector store in delete_all

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1920,19 +1920,18 @@ class Memory(MemoryBase):
         deleted_count = 0
         seen_batches = set()
         while True:
-            memories = self.vector_store.list(
-                filters=filters, top_k=DELETE_ALL_BATCH_SIZE
-            )[0]
-            if not memories:
+            memories = self.vector_store.list(filters=filters, top_k=DELETE_ALL_BATCH_SIZE)
+            batch = memories[0] if memories else []
+            if not batch:
                 break
-            batch_ids = tuple(sorted(str(memory.id) for memory in memories))
+            batch_ids = tuple(sorted(str(memory.id) for memory in batch))
             if batch_ids in seen_batches:
                 logger.warning("Stopping delete_all after a repeated memory batch")
                 break
             seen_batches.add(batch_ids)
-            for memory in memories:
+            for memory in batch:
                 self._delete_memory(memory.id)
-            deleted_count += len(memories)
+            deleted_count += len(batch)
 
         logger.info(f"Deleted {deleted_count} memories")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -310,6 +310,17 @@ def test_delete_all_paginates_beyond_vector_store_page_size(memory_instance):
     assert memory_instance.vector_store.list.call_count == 3
 
 
+def test_delete_all_handles_empty_list_from_vector_store(memory_instance):
+    """Regression: vector stores that return [] instead of ([], None) should not raise IndexError."""
+    memory_instance.vector_store.list = Mock(return_value=[])
+    memory_instance._delete_memory = Mock()
+
+    result = memory_instance.delete_all(user_id="test_user")
+
+    memory_instance._delete_memory.assert_not_called()
+    assert result["message"] == "Memories deleted successfully!"
+
+
 def test_get_all(memory_instance):
     mock_memories = [Mock(id="1", payload={"data": "Memory 1", "user_id": "test_user"})]
     memory_instance.vector_store.list = Mock(return_value=(mock_memories, None))


### PR DESCRIPTION
## Problem

`Memory.delete_all()` calls `self.vector_store.list(...)[0]` before checking whether the list is empty. Some vector-store backends return an empty list `[]` (rather than a tuple `([], None)`), which causes an `IndexError` instead of gracefully finishing.

Closes #7031

## Changes

- Take `memories[0]` only when the vector-store result is truthy, mirroring the existing async implementation in `AsyncMemory.delete_all()`.
- Added a regression test that mocks `vector_store.list` to return `[]`.

## Testing

```bash
MEM0_TELEMETRY=False pytest tests/test_main.py::test_delete_all \
  tests/test_main.py::test_delete_all_paginates_beyond_vector_store_page_size \
  tests/test_main.py::test_delete_all_handles_empty_list_from_vector_store -x
```

All three tests pass locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have read the CLA Document and I sign the CLA

Made with [Cursor](https://cursor.com)