### PR TITLE
fix(vector_stores/faiss): reset index after load failure

### DIFF
--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -221,8 +221,10 @@ class FAISS(VectorStoreBase):
             raise ValueError(f"Failed to load FAISS docstore: potentially malicious pickle file. {e}") from e
         except Exception as e:
             logger.warning(f"Failed to load FAISS index: {e}")
+            self.index = None
             self.docstore = {}
             self.index_to_id = {}
+            self.create_col(self.collection_name)
 
     def _save(self):
         """Save FAISS index and docstore to disk using JSON format (secure)."""

--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -190,9 +190,7 @@ def test_search_with_filters_overfetch_not_truncated(faiss_instance, mock_faiss_
     search_indices = np.array([[0, 1, 2, 3]])
     mock_faiss_index.search.return_value = (search_scores, search_indices)
 
-    results = faiss_instance.search(
-        query="test query", vectors=query_vector, top_k=2, filters={"category": "A"}
-    )
+    results = faiss_instance.search(query="test query", vectors=query_vector, top_k=2, filters={"category": "A"})
 
     # Two matching vectors exist among the over-fetched set, so we must get top_k of them.
     assert len(results) == 2
@@ -671,6 +669,78 @@ class TestFAISSSecurityIntegration:
                     # JSON file should now exist (auto-migrated)
                     json_path = os.path.join(faiss_path, "legacy.json")
                     assert os.path.exists(json_path), "JSON file should be created during migration"
+
+    def test_failed_json_load_recreates_empty_collection(self):
+        """Failed JSON load should not keep stale FAISS vectors without mappings."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            faiss_path = os.path.join(temp_dir, "test_faiss")
+            os.makedirs(faiss_path)
+
+            with open(os.path.join(faiss_path, "broken_json.json"), "w") as f:
+                f.write("{")
+
+            stale_index = Mock()
+            stale_index.ntotal = 2
+            empty_index = Mock()
+            empty_index.ntotal = 0
+
+            with patch("mem0.vector_stores.faiss.faiss.read_index", return_value=stale_index):
+                with patch("mem0.vector_stores.faiss.faiss.IndexFlatL2", return_value=empty_index) as mock_index:
+                    with patch("mem0.vector_stores.faiss.faiss.write_index"):
+                        faiss_store = FAISS.__new__(FAISS)
+                        faiss_store.collection_name = "broken_json"
+                        faiss_store.path = faiss_path
+                        faiss_store.distance_strategy = "euclidean"
+                        faiss_store.embedding_model_dims = 128
+                        faiss_store.normalize_L2 = False
+                        faiss_store.index = None
+                        faiss_store.docstore = {"stale": {"data": "old"}}
+                        faiss_store.index_to_id = {0: "stale"}
+
+                        faiss_store._load(
+                            os.path.join(faiss_path, "broken_json.faiss"),
+                            os.path.join(faiss_path, "broken_json.pkl"),
+                        )
+
+            mock_index.assert_called_once_with(128)
+            assert faiss_store.index is empty_index
+            assert faiss_store.docstore == {}
+            assert faiss_store.index_to_id == {}
+
+    def test_failed_index_load_recreates_empty_collection(self):
+        """Failed index load should leave the store usable for later inserts."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            faiss_path = os.path.join(temp_dir, "test_faiss")
+            os.makedirs(faiss_path)
+
+            with open(os.path.join(faiss_path, "broken_index.json"), "w") as f:
+                json.dump({"docstore": {"id1": {"data": "old"}}, "index_to_id": {"0": "id1"}}, f)
+
+            empty_index = Mock()
+            empty_index.ntotal = 0
+
+            with patch("mem0.vector_stores.faiss.faiss.read_index", side_effect=RuntimeError("bad index")):
+                with patch("mem0.vector_stores.faiss.faiss.IndexFlatL2", return_value=empty_index) as mock_index:
+                    with patch("mem0.vector_stores.faiss.faiss.write_index"):
+                        faiss_store = FAISS.__new__(FAISS)
+                        faiss_store.collection_name = "broken_index"
+                        faiss_store.path = faiss_path
+                        faiss_store.distance_strategy = "euclidean"
+                        faiss_store.embedding_model_dims = 128
+                        faiss_store.normalize_L2 = False
+                        faiss_store.index = None
+                        faiss_store.docstore = {}
+                        faiss_store.index_to_id = {}
+
+                        faiss_store._load(
+                            os.path.join(faiss_path, "broken_index.faiss"),
+                            os.path.join(faiss_path, "broken_index.pkl"),
+                        )
+
+            mock_index.assert_called_once_with(128)
+            assert faiss_store.index is empty_index
+            assert faiss_store.docstore == {}
+            assert faiss_store.index_to_id == {}
 
     def test_delete_col_removes_json_and_pkl(self):
         """delete_col should remove both JSON and legacy pickle files."""


### PR DESCRIPTION
Fixes #7117

## Summary

- Reset the in-memory FAISS index when persisted index/docstore loading fails.
- Recreate an empty collection after the load failure fallback clears `docstore` and `index_to_id`.
- Add regression tests for both corrupted JSON docstore and corrupted FAISS index paths.

## Validation

- `.venv/bin/python -m pytest tests/vector_stores/test_faiss.py -q -k 'failed_json_load or failed_index_load'`
- `.venv/bin/python -m pytest tests/vector_stores/test_faiss.py -q`
- `python3 -m ruff check mem0/vector_stores/faiss.py tests/vector_stores/test_faiss.py`
- `python3 -m ruff format --check mem0/vector_stores/faiss.py tests/vector_stores/test_faiss.py`

## Risk

This keeps the existing load-failure fallback behavior of starting from an empty local collection, but makes the reset complete: stale FAISS vectors are discarded along with their mappings, and a corrupted index no longer leaves later `insert()` calls stuck behind `Collection not initialized`. It does not change successful JSON or legacy pickle loading, malicious pickle handling, distance strategy selection, search scoring, or persistence format.