### PR TITLE
docs: fix Vercel AI SDK skill link

### DIFF
--- a/skills/mem0/references/integration-patterns.md
+++ b/skills/mem0/references/integration-patterns.md
@@ -116,7 +116,7 @@ result = crew.kickoff()
 
 ## Vercel AI SDK
 
-> **Dedicated skill available.** For comprehensive Vercel AI SDK documentation, see the [mem0-vercel-ai-sdk skill](../mem0-vercel-ai-sdk/SKILL.md) ([GitHub](https://github.com/mem0ai/mem0/tree/main/skills/mem0-vercel-ai-sdk)).
+> **Dedicated skill available.** For comprehensive Vercel AI SDK documentation, see the [mem0-vercel-ai-sdk skill](../../mem0-vercel-ai-sdk/SKILL.md) ([GitHub](https://github.com/mem0ai/mem0/tree/main/skills/mem0-vercel-ai-sdk)).
 
 Install: `npm install @mem0/vercel-ai-provider`
 


### PR DESCRIPTION
Fixes the relative path from `skills/mem0/references/integration-patterns.md` to the dedicated Vercel AI SDK skill.

The previous path resolved to a nonexistent location.

AI-assisted with Codex; I verified the target file exists and reviewed the diff.