### PR TITLE
feat(vector-stores): make pgvector schema configurable

### DIFF
--- a/docs/components/vectordbs/dbs/pgvector.mdx
+++ b/docs/components/vectordbs/dbs/pgvector.mdx
@@ -86,6 +86,7 @@ Here are the parameters available for configuring pgvector:
 | `connection_string`  | Python only             | PostgreSQL connection string, overrides individual connection parameters.                                                                                      | `None`                                  |
 | `sslmode`            | Python only             | SSL mode for PostgreSQL connections, such as `require`, `prefer`, or `disable`.                                                                                | `None`                                  |
 | `connection_pool`    | Python only             | psycopg connection pool object, overrides connection string and individual connection parameters.                                                              | `None`                                  |
+| `db_schema`          | Python only             | PostgreSQL schema that holds the collection table. Created automatically (`CREATE SCHEMA IF NOT EXISTS`) if it does not already exist.                         | `None` (connection's `search_path`)     |
 
 **TypeScript OSS:** Use `connectionString` plus optional `ssl` for managed Postgres setups. If you omit `connectionString`, Mem0 falls back to split fields and uses `dbname`, `user`, `password`, `host`, `port`, and optional `ssl`.
 
@@ -96,3 +97,25 @@ Here are the parameters available for configuring pgvector:
 1. `connection_pool` (highest priority)
 2. `connection_string`
 3. Individual connection parameters (`user`, `password`, `host`, `port`, `sslmode`)
+
+**Custom schema (Python):** By default the collection table lives wherever the connection's
+`search_path` resolves (typically `public`). Set `db_schema` to isolate it in its own schema, e.g.
+for a multi-tenant database:
+
+```python Python
+config = {
+    "vector_store": {
+        "provider": "pgvector",
+        "config": {
+            "user": "test",
+            "password": "123",
+            "host": "127.0.0.1",
+            "port": "5432",
+            "db_schema": "mem0",
+        },
+    }
+}
+```
+
+Mem0 runs `CREATE SCHEMA IF NOT EXISTS` for you, but the `vector` extension itself still needs to be
+resolvable from the connection's `search_path` (it's usually installed in `public`).

--- a/mem0/configs/vector_stores/pgvector.py
+++ b/mem0/configs/vector_stores/pgvector.py
@@ -19,6 +19,10 @@ class PGVectorConfig(BaseModel):
     sslmode: Optional[str] = Field(None, description="SSL mode for PostgreSQL connection (e.g., 'require', 'prefer', 'disable')")
     connection_string: Optional[str] = Field(None, description="PostgreSQL connection string (overrides individual connection parameters)")
     connection_pool: Optional[Any] = Field(None, description="psycopg connection pool object (overrides connection string and individual parameters)")
+    db_schema: Optional[str] = Field(
+        None,
+        description="PostgreSQL schema that holds the collection table. Defaults to the connection's search_path (usually 'public').",
+    )
 
     @model_validator(mode="before")
     def check_auth_and_connection(cls, values):

--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -160,6 +160,7 @@ class PGVector(VectorStoreBase):
         sslmode=None,
         connection_string=None,
         connection_pool=None,
+        db_schema=None,
     ):
         """
         Initialize the PGVector database.
@@ -179,8 +180,11 @@ class PGVector(VectorStoreBase):
             sslmode (str, optional): SSL mode for PostgreSQL connection (e.g., 'require', 'prefer', 'disable')
             connection_string (str, optional): PostgreSQL connection string (overrides individual connection parameters)
             connection_pool (Any, optional): psycopg2 connection pool object (overrides connection string and individual parameters)
+            db_schema (str, optional): PostgreSQL schema that holds the collection table. Defaults to the
+                connection's search_path (usually 'public'). Created automatically if it does not exist.
         """
         self.collection_name = collection_name
+        self.db_schema = db_schema
         self.use_diskann = diskann
         self.use_hnsw = hnsw
         self.embedding_model_dims = embedding_model_dims
@@ -257,6 +261,8 @@ class PGVector(VectorStoreBase):
 
     def _col(self) -> "sql.Identifier":
         """Return a safely-quoted SQL identifier for the collection table."""
+        if self.db_schema:
+            return sql.Identifier(self.db_schema, self.collection_name)
         return sql.Identifier(self.collection_name)
 
     def create_col(self) -> None:
@@ -266,6 +272,8 @@ class PGVector(VectorStoreBase):
         """
         with self._get_cursor(commit=True) as cur:
             cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            if self.db_schema:
+                cur.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self.db_schema)))
             cur.execute(
                 sql.SQL("""
                 CREATE TABLE IF NOT EXISTS {} (
@@ -479,7 +487,10 @@ class PGVector(VectorStoreBase):
             List[str]: List of collection names.
         """
         with self._get_cursor() as cur:
-            cur.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'")
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = COALESCE(%s, current_schema())",
+                (self.db_schema,),
+            )
             return [row[0] for row in cur.fetchall()]
 
     def delete_col(self) -> None:
@@ -501,11 +512,11 @@ class PGVector(VectorStoreBase):
                 SELECT
                     table_name,
                     (SELECT COUNT(*) FROM {}) as row_count,
-                    (SELECT pg_size_pretty(pg_total_relation_size({}::regclass))) as total_size
+                    pg_size_pretty(pg_total_relation_size(format('%%I.%%I', table_schema, table_name)::regclass)) as total_size
                 FROM information_schema.tables
-                WHERE table_schema = 'public' AND table_name = %s
-            """).format(self._col(), sql.Literal(self.collection_name)),
-                (self.collection_name,),
+                WHERE table_schema = COALESCE(%s, current_schema()) AND table_name = %s
+            """).format(self._col()),
+                (self.db_schema, self.collection_name),
             )
             result = cur.fetchone()
         return {"name": result[0], "count": result[1], "size": result[2]}

--- a/tests/vector_stores/test_pgvector.py
+++ b/tests/vector_stores/test_pgvector.py
@@ -2335,6 +2335,103 @@ class TestPGVector(unittest.TestCase):
         pass
 
 
+class TestPGVectorDbSchema(unittest.TestCase):
+    """Tests for the optional db_schema parameter (custom PostgreSQL schema support)."""
+
+    def setUp(self):
+        self.mock_cursor = MagicMock()
+        self.mock_cursor.fetchall.return_value = []
+
+    def _make_pgvector(self, mock_get_cursor, mock_connection_pool, db_schema=None):
+        mock_connection_pool.return_value = MagicMock()
+        mock_get_cursor.return_value.__enter__.return_value = self.mock_cursor
+        mock_get_cursor.return_value.__exit__.return_value = None
+        return PGVector(
+            dbname="test_db",
+            collection_name="test_collection",
+            embedding_model_dims=3,
+            user="test_user",
+            password="test_pass",
+            host="localhost",
+            port=5432,
+            diskann=False,
+            hnsw=False,
+            minconn=1,
+            maxconn=4,
+            db_schema=db_schema,
+        )
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    @patch.object(PGVector, '_get_cursor')
+    def test_col_qualifies_table_with_db_schema(self, mock_get_cursor, mock_connection_pool):
+        pgvector = self._make_pgvector(mock_get_cursor, mock_connection_pool, db_schema="my_schema")
+        self.assertEqual(pgvector._col().as_string(None), '"my_schema"."test_collection"')
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    @patch.object(PGVector, '_get_cursor')
+    def test_col_unqualified_without_db_schema(self, mock_get_cursor, mock_connection_pool):
+        pgvector = self._make_pgvector(mock_get_cursor, mock_connection_pool, db_schema=None)
+        self.assertEqual(pgvector._col().as_string(None), '"test_collection"')
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    @patch.object(PGVector, '_get_cursor')
+    def test_create_col_creates_schema_when_db_schema_set(self, mock_get_cursor, mock_connection_pool):
+        pgvector = self._make_pgvector(mock_get_cursor, mock_connection_pool, db_schema="my_schema")
+        pgvector.create_col()
+
+        schema_calls = [call for call in self.mock_cursor.execute.call_args_list
+                        if "CREATE SCHEMA IF NOT EXISTS" in str(call) and "my_schema" in str(call)]
+        self.assertEqual(len(schema_calls), 1)
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    @patch.object(PGVector, '_get_cursor')
+    def test_create_col_skips_schema_creation_by_default(self, mock_get_cursor, mock_connection_pool):
+        pgvector = self._make_pgvector(mock_get_cursor, mock_connection_pool, db_schema=None)
+        pgvector.create_col()
+
+        schema_calls = [call for call in self.mock_cursor.execute.call_args_list
+                        if "CREATE SCHEMA IF NOT EXISTS" in str(call)]
+        self.assertEqual(len(schema_calls), 0)
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    @patch.object(PGVector, '_get_cursor')
+    def test_list_cols_filters_by_db_schema(self, mock_get_cursor, mock_connection_pool):
+        pgvector = self._make_pgvector(mock_get_cursor, mock_connection_pool, db_schema="my_schema")
+        pgvector.list_cols()
+
+        args, _ = self.mock_cursor.execute.call_args
+        self.assertIn("table_schema = COALESCE(%s, current_schema())", args[0])
+        self.assertEqual(args[1], ("my_schema",))
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    @patch.object(PGVector, '_get_cursor')
+    def test_list_cols_falls_back_to_current_schema_by_default(self, mock_get_cursor, mock_connection_pool):
+        pgvector = self._make_pgvector(mock_get_cursor, mock_connection_pool, db_schema=None)
+        pgvector.list_cols()
+
+        args, _ = self.mock_cursor.execute.call_args
+        self.assertEqual(args[1], (None,))
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    @patch.object(PGVector, '_get_cursor')
+    def test_col_info_filters_by_db_schema(self, mock_get_cursor, mock_connection_pool):
+        pgvector = self._make_pgvector(mock_get_cursor, mock_connection_pool, db_schema="my_schema")
+        self.mock_cursor.fetchone.return_value = ("test_collection", 0, "0 bytes")
+
+        pgvector.col_info()
+
+        args, _ = self.mock_cursor.execute.call_args
+        self.assertIn("table_schema = COALESCE(%s, current_schema())", str(args[0]))
+        self.assertEqual(args[1], ("my_schema", "test_collection"))
+
+
 class TestBuildFilterConditions(unittest.TestCase):
     """Tests for the _build_filter_conditions helper that translates filter dicts to SQL."""
 


### PR DESCRIPTION
## Linked Issue

Closes #7107

## Description

Makes the PostgreSQL schema used by the pgvector vector store configurable (Python SDK only). It
was hardcoded to `public`: `list_cols()`/`col_info()` filtered on `table_schema = 'public'`
literally, and table/index references were never schema-qualified. This blocks isolating mem0's
tables in a dedicated schema on shared/multi-tenant databases, and the `search_path`-in-connection
workaround only works halfway (collection detection kept looking at `public`).

Adds an optional `db_schema` field to `PGVectorConfig` / `PGVector.__init__`, default `None`
(current behavior, resolved via `current_schema()`). When set:
- `create_col()` runs `CREATE SCHEMA IF NOT EXISTS` first.
- `_col()` returns a schema-qualified `sql.Identifier(db_schema, collection_name)`, which
  propagates to every method built on top of it (`insert`, `search`, `keyword_search`, `delete`,
  `update`, `get`, `list`, `delete_col`, `reset`).
- `list_cols()` / `col_info()` filter by the configured schema instead of the `'public'` literal.

Named `db_schema` rather than `schema` because a Pydantic v2 field literally named `schema`
triggers `UserWarning: Field name "schema" ... shadows an attribute in parent "BaseModel"` on
every import (checked locally against pydantic 2.12.5).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Written by Claude Code (Anthropic), directed by @ferponse: I asked it to investigate whether
mem0's pgvector connector supports a non-`public` schema, then to open this issue/PR once we
confirmed it doesn't.

- [ ] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added 7 unit tests in `tests/vector_stores/test_pgvector.py` (mocked, following the file's
existing pattern) covering `_col()` qualification, `create_col()` schema creation, and the
`list_cols()`/`col_info()` filters, both with and without `db_schema` set. Full existing suite
(94 tests) still passes.

Also ran a manual end-to-end check against a real `pgvector/pgvector:pg16` container: inserted
and searched through `PGVector` with `db_schema="mem0_custom"`, then confirmed directly via
`psql` that the table landed in `mem0_custom` and not in `public`, alongside a `db_schema=None`
run confirming unchanged default behavior (table in `public`).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
