### PR TITLE
fix(gcp): read credential json as utf-8

### DIFF
--- a/mem0/utils/gcp_auth.py
+++ b/mem0/utils/gcp_auth.py
@@ -57,7 +57,7 @@ class GCPAuthenticator:
                 credentials_path, scopes=scopes
             )
             # Extract project_id from the file
-            with open(credentials_path, 'r') as f:
+            with open(credentials_path, "r", encoding="utf-8") as f:
                 cred_data = json.load(f)
                 project_id = cred_data.get("project_id")
 
@@ -69,7 +69,7 @@ class GCPAuthenticator:
                     env_path, scopes=scopes
                 )
                 # Extract project_id from the file
-                with open(env_path, 'r') as f:
+                with open(env_path, "r", encoding="utf-8") as f:
                     cred_data = json.load(f)
                     project_id = cred_data.get("project_id")
 

--- a/tests/test_gcp_auth.py
+++ b/tests/test_gcp_auth.py
@@ -1,0 +1,56 @@
+import json
+
+from mem0.utils.gcp_auth import GCPAuthenticator
+
+
+def test_get_credentials_reads_service_account_json_as_utf8(monkeypatch, tmp_path):
+    credentials_path = tmp_path / "service-account.json"
+    credentials_path.write_text(
+        json.dumps({"project_id": "proyecto-niño"}),
+        encoding="utf-8",
+    )
+
+    class Credentials:
+        @staticmethod
+        def from_service_account_file(path, scopes=None):
+            return {"path": path, "scopes": scopes}
+
+    monkeypatch.setattr(
+        "mem0.utils.gcp_auth.service_account.Credentials",
+        Credentials,
+    )
+
+    credentials, project_id = GCPAuthenticator.get_credentials(
+        credentials_path=str(credentials_path),
+        scopes=["scope"],
+    )
+
+    assert credentials == {"path": str(credentials_path), "scopes": ["scope"]}
+    assert project_id == "proyecto-niño"
+
+
+def test_get_credentials_reads_env_service_account_json_as_utf8(
+    monkeypatch,
+    tmp_path,
+):
+    credentials_path = tmp_path / "env-service-account.json"
+    credentials_path.write_text(
+        json.dumps({"project_id": "proyecto-niño"}),
+        encoding="utf-8",
+    )
+
+    class Credentials:
+        @staticmethod
+        def from_service_account_file(path, scopes=None):
+            return {"path": path, "scopes": scopes}
+
+    monkeypatch.setattr(
+        "mem0.utils.gcp_auth.service_account.Credentials",
+        Credentials,
+    )
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(credentials_path))
+
+    credentials, project_id = GCPAuthenticator.get_credentials(scopes=["scope"])
+
+    assert credentials == {"path": str(credentials_path), "scopes": ["scope"]}
+    assert project_id == "proyecto-niño"


### PR DESCRIPTION
## Summary
- read GCP service account JSON files with explicit UTF-8 encoding
- cover both direct `credentials_path` and `GOOGLE_APPLICATION_CREDENTIALS` paths with non-ASCII project IDs

## Tests
- `python -m pytest tests/test_gcp_auth.py -q`
- `python -m py_compile mem0/utils/gcp_auth.py tests/test_gcp_auth.py`
- `git diff --check`



Closes #7209

