### PR TITLE
fix(llms): classify gpt-5 dash family as reasoning models

### DIFF
--- a/mem0/llms/base.py
+++ b/mem0/llms/base.py
@@ -72,6 +72,18 @@ class LLMBase(ABC):
         if any(base_model.startswith(prefix) for prefix in ["o1-", "o1.", "o3-", "o3."]):
             return True
 
+        # Match the original GPT-5 dash family (gpt-5-mini, gpt-5-nano and their
+        # dated variants like gpt-5-mini-2025-08-07). These are reasoning models
+        # that reject a non-default temperature. This must NOT match the newer
+        # dot-versioned models (gpt-5.4-mini) which support temperature, hence
+        # the explicit "gpt-5-" (dash) prefix rather than a bare "gpt-5" substring.
+        #
+        # Exclude the "gpt-5-chat" family (gpt-5-chat, gpt-5-chat-latest): these
+        # are the non-reasoning chat variants that DO accept a custom temperature,
+        # so they must stay on the temperature path.
+        if base_model.startswith("gpt-5-") and not base_model.startswith("gpt-5-chat"):
+            return True
+
         return False
 
     def _uses_max_completion_tokens(self, model: str) -> bool:

--- a/tests/llms/test_openai.py
+++ b/tests/llms/test_openai.py
@@ -323,11 +323,48 @@ def test_is_reasoning_model_classification(mock_openai_client):
     assert llm._is_reasoning_model("o1-2024-12-17") is True
     assert llm._is_reasoning_model("openai/o3-mini") is True
 
+    # GPT-5 dash family — reasoning models that reject non-default temperature
+    # (regression for https://github.com/mem0ai/mem0/issues/6085)
+    assert llm._is_reasoning_model("gpt-5-mini") is True
+    assert llm._is_reasoning_model("gpt-5-nano") is True
+    assert llm._is_reasoning_model("gpt-5-mini-2025-08-07") is True
+    assert llm._is_reasoning_model("openai/gpt-5-mini") is True
+
     # Non-reasoning models — should return False
     assert llm._is_reasoning_model("gpt-5.4-mini") is False
     assert llm._is_reasoning_model("gpt-5.4") is False
+    # gpt-5-chat family is the non-reasoning chat variant and DOES accept a
+    # custom temperature, so the gpt-5- dash rule must not strip it.
+    assert llm._is_reasoning_model("gpt-5-chat") is False
+    assert llm._is_reasoning_model("gpt-5-chat-latest") is False
+    assert llm._is_reasoning_model("openai/gpt-5-chat") is False
     assert llm._is_reasoning_model("gpt-4.1") is False
     assert llm._is_reasoning_model("gpt-4.1-nano-2025-04-14") is False
+
+
+def test_default_gpt5_mini_omits_temperature(mock_openai_client):
+    """Default OSS config must not send temperature for the resolved gpt-5-mini.
+
+    Regression test for https://github.com/mem0ai/mem0/issues/6085: with all
+    defaults, ``model`` resolves to ``gpt-5-mini`` (a reasoning model that
+    rejects any non-default temperature). Previously the default temperature
+    0.1 was still sent, so every add() failed LLM extraction and silently
+    stored nothing. The dash family must now be classified as reasoning so
+    temperature is stripped.
+    """
+    config = OpenAIConfig(temperature=0.1)  # model=None -> resolves to gpt-5-mini
+    llm = OpenAILLM(config)
+    assert llm.config.model == "gpt-5-mini"
+
+    messages = [{"role": "user", "content": "Hello"}]
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Response"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    call_kwargs = mock_openai_client.chat.completions.create.call_args
+    assert "temperature" not in call_kwargs[1]
 
 
 def test_is_reasoning_model_explicit_override(mock_openai_client):


### PR DESCRIPTION
## Problem

The default OSS config resolves `model=None` to `gpt-5-mini`, which is a reasoning model that rejects any non-default `temperature`. The existing `_is_reasoning_model` heuristic only matched the exact string `gpt-5`, so `gpt-5-mini` fell through to the temperature path. This caused every default `Memory().add(...)` to fail LLM extraction and silently store nothing.

Closes #6085

## Changes

- Updated `mem0/llms/base.py` to classify the GPT-5 dash family (`gpt-5-mini`, `gpt-5-nano`, and dated variants) as reasoning models.
- Explicitly excluded `gpt-5-chat*` variants, which are non-reasoning chat models that still accept a custom temperature.
- Added regression tests covering the classification and the end-to-end API call (no `temperature` is sent for the default `gpt-5-mini`).

## Testing

```bash
MEM0_TELEMETRY=False hatch run pytest tests/llms/test_openai.py::test_is_reasoning_model_classification tests/llms/test_openai.py::test_default_gpt5_mini_omits_temperature -x
```

All tests pass. `ruff check` also passes.

## Checklist

- [x] I have read the CLA Document and I sign the CLA
