### PR TITLE
fix(vector_stores/faiss): recover into a consistent state when _load() fails

### DIFF
--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -220,9 +220,30 @@ class FAISS(VectorStoreBase):
             logger.error(f"Security error loading FAISS docstore: {e}")
             raise ValueError(f"Failed to load FAISS docstore: potentially malicious pickle file. {e}") from e
         except Exception as e:
-            logger.warning(f"Failed to load FAISS index: {e}")
+            # Recover into a consistent state: quarantine whatever is on disk and
+            # start a fresh, empty collection. Keeping the loaded index while
+            # clearing the mapping desynchronizes index positions from ids (new
+            # inserts get numbered from 0 while FAISS appends at ntotal), and
+            # leaving self.index as None makes the store permanently unusable.
+            logger.error(
+                f"Failed to load FAISS index: {e}. "
+                f"Persisted data appears corrupted; backing it up and starting a fresh collection."
+            )
+            self._quarantine_corrupt_files(index_path)
             self.docstore = {}
             self.index_to_id = {}
+            self.create_col(self.collection_name)
+
+    def _quarantine_corrupt_files(self, index_path: str):
+        """Rename corrupted persistence files so they are kept for inspection
+        instead of being overwritten by the next _save()."""
+        json_path = f"{self.path}/{self.collection_name}.json"
+        for file_path in (index_path, json_path):
+            try:
+                if os.path.exists(file_path):
+                    os.replace(file_path, f"{file_path}.corrupt")
+            except OSError as e:
+                logger.warning(f"Could not back up corrupted file {file_path}: {e}")
 
     def _save(self):
         """Save FAISS index and docstore to disk using JSON format (secure)."""
@@ -234,7 +255,11 @@ class FAISS(VectorStoreBase):
             index_path = f"{self.path}/{self.collection_name}.faiss"
             json_docstore_path = f"{self.path}/{self.collection_name}.json"
 
-            faiss.write_index(self.index, index_path)
+            # Write to temp files and rename so a crash mid-write can never
+            # leave a truncated index or docstore behind (os.replace is atomic).
+            tmp_index_path = f"{index_path}.tmp"
+            faiss.write_index(self.index, tmp_index_path)
+            os.replace(tmp_index_path, index_path)
 
             # Save docstore as JSON (safe format, no code execution risk)
             # JSON keys must be strings, so convert int keys to str
@@ -242,8 +267,10 @@ class FAISS(VectorStoreBase):
                 "docstore": self.docstore,
                 "index_to_id": {str(k): v for k, v in self.index_to_id.items()},
             }
-            with open(json_docstore_path, "w", encoding="utf-8") as f:
+            tmp_json_path = f"{json_docstore_path}.tmp"
+            with open(tmp_json_path, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
+            os.replace(tmp_json_path, json_docstore_path)
 
         except Exception as e:
             logger.warning(f"Failed to save FAISS index: {e}")

--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -532,7 +532,12 @@ class TestFAISSSecurityIntegration:
             mock_index.ntotal = 0
 
             with patch("mem0.vector_stores.faiss.faiss.IndexFlatL2", return_value=mock_index):
-                with patch("mem0.vector_stores.faiss.faiss.write_index"):
+                # write_index must create the target file: _save() writes to a
+                # temp path and renames it into place.
+                with patch(
+                    "mem0.vector_stores.faiss.faiss.write_index",
+                    side_effect=lambda index, path: open(path, "wb").close(),
+                ):
                     faiss_store = FAISS(
                         collection_name="test_security",
                         path=os.path.join(temp_dir, "test_faiss"),
@@ -651,7 +656,10 @@ class TestFAISSSecurityIntegration:
             mock_index.ntotal = 1
 
             with patch("mem0.vector_stores.faiss.faiss.read_index", return_value=mock_index):
-                with patch("mem0.vector_stores.faiss.faiss.write_index"):
+                with patch(
+                    "mem0.vector_stores.faiss.faiss.write_index",
+                    side_effect=lambda index, path: open(path, "wb").close(),
+                ):
                     faiss_store = FAISS.__new__(FAISS)
                     faiss_store.collection_name = "legacy"
                     faiss_store.path = faiss_path
@@ -754,3 +762,105 @@ class TestCosineNormalization:
 
             assert results[0].id == "x"
             assert results[0].score == pytest.approx(1.0, abs=1e-5)
+
+
+class TestLoadFailureRecovery:
+    """Regression tests for #7117: a failed _load() must leave the store consistent.
+
+    Before the fix, a corrupted .json docstore kept the old vectors in the
+    index while clearing the mapping (subsequent inserts were numbered from 0
+    but appended at ntotal, so search returned the wrong memory), and a
+    corrupted .faiss index left self.index as None permanently.
+    """
+
+    DIMS = 8
+
+    def _vec(self, i):
+        v = np.zeros(self.DIMS, dtype=np.float32)
+        v[i] = 1.0
+        return v.tolist()
+
+    def _store(self, temp_dir):
+        return FAISS(
+            collection_name="recovery",
+            path=os.path.join(temp_dir, "recovery"),
+            embedding_model_dims=self.DIMS,
+        )
+
+    def test_corrupted_json_recovers_into_consistent_state(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = self._store(temp_dir)
+            store.insert(
+                [self._vec(0), self._vec(1)],
+                payloads=[{"data": "apple"}, {"data": "banana"}],
+                ids=["id-apple", "id-banana"],
+            )
+            json_path = os.path.join(temp_dir, "recovery", "recovery.json")
+            with open(json_path, "r+", encoding="utf-8") as f:
+                content = f.read()
+                f.seek(0)
+                f.truncate()
+                f.write(content[: len(content) // 2])
+
+            store2 = self._store(temp_dir)
+
+            # Fresh empty collection: index and mapping agree.
+            assert store2.index is not None
+            assert store2.index.ntotal == 0
+            assert store2.index_to_id == {}
+            assert store2.docstore == {}
+
+            # New inserts map to the right memory again.
+            store2.insert([self._vec(2)], payloads=[{"data": "cherry"}], ids=["id-cherry"])
+            results = store2.search(query="", vectors=self._vec(2), top_k=1)
+            assert results[0].id == "id-cherry"
+            assert results[0].payload == {"data": "cherry"}
+
+            # Searching an old vector must not resolve to a wrong memory.
+            results = store2.search(query="", vectors=self._vec(0), top_k=5)
+            assert all(r.id == "id-cherry" for r in results)
+
+    def test_corrupted_json_is_backed_up_not_overwritten(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = self._store(temp_dir)
+            store.insert([self._vec(0)], payloads=[{"data": "apple"}], ids=["id-apple"])
+            json_path = os.path.join(temp_dir, "recovery", "recovery.json")
+            with open(json_path, "w", encoding="utf-8") as f:
+                f.write("{ not json")
+
+            self._store(temp_dir)
+
+            assert os.path.exists(f"{json_path}.corrupt")
+            with open(f"{json_path}.corrupt", encoding="utf-8") as f:
+                assert f.read() == "{ not json"
+
+    def test_corrupted_index_recovers_usable_store(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = self._store(temp_dir)
+            store.insert([self._vec(0)], payloads=[{"data": "apple"}], ids=["id-apple"])
+            index_path = os.path.join(temp_dir, "recovery", "recovery.faiss")
+            with open(index_path, "wb") as f:
+                f.write(b"garbage")
+
+            store2 = self._store(temp_dir)
+
+            # Not permanently dead: insert and search work on the fresh collection.
+            assert store2.index is not None
+            store2.insert([self._vec(1)], payloads=[{"data": "banana"}], ids=["id-banana"])
+            results = store2.search(query="", vectors=self._vec(1), top_k=1)
+            assert results[0].id == "id-banana"
+            assert os.path.exists(f"{index_path}.corrupt")
+
+    def test_save_failure_leaves_previous_docstore_intact(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = self._store(temp_dir)
+            store.insert([self._vec(0)], payloads=[{"data": "apple"}], ids=["id-apple"])
+            json_path = os.path.join(temp_dir, "recovery", "recovery.json")
+
+            with patch("json.dump", side_effect=RuntimeError("disk full")):
+                store._save()  # logs a warning, must not corrupt the file
+
+            with open(json_path, encoding="utf-8") as f:
+                data = json.load(f)
+            assert data["docstore"] == {"id-apple": {"data": "apple"}}
+            assert data["index_to_id"] == {"0": "id-apple"}


### PR DESCRIPTION
## Linked Issue

Closes #7117

## Description

`FAISS._load()` catches all exceptions, logs a warning, and resets `docstore` and `index_to_id` to empty dicts. It never touches `self.index`, and `create_col()` skips the rebuild because it only runs when both files are missing. This leaves the store in one of two broken states depending on which file failed to load:

1. `.json` corrupted, `.faiss` intact: the index still holds the old vectors but the id mapping is empty. New inserts get internal ids starting from `len(index_to_id) == 0` while FAISS appends at `ntotal`, so ids and vectors go out of sync. A later search matches an old vector and returns a different user's memory with score 1.0.
2. `.faiss` corrupted: `self.index` stays `None` and every operation fails with "Collection not initialized" until someone manually deletes the files.

The root cause of scenario 1 in practice is that `_save()` was not atomic, so a process killed mid-write leaves one file truncated.

Changes:

- On `_load()` failure, rename the on-disk files to `<file>.corrupt` (so the data is kept for inspection instead of being overwritten on the next save) and rebuild an empty index via `create_col()`. The store comes back empty but internally consistent.
- Make `_save()` atomic: write to `<path>.tmp`, then `os.replace()`. A crash during save can no longer truncate the previous state.
- The existing `pickle.UnpicklingError` branch (legacy `.pkl` migration) is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Tool: GitHub Copilot. I reviewed the diff line by line, reproduced both failure scenarios locally with a standalone script before writing the fix, and re-ran the full faiss test file with the fix reverted to confirm the new tests fail without it (4/4 fail, 37/37 pass with it).

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `TestLoadFailureRecovery` with a real FAISS index (no mocks for the failure paths):

- corrupted `.json` + intact `.faiss`: store recovers, insert/search work, and the search no longer returns a stale memory with score 1.0
- corrupted files are renamed to `.corrupt`, not overwritten
- corrupted `.faiss`: store is usable again instead of raising "Collection not initialized" forever
- a failure during `_save()` leaves the previous on-disk state intact

Two existing tests mocked `faiss.write_index` as a no-op; updated the mock to create the target file since `_save()` now renames from a tmp file.

Ran locally: `pytest tests/vector_stores/test_faiss.py` (37 passed), `ruff check`, `isort --check-only`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed