### PR TITLE
fix: include keyword-only hybrid search candidates

### DIFF
--- a/docs/core-concepts/memory-operations/search.mdx
+++ b/docs/core-concepts/memory-operations/search.mdx
@@ -13,7 +13,7 @@ Mem0's search operation lets agents ask natural-language questions and get back 
 
 - **Query**: Natural-language question or statement you pass to `search`.
 - **Filters**: JSON logic (AND/OR, comparison operators) that narrows results by user, categories, dates, etc.
-- **top_k / threshold**: Controls how many memories return and the minimum similarity score.
+- **top_k / threshold**: `top_k` caps the result count, while `threshold` filters semantic candidates. In OSS hybrid search, positive keyword-only matches can also enter the ranked result set.
 - **Rerank**: Optional second pass that boosts precision when a reranker is configured.
 
 ## Architecture
@@ -174,7 +174,7 @@ console.log(results.results[0].score_details);
 ```
 </CodeGroup>
 
-Each result includes `score_details` with the semantic score, normalized BM25 score, entity boost, raw combined score, maximum possible score, final score, and threshold used for filtering. The field is omitted unless `explain` is enabled, so existing response shapes stay unchanged.
+Each result includes `score_details` with the semantic score, normalized BM25 score, entity boost, raw combined score, maximum possible score, final score, and configured semantic threshold. The threshold filters semantic candidates; keyword-only candidates have no semantic score to threshold and are ranked by their normalized BM25 contribution. The field is omitted unless `explain` is enabled, so existing response shapes stay unchanged.
 
 ## Filter patterns
 
@@ -234,7 +234,7 @@ client.search("preferences", filters={
   - **OSS**: Use `filters={"user_id": "alice"}` (passing `user_id` as a top-level kwarg raises `ValueError` in v3)
 - **Combine filters**: Use AND/OR logic to create precise queries (Platform)
 - **Consider wildcard filters**: Use wildcard filters (e.g., `run_id: "*"`) for broader matches
-- **Tune parameters**: Adjust `top_k` for result count, `threshold` for relevance cutoff
+- **Tune parameters**: Adjust `top_k` for result count and `threshold` for the semantic relevance cutoff; OSS keyword-only matches are ranked by keyword relevance
 - **Enable reranking**: Use `rerank=True` (default is `False`) when you have a reranker configured
 
 <Callout type="tip" icon="plug">

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -8,6 +8,7 @@ import os
 import time
 import uuid
 import warnings
+from collections.abc import Mapping
 from copy import deepcopy
 from datetime import date, datetime, timezone
 from typing import Any, Dict, Optional
@@ -88,6 +89,55 @@ def _vector_store_list_rows(listed):
     if isinstance(listed, (list, tuple)):
         return listed
     return []
+
+
+def _search_result_value(result, field, default=None):
+    if isinstance(result, Mapping):
+        return result.get(field, default)
+    return getattr(result, field, default)
+
+
+def _build_hybrid_candidates(semantic_results, keyword_results, bm25_scores, show_expired=False):
+    """Union dense and sparse search results while preserving dense scores for overlaps."""
+    candidates_by_id = {}
+    seen_ids = set()
+
+    for result in semantic_results or []:
+        memory_id = _search_result_value(result, "id")
+        if memory_id is None:
+            continue
+        memory_id = str(memory_id)
+        if memory_id in seen_ids:
+            continue
+        seen_ids.add(memory_id)
+        payload = _search_result_value(result, "payload", {}) or {}
+        if not show_expired and _payload_is_expired(payload):
+            continue
+        candidates_by_id[memory_id] = {
+            "id": memory_id,
+            "score": _search_result_value(result, "score"),
+            "payload": payload,
+        }
+
+    for result in keyword_results or []:
+        memory_id = _search_result_value(result, "id")
+        if memory_id is None:
+            continue
+        memory_id = str(memory_id)
+        if memory_id in seen_ids or memory_id not in bm25_scores:
+            continue
+        seen_ids.add(memory_id)
+        payload = _search_result_value(result, "payload", {}) or {}
+        if not show_expired and _payload_is_expired(payload):
+            continue
+        candidates_by_id[memory_id] = {
+            "id": memory_id,
+            "score": 0.0,
+            "payload": payload,
+            "_keyword_only": True,
+        }
+
+    return list(candidates_by_id.values())
 
 
 # Fields that hold runtime auth/connection objects and must be preserved.
@@ -1415,7 +1465,8 @@ class Memory(MemoryBase):
                 - {"AND": [filter1, filter2]} - logical AND
                 - {"OR": [filter1, filter2]} - logical OR
                 - {"NOT": [filter1]} - logical NOT
-            threshold (float, optional): Minimum score for a memory to be included. Defaults to 0.1.
+            threshold (float, optional): Minimum semantic similarity score for candidates returned by
+                vector search. Keyword-only candidates are ranked by keyword relevance. Defaults to 0.1.
             rerank (bool, optional): Whether to rerank results. Defaults to False.
             explain (bool, optional): Whether to include score_details for each result. Defaults to False.
             reference_date (Any, optional): Platform-only temporal parameter. Not supported in OSS.
@@ -1653,28 +1704,23 @@ class Memory(MemoryBase):
         if keyword_results is not None:
             midpoint, steepness = get_bm25_params(query, lemmatized=query_lemmatized)
             for mem in keyword_results:
-                mem_id = str(mem.id) if hasattr(mem, 'id') else str(mem.get('id', ''))
-                raw_score = mem.score if hasattr(mem, 'score') else mem.get('score', 0)
-                if raw_score and raw_score > 0:
-                    bm25_scores[mem_id] = normalize_bm25(raw_score, midpoint, steepness)
+                memory_id = _search_result_value(mem, "id")
+                raw_score = _search_result_value(mem, "score", 0)
+                if memory_id is not None and raw_score and raw_score > 0:
+                    bm25_scores[str(memory_id)] = normalize_bm25(raw_score, midpoint, steepness)
 
         # Step 6: Compute entity boosts
         entity_boosts = {}
         if query_entities:
             entity_boosts = self._compute_entity_boosts(query_entities, filters)
 
-        # Step 7: Build candidate set from semantic results
-        candidates = []
-        for mem in semantic_results:
-            payload = mem.payload if hasattr(mem, 'payload') else {}
-            if not show_expired and _payload_is_expired(payload):
-                continue
-            mem_id = str(mem.id)
-            candidates.append({
-                "id": mem_id,
-                "score": mem.score,
-                "payload": payload,
-            })
+        # Step 7: Union semantic and keyword candidates before scoring
+        candidates = _build_hybrid_candidates(
+            semantic_results,
+            keyword_results,
+            bm25_scores,
+            show_expired=show_expired,
+        )
 
         # Step 8: Score and rank
         scored_results = score_and_rank(
@@ -3073,7 +3119,8 @@ class AsyncMemory(MemoryBase):
                 - {"AND": [filter1, filter2]} - logical AND
                 - {"OR": [filter1, filter2]} - logical OR
                 - {"NOT": [filter1]} - logical NOT
-            threshold (float, optional): Minimum score for a memory to be included. Defaults to 0.1.
+            threshold (float, optional): Minimum semantic similarity score for candidates returned by
+                vector search. Keyword-only candidates are ranked by keyword relevance. Defaults to 0.1.
             rerank (bool, optional): Whether to rerank results. Defaults to False.
             explain (bool, optional): Whether to include score_details for each result. Defaults to False.
             reference_date (Any, optional): Platform-only temporal parameter. Not supported in OSS.
@@ -3317,28 +3364,23 @@ class AsyncMemory(MemoryBase):
         if keyword_results is not None:
             midpoint, steepness = get_bm25_params(query, lemmatized=query_lemmatized)
             for mem in keyword_results:
-                mem_id = str(mem.id) if hasattr(mem, 'id') else str(mem.get('id', ''))
-                raw_score = mem.score if hasattr(mem, 'score') else mem.get('score', 0)
-                if raw_score and raw_score > 0:
-                    bm25_scores[mem_id] = normalize_bm25(raw_score, midpoint, steepness)
+                memory_id = _search_result_value(mem, "id")
+                raw_score = _search_result_value(mem, "score", 0)
+                if memory_id is not None and raw_score and raw_score > 0:
+                    bm25_scores[str(memory_id)] = normalize_bm25(raw_score, midpoint, steepness)
 
         # Step 6: Compute entity boosts
         entity_boosts = {}
         if query_entities:
             entity_boosts = await self._compute_entity_boosts_async(query_entities, filters)
 
-        # Step 7: Build candidate set from semantic results
-        candidates = []
-        for mem in semantic_results:
-            payload = mem.payload if hasattr(mem, 'payload') else {}
-            if not show_expired and _payload_is_expired(payload):
-                continue
-            mem_id = str(mem.id)
-            candidates.append({
-                "id": mem_id,
-                "score": mem.score,
-                "payload": payload,
-            })
+        # Step 7: Union semantic and keyword candidates before scoring
+        candidates = _build_hybrid_candidates(
+            semantic_results,
+            keyword_results,
+            bm25_scores,
+            show_expired=show_expired,
+        )
 
         # Step 8: Score and rank
         scored_results = score_and_rank(

--- a/mem0/utils/scoring.py
+++ b/mem0/utils/scoring.py
@@ -71,8 +71,8 @@ def score_and_rank(
         semantic_score is taken from the result's score field.
         combined = (semantic + bm25 + entity_boost) / max_possible
 
-    Threshold gates the semantic score BEFORE combining -- candidates
-    below the threshold are excluded even if BM25/entity would boost them.
+    Threshold gates semantic candidates BEFORE combining. Keyword-only
+    candidates have no semantic score to threshold and are ranked by BM25.
 
     The divisor adapts based on which signals are active:
         - Semantic only: max_possible = 1.0
@@ -84,7 +84,7 @@ def score_and_rank(
         semantic_results: Candidate memories from vector search.
         bm25_scores: Normalized keyword scores keyed by memory ID.
         entity_boosts: Entity-link boosts keyed by memory ID.
-        threshold: Minimum semantic score required before hybrid scoring.
+        threshold: Minimum score for candidates returned by semantic search.
         top_k: Maximum number of results to return.
         explain: Include score_details in each result when true.
 
@@ -108,7 +108,8 @@ def score_and_rank(
             continue
 
         semantic_score = result.get("score") or 0.0
-        if semantic_score < threshold:
+        keyword_only = result.get("_keyword_only", False)
+        if not keyword_only and semantic_score < threshold:
             continue
 
         mem_id_str = str(mem_id)

--- a/tests/memory/test_hybrid_candidate_union.py
+++ b/tests/memory/test_hybrid_candidate_union.py
@@ -1,0 +1,247 @@
+from collections import UserDict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mem0 import AsyncMemory, Memory
+
+
+class SearchResult:
+    def __init__(self, memory_id, data, score, **payload):
+        self.id = memory_id
+        self.payload = {"data": data, "user_id": "user-1", **payload}
+        self.score = score
+
+
+@pytest.fixture(autouse=True)
+def patch_query_preprocessing():
+    with (
+        patch("mem0.memory.main.extract_entities", return_value=[]),
+        patch("mem0.memory.main.lemmatize_for_bm25", return_value="zxq 914"),
+    ):
+        yield
+
+
+def build_memory(memory_class, semantic_results, keyword_results):
+    memory = memory_class.__new__(memory_class)
+    memory.embedding_model = MagicMock()
+    memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+    memory.vector_store = MagicMock()
+    memory.vector_store.search.return_value = semantic_results
+    memory.vector_store.keyword_search.return_value = keyword_results
+    return memory
+
+
+def test_search_returns_strong_keyword_only_candidate():
+    memory = build_memory(
+        Memory,
+        [SearchResult("semantic-only", "General product documentation", 0.8)],
+        [SearchResult("keyword-only", "Replacement procedure for part ZXQ-914", 20.0)],
+    )
+
+    results = memory._search_vector_store("ZXQ-914", {"user_id": "user-1"}, limit=2)
+
+    assert [result["id"] for result in results] == ["keyword-only", "semantic-only"]
+    assert all("_keyword_only" not in result for result in results)
+
+
+@pytest.mark.asyncio
+async def test_async_search_returns_strong_keyword_only_candidate():
+    memory = build_memory(
+        AsyncMemory,
+        [SearchResult("semantic-only", "General product documentation", 0.8)],
+        [SearchResult("keyword-only", "Replacement procedure for part ZXQ-914", 20.0)],
+    )
+
+    results = await memory._search_vector_store("ZXQ-914", {"user_id": "user-1"}, limit=2)
+
+    assert [result["id"] for result in results] == ["keyword-only", "semantic-only"]
+
+
+def test_semantic_only_results_keep_scores_and_order():
+    memory = build_memory(
+        Memory,
+        [
+            SearchResult("first", "First semantic result", 0.9),
+            SearchResult("second", "Second semantic result", 0.4),
+        ],
+        [],
+    )
+
+    results = memory._search_vector_store("semantic query", {"user_id": "user-1"}, limit=2)
+
+    assert [result["id"] for result in results] == ["first", "second"]
+    assert [result["score"] for result in results] == pytest.approx([0.9, 0.4])
+
+
+def test_duplicate_semantic_id_keeps_first_result():
+    memory = build_memory(
+        Memory,
+        [
+            SearchResult("shared", "First semantic payload", 0.9),
+            SearchResult("shared", "Duplicate semantic payload", 0.4),
+        ],
+        [],
+    )
+
+    results = memory._search_vector_store("semantic query", {"user_id": "user-1"}, limit=2)
+
+    assert len(results) == 1
+    assert results[0]["memory"] == "First semantic payload"
+    assert results[0]["score"] == pytest.approx(0.9)
+
+
+def test_overlapping_candidate_is_deduplicated_and_keeps_semantic_payload():
+    memory = build_memory(
+        Memory,
+        [SearchResult("shared", "Semantic payload", 0.8)],
+        [SearchResult("shared", "Keyword payload", 20.0)],
+    )
+
+    results = memory._search_vector_store(
+        "ZXQ-914",
+        {"user_id": "user-1"},
+        limit=2,
+        explain=True,
+    )
+
+    assert len(results) == 1
+    assert results[0]["memory"] == "Semantic payload"
+    assert results[0]["score_details"]["semantic_score"] == 0.8
+    assert results[0]["score_details"]["bm25_score"] > 0.99
+
+
+def test_expired_keyword_only_candidate_respects_show_expired():
+    keyword_result = SearchResult(
+        "expired",
+        "Old procedure for ZXQ-914",
+        20.0,
+        expiration_date="2000-01-01",
+    )
+    memory = build_memory(Memory, [], [keyword_result])
+
+    hidden = memory._search_vector_store("ZXQ-914", {"user_id": "user-1"}, limit=2)
+    visible = memory._search_vector_store(
+        "ZXQ-914",
+        {"user_id": "user-1"},
+        limit=2,
+        show_expired=True,
+    )
+
+    assert hidden == []
+    assert [result["id"] for result in visible] == ["expired"]
+
+
+def test_expired_semantic_candidate_is_not_readmitted_by_sparse_overlap():
+    memory = build_memory(
+        Memory,
+        [
+            SearchResult(
+                "expired-overlap",
+                "Expired semantic payload",
+                0.8,
+                expiration_date="2000-01-01",
+            )
+        ],
+        [SearchResult("expired-overlap", "Sparse payload without expiration", 20.0)],
+    )
+
+    results = memory._search_vector_store("ZXQ-914", {"user_id": "user-1"}, limit=2)
+
+    assert results == []
+
+
+def test_keyword_only_mapping_result_is_supported():
+    memory = build_memory(
+        Memory,
+        [],
+        [
+            UserDict(
+                {
+                    "id": "mapping-result",
+                    "payload": {"data": "Procedure for ZXQ-914", "user_id": "user-1"},
+                    "score": 20.0,
+                }
+            )
+        ],
+    )
+
+    results = memory._search_vector_store("ZXQ-914", {"user_id": "user-1"}, limit=1)
+
+    assert [result["id"] for result in results] == ["mapping-result"]
+
+
+def test_mapping_fields_take_precedence_over_attributes():
+    keyword_result = UserDict(
+        {
+            "id": "mapping-result",
+            "payload": {"data": "Procedure for ZXQ-914", "user_id": "user-1"},
+            "score": 20.0,
+        }
+    )
+    keyword_result.id = "attribute-result"
+    keyword_result.score = 20.0
+    memory = build_memory(Memory, [], [keyword_result])
+
+    results = memory._search_vector_store("ZXQ-914", {"user_id": "user-1"}, limit=1)
+
+    assert [result["id"] for result in results] == ["mapping-result"]
+
+
+def test_idless_keyword_result_does_not_rescale_semantic_candidates():
+    memory = build_memory(
+        Memory,
+        [SearchResult("semantic-only", "Semantic payload", 0.8)],
+        [UserDict({"payload": {"data": "ID-less sparse payload"}, "score": 20.0})],
+    )
+
+    results = memory._search_vector_store("ZXQ-914", {"user_id": "user-1"}, limit=1)
+
+    assert [result["id"] for result in results] == ["semantic-only"]
+    assert results[0]["score"] == pytest.approx(0.8)
+
+
+def test_non_positive_keyword_score_does_not_create_candidate():
+    memory = build_memory(
+        Memory,
+        [],
+        [SearchResult("no-match", "Unscored keyword result", 0.0)],
+    )
+
+    results = memory._search_vector_store("ZXQ-914", {"user_id": "user-1"}, limit=1)
+
+    assert results == []
+
+
+def test_search_passes_identical_filters_to_dense_and_sparse_retrieval():
+    memory = build_memory(Memory, [], [])
+    filters = {"user_id": "user-1", "category": "manual"}
+
+    memory._search_vector_store("ZXQ-914", filters, limit=2)
+
+    memory.vector_store.search.assert_called_once_with(
+        query="ZXQ-914",
+        vectors=[0.1, 0.2, 0.3],
+        top_k=60,
+        filters=filters,
+    )
+    memory.vector_store.keyword_search.assert_called_once_with(
+        query="zxq 914",
+        top_k=60,
+        filters=filters,
+    )
+
+
+def test_tied_keyword_only_candidates_keep_provider_order():
+    memory = build_memory(
+        Memory,
+        [],
+        [
+            SearchResult("first", "First ZXQ-914 procedure", 20.0),
+            SearchResult("second", "Second ZXQ-914 procedure", 20.0),
+        ],
+    )
+
+    results = memory._search_vector_store("ZXQ-914", {"user_id": "user-1"}, limit=2)
+
+    assert [result["id"] for result in results] == ["first", "second"]

--- a/tests/utils/test_scoring.py
+++ b/tests/utils/test_scoring.py
@@ -91,10 +91,24 @@ class TestScoreAndRank:
             {"id": "a", "score": 0.05, "payload": {"data": "mem a"}},  # Below threshold
             {"id": "b", "score": 0.5, "payload": {"data": "mem b"}},
         ]
-        bm25 = {"a": 0.99}  # High BM25 shouldn't save it
+        bm25 = {"a": 0.99}  # High BM25 shouldn't save a semantic candidate
         scored = score_and_rank(results, bm25, {}, threshold=0.1, top_k=10)
         assert len(scored) == 1
         assert scored[0]["id"] == "b"
+
+    def test_keyword_only_candidate_is_not_gated_by_semantic_threshold(self):
+        results = [
+            {
+                "id": "a",
+                "score": 0.0,
+                "payload": {"data": "mem a"},
+                "_keyword_only": True,
+            }
+        ]
+        scored = score_and_rank(results, {"a": 0.9}, {}, threshold=0.9, top_k=10)
+        assert len(scored) == 1
+        assert scored[0]["id"] == "a"
+        assert scored[0]["score"] == pytest.approx(0.45)
 
     def test_top_k_limit(self):
         results = [{"id": str(i), "score": 0.5, "payload": {}} for i in range(20)]


### PR DESCRIPTION
## Linked Issue

Closes #5742

> **Scope note:** This draft addresses the keyword-only candidate-loss path described in #5742. Entity-only rescue and broader multi-signal threshold semantics remain separate follow-ups. The repository gate requires closing-reference syntax for an issue carrying the `accepted` label; maintainers should confirm this linkage before merge.

## Description

Hybrid search computed normalized BM25 scores for sparse results, but both sync and async candidate lists were built exclusively from semantic results. A strong keyword-only hit therefore could not enter the final top-K.

This change:

- unions semantic and positive-scored keyword candidates before ranking;
- keeps semantic candidates first and preserves their score and payload on overlap;
- deduplicates IDs with stable provider ordering for ties;
- applies the existing semantic threshold only to candidates returned by semantic search;
- handles object and mapping-shaped provider results consistently;
- preserves expiration filtering and prevents expired semantic overlaps from sparse re-admission;
- ignores missing-ID and non-positive sparse rows so they cannot alter semantic-only scoring;
- uses the same shared candidate builder in sync and async paths; and
- documents OSS hybrid threshold behavior.

### Behavioral evidence

The same controlled nine-case behavior suite was run against pinned upstream commit `19cb89aff472325c707f64b2f34ae6afdbf7faf7` and this patch:

| Run | Result |
| --- | --- |
| Upstream baseline | 5 failed, 4 passed |
| Patched branch | 9 passed |

A deterministic ten-run probe measured:

| Metric | Baseline | Patched |
| --- | ---: | ---: |
| Keyword-only recall@2 | 0 | 1 |
| Semantic-only recall@2 | 1.0 | 1.0 |
| Semantic-only scores | `[0.9, 0.4]` | `[0.9, 0.4]` |
| Sync/async equivalent | true | true |
| Deterministic ordering | true | true |
| Expiration violations | 0 | 0 |
| Internal marker leaks | 0 | 0 |

### Non-goals

This intentionally does not add entity-only hydration, RRF, provider-specific SQL/routing, pooling changes, or other retrieval architecture changes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Kiro (GPT-5.6 sol) generated most of the implementation and tests under author direction. The change was regression-first, reviewed against the complete diff, independently re-reviewed, and validated with the test and A/B evidence above. This remains a draft for the author's own line-by-line review.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Validation performed locally with the required Python 3.12 Hatch environment:

- `1879 passed, 75 skipped` for the full `tests/` suite;
- `205 passed` for the affected memory/scoring/vector-store suite before the final extraction hardening;
- Ruff lint passed all changed Python files;
- relevant Ruff formatting and isort checks passed;
- `git diff --check` passed; and
- controlled baseline/patched A/B and deterministic numerical probe passed as shown above.

The pinned upstream baseline itself reports the existing whole-file Ruff-format difference in `mem0/memory/main.py` and existing isort difference in `tests/utils/test_scoring.py`; this patch does not introduce those formatting deltas.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
