### PR TITLE
fix(faiss): fail fast on corrupt persisted state

### DIFF
--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -221,8 +221,10 @@ class FAISS(VectorStoreBase):
             raise ValueError(f"Failed to load FAISS docstore: potentially malicious pickle file. {e}") from e
         except Exception as e:
             logger.warning(f"Failed to load FAISS index: {e}")
+            self.index = None
             self.docstore = {}
             self.index_to_id = {}
+            raise ValueError(f"Failed to load FAISS index: {e}") from e
 
     def _save(self):
         """Save FAISS index and docstore to disk using JSON format (secure)."""

--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -635,6 +635,21 @@ class TestFAISSSecurityIntegration:
                 pwned_file = os.path.join(temp_dir, "pwned")
                 assert not os.path.exists(pwned_file), "Malicious payload should NOT have been executed!"
 
+    def test_faiss_resets_index_when_load_fails(self):
+        """A failed load must not leave a stale index with empty mappings."""
+        faiss_store = FAISS.__new__(FAISS)
+        faiss_store.index = Mock()
+        faiss_store.docstore = {"stale": {"data": "stale"}}
+        faiss_store.index_to_id = {0: "stale"}
+
+        with patch("mem0.vector_stores.faiss.faiss.read_index", side_effect=RuntimeError("corrupt index")):
+            with pytest.raises(ValueError, match="Failed to load FAISS index"):
+                faiss_store._load("missing.faiss", "missing.pkl")
+
+        assert faiss_store.index is None
+        assert faiss_store.docstore == {}
+        assert faiss_store.index_to_id == {}
+
     def test_faiss_migrates_legacy_pickle_to_json(self):
         """FAISS should auto-migrate valid pickle files to JSON format."""
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Related issue

Fixes #7117

## Background

When loading a persisted FAISS index fails, the current exception handler clears the docstore and index mapping but leaves `self.index` populated. A later insert then uses mismatched positions and can return the wrong memory without an error. Corrupt FAISS files also leave the store unusable without telling the caller.

## Changes

- Clear `self.index` along with the mappings when loading fails.
- Raise `ValueError` so callers cannot continue with inconsistent persisted state.
- Add a regression test covering stale-index cleanup and the visible failure.

This preserves the existing successful JSON/pickle load paths and changes only the corrupt-load failure path to fail fast.

## Verification

- `python -m pytest tests/vector_stores/test_faiss.py -q -k resets_index_when_load_fails` — 1 passed.
- `python -m pytest tests/vector_stores/test_faiss.py -q` — 33 passed, 1 pre-existing Windows-only failure: the existing `test_safe_unpickler_blocks_os_system` expects `posix.system`, while Windows reports `nt.system`.
- `python -m ruff check mem0/vector_stores/faiss.py tests/vector_stores/test_faiss.py` — passed.
- `git diff --check` — passed.
- `python -m ruff format --check ...` — reports both touched files would be reformatted; no formatter changes were applied because that would expand this minimal PR beyond the issue.


## Limitations

No external services or LLM/API keys are required. The full suite was not run because this is an isolated FAISS change and the focused suite exposed an unrelated platform-specific baseline failure.

AI assistance was used to identify and implement this fix; the reproduction and verification were performed locally.
