### PR TITLE
fix(supabase): convert vecs distance to similarity per index_measure

### DIFF
--- a/mem0/vector_stores/supabase.py
+++ b/mem0/vector_stores/supabase.py
@@ -117,6 +117,15 @@ class Supabase(VectorStoreBase):
 
         self.collection.upsert(records)
 
+    def _to_similarity_score(self, value: float) -> float:
+        """Convert vecs' raw measure value to a similarity score (higher = more similar)."""
+        value = float(value)
+        if self.index_measure == IndexMeasure.COSINE:
+            return max(0.0, 1.0 - value)
+        if self.index_measure == IndexMeasure.MAX_INNER_PRODUCT:
+            return -value
+        return 1.0 / (1.0 + value)
+
     def search(
         self, query: str, vectors: List[float], top_k: int = 5, filters: Optional[dict] = None
     ) -> List[OutputData]:
@@ -145,7 +154,7 @@ class Supabase(VectorStoreBase):
         )
 
         return [
-            OutputData(id=str(result[0]), score=max(0.0, 1.0 - float(result[1])), payload=result[2])
+            OutputData(id=str(result[0]), score=self._to_similarity_score(result[1]), payload=result[2])
             for result in results
         ]
 


### PR DESCRIPTION
Closes #7130.

`supabase.search()` hardcoded the cosine distance->similarity conversion (`max(0.0, 1.0 - value)`) for every `index_measure`. `vecs` returns the raw value of the configured measure, so for `l2_distance` / `l1_distance` (values in `[0, inf)`) any distance `>= 1.0` clamps to `0.0` — mem0's `score_and_rank` threshold then drops those legitimate matches and loses their ordering; for `max_inner_product` the sign/scale is wrong. Only the default cosine path was correct.

This adds `_to_similarity_score()` that converts per `self.index_measure` (cosine unchanged; L2/L1 -> `1/(1+d)` per the `VectorStoreBase.search` contract; inner product -> `-value`), mirroring the per-metric handling already in the Oracle store. Same defect class as pgvector (#6883), Milvus (#6933), LangChain (#6884), Baidu (#6434), Chroma (#4999).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
## Reproduction
A standalone, no-DB reproduction is in #7130 (models `index_measure=L2` and shows the current formula drops the nearest matches). Happy to add a formal regression test (mocking `collection.query` with L2 distances) to this PR if preferred.

**AI assistance:** AI helped me find this by auditing every vector-store `search()` against the base contract; I reproduced the L2 clamp/drop myself and reviewed the fix.