### PR TITLE
fix(faiss): reset index after failed load

### DIFF
--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -223,6 +223,7 @@ class FAISS(VectorStoreBase):
             logger.warning(f"Failed to load FAISS index: {e}")
             self.docstore = {}
             self.index_to_id = {}
+            self.create_col(self.collection_name)
 
     def _save(self):
         """Save FAISS index and docstore to disk using JSON format (secure)."""

--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -595,6 +595,37 @@ class TestFAISSSecurityIntegration:
                     # Should have loaded from JSON, not pickle
                     assert faiss_store.docstore == {"id1": {"source": "json"}}
 
+    @pytest.mark.parametrize("index_is_corrupt", [False, True])
+    def test_load_failure_recreates_empty_index(self, index_is_corrupt):
+        """A failed load must not leave the index and mappings out of sync."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            faiss_path = os.path.join(temp_dir, "test_faiss")
+            os.makedirs(faiss_path)
+            with open(os.path.join(faiss_path, "broken.json"), "w") as f:
+                f.write("{")
+
+            faiss_store = FAISS.__new__(FAISS)
+            faiss_store.collection_name = "broken"
+            faiss_store.path = faiss_path
+            faiss_store.distance_strategy = "euclidean"
+            faiss_store.embedding_model_dims = 3
+            faiss_store.index = None
+            faiss_store.docstore = {"old": {}}
+            faiss_store.index_to_id = {0: "old"}
+
+            stale_index, empty_index = Mock(ntotal=1), Mock(ntotal=0)
+            read_error = ValueError("bad index") if index_is_corrupt else None
+            with (
+                patch("mem0.vector_stores.faiss.faiss.read_index", return_value=stale_index, side_effect=read_error),
+                patch("mem0.vector_stores.faiss.faiss.IndexFlatL2", return_value=empty_index),
+                patch("mem0.vector_stores.faiss.faiss.write_index"),
+            ):
+                faiss_store._load(os.path.join(faiss_path, "broken.faiss"), os.path.join(faiss_path, "broken.pkl"))
+
+            assert faiss_store.index is empty_index
+            assert faiss_store.docstore == {}
+            assert faiss_store.index_to_id == {}
+
     def test_faiss_blocks_malicious_pickle_on_load(self):
         """FAISS should block loading of malicious pickle files."""
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Linked Issue

Closes #7117

## Description

Recreate an empty FAISS index whenever persisted state fails to load, so the in-memory index, docstore, and index mapping always recover together. Regression coverage exercises both a corrupted JSON docstore with an otherwise valid index and a corrupted FAISS index.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Codex generated the patch. I verified the original regression failures, reviewed the recovery behavior line by line, and ran the focused tests and lint locally.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

`./.venv/bin/pytest tests/vector_stores/test_faiss.py -q` — 35 passed

`./.venv/bin/ruff check mem0/vector_stores/faiss.py tests/vector_stores/test_faiss.py` — passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed — N/A; this is an internal recovery invariant with no public API change.
