### PR TITLE
fix(reranker/huggingface): forward documented config options to from_pretrained

### DIFF
--- a/mem0/configs/rerankers/huggingface.py
+++ b/mem0/configs/rerankers/huggingface.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 from pydantic import Field
 
 from mem0.configs.rerankers.base import BaseRerankerConfig
@@ -15,3 +15,7 @@ class HuggingFaceRerankerConfig(BaseRerankerConfig):
     batch_size: int = Field(default=32, description="Batch size for processing documents")
     max_length: int = Field(default=512, description="Maximum length for tokenization")
     normalize: bool = Field(default=True, description="Whether to normalize scores")
+    trust_remote_code: bool = Field(default=False, description="Whether to allow custom remote code when loading the model")
+    model_kwargs: Optional[Dict[str, Any]] = Field(default=None, description="Additional kwargs for model loading (e.g. torch_dtype)")
+    use_auth_token: Optional[str] = Field(default=None, description="Auth token for private/gated models")
+    local_files_only: bool = Field(default=False, description="Only load from local files, do not download")

--- a/mem0/reranker/huggingface_reranker.py
+++ b/mem0/reranker/huggingface_reranker.py
@@ -54,9 +54,25 @@ class HuggingFaceReranker(BaseReranker):
         else:
             self.device = self.config.device
 
-        # Load model and tokenizer
-        self.tokenizer = AutoTokenizer.from_pretrained(self.config.model)
-        self.model = AutoModelForSequenceClassification.from_pretrained(self.config.model)
+        # Load model and tokenizer - forward documented config options
+        tok_kwargs: Dict[str, Any] = {}
+        model_kwargs: Dict[str, Any] = {}
+        if getattr(self.config, "trust_remote_code", False):
+            tok_kwargs["trust_remote_code"] = True
+            model_kwargs["trust_remote_code"] = True
+        if getattr(self.config, "use_auth_token", None):
+            tok_kwargs["use_auth_token"] = self.config.use_auth_token
+            model_kwargs["use_auth_token"] = self.config.use_auth_token
+        if getattr(self.config, "local_files_only", False):
+            tok_kwargs["local_files_only"] = True
+            model_kwargs["local_files_only"] = True
+        # model_kwargs from config (e.g. torch_dtype) - spread into model kwargs
+        cfg_model_kwargs = getattr(self.config, "model_kwargs", None)
+        if cfg_model_kwargs:
+            model_kwargs.update(cfg_model_kwargs)
+
+        self.tokenizer = AutoTokenizer.from_pretrained(self.config.model, **tok_kwargs)
+        self.model = AutoModelForSequenceClassification.from_pretrained(self.config.model, **model_kwargs)
         self.model.to(self.device)
         self.model.eval()
 


### PR DESCRIPTION
Closes #7112

HuggingFaceRerankerConfig silently ignored 4 documented options due to extra="ignore": trust_remote_code, model_kwargs, use_auth_token, local_files_only. Users following docs got no error but options were dropped (e.g. torch_dtype float16 ignored, private model auth failed).

Add the 4 fields to HuggingFaceRerankerConfig and forward them to AutoTokenizer.from_pretrained and AutoModelForSequenceClassification.from_pretrained (model_kwargs spread into model load).

Verified: config now accepts all 4 keys and reports hasattr True (was False).

## Type of Change
- [x] Bug fix
- AI-assisted (Muse Spark via OpenCode)
- [x] I can explain every line
## Test Coverage
- [x] I tested manually
## Checklist
- [x] My code follows style guidelines
- [x] I performed self-review
- [x] New and existing tests pass locally