### PR TITLE
fix(pgvector): support configurable database schema

### DIFF
--- a/mem0/configs/vector_stores/pgvector.py
+++ b/mem0/configs/vector_stores/pgvector.py
@@ -19,6 +19,7 @@ class PGVectorConfig(BaseModel):
     sslmode: Optional[str] = Field(None, description="SSL mode for PostgreSQL connection (e.g., 'require', 'prefer', 'disable')")
     connection_string: Optional[str] = Field(None, description="PostgreSQL connection string (overrides individual connection parameters)")
     connection_pool: Optional[Any] = Field(None, description="psycopg connection pool object (overrides connection string and individual parameters)")
+    db_schema: Optional[str] = Field(None, description="PostgreSQL schema for the collection (defaults to the connection search path)")
 
     @model_validator(mode="before")
     def check_auth_and_connection(cls, values):

--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -160,6 +160,7 @@ class PGVector(VectorStoreBase):
         sslmode=None,
         connection_string=None,
         connection_pool=None,
+        db_schema=None,
     ):
         """
         Initialize the PGVector database.
@@ -184,6 +185,7 @@ class PGVector(VectorStoreBase):
         self.use_diskann = diskann
         self.use_hnsw = hnsw
         self.embedding_model_dims = embedding_model_dims
+        self.db_schema = db_schema
         self.connection_pool = None
         self._collection_ensured = False
 
@@ -257,6 +259,8 @@ class PGVector(VectorStoreBase):
 
     def _col(self) -> "sql.Identifier":
         """Return a safely-quoted SQL identifier for the collection table."""
+        if self.db_schema:
+            return sql.Identifier(self.db_schema, self.collection_name)
         return sql.Identifier(self.collection_name)
 
     def create_col(self) -> None:
@@ -266,6 +270,8 @@ class PGVector(VectorStoreBase):
         """
         with self._get_cursor(commit=True) as cur:
             cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            if self.db_schema:
+                cur.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self.db_schema)))
             cur.execute(
                 sql.SQL("""
                 CREATE TABLE IF NOT EXISTS {} (
@@ -479,7 +485,13 @@ class PGVector(VectorStoreBase):
             List[str]: List of collection names.
         """
         with self._get_cursor() as cur:
-            cur.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'")
+            if self.db_schema:
+                cur.execute(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = %s",
+                    (self.db_schema,),
+                )
+            else:
+                cur.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = current_schema()")
             return [row[0] for row in cur.fetchall()]
 
     def delete_col(self) -> None:
@@ -503,9 +515,9 @@ class PGVector(VectorStoreBase):
                     (SELECT COUNT(*) FROM {}) as row_count,
                     (SELECT pg_size_pretty(pg_total_relation_size({}::regclass))) as total_size
                 FROM information_schema.tables
-                WHERE table_schema = 'public' AND table_name = %s
+                WHERE table_schema = COALESCE(%s, current_schema()) AND table_name = %s
             """).format(self._col(), sql.Literal(self.collection_name)),
-                (self.collection_name,),
+                (self.db_schema, self.collection_name),
             )
             result = cur.fetchone()
         return {"name": result[0], "count": result[1], "size": result[2]}

--- a/tests/vector_stores/test_pgvector.py
+++ b/tests/vector_stores/test_pgvector.py
@@ -72,6 +72,21 @@ class TestPGVector(unittest.TestCase):
 
     @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
     @patch('mem0.vector_stores.pgvector.ConnectionPool')
+    def test_db_schema_qualifies_collection(self, mock_psycopg_pool):
+        pool = MagicMock()
+        mock_psycopg_pool.return_value = pool
+
+        pgvector = PGVector(
+            dbname="test_db", collection_name="memories", embedding_model_dims=3,
+            user="user", password="pass", host="localhost", port=5432,
+            diskann=False, hnsw=False, db_schema="app_data",
+        )
+
+        self.assertEqual(pgvector.db_schema, "app_data")
+        self.assertEqual(pgvector._col().as_string(None), '"app_data"."memories"')
+
+    @patch('mem0.vector_stores.pgvector.PSYCOPG_VERSION', 3)
+    @patch('mem0.vector_stores.pgvector.ConnectionPool')
     def test_init_does_not_block_on_unreachable_host_psycopg3(self, mock_psycopg_pool):
         """Regression test for issue #3950.
 


### PR DESCRIPTION
## Summary

Closes #7107.

The pgvector connector hard-coded the `public` schema when discovering collections and metadata, while table identifiers were never schema-qualified. This prevented deployments that require application-owned PostgreSQL schemas.

## Changes

- Add optional `db_schema` to `PGVectorConfig` and `PGVector` (default `None`, preserving the connection search path behavior).
- Create the configured schema when creating a collection.
- Schema-qualify collection identifiers and use the configured/current schema for collection discovery and metadata.
- Add a focused regression test for schema-qualified identifiers.

## Compatibility

The new field is optional and existing configurations remain valid. No database migration is required; existing unqualified configurations continue to use the connection's current schema.

## Verification

- `python -m pytest tests/vector_stores/test_pgvector.py -q` — 88 passed
- `python -m compileall -q mem0` — passed
- `git diff --check` — passed

Not run: full repository test suite, because this change is isolated to the pgvector connector and its unit tests; no live PostgreSQL/pgvector service was available in this environment.
