### PR TITLE
docs(rerankers): pass entity IDs via filters in reranker search examples

### DIFF
--- a/docs/components/rerankers/models/huggingface.mdx
+++ b/docs/components/rerankers/models/huggingface.mdx
@@ -188,7 +188,7 @@ m.add("I enjoy reading science fiction books", user_id="alice")
 # Search with reranking
 results = m.search(
     "What outdoor activities do I enjoy?",
-    user_id="alice",
+    filters={"user_id": "alice"},
     rerank=True
 )
 
@@ -266,7 +266,7 @@ config = {
 try:
     results = m.search(
         "test query",
-        user_id="alice",
+        filters={"user_id": "alice"},
         rerank=True
     )
 except Exception as e:
@@ -274,7 +274,7 @@ except Exception as e:
     # Fall back to vector search only
     results = m.search(
         "test query",
-        user_id="alice",
+        filters={"user_id": "alice"},
         rerank=False
     )
 ```

--- a/docs/components/rerankers/models/llm_reranker.mdx
+++ b/docs/components/rerankers/models/llm_reranker.mdx
@@ -305,7 +305,7 @@ m.add("I'm vegetarian", user_id="alice")
 # Search with LLM reranking
 results = m.search(
     "What foods should I avoid?",
-    user_id="alice",
+    filters={"user_id": "alice"},
     rerank=True
 )
 


### PR DESCRIPTION
## Linked Issue

Documentation-only change — exempt from the accepted-issue requirement per [`CONTRIBUTING.md`](https://github.com/mem0ai/mem0/blob/main/CONTRIBUTING.md) and the `isDocs` predicate in `pr-gate.yml`.

Context: #6705 identified this exact problem and explicitly deferred it as out of scope, noting it "wants its own pass rather than a partial fix here." This is that pass.

## Description

The HuggingFace and LLM reranker pages demonstrate `search()` calls that raise `ValueError` on current `main`.

`search()` does not declare `user_id` as a parameter, so a top-level `user_id="alice"` lands in `**kwargs`, where `_reject_top_level_entity_params` (`mem0/memory/main.py:1436`) intersects it against `ENTITY_PARAMS` and raises:

```
ValueError: Top-level entity parameters frozenset({'user_id'}) are not supported in search().
Use filters={'user_id': '...'} instead.
```

This fires before any embedding, vector-store, or LLM call, so it happens regardless of backend configuration.

Four call sites were affected:

- `huggingface.mdx:189` — "Search with reranking"
- `huggingface.mdx:267` and `:275` — the "Error Handling" block
- `llm_reranker.mdx:306` — "Search with LLM reranking"

The Error Handling block is the worst case. It catches the exception and reports it as `"Reranking failed"` — for an error that has nothing to do with reranking, from a call that never reached a reranker — and then its fallback repeats the same mistake and raises again, so the `try/except` never recovers.

Moving the entity ID into `filters` is not merely the form that avoids rejection; it is the required form. `search()` rejects `filters={}` and `filters={"category": "movies"}` with `filters must contain at least one of: user_id, agent_id, run_id`. The old snippets were wrong in both directions at once — the ID was in the forbidden place and absent from the mandatory one.

`add()` is deliberately untouched. It declares `user_id`/`agent_id`/`run_id` as real keyword parameters and never calls the guard, so `m.add("...", user_id="alice")` is correct as written.

The target form already appears on the same page at `huggingface.mdx:212`, which used `filters={"user_id": "alice"}` correctly. This makes the pages internally consistent.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Written with Claude Code. I reviewed the change line by line before opening this and verified independently: that `search()` has no `user_id` parameter while `add()` declares one, that the guard at `main.py:1436` is what rejects the old form, and that `filters` is required rather than merely permitted. I can explain each of the four changed lines and why the `add()` calls on the same pages are correct as-is.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Reproduced each snippet against the real SDK before the change, with the vector store, LLM, and embedder factories mocked so no API keys or network are involved — the guard runs before any of those are reached. All four raised `ValueError`, and the Error Handling fallback raised the same error it claims to handle.

After the change, every `m.search(...)` call extracted from both pages (7 in total, including the ones already correct) passes validation.

`python scripts/check-llms-txt-coverage.py` reports `docs/llms.txt` in sync, which is the CI check that applies to `docs/**/*.mdx` changes. No source files changed, so no package test suite is affected.

I also re-scanned the full `docs/` tree for the same pattern. The remaining occurrences are intentional or already covered, and are left alone:

- `docs/migration/oss-v2-to-v3.mdx` — appears under `# Before` in before/after blocks teaching this exact migration.
- `docs/components/vectordbs/dbs/oracledb.mdx:223` — same bug, already addressed by #7111.
- `docs/migration/oss-to-platform.mdx` — presents this as an OSS-vs-Platform difference when both SDKs now reject the top-level form. A real problem, but a wording judgment about that guide's intent, so out of scope here.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed

Two boxes left unticked deliberately: this is a documentation-only change with no source edits, so there is nothing for a unit test to assert, and I did not run the package suites since no package code is touched. The applicable docs CI gate is reported above.
