### PR TITLE
feat: CJK tokenizer for BM25 keyword matching (unigram+bigram, zero deps)

### DIFF
--- a/mem0/utils/cjk_tokenizer.py
+++ b/mem0/utils/cjk_tokenizer.py
@@ -1,0 +1,90 @@
+"""CJK tokenization for BM25 keyword matching.
+
+Pure-Python, zero dependencies. Handles Chinese/Japanese/Korean text that
+space-based tokenizers (Postgres ``to_tsvector('simple')``, spaCy English
+lemmatizer) cannot segment: a Chinese sentence like ``我们最近配置的 rerank``
+has no spaces, so naive tokenizers treat the whole run as one token and the
+BM25 leg never matches.
+
+Approach:
+- Split text into contiguous CJK chunks and latin/number words.
+- For each CJK chunk, emit **unigrams + bigrams** (e.g. ``混合检索`` ->
+  ``混``, ``合``, ``检``, ``索``, ``混合``, ``合检``, ``检索``). No dictionary,
+  no jieba, no spaCy.
+- Latin/number words (``9router``, ``memobase-use``, ``GOALS.md``) are kept
+  as exact tokens with trailing ``._-`` stripped.
+- Single-char CJK stopwords (的/是/了/在/和…) are dropped from the index.
+
+Two modes:
+- ``tokenize(text)`` — document side: unigrams + bigrams (max recall).
+- ``tokenize(text, query_mode=True)`` — query side: bigrams only, because
+  single-char unigrams are high-df noise for short queries (生日/模型 match
+  almost every doc); single-char chunks fall back to unigram.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+# Latin/number word: allow inner dots/hyphens/underscores but never trailing.
+_LATIN_RE = re.compile(r"[a-z0-9]+(?:[._-][a-z0-9]+)*", re.IGNORECASE)
+# Contiguous CJK runs (ideographs only — no CJK punctuation).
+_CJK_RE = re.compile(r"[\u4e00-\u9fff\u3400-\u4dbf]+")
+# Single-char CJK stopwords (function words / pronouns / particles).
+_CJK_STOPWORDS = frozenset(
+    "的了是在和有我你他她它这那就都而及与着或个们把被让对从向为以于"
+)
+
+
+def _has_cjk(text: str) -> bool:
+    """True if the text contains any CJK ideograph."""
+    return _CJK_RE.search(text) is not None
+
+
+def tokenize(text: str, query_mode: bool = False) -> List[str]:
+    """CJK unigram+bigram (per contiguous chunk) + latin words. Lowercased.
+
+    Args:
+        text: Input text.
+        query_mode: If True, CJK chunks of len>=2 emit bigrams only (cuts
+            high-df unigram noise for short queries); single-char chunks fall
+            back to unigram. Document side keeps unigram+bigram for recall.
+
+    Returns:
+        List of tokens (lowercased).
+    """
+    if not text:
+        return []
+    tokens: List[str] = []
+    t = text.lower()
+    for m in _LATIN_RE.finditer(t):
+        w = m.group(0).rstrip("._-")
+        if len(w) >= 2:
+            tokens.append(w)
+    for chunk in _CJK_RE.findall(t):
+        n = len(chunk)
+        if n == 1:
+            if chunk not in _CJK_STOPWORDS:
+                tokens.append(chunk)
+            continue
+        if query_mode:
+            # bigrams only — unigrams are high-df noise for queries
+            for i in range(n - 1):
+                tokens.append(chunk[i : i + 2])
+        else:
+            for ch in chunk:
+                if ch not in _CJK_STOPWORDS:
+                    tokens.append(ch)
+            for i in range(n - 1):
+                tokens.append(chunk[i : i + 2])
+    return tokens
+
+
+def tokenize_for_bm25(text: str, query_mode: bool = False) -> str:
+    """Space-joined token string for BM25/full-text search.
+
+    Mirrors ``lemmatize_for_bm25``'s contract (space-joined tokens) so it can
+    be used as a drop-in for the CJK path.
+    """
+    return " ".join(tokenize(text, query_mode=query_mode))

--- a/mem0/utils/lemmatization.py
+++ b/mem0/utils/lemmatization.py
@@ -24,7 +24,17 @@ def lemmatize_for_bm25(text: str) -> str:
 
     Returns space-joined lemmas for full-text search. Falls back to
     the original text if spaCy is unavailable.
+
+    CJK text (Chinese/Japanese/Korean) is routed to the pure-Python
+    unigram+bigram tokenizer instead — spaCy's English lemmatizer cannot
+    segment space-less CJK runs, and ``to_tsvector('simple')`` treats a
+    whole Chinese sentence as one token.
     """
+    from mem0.utils.cjk_tokenizer import _has_cjk, tokenize_for_bm25
+
+    if _has_cjk(text):
+        return tokenize_for_bm25(text)
+
     from mem0.utils.spacy_models import get_nlp_lemma
 
     nlp = get_nlp_lemma()

