### PR TITLE
fix(server): return 4xx for invalid memory IDs

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -21,6 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from models import RequestLog, User
 from pydantic import BaseModel, Field
+from psycopg.errors import InvalidTextRepresentation
 from rate_limit import limiter
 from routers import api_keys as api_keys_router
 from routers import auth as auth_router
@@ -445,6 +446,8 @@ def get_memory(memory_id: str, _auth=Depends(verify_auth)):
     """Retrieve a specific memory by ID."""
     try:
         return get_memory_instance().get(memory_id)
+    except (ValueError, Mem0ValidationError, InvalidTextRepresentation) as e:
+        raise _client_error(e)
     except Exception:
         raise upstream_error()
 
@@ -518,7 +521,7 @@ def delete_memory(memory_id: str, _auth=Depends(verify_auth)):
     try:
         get_memory_instance().delete(memory_id=memory_id)
         return MessageResponse(message="Memory deleted successfully")
-    except (ValueError, Mem0ValidationError) as e:
+    except (ValueError, Mem0ValidationError, InvalidTextRepresentation) as e:
         raise _client_error(e)
     except Exception:
         raise upstream_error()

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -11,6 +11,7 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from psycopg.errors import InvalidTextRepresentation
 
 from mem0.exceptions import ValidationError as Mem0ValidationError
 
@@ -756,6 +757,18 @@ class TestWriteHandlerErrorMapping:
         mock_memory.delete.side_effect = ValueError("Memory with id mem-1 not found")
         resp = client.delete("/memories/mem-1")
         assert resp.status_code == 404
+
+    def test_get_invalid_postgres_memory_id_returns_400(self, client, mock_memory):
+        mock_memory.get.side_effect = InvalidTextRepresentation("invalid input syntax for type uuid")
+        resp = client.get("/memories/GPK0F14H")
+        assert resp.status_code == 400
+        assert "invalid input syntax for type uuid" in resp.json()["detail"]
+
+    def test_delete_invalid_postgres_memory_id_returns_400(self, client, mock_memory):
+        mock_memory.delete.side_effect = InvalidTextRepresentation("invalid input syntax for type uuid")
+        resp = client.delete("/memories/GPK0F14H")
+        assert resp.status_code == 400
+        assert "invalid input syntax for type uuid" in resp.json()["detail"]
 
     def test_update_other_value_error_returns_400(self, client, mock_memory):
         mock_memory.update.side_effect = ValueError("data must be a non-empty string")


### PR DESCRIPTION
## Linked Issue

Closes #7140

## Description

### Problem

The ID-addressed GET and DELETE memory endpoints returned `502 Bad Gateway` when PostgreSQL received a syntactically invalid value for the UUID-backed memory ID. This is a client input error and should return a 4xx response.

### Changes

- Map `psycopg.errors.InvalidTextRepresentation` to the existing client-error handler in GET and DELETE `/memories/{memory_id}`.
- Add focused regression coverage for both endpoints using the PostgreSQL exception that caused the original failure.

The change deliberately avoids validating IDs at the route boundary so backends that support non-UUID identifiers keep their existing behavior. Existing not-found and upstream-error mappings remain unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

The agent inspected the repository instructions, the endpoint-to-vector-store call chain, the PostgreSQL exception hierarchy, and the resulting diff. I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (described below)
- [ ] No tests needed (explain why)

### Tests

- `python -m pytest tests/test_server_params.py -k invalid_postgres_memory_id -q` in Docker — 2 passed after the fix; the pre-fix run failed with 502 as expected.
- `python -m pytest tests/test_server_params.py -q` in Docker — 70 passed.
- A temporary UUID-column query in the isolated pgvector container — reproduced `InvalidTextRepresentation` for `GPK0F14H`.
- `ruff check` — passed.
- `python -m compileall -q server/main.py tests/test_server_params.py` — passed.
- `git diff --check` — passed.

## Compatibility / Known Limitations

This pull request is intentionally a draft while Issue #7140 awaits the repository's `accepted` label. The repository's `server/dev.Dockerfile` build and the Compose `pgvector:pg17` service were attempted but could not complete because the configured Docker Hub mirror returned EOF while fetching base images. The tests above therefore ran in a Docker `python:3.12-slim` environment with the repository package installed editable and an isolated cached pgvector service; the provider packages not imported by this focused server suite were not installed. `ruff format --check` reports pre-existing formatting changes outside this diff, so no unrelated formatting was applied.

The repository check, label, and CLA checks pass for this draft. The Vercel preview check cannot deploy because the preview requires Mem0 organization authorization.

## Remote Verification

- PR #7146 is open as a Draft against `main` and closes Issue #7140.
- The remote head is `e943d00d1622a475f48deec4ac0885ddab201a6d`; the base is `fdfb763d6e5e5509bdb35d4ddc9ca8003f6af009`.
- The repository check, label, and license/CLA checks pass. The Vercel preview remains blocked by organization authorization.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
