### PR TITLE
fix(vector_stores/elasticsearch): map dynamic metadata string fields to keyword

### DIFF
--- a/mem0/vector_stores/elasticsearch.py
+++ b/mem0/vector_stores/elasticsearch.py
@@ -74,6 +74,19 @@ class ElasticsearchDB(VectorStoreBase):
         index_settings = {
             "settings": {"index": {"number_of_replicas": 1, "number_of_shards": 5, "refresh_interval": "1s"}},
             "mappings": {
+                # Map every dynamic metadata.* string field to `keyword` so exact-match
+                # `term` filters on custom metadata keys actually match (#7157). The
+                # explicit `data`/`text_lemmatized` properties below are pinned to
+                # `text` so keyword_search()'s BM25 `match` queries are unaffected.
+                "dynamic_templates": [
+                    {
+                        "metadata_strings_as_keyword": {
+                            "path_match": "metadata.*",
+                            "match_mapping_type": "string",
+                            "mapping": {"type": "keyword"},
+                        }
+                    }
+                ],
                 "properties": {
                     "text": {"type": "text"},
                     "vector": {
@@ -88,9 +101,11 @@ class ElasticsearchDB(VectorStoreBase):
                             "user_id": {"type": "keyword"},
                             "agent_id": {"type": "keyword"},
                             "run_id": {"type": "keyword"},
+                            "data": {"type": "text"},
+                            "text_lemmatized": {"type": "text"},
                         },
                     },
-                }
+                },
             },
         }
 

--- a/tests/vector_stores/test_elasticsearch.py
+++ b/tests/vector_stores/test_elasticsearch.py
@@ -111,6 +111,39 @@ class TestElasticsearchDB(unittest.TestCase):
         # Verify create was not called when index exists
         self.client_mock.indices.create.assert_not_called()
 
+    def test_create_index_dynamic_templates_string_keyword(self):
+        """Regression for #7157: custom metadata string fields must be mapped as
+        `keyword` so exact-match `term` filters on them actually match."""
+        self.client_mock.indices.exists.return_value = False
+        self.es_db.create_index()
+
+        create_args = self.client_mock.indices.create.call_args[1]
+        mappings = create_args["body"]["mappings"]
+        templates = mappings.get("dynamic_templates", [])
+        self.assertTrue(templates, "expected dynamic_templates mapping rule for metadata string fields")
+
+        # The dynamic template must map any metadata.* string field to keyword
+        keyword_rule = None
+        for template in templates:
+            for name, rule in template.items():
+                if rule.get("path_match") == "metadata.*" and rule.get("match_mapping_type") == "string":
+                    keyword_rule = rule
+        self.assertIsNotNone(keyword_rule, "expected a metadata.* string -> keyword dynamic template")
+        self.assertEqual(keyword_rule["mapping"]["type"], "keyword")
+
+    def test_create_index_keeps_keyword_search_text_fields(self):
+        """Regression for #7157: `data`/`text_lemmatized` must stay `text` so
+        keyword_search()'s BM25 match queries keep working (keyword fields can't be
+        `match`-queried)."""
+        self.client_mock.indices.exists.return_value = False
+        self.es_db.create_index()
+
+        create_args = self.client_mock.indices.create.call_args[1]
+        mappings = create_args["body"]["mappings"]
+        metadata_props = mappings["properties"]["metadata"]["properties"]
+        self.assertEqual(metadata_props["data"]["type"], "text")
+        self.assertEqual(metadata_props["text_lemmatized"]["type"], "text")
+
     def test_auto_create_index(self):
         # Reset mock
         self.client_mock.reset_mock()


### PR DESCRIPTION
## Linked Issue

Closes #7157

## Description

Custom metadata keys other than `user_id`/`agent_id`/`run_id` fall through to Elasticsearch's default dynamic mapping, which creates an **analyzed** `text` field. `search()`, `keyword_search()`, and `list()` build exact-match `term` queries against the bare field name, so any real-world string value (uppercase, multi-word, punctuation) silently matches nothing — no error, no warning.

This adds a `dynamic_templates` rule in `create_index()` mapping every `metadata.*` string field to `keyword`, so custom filter keys get exact-match mapping like the identity keys already do. `data`/`text_lemmatized` are pinned as explicit `text` properties so `keyword_search()`'s BM25 `match` queries are unaffected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [x] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [ ] AI-generated (an agent wrote most or all of this diff)

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Two regression tests that fail without the fix:
- `test_create_index_dynamic_templates_string_keyword` — asserts the dynamic template rule exists and maps `metadata.*` strings to `keyword`
- `test_create_index_keeps_keyword_search_text_fields` — asserts `data`/`text_lemmatized` stay `text` so BM25 `match` queries keep working

Full `tests/vector_stores/test_elasticsearch.py` suite: 24 passed. `ruff check` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