--- a/tests/utils/test_cjk_tokenizer.py
+++ b/tests/utils/test_cjk_tokenizer.py
@@ -1,0 +1,83 @@
+"""Tests for the pure-Python CJK tokenizer used by BM25 keyword matching."""
+
+import pytest
+
+
+class TestCjkTokenizer:
+    def test_chinese_sentence_segmented(self):
+        from mem0.utils.cjk_tokenizer import tokenize
+
+        result = tokenize("我们最近配置的 rerank 精排是什么模型")
+        # Latin word kept as exact token
+        assert "rerank" in result
+        # CJK bigrams present
+        assert "最近" in result
+        assert "配置" in result
+        assert "模型" in result
+        # Single-char stopwords dropped from document side
+        assert "的" not in result
+        assert "是" not in result
+
+    def test_query_mode_bigrams_only(self):
+        from mem0.utils.cjk_tokenizer import tokenize
+
+        result = tokenize("混合检索", query_mode=True)
+        # bigrams only — no unigrams
+        assert "混合" in result
+        assert "合检" in result
+        assert "检索" in result
+        assert "混" not in result
+        assert "检" not in result
+
+    def test_single_char_chunk_falls_back_to_unigram(self):
+        from mem0.utils.cjk_tokenizer import tokenize
+
+        result = tokenize("生日", query_mode=True)
+        assert "生日" in result
+
+    def test_latin_identifiers_kept_exact(self):
+        from mem0.utils.cjk_tokenizer import tokenize
+
+        result = tokenize("9router 的 memobase-use 映射 GOALS.md.")
+        assert "9router" in result
+        assert "memobase-use" in result
+        assert "goals.md" in result  # trailing period stripped
+
+    def test_empty_string(self):
+        from mem0.utils.cjk_tokenizer import tokenize
+
+        assert tokenize("") == []
+        assert tokenize("", query_mode=True) == []
+
+    def test_pure_latin_no_cjk(self):
+        from mem0.utils.cjk_tokenizer import tokenize
+
+        result = tokenize("The cats are running quickly")
+        assert "cats" in result
+        assert "running" in result
+
+
+class TestLemmatizeForBm25Cjk:
+    def test_cjk_routed_to_tokenizer(self):
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        result = lemmatize_for_bm25("我们最近配置的 rerank 精排是什么模型")
+        # Space-joined tokens, CJK segmented
+        assert "rerank" in result.split()
+        assert "最近" in result.split()
+        assert "模型" in result.split()
+
+    def test_english_path_unchanged(self):
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        result = lemmatize_for_bm25("The cats are running quickly")
+        # English path still works (spaCy or fallback)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_mixed_cjk_latin(self):
+        from mem0.utils.lemmatization import lemmatize_for_bm25
+
+        result = lemmatize_for_bm25("hybrid_retriever.py 里 RRF 的 k 是多少")
+        assert "hybrid_retriever.py" in result.split()
+        assert "rrf" in result.split()


### PR DESCRIPTION
## Summary

Chinese/Japanese/Korean text has no spaces, so the current BM25 keyword path
(`to_tsvector('simple', ...)` on pgvector, spaCy English lemmatizer) treats a
whole CJK run as **one token** — the BM25 leg effectively never matches for
CJK queries. This adds a pure-Python CJK tokenizer (zero new dependencies)
and routes CJK text in `lemmatize_for_bm25()` to it; the English spaCy path is
unchanged.

## Changes

- **`mem0/utils/cjk_tokenizer.py`** (new): `tokenize(text, query_mode=False)`
  - Splits text into contiguous CJK chunks and latin/number words.
  - CJK chunks emit **unigrams + bigrams** (`混合检索` → `混`, `合`, `检`,
    `索`, `混合`, `合检`, `检索`). No dictionary, no jieba, no spaCy.
  - Latin/number identifiers (`9router`, `memobase-use`, `GOALS.md`) kept as
    exact tokens, trailing `._-` stripped.
  - Single-char CJK stopwords (的/是/了/在/和…) dropped from the index.
  - `query_mode=True` emits bigrams only — single-char unigrams are high-df
    noise for short queries (生日/模型 match almost every doc).
- **`mem0/utils/lemmatization.py`**: `lemmatize_for_bm25()` routes CJK text
  to the tokenizer (space-joined, same contract). English path untouched.
- **`tests/utils/test_cjk_tokenizer.py`** (new): 9 tests covering CJK
  segmentation, query mode, latin identifiers, stopwords, empty input, and
  the English-path regression.

## Measured impact

Same 110 Chinese events, 43 labeled queries (self-hosted memory store):

| Metric | `to_tsvector('simple')` (current) | CJK unigram+bigram |
|---|---|---|
| MRR@10 | 0.270 | **0.693** |
| Recall@10 | 0.264 | **0.676** |
| Queries with any hit | 15/43 | 34/43 |

By query type (MRR@10): temporal 0.300 → 0.920, entity 0.460 → 0.733,
short 0.000 → 0.229, vague 0.100 → 0.511, mixed 0.375 → 0.875.

One honest caveat: `simple` wins on a few queries dominated by latin
identifiers (`rerank`, `9router`, `SOUL`) — exact token matching is strong
there. The tokenizer keeps latin/number tokens exact, which covers that.

## Notes

- This is the dependency-free fallback; a CJK-aware `tsvector` config
  (`zhparser`/`pg_jieba`) would fix the pgvector path directly. The
  tokenizer also works for other vector stores.
- The entity extraction path has the same English assumption (spaCy
  `en_core_web_sm`); a rule-based extractor could be a follow-up.

Closes #4884 (partial — BM25 keyword path; entity extraction follow-up
separate).