### PR TITLE
fix: keep FAISS state consistent after load failure

### DIFF
--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -221,6 +221,7 @@ class FAISS(VectorStoreBase):
             raise ValueError(f"Failed to load FAISS docstore: potentially malicious pickle file. {e}") from e
         except Exception as e:
             logger.warning(f"Failed to load FAISS index: {e}")
+            self.index = None
             self.docstore = {}
             self.index_to_id = {}
 

--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -57,6 +57,26 @@ def test_create_col(faiss_instance, mock_faiss_index):
             mock_index_flat_ip.assert_called_once_with(faiss_instance.embedding_model_dims)
 
 
+def test_load_failure_clears_index_and_docstore(mock_faiss_index):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        index_path = os.path.join(temp_dir, "test_collection.faiss")
+        json_path = os.path.join(temp_dir, "test_collection.json")
+        open(index_path, "a").close()
+        with open(json_path, "w", encoding="utf-8") as file:
+            file.write("{invalid")
+
+        with patch("faiss.read_index", return_value=mock_faiss_index):
+            store = FAISS(
+                collection_name="test_collection",
+                path=temp_dir,
+                distance_strategy="euclidean",
+            )
+
+        assert store.index is None
+        assert store.docstore == {}
+        assert store.index_to_id == {}
+
+
 def test_insert(faiss_instance, mock_faiss_index):
     # Prepare test data
     vectors = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]


### PR DESCRIPTION
## Summary / Problem

Fixes #7117. When loading a persisted FAISS index fails, the loader cleared the docstore and ID mapping but retained the loaded index, allowing later inserts to associate IDs with the wrong vector positions.

## Changes

- Clear `self.index` along with the docstore and ID mapping when loading fails.
- Add a regression test covering invalid persisted JSON.

## Tests

- `python -m pytest tests/vector_stores/test_faiss.py::test_load_failure_clears_index_and_docstore -q` — passed.
- `python -m pytest tests/vector_stores/test_faiss.py -q` — 33 passed; 1 pre-existing Windows-specific assertion failure in `test_safe_unpickler_blocks_os_system` (`nt.system` vs `posix.system`).
- `python -m ruff check mem0/vector_stores/faiss.py tests/vector_stores/test_faiss.py` — passed.
- `python -m ruff format --check ...` — reports existing formatting differences in both touched files; no formatter changes were applied.
- `git diff --check` — passed.

## Compatibility / Known limitations

On a failed persisted-state load, the FAISS store now remains uninitialized instead of retaining a potentially inconsistent index; subsequent operations receive the existing `Collection not initialized` error until the collection is recreated. The pre-existing platform-specific test failure is unrelated to this change.

Issue: https://github.com/mem0ai/mem0/issues/7117
