### PR TITLE
fix(dashboard): proxy API on same origin so Docker login works

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir "psycopg[binary]" "psycopg-pool"
 
 COPY . .
 

--- a/server/dashboard/next.config.mjs
+++ b/server/dashboard/next.config.mjs
@@ -23,6 +23,13 @@ const nextConfig = {
           { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "Cache-Control", value: "no-store, must-revalidate" },
+        ],
+      },
+      {
+        source: "/_next/static/:path*",
+        headers: [
+          { key: "Cache-Control", value: "no-store, must-revalidate" },
         ],
       },
     ];

--- a/server/dashboard/src/app/mem0-api/[...path]/route.ts
+++ b/server/dashboard/src/app/mem0-api/[...path]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerApiUrl } from "@/lib/server-api-url";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+  "content-length",
+]);
+
+async function proxy(
+  request: NextRequest,
+  context: { params: Promise<{ path: string[] }> },
+) {
+  const { path } = await context.params;
+  const target = `${getServerApiUrl().replace(/\/$/, "")}/${path.join("/")}${request.nextUrl.search}`;
+
+  const headers = new Headers();
+  request.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP.has(key.toLowerCase())) {
+      headers.set(key, value);
+    }
+  });
+
+  const init: RequestInit = { method: request.method, headers };
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    init.body = await request.arrayBuffer();
+  }
+
+  const upstream = await fetch(target, init);
+  const outHeaders = new Headers();
+  upstream.headers.forEach((value, key) => {
+    const lower = key.toLowerCase();
+    if (!HOP_BY_HOP.has(lower) && lower !== "content-encoding") {
+      outHeaders.set(key, value);
+    }
+  });
+
+  return new NextResponse(upstream.body, {
+    status: upstream.status,
+    headers: outHeaders,
+  });
+}
+
+export const GET = proxy;
+export const POST = proxy;
+export const PUT = proxy;
+export const PATCH = proxy;
+export const DELETE = proxy;
+export const OPTIONS = proxy;

--- a/server/dashboard/src/middleware.ts
+++ b/server/dashboard/src/middleware.ts
@@ -6,6 +6,7 @@ const PUBLIC_PATHS = [
   "/_next",
   "/api/auth",
   "/api/health",
+  "/mem0-api",
   "/fonts",
   "/favicon",
 ];

--- a/server/dashboard/src/utils/api.ts
+++ b/server/dashboard/src/utils/api.ts
@@ -2,6 +2,8 @@ import axios, { AxiosError, AxiosInstance } from "axios";
 
 let cachedToken: string | null = null;
 const LOGIN_PATH = "/login";
+/** Same-origin proxy — browser must never call host.docker.internal. */
+const BROWSER_API_BASE = "/mem0-api";
 
 export const setAccessToken = (token: string | null) => {
   cachedToken = token;
@@ -40,7 +42,7 @@ const createApi = (): AxiosInstance & {
   postStream: (url: string, data: unknown) => Promise<Response>;
 } => {
   const api = axios.create({
-    baseURL: process.env.NEXT_PUBLIC_API_URL,
+    baseURL: BROWSER_API_BASE,
   });
 
   api.interceptors.request.use(
@@ -84,7 +86,7 @@ const createApi = (): AxiosInstance & {
   );
 
   const postStream = async (url: string, data: unknown): Promise<Response> => {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${url}`, {
+    const response = await fetch(`${BROWSER_API_BASE}${url}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Linked Issue

Closes #7171

## Description

Self-hosted dashboard Sign in currently uses `NEXT_PUBLIC_API_URL` as the **browser** axios base URL (`server/dashboard/src/utils/api.ts`). In Docker that is often `http://host.docker.internal:…`, which the host browser cannot call, so login shows Network Error while `POST http://localhost:8888/auth/login` returns 200.

This PR makes the browser call same-origin `/mem0-api/*`. A Next.js route handler proxies to `API_INTERNAL_URL` / `getServerApiUrl()` (`http://mem0:8000` in compose). That matches the split already documented in `server/docker-compose.yaml` (browser `localhost:8888` vs internal `http://mem0:8000`).

Also:
- `psycopg[binary]` in `server/Dockerfile` so the API image does not need extra OS libpq packages.
- `Cache-Control: no-store` on dashboard responses so `entrypoint.sh` env substitution is not stuck in an old hashed chunk after compose env changes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Tool: Cursor agent. I reproduced the failure in the browser (login XHR to `host.docker.internal`, status 0, UI Network Error) and verified curl `POST /auth/login` on `localhost:8888` returns 200. After the proxy rebuild, served JS contains `/mem0-api` and `POST /mem0-api/auth/login` returns 200.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A. Browser traffic moves from `NEXT_PUBLIC_API_URL` to `/mem0-api` on the dashboard origin. Direct API access on port 8888 is unchanged. Curl snippets in the setup wizard still use `NEXT_PUBLIC_API_URL` for the public API URL.

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Manual:
1. Recreated dashboard image with this diff.
2. `POST http://localhost:3001/mem0-api/auth/login` with a valid admin body → 200 tokens.
3. Login page JS chunks (`page-ce7a4481c3af0281.js`) contain `/mem0-api`, not `host.docker.internal`.
4. `GET /auth/setup-status` still `{ "needsSetup": false }` after first admin, so `/setup` → `/login` is unchanged and correct.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed
