### PR TITLE
perf(memory): clear entity store once per sync delete_all instead of per deleted memory

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -649,6 +649,26 @@ class Memory(MemoryBase):
         except Exception as e:
             logger.warning(f"Entity upsert failed for '{entity_text}': {e}")
 
+    def _bulk_clear_entity_store(self, filters):
+        """Delete all entity records matching the given scope filters.
+
+        Used by delete_all so the entity store is listed once per call instead
+        of once per deleted memory.
+        """
+        if self._entity_store is None:
+            return
+        search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
+        try:
+            listed = self.entity_store.list(filters=search_filters, top_k=10000)
+            rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
+            for row in rows or []:
+                try:
+                    self.entity_store.delete(vector_id=row.id)
+                except Exception as e:
+                    logger.debug(f"Bulk entity delete failed for id={row.id}: {e}")
+        except Exception as e:
+            logger.warning(f"Bulk entity store cleanup failed: {e}")
+
     def _remove_memory_from_entity_store(self, memory_id, filters):
         """Strip `memory_id` from every entity record scoped to `filters`.
 
@@ -1931,8 +1951,11 @@ class Memory(MemoryBase):
                 break
             seen_batches.add(batch_ids)
             for memory in memories:
-                self._delete_memory(memory.id)
+                self._delete_memory(memory.id, skip_entity_cleanup=True)
             deleted_count += len(memories)
+
+        if self._entity_store is not None:
+            self._bulk_clear_entity_store(filters)
 
         logger.info(f"Deleted {deleted_count} memories")
 
@@ -2097,7 +2120,7 @@ class Memory(MemoryBase):
 
         return memory_id
 
-    def _delete_memory(self, memory_id, existing_memory=None):
+    def _delete_memory(self, memory_id, existing_memory=None, skip_entity_cleanup=False):
         logger.info(f"Deleting memory with {memory_id=}")
         if existing_memory is None:
             existing_memory = self.vector_store.get(vector_id=memory_id)
@@ -2122,8 +2145,10 @@ class Memory(MemoryBase):
         )
 
         # Entity-store cleanup: strip this memory's id from any entity records
-        # that linked to it. Non-fatal — the helper swallows errors.
-        self._remove_memory_from_entity_store(memory_id, session_filters)
+        # that linked to it. Non-fatal — the helper swallows errors. Skipped by
+        # delete_all, which clears the entity store in bulk once at the end.
+        if not skip_entity_cleanup:
+            self._remove_memory_from_entity_store(memory_id, session_filters)
 
         return memory_id
 

--- a/tests/memory/test_decay_usage_notice.py
+++ b/tests/memory/test_decay_usage_notice.py
@@ -11,6 +11,7 @@ def make_sync_memory():
     memory = Memory.__new__(Memory)
     memory.vector_store = MagicMock()
     memory._delete_memory = MagicMock()
+    memory._entity_store = None
     return memory
 
 

--- a/tests/memory/test_delete_all_entity_cleanup.py
+++ b/tests/memory/test_delete_all_entity_cleanup.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mem0.memory import main as memory_main
+from mem0.memory.main import Memory
+
+
+def make_sync_memory():
+    memory = Memory.__new__(Memory)
+    memory.vector_store = MagicMock()
+    memory._delete_memory = MagicMock()
+    memory._entity_store = None
+    return memory
+
+
+def test_delete_all_defers_entity_cleanup_to_bulk_clear(monkeypatch):
+    """delete_all must not run per-memory entity cleanup; one bulk clear at the end."""
+    memory = make_sync_memory()
+    memory._entity_store = MagicMock()  # initialized, so the bulk clear path runs
+    memories = [SimpleNamespace(id="memory-1"), SimpleNamespace(id="memory-2")]
+    memory.vector_store.list.side_effect = [(memories, None), ([], None)]
+    memory._remove_memory_from_entity_store = MagicMock()
+    memory._bulk_clear_entity_store = MagicMock()
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice", MagicMock())
+
+    Memory.delete_all(memory, user_id="u1")
+
+    memory._remove_memory_from_entity_store.assert_not_called()
+    memory._bulk_clear_entity_store.assert_called_once_with({"user_id": "u1"})
+    for call in memory._delete_memory.call_args_list:
+        assert call.kwargs.get("skip_entity_cleanup") is True
+
+
+def test_delete_all_lists_entity_store_once_not_per_memory(monkeypatch):
+    """With an entity store attached, delete_all lists it once in total, not once per memory."""
+    memory = make_sync_memory()
+    memory._entity_store = MagicMock()
+    memory._entity_store.list.return_value = [SimpleNamespace(id="entity-1")]
+    memories = [SimpleNamespace(id=f"memory-{i}") for i in range(5)]
+    memory.vector_store.list.side_effect = [(memories, None), ([], None)]
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete_all", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice", MagicMock())
+
+    Memory.delete_all(memory, user_id="u1")
+
+    assert memory._entity_store.list.call_count == 1
+    memory._entity_store.delete.assert_called_once_with(vector_id="entity-1")
+
+
+def test_single_delete_still_cleans_entity_store(monkeypatch):
+    """A plain delete() keeps its per-memory entity cleanup — only delete_all defers it."""
+    memory = make_sync_memory()
+    del memory._delete_memory  # exercise the real _delete_memory implementation
+    memory.db = MagicMock()
+    memory._entity_store = MagicMock()
+    memory.vector_store.get.return_value = SimpleNamespace(id="memory-1", payload={"user_id": "u1"})
+    memory._remove_memory_from_entity_store = MagicMock()
+    monkeypatch.setattr(memory_main, "capture_event", MagicMock())
+    monkeypatch.setattr(memory_main, "detect_decay_usage_from_delete", MagicMock(return_value=None))
+    monkeypatch.setattr(memory_main, "display_first_run_notice", MagicMock())
+
+    Memory.delete(memory, "memory-1")
+
+    memory._remove_memory_from_entity_store.assert_called_once_with("memory-1", {"user_id": "u1"})


### PR DESCRIPTION
### What

Port the async path's entity-store cleanup structure to the sync `delete_all`:

- sync `Memory._delete_memory` gains `skip_entity_cleanup: bool = False`
- `Memory.delete_all` passes `skip_entity_cleanup=True` per memory and calls a new sync `Memory._bulk_clear_entity_store(filters)` once after the delete loop
- single `delete()` behavior is unchanged

Fixes #7173

### Why

Sync `delete_all` ran `_remove_memory_from_entity_store` for every deleted memory; that helper lists up to 10,000 entity rows per call, so deleting N memories cost N full entity-store listings. `AsyncMemory.delete_all` already avoids this with per-item `skip_entity_cleanup=True` plus one bulk clear at the end.

### How verified

- New tests in `tests/memory/test_delete_all_entity_cleanup.py`: the two `delete_all` cases fail on unpatched `main` and pass with this change (entity store listed once per call regardless of memory count; per-memory cleanup suppressed; bulk clear called once with scope filters). `test_single_delete_still_cleans_entity_store` covers the unchanged single-delete path.
- `pytest tests/memory/`: 323 passed, 0 failed with the patch; the 53 collection errors in that directory are pre-existing on `main` (missing optional deps such as `spacy`).

Prepared with AI assistance; run and verified locally.