### PR TITLE
fix(huggingface): replace deprecated get_sentence_embedding_dimension…

### DIFF
--- a/mem0/embeddings/huggingface.py
+++ b/mem0/embeddings/huggingface.py
@@ -24,7 +24,11 @@ class HuggingFaceEmbedding(EmbeddingBase):
 
             self.model = SentenceTransformer(self.config.model, **self.config.model_kwargs)
 
-            self.config.embedding_dims = self.config.embedding_dims or self.model.get_sentence_embedding_dimension()
+            self.config.embedding_dims = self.config.embedding_dims or (
+                self.model.get_embedding_dimension()
+                if hasattr(self.model, "get_embedding_dimension")
+                else self.model.get_sentence_embedding_dimension()
+            )
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """

--- a/tests/embeddings/test_huggingface_embeddings.py
+++ b/tests/embeddings/test_huggingface_embeddings.py
@@ -51,11 +51,11 @@ def test_embed_with_model_kwargs(mock_sentence_transformer):
 def test_embed_sets_embedding_dims(mock_sentence_transformer):
     config = BaseEmbedderConfig()
 
-    mock_sentence_transformer.get_sentence_embedding_dimension.return_value = 384
+    mock_sentence_transformer.get_embedding_dimension.return_value = 384
     embedder = HuggingFaceEmbedding(config)
 
     assert embedder.config.embedding_dims == 384
-    mock_sentence_transformer.get_sentence_embedding_dimension.assert_called_once()
+    mock_sentence_transformer.get_embedding_dimension.assert_called_once()
 
 
 def test_embed_with_custom_embedding_dims(mock_sentence_transformer):
@@ -181,3 +181,14 @@ def test_embed_batch_count_mismatch_raises_sentence_transformer(mock_sentence_tr
 
     with pytest.raises(ValueError, match="returned 1 embeddings for 2 texts"):
         embedder.embed_batch(["first text", "second text"])
+
+
+def test_embed_sets_embedding_dims_legacy_sentence_transformer():
+    legacy_model = Mock(spec=["get_sentence_embedding_dimension"])
+    legacy_model.get_sentence_embedding_dimension.return_value = 384
+
+    with patch("mem0.embeddings.huggingface.SentenceTransformer", return_value=legacy_model):
+        embedder = HuggingFaceEmbedding(BaseEmbedderConfig())
+
+    assert embedder.config.embedding_dims == 384
+    legacy_model.get_sentence_embedding_dimension.assert_called_once()


### PR DESCRIPTION
## Linked Issue

Closes #7019
Reopen #7020

## Description

We're currently depending on ["sentence-transformers>=5.2.0"](https://github.com/mem0ai/mem0/blob/001c235229be8795e3834520467bd0d661ed8f34/pyproject.toml#L72). Since 5.4.0, the get_sentence_embedding_dimension is replaced with get_embedding_dimension, thus, whenever we're using HuggingFace embedding model, the following warning appears.

```
FutureWarning: The `get_sentence_embedding_dimension` method has been renamed to `get_embedding_dimension `.
```

This PR is to mitigate the warning by calling `get_embedding_dimension` whenever is available. For the user who is still using/prefer the old version, this change will fall back to `get_sentence_embedding_dimension`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

<!-- This is about the code, not this description. Writing the description with AI is fine. -->

- [ ] No AI assistance
- [x] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [ ] AI-generated (an agent wrote most or all of this diff)

<!-- If you ticked either AI box, name the tool and what you checked yourself. -->

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

Run locally with the updated framework, I was able to see the warning message disappeared.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
