### PR TITLE
fix(vector-stores): normalize Supabase scores by index measure

### DIFF
--- a/mem0/vector_stores/supabase.py
+++ b/mem0/vector_stores/supabase.py
@@ -144,9 +144,16 @@ class Supabase(VectorStoreBase):
             data=vectors, limit=limit, filters=filters, include_metadata=True, include_value=True
         )
 
+        def distance_to_score(value: float) -> float:
+            value = float(value)
+            if self.index_measure == IndexMeasure.MAX_INNER_PRODUCT:
+                return -value
+            if self.index_measure in (IndexMeasure.L1, IndexMeasure.L2):
+                return 1.0 / (1.0 + value)
+            return max(0.0, 1.0 - value)
+
         return [
-            OutputData(id=str(result[0]), score=max(0.0, 1.0 - float(result[1])), payload=result[2])
-            for result in results
+            OutputData(id=str(result[0]), score=distance_to_score(result[1]), payload=result[2]) for result in results
         ]
 
     def delete(self, vector_id: str):

--- a/tests/vector_stores/test_supabase.py
+++ b/tests/vector_stores/test_supabase.py
@@ -79,6 +79,26 @@ def test_search_vectors(supabase_instance, mock_collection):
     assert results[0].payload == {"name": "vector1"}
 
 
+@pytest.mark.parametrize(
+    ("index_measure", "raw_value", "expected_score"),
+    [
+        (IndexMeasure.COSINE, 0.3, 0.7),
+        (IndexMeasure.L1, 1.5, 1 / 2.5),
+        (IndexMeasure.L2, 1.5, 1 / 2.5),
+        (IndexMeasure.MAX_INNER_PRODUCT, -0.8, 0.8),
+    ],
+)
+def test_search_converts_scores_for_each_index_measure(
+    supabase_instance, mock_collection, index_measure, raw_value, expected_score
+):
+    supabase_instance.index_measure = index_measure
+    mock_collection.query.return_value = [("id1", raw_value, {})]
+
+    results = supabase_instance.search(query="", vectors=[[0.1, 0.2, 0.3]])
+
+    assert results[0].score == pytest.approx(expected_score)
+
+
 def test_delete_vector(supabase_instance, mock_collection):
     vector_id = "id1"
     supabase_instance.delete(vector_id=vector_id)


### PR DESCRIPTION
## Summary

`Supabase.search()` always converted the value returned by `vecs` using the cosine-distance formula, even when the collection was configured with L1, L2, or maximum inner-product indexing. This produced invalid similarity scores, dropped non-cosine matches at the threshold, and could invert ranking.

This change converts query values according to the configured `IndexMeasure`: cosine keeps the existing conversion, L1/L2 use the base vector-store distance formula, and maximum inner product negates the value returned by `vecs`.

## Testing

- `pytest tests/vector_stores/test_supabase.py -q` (18 passed)
- `ruff format --check mem0/vector_stores/supabase.py tests/vector_stores/test_supabase.py`
- `ruff check mem0/vector_stores/supabase.py tests/vector_stores/test_supabase.py`
- `git diff --check`

Closes #7130
