### PR TITLE
fix(vector-stores): fix Azure AI Search indexing error handling for IndexingResult objects and dicts

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -169,6 +169,33 @@ class AzureAISearch(VectorStoreBase):
                 document[field] = payload[field]
         return document
 
+    def _validate_indexing_results(self, response, operation: str, default_id: str = None):
+        for doc in response:
+            if isinstance(doc, dict):
+                succeeded = doc.get("succeeded", doc.get("status"))
+                status_code = doc.get("status_code")
+                doc_id = doc.get("key", doc.get("id", default_id))
+                error_message = doc.get("error_message", doc.get("errorMessage"))
+            else:
+                succeeded = getattr(doc, "succeeded", None)
+                status_code = getattr(doc, "status_code", None)
+                doc_id = getattr(doc, "key", getattr(doc, "id", default_id))
+                error_message = getattr(doc, "error_message", getattr(doc, "errorMessage", None))
+
+            is_success = True
+            if succeeded is not None:
+                is_success = bool(succeeded)
+            elif status_code is not None:
+                is_success = status_code in (200, 201)
+
+            if not is_success:
+                msg = f"{operation} failed for document {doc_id}"
+                if error_message:
+                    msg += f": {error_message}"
+                else:
+                    msg += f": {doc}"
+                raise Exception(msg)
+
     # Note: Explicit "insert" calls may later be decoupled from memory management decisions.
     def insert(self, vectors, payloads=None, ids=None):
         """
@@ -184,9 +211,7 @@ class AzureAISearch(VectorStoreBase):
             self._generate_document(vector, payload, id) for id, vector, payload in zip(ids, vectors, payloads)
         ]
         response = self.search_client.upload_documents(documents)
-        for doc in response:
-            if not hasattr(doc, "status_code") and doc.get("status_code") != 201:
-                raise Exception(f"Insert failed for document {doc.get('id')}: {doc}")
+        self._validate_indexing_results(response, "Insert")
         return response
 
     def _sanitize_key(self, key: str) -> str:
@@ -289,9 +314,7 @@ class AzureAISearch(VectorStoreBase):
             vector_id (str): ID of the vector to delete.
         """
         response = self.search_client.delete_documents(documents=[{"id": vector_id}])
-        for doc in response:
-            if not hasattr(doc, "status_code") and doc.get("status_code") != 200:
-                raise Exception(f"Delete failed for document {vector_id}: {doc}")
+        self._validate_indexing_results(response, "Delete", default_id=vector_id)
         logger.info(f"Deleted document with ID '{vector_id}' from index '{self.index_name}'.")
         return response
 
@@ -313,9 +336,7 @@ class AzureAISearch(VectorStoreBase):
             for field in ["user_id", "run_id", "agent_id"]:
                 document[field] = payload.get(field)
         response = self.search_client.merge_or_upload_documents(documents=[document])
-        for doc in response:
-            if not hasattr(doc, "status_code") and doc.get("status_code") != 200:
-                raise Exception(f"Update failed for document {vector_id}: {doc}")
+        self._validate_indexing_results(response, "Update", default_id=vector_id)
         return response
 
     def get(self, vector_id) -> OutputData:

--- a/tests/vector_stores/test_azure_ai_search.py
+++ b/tests/vector_stores/test_azure_ai_search.py
@@ -535,6 +535,97 @@ def test_update_allows_empty_vector(azure_ai_search_instance):
     mock_search_client.merge_or_upload_documents.assert_called_once_with(documents=[{"id": "doc1", "vector": []}])
 
 
+def test_insert_with_indexing_result_object(azure_ai_search_instance):
+    """Test insert with IndexingResult-like objects for success and failure."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+
+    class MockIndexingResult:
+        def __init__(self, key, status_code, succeeded, error_message=None):
+            self.key = key
+            self.status_code = status_code
+            self.succeeded = succeeded
+            self.error_message = error_message
+
+    # Test failure with IndexingResult object
+    mock_search_client.upload_documents.return_value = [
+        MockIndexingResult(key="doc1", status_code=500, succeeded=False, error_message="Document upload failed")
+    ]
+
+    vectors = [[0.1, 0.2, 0.3]]
+    payloads = [{"user_id": "user1"}]
+    ids = ["doc1"]
+
+    with pytest.raises(Exception) as exc_info:
+        instance.insert(vectors, payloads, ids)
+
+    assert "Insert failed for document doc1: Document upload failed" in str(exc_info.value)
+
+    # Test success with IndexingResult object
+    mock_search_client.upload_documents.return_value = [
+        MockIndexingResult(key="doc1", status_code=201, succeeded=True)
+    ]
+    res = instance.insert(vectors, payloads, ids)
+    assert len(res) == 1
+
+
+def test_delete_with_indexing_result_object(azure_ai_search_instance):
+    """Test delete with IndexingResult-like objects for success and failure."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+
+    class MockIndexingResult:
+        def __init__(self, key, status_code, succeeded, error_message=None):
+            self.key = key
+            self.status_code = status_code
+            self.succeeded = succeeded
+            self.error_message = error_message
+
+    # Test failure
+    mock_search_client.delete_documents.return_value = [
+        MockIndexingResult(key="doc1", status_code=404, succeeded=False, error_message="Document not found")
+    ]
+
+    with pytest.raises(Exception) as exc_info:
+        instance.delete("doc1")
+
+    assert "Delete failed for document doc1: Document not found" in str(exc_info.value)
+
+    # Test success
+    mock_search_client.delete_documents.return_value = [
+        MockIndexingResult(key="doc1", status_code=200, succeeded=True)
+    ]
+    res = instance.delete("doc1")
+    assert len(res) == 1
+
+
+def test_update_with_indexing_result_object(azure_ai_search_instance):
+    """Test update with IndexingResult-like objects for success and failure."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+
+    class MockIndexingResult:
+        def __init__(self, key, status_code, succeeded, error_message=None):
+            self.key = key
+            self.status_code = status_code
+            self.succeeded = succeeded
+            self.error_message = error_message
+
+    # Test failure
+    mock_search_client.merge_or_upload_documents.return_value = [
+        MockIndexingResult(key="doc1", status_code=400, succeeded=False, error_message="Update failed")
+    ]
+
+    with pytest.raises(Exception) as exc_info:
+        instance.update("doc1", payload={"key": "val"})
+
+    assert "Update failed for document doc1: Update failed" in str(exc_info.value)
+
+    # Test success
+    mock_search_client.merge_or_upload_documents.return_value = [
+        MockIndexingResult(key="doc1", status_code=200, succeeded=True)
+    ]
+    res = instance.update("doc1", payload={"key": "val"})
+    assert len(res) == 1
+
+
 # --- Tests for search method ---
 
 


### PR DESCRIPTION
Fixes #7211

### Description
Fixes silent error swallowing in Azure AI Search vector store (`mem0/vector_stores/azure_ai_search.py`).

**Problem:** `insert`, `update`, and `delete` used `hasattr(doc, "status_code")` to detect failures. But Azure SDK `IndexingResult` objects always have `status_code`, so failed operations (400/500) were silently ignored.

**Fix:**
- Added `_validate_indexing_results` to check `doc.succeeded`, `status_code`, and `error_message`.
- Updated `insert()`, `update()`, and `delete()` to use unified validation.
- Added unit tests for success and failure scenarios.