### PR TITLE
fix(supabase): normalize scores for configured index measures

### DIFF
--- a/mem0/vector_stores/supabase.py
+++ b/mem0/vector_stores/supabase.py
@@ -144,9 +144,16 @@ class Supabase(VectorStoreBase):
             data=vectors, limit=limit, filters=filters, include_metadata=True, include_value=True
         )
 
+        def distance_to_score(value: float) -> float:
+            value = float(value)
+            if self.index_measure == IndexMeasure.MAX_INNER_PRODUCT:
+                return -value
+            if self.index_measure in (IndexMeasure.L1, IndexMeasure.L2):
+                return 1.0 / (1.0 + value)
+            return max(0.0, 1.0 - value)
+
         return [
-            OutputData(id=str(result[0]), score=max(0.0, 1.0 - float(result[1])), payload=result[2])
-            for result in results
+            OutputData(id=str(result[0]), score=distance_to_score(result[1]), payload=result[2]) for result in results
         ]
 
     def delete(self, vector_id: str):

--- a/tests/vector_stores/test_supabase.py
+++ b/tests/vector_stores/test_supabase.py
@@ -79,6 +79,26 @@ def test_search_vectors(supabase_instance, mock_collection):
     assert results[0].payload == {"name": "vector1"}
 
 
+@pytest.mark.parametrize(
+    ("index_measure", "raw_value", "expected_score"),
+    [
+        (IndexMeasure.COSINE, 0.3, 0.7),
+        (IndexMeasure.L1, 1.5, 1 / 2.5),
+        (IndexMeasure.L2, 1.5, 1 / 2.5),
+        (IndexMeasure.MAX_INNER_PRODUCT, -0.8, 0.8),
+    ],
+)
+def test_search_converts_scores_for_each_index_measure(
+    supabase_instance, mock_collection, index_measure, raw_value, expected_score
+):
+    supabase_instance.index_measure = index_measure
+    mock_collection.query.return_value = [("id1", raw_value, {})]
+
+    results = supabase_instance.search(query="", vectors=[[0.1, 0.2, 0.3]])
+
+    assert results[0].score == pytest.approx(expected_score)
+
+
 def test_delete_vector(supabase_instance, mock_collection):
     vector_id = "id1"
     supabase_instance.delete(vector_id=vector_id)


### PR DESCRIPTION
## Summary

Supabase vector search currently treats every returned distance as a cosine distance. This produces incorrect similarity scores and reverses ranking for non-cosine index measures.

This change converts the provider distance according to the configured index measure while preserving the existing cosine behavior. It adds deterministic coverage for cosine, L1, L2, and max inner product searches.

## Testing

- `python -m pytest tests/vector_stores/test_supabase.py -q` (18 passed)
- `python -m ruff check mem0/vector_stores/supabase.py tests/vector_stores/test_supabase.py`
- `python -m ruff format --check mem0/vector_stores/supabase.py tests/vector_stores/test_supabase.py`
- `git diff --check`

Fixes #7130
