### PR TITLE
docs: clarify OpenAI-compatible LLM base URLs

### DIFF
--- a/docs/components/llms/models/openai.mdx
+++ b/docs/components/llms/models/openai.mdx
@@ -74,6 +74,27 @@ await memory.add(messages, { userId: "alice", metadata: { category: "movies" } }
 ```
 </CodeGroup>
 
+### OpenAI-compatible LLM endpoints
+
+For an OpenAI-compatible LLM endpoint, set `openai_base_url` in the LLM configuration to the API root (for example, `https://api.example.com/v1`), rather than to a specific endpoint such as `/v1/chat/completions`.
+
+```python
+config = {
+    "llm": {
+        "provider": "openai",
+        "config": {
+            "model": "your-model",
+            "api_key": "your-api-key",
+            "openai_base_url": "https://api.example.com/v1",
+        },
+    },
+}
+```
+
+<Note>
+`openai_base_url` in the LLM configuration applies only to the LLM client. `OPENAI_BASE_URL` is a process-wide fallback that the OpenAI embedder also reads. Do not set `OPENAI_BASE_URL` to a chat-completions path or to an API base that does not support embeddings: the OpenAI embedder derives its `/embeddings` request from that value. Configure an embedder that supports embeddings separately, and use `llm.config.openai_base_url` for a chat-only LLM endpoint.
+</Note>
+
 We also support the new [OpenAI structured-outputs](https://platform.openai.com/docs/guides/structured-outputs/introduction) model.
 
 ```python

--- a/docs/components/llms/models/openai.mdx
+++ b/docs/components/llms/models/openai.mdx
@@ -95,6 +95,8 @@ config = {
 `openai_base_url` in the LLM configuration applies only to the LLM client. `OPENAI_BASE_URL` is a process-wide fallback that the OpenAI embedder also reads. Do not set `OPENAI_BASE_URL` to a chat-completions path or to an API base that does not support embeddings: the OpenAI embedder derives its `/embeddings` request from that value. Configure an embedder that supports embeddings separately, and use `llm.config.openai_base_url` for a chat-only LLM endpoint.
 </Note>
 
+### Structured outputs
+
 We also support the new [OpenAI structured-outputs](https://platform.openai.com/docs/guides/structured-outputs/introduction) model.
 
 ```python


### PR DESCRIPTION
## Linked Issue

Closes #7149

## Description

Clarifies configuration for OpenAI-compatible LLM endpoints in the Python SDK documentation.

- Documents that `llm.config.openai_base_url` should be an API root, such as `https://api.example.com/v1`.
- Explains that this LLM setting is separate from OpenAI embedder configuration.
- Warns that the OpenAI embedder derives its `/embeddings` request from the process-wide `OPENAI_BASE_URL`; it must not be a chat-completions path or an API base that does not support embeddings.

This is documentation-only. It does not add or endorse a provider and does not alter runtime behavior.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (documentation-only change; no runtime behavior changed)

Validation performed:

- Confirmed the documentation against `mem0/llms/openai.py` and `mem0/embeddings/openai.py`.
- Ran `git diff --check`.
- Ran `python scripts/check-llms-txt-coverage.py`; `docs/llms.txt` is in sync.

Mintlify preview was not run locally because the Mintlify CLI is not installed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed