### PR TITLE
docs: add 301 redirects for 49 legacy 404 pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1315,6 +1315,202 @@
     {
       "source": "/api-reference/entities/get-entities",
       "destination": "/api-reference/entities/get-users"
+    },
+    {
+      "source": "/api-reference/event/get-events",
+      "destination": "/api-reference/events/get-events"
+    },
+    {
+      "source": "/api-reference/entities/delete-users",
+      "destination": "/api-reference/entities/delete-user"
+    },
+    {
+      "source": "/api-reference/organization/update-organization-member",
+      "destination": "/api-reference/organization/update-org-member"
+    },
+    {
+      "source": "/api-reference/organization/get-organizations",
+      "destination": "/api-reference/organization/get-orgs"
+    },
+    {
+      "source": "/api-reference/entities/get-user",
+      "destination": "/api-reference/entities/get-users"
+    },
+    {
+      "source": "/api-reference/export/create-memory-export",
+      "destination": "/api-reference/memory/create-memory-export"
+    },
+    {
+      "source": "/integrations/mcp",
+      "destination": "/platform/mem0-mcp"
+    },
+    {
+      "source": "/platform/api-reference",
+      "destination": "/api-reference"
+    },
+    {
+      "source": "/api-reference/memory/add-memory",
+      "destination": "/api-reference/memory/add-memories"
+    },
+    {
+      "source": "/api-reference/overview",
+      "destination": "/api-reference"
+    },
+    {
+      "source": "/platform/reference/python-sdk",
+      "destination": "/open-source/python-quickstart"
+    },
+    {
+      "source": "/platform/python",
+      "destination": "/open-source/python-quickstart"
+    },
+    {
+      "source": "/platform/features/memory",
+      "destination": "/platform/features/memory-decay"
+    },
+    {
+      "source": "/platform/api-reference/python",
+      "destination": "/open-source/python-quickstart"
+    },
+    {
+      "source": "/api-reference/webhooks",
+      "destination": "/api-reference/webhook/create-webhook"
+    },
+    {
+      "source": "/platform/python-quickstart",
+      "destination": "/open-source/python-quickstart"
+    },
+    {
+      "source": "/api-reference/organization/delete-org-project",
+      "destination": "/api-reference/organization/delete-org"
+    },
+    {
+      "source": "/platform/features/scoping",
+      "destination": "/platform/features/entity-scoped-memory"
+    },
+    {
+      "source": "/platform/quickstart/python",
+      "destination": "/open-source/python-quickstart"
+    },
+    {
+      "source": "/api-reference/memory/history",
+      "destination": "/api-reference/memory/history-memory"
+    },
+    {
+      "source": "/api-reference/entities/get-user-memories",
+      "destination": "/api-reference/entities/get-users"
+    },
+    {
+      "source": "/platform/api-reference/webhooks/create",
+      "destination": "/api-reference/webhook/create-webhook"
+    },
+    {
+      "source": "/platform/python/quickstart",
+      "destination": "/open-source/python-quickstart"
+    },
+    {
+      "source": "/api-reference/memory/batch-update-memory",
+      "destination": "/api-reference/memory/batch-update"
+    },
+    {
+      "source": "/api-reference/memories/add",
+      "destination": "/api-reference/memory/add-memories"
+    },
+    {
+      "source": "/python-quickstart",
+      "destination": "/open-source/python-quickstart"
+    },
+    {
+      "source": "/api-reference/webhook/list-webhooks",
+      "destination": "/api-reference/webhook/get-webhook"
+    },
+    {
+      "source": "/platform/reference/memory/delete-memory",
+      "destination": "/api-reference/memory/delete-memory"
+    },
+    {
+      "source": "/platform/webhooks",
+      "destination": "/platform/features/webhooks"
+    },
+    {
+      "source": "/platform/api-reference/memories/add",
+      "destination": "/api-reference/memory/add-memories"
+    },
+    {
+      "source": "/api-reference/organization/organizations",
+      "destination": "/api-reference/organization/create-org"
+    },
+    {
+      "source": "/sdk/python/quickstart",
+      "destination": "/open-source/python-quickstart"
+    },
+    {
+      "source": "/platform/export",
+      "destination": "/platform/features/memory-export"
+    },
+    {
+      "source": "/open-source/python-memory",
+      "destination": "/open-source/python-quickstart"
+    },
+    {
+      "source": "/platform/reference",
+      "destination": "/api-reference"
+    },
+    {
+      "source": "/api-reference/memory/get-all-memories",
+      "destination": "/api-reference/memory/get-memories"
+    },
+    {
+      "source": "/api-reference/user/delete-users",
+      "destination": "/api-reference/entities/delete-user"
+    },
+    {
+      "source": "/api-reference/memories/search-memories",
+      "destination": "/api-reference/memory/search-memories"
+    },
+    {
+      "source": "/api-reference/organization/update-members",
+      "destination": "/api-reference/project/update-project-member"
+    },
+    {
+      "source": "/platform/api-reference/memory/batch-update",
+      "destination": "/api-reference/memory/batch-update"
+    },
+    {
+      "source": "/api-reference/memory/search",
+      "destination": "/api-reference/memory/search-memories"
+    },
+    {
+      "source": "/api-reference/batch/update-memories",
+      "destination": "/api-reference/memory/batch-update"
+    },
+    {
+      "source": "/api-reference/organization/update-organization-member-role",
+      "destination": "/api-reference/project/update-project-member"
+    },
+    {
+      "source": "/api-reference/webhooks/delete",
+      "destination": "/api-reference/webhook/delete-webhook"
+    },
+    {
+      "source": "/api-reference/memory/delete-all-memories",
+      "destination": "/api-reference/memory/delete-memories"
+    },
+    {
+      "source": "/platform/reference/overview",
+      "destination": "/api-reference"
+    },
+    {
+      "source": "/api-reference/mem0/add-memories",
+      "destination": "/api-reference/memory/add-memories"
+    },
+    {
+      "source": "/platform/mcp/overview",
+      "destination": "/platform/mem0-mcp"
+    },
+    {
+      "source": "/openmemory/mcp/introduction",
+      "destination": "https://mem0.ai/blog/introducing-openmemory-mcp"
     }
   ]
 }


### PR DESCRIPTION
## Linked Issue

N/A (documentation-only change)

## Description

Adds 49 redirect entries to `docs/docs.json` so legacy URLs that currently 404 on docs.mem0.ai resolve to their current pages (old API reference paths such as `/api-reference/memory/add-memory`, `/api-reference/organization/get-organizations`, old platform paths such as `/platform/python-quickstart`, `/platform/api-reference`, and `/integrations/mcp`).

Two rows from the source list were corrected because they pointed at `/api-reference/mem0/add-memories`, which does not exist. Both now target `/api-reference/memory/add-memories` (one of them was also a self-redirect as originally listed).

`/openmemory/mcp/introduction` redirects to the external announcement post `https://mem0.ai/blog/introducing-openmemory-mcp`, matching the existing precedent for `/what-is-mem0`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Claude Code generated the entries from a supplied 404 to target mapping. Each destination was verified against the docs tree and navigation.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

- `docs.json` parses as valid JSON; 221 redirects total, no duplicate sources, no self-redirects.
- Every new destination resolves to an existing `.mdx` page, a `docs.json` navigation entry, or the one external URL.
- `mintlify broken-links` from `docs/`: `success no broken links found`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed