### PR TITLE
fix(dashboard): proxy API on same origin so Docker login works

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir "psycopg[binary]" "psycopg-pool"
 
 COPY . .
 

--- a/server/dashboard/next.config.mjs
+++ b/server/dashboard/next.config.mjs
@@ -23,6 +23,13 @@ const nextConfig = {
           { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "Cache-Control", value: "no-store, must-revalidate" },
+        ],
+      },
+      {
+        source: "/_next/static/:path*",
+        headers: [
+          { key: "Cache-Control", value: "no-store, must-revalidate" },
         ],
       },
     ];

--- a/server/dashboard/src/app/mem0-api/[...path]/route.ts
+++ b/server/dashboard/src/app/mem0-api/[...path]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerApiUrl } from "@/lib/server-api-url";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+  "content-length",
+]);
+
+async function proxy(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> },
+) {
+  const { path } = await context.params;
+  const target = `${getServerApiUrl().replace(/\/$/, "")}/${path.join("/")}${request.nextUrl.search}`;
+
+  const headers = new Headers();
+  request.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP.has(key.toLowerCase())) {
+      headers.set(key, value);
+    }
+  });
+
+  const init: RequestInit = { method: request.method, headers };
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    init.body = await request.arrayBuffer();
+  }
+
+  const upstream = await fetch(target, init);
+  const outHeaders = new Headers();
+  upstream.headers.forEach((value, key) => {
+    const lower = key.toLowerCase();
+    if (!HOP_BY_HOP.has(lower) && lower !== "content-encoding") {
+      outHeaders.set(key, value);
+    }
+  });
+
+  return new NextResponse(upstream.body, {
+    status: upstream.status,
+    headers: outHeaders,
+  });
+}
+
+export const GET = proxy;
+export const POST = proxy;
+export const PUT = proxy;
+export const PATCH = proxy;
+export const DELETE = proxy;
+export const OPTIONS = proxy;

--- a/server/dashboard/src/middleware.ts
+++ b/server/dashboard/src/middleware.ts
@@ -6,6 +6,7 @@ const PUBLIC_PATHS = [
   "/_next",
   "/api/auth",
   "/api/health",
+  "/mem0-api",
   "/fonts",
   "/favicon",
 ];

--- a/server/dashboard/src/utils/api.ts
+++ b/server/dashboard/src/utils/api.ts
@@ -2,6 +2,8 @@ import axios, { AxiosError, AxiosInstance } from "axios";
 
 let cachedToken: string | null = null;
 const LOGIN_PATH = "/login";
+/** Same-origin proxy — browser must never call host.docker.internal. */
+const BROWSER_API_BASE = "/mem0-api";
 
 export const setAccessToken = (token: string | null) => {
   cachedToken = token;
@@ -40,7 +42,7 @@ const createApi = (): AxiosInstance & {
   postStream: (url: string, data: unknown) => Promise<Response>;
 } => {
   const api = axios.create({
-    baseURL: process.env.NEXT_PUBLIC_API_URL,
+    baseURL: BROWSER_API_BASE,
   });
 
   api.interceptors.request.use(
@@ -84,7 +86,7 @@ const createApi = (): AxiosInstance & {
   );
 
   const postStream = async (url: string, data: unknown): Promise<Response> => {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${url}`, {
+    const response = await fetch(`${BROWSER_API_BASE}${url}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- Route dashboard browser calls through a same-origin `/mem0-api` proxy instead of `NEXT_PUBLIC_API_URL`, so Sign in never hits `host.docker.internal` (or a stale cached API host).
- Install `psycopg[binary]` in the server image so Postgres connections work without extra OS packages.
- Send `Cache-Control: no-store` on dashboard assets so runtime env substitution is not stuck in an old JS bundle.

## Test plan
- [ ] `docker compose` up for the self-hosted server + dashboard
- [ ] Open the dashboard in a browser (hard refresh once if an older bundle was cached)
- [ ] Confirm Sign in posts to `/mem0-api/auth/login` on the dashboard origin, not `host.docker.internal`
- [ ] Sign in with an existing admin email/password and reach `/dashboard/requests`
- [ ] Confirm `/setup` still redirects to `/login` after the first admin exists
