### PR TITLE
fix(vector_stores/pgvector): make PostgreSQL schema configurable via db_schema

### DIFF
--- a/mem0/configs/vector_stores/pgvector.py
+++ b/mem0/configs/vector_stores/pgvector.py
@@ -19,6 +19,9 @@ class PGVectorConfig(BaseModel):
     sslmode: Optional[str] = Field(None, description="SSL mode for PostgreSQL connection (e.g., 'require', 'prefer', 'disable')")
     connection_string: Optional[str] = Field(None, description="PostgreSQL connection string (overrides individual connection parameters)")
     connection_pool: Optional[Any] = Field(None, description="psycopg connection pool object (overrides connection string and individual parameters)")
+    db_schema: Optional[str] = Field(
+        None, description="PostgreSQL schema for the collection (default: connection search_path; avoids Pydantic shadow of 'schema')"
+    )
 
     @model_validator(mode="before")
     def check_auth_and_connection(cls, values):

--- a/mem0/vector_stores/pgvector.py
+++ b/mem0/vector_stores/pgvector.py
@@ -160,6 +160,7 @@ class PGVector(VectorStoreBase):
         sslmode=None,
         connection_string=None,
         connection_pool=None,
+        db_schema=None,
     ):
         """
         Initialize the PGVector database.
@@ -181,6 +182,7 @@ class PGVector(VectorStoreBase):
             connection_pool (Any, optional): psycopg2 connection pool object (overrides connection string and individual parameters)
         """
         self.collection_name = collection_name
+        self.db_schema = db_schema
         self.use_diskann = diskann
         self.use_hnsw = hnsw
         self.embedding_model_dims = embedding_model_dims
@@ -257,6 +259,8 @@ class PGVector(VectorStoreBase):
 
     def _col(self) -> "sql.Identifier":
         """Return a safely-quoted SQL identifier for the collection table."""
+        if self.db_schema:
+            return sql.Identifier(self.db_schema, self.collection_name)
         return sql.Identifier(self.collection_name)
 
     def create_col(self) -> None:
@@ -265,6 +269,8 @@ class PGVector(VectorStoreBase):
         Will also initialize vector search index if specified.
         """
         with self._get_cursor(commit=True) as cur:
+            if self.db_schema:
+                cur.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(self.db_schema)))
             cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
             cur.execute(
                 sql.SQL("""
@@ -479,7 +485,14 @@ class PGVector(VectorStoreBase):
             List[str]: List of collection names.
         """
         with self._get_cursor() as cur:
-            cur.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'")
+            if self.db_schema:
+                cur.execute(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = %s", (self.db_schema,)
+                )
+            else:
+                cur.execute(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = current_schema()"
+                )
             return [row[0] for row in cur.fetchall()]
 
     def delete_col(self) -> None:
@@ -496,17 +509,30 @@ class PGVector(VectorStoreBase):
         """
         self._ensure_collection()
         with self._get_cursor() as cur:
-            cur.execute(
-                sql.SQL("""
-                SELECT
-                    table_name,
-                    (SELECT COUNT(*) FROM {}) as row_count,
-                    (SELECT pg_size_pretty(pg_total_relation_size({}::regclass))) as total_size
-                FROM information_schema.tables
-                WHERE table_schema = 'public' AND table_name = %s
-            """).format(self._col(), sql.Literal(self.collection_name)),
-                (self.collection_name,),
-            )
+            if self.db_schema:
+                cur.execute(
+                    sql.SQL("""
+                    SELECT
+                        table_name,
+                        (SELECT COUNT(*) FROM {}) as row_count,
+                        (SELECT pg_size_pretty(pg_total_relation_size({}::regclass))) as total_size
+                    FROM information_schema.tables
+                    WHERE table_schema = %s AND table_name = %s
+                """).format(self._col(), sql.Literal(f"{self.db_schema}.{self.collection_name}")),
+                    (self.db_schema, self.collection_name),
+                )
+            else:
+                cur.execute(
+                    sql.SQL("""
+                    SELECT
+                        table_name,
+                        (SELECT COUNT(*) FROM {}) as row_count,
+                        (SELECT pg_size_pretty(pg_total_relation_size({}::regclass))) as total_size
+                    FROM information_schema.tables
+                    WHERE table_schema = current_schema() AND table_name = %s
+                """).format(self._col(), sql.Literal(self.collection_name)),
+                    (self.collection_name,),
+                )
             result = cur.fetchone()
         return {"name": result[0], "count": result[1], "size": result[2]}
 


### PR DESCRIPTION
Closes #7107

Hardcoded 'public' schema blocked adoption under org policy requiring app-specific schemas. Add optional db_schema to PGVectorConfig / PGVector (default None = use current_schema(), avoids Pydantic shadow of 'schema'). When set:

- _col() returns schema-qualified Identifier(db_schema, collection_name) so insert/search/delete/list etc automatically target the right schema
- create_col() runs CREATE SCHEMA IF NOT EXISTS before table
- list_cols() filters by configured schema or current_schema()
- col_info() filters by configured schema or current_schema() and uses qualified regclass

Tested config parsing and _col qualification.

## Type of Change
- [x] Bug fix
- AI-assisted (Claude Fable 5 via ClaudeCode)
- [x] I can explain every line
## Test Coverage
- [x] I tested manually
## Checklist
- [x] My code follows style guidelines
- [x] I performed self-review
- [x] New and existing tests pass locally