### PR TITLE
feat: relevance-based buffer refresh (admit + evict in one LLM call)

### DIFF
--- a/mem0/configs/base.py
+++ b/mem0/configs/base.py
@@ -55,6 +55,23 @@ class MemoryConfig(BaseModel):
         description="Custom instructions for fact extraction",
         default=None,
     )
+    cache_refresh_interval: int = Field(
+        description=(
+            "Number of messages after which the message buffer is refreshed by "
+            "relevance. When 0 or negative, relevance-based cache refresh is "
+            "disabled (default pure time-FIFO behavior). When positive, every "
+            "`cache_refresh_interval` messages the buffer's stored messages are "
+            "scored against the current conversation topic by the LLM and "
+            "irrelevant ones are evicted, so extraction context stays correlated "
+            "with the active session instead of carrying stale cross-session "
+            "content."
+        ),
+        default=20,
+    )
+    cache_refresh_max_batch: int = Field(
+        description="Max messages considered in a single relevance refresh (safety cap on prompt size).",
+        default=40,
+    )
 
 
 class AzureConfig(BaseModel):

--- a/mem0/configs/prompts.py
+++ b/mem0/configs/prompts.py
@@ -1060,3 +1060,61 @@ def generate_additive_extraction_prompt(
 
     sections.append("# Output:")
     return "\n\n".join(sections)
+
+
+CACHE_REFRESH_PROMPT = """You are a conversation buffer curator. Your job: given the CURRENT conversation messages and a list of buffered PAST messages, decide TWO things in ONE pass:
+
+1. ADMIT: which of the current (new) messages should be ADDED to the buffer
+2. KEEP: which of the buffered (old) messages are still RELEVANT to the current conversation and should be KEPT
+
+ADMIT a new message if it:
+- Advances the current conversation topic (not a trivial acknowledgment)
+- Contains information worth remembering for the ongoing discussion
+
+DROP a new message (do NOT admit) if it:
+- Is a different, unrelated topic that would pollute the buffer
+- Is trivial filler that adds no context
+
+KEEP a buffered message if it:
+- Discusses the same topic as the current conversation
+- Contains facts, decisions, or context the current conversation depends on
+- Is likely needed to understand the current conversation's purpose
+
+EVICT a buffered message if it:
+- Belongs to a different, unrelated conversation topic
+- Is stale or superseded by newer messages
+- Would pollute memory extraction with irrelevant cross-session content
+
+Rules:
+- Output STRICTLY valid JSON, no markdown fences, no commentary.
+- The output must be: {{"admit_indices": [0-based indices of current messages to ADD], "keep_indices": [0-based indices of buffered messages to KEEP]}}
+- admit_indices refer to the Current Conversation Messages list.
+- keep_indices refer to the Buffered Messages list.
+- If none are relevant, output empty lists.
+
+## Current Conversation Messages (new, to admit, 0-based indices)
+{candidate_messages}
+
+## Buffered Messages (old, 0-based indices)
+{buffered_messages}
+"""
+
+
+def build_cache_refresh_prompt(candidate_messages, buffered_messages) -> str:
+    """Build the prompt asking the LLM which current messages to ADMIT and
+    which buffered messages to KEEP — admission and eviction in one call.
+
+    Both lists are numbered [i] so admit_indices / keep_indices map 1:1.
+    """
+    candidate_text = "\n".join(
+        f"[{i}] {m.get('role', 'unknown')}: {_truncate_content(m.get('content', ''), 200)}"
+        for i, m in enumerate(candidate_messages or [])
+    )
+    buffer_text = "\n".join(
+        f"[{i}] {m.get('role', 'unknown')}: {_truncate_content(m.get('content', ''), 200)}"
+        for i, m in enumerate(buffered_messages or [])
+    )
+    return CACHE_REFRESH_PROMPT.format(
+        candidate_messages=candidate_text or "(empty)",
+        buffered_messages=buffer_text or "(empty)",
+    )

--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -876,6 +876,125 @@ class Memory(MemoryBase):
             display_first_run_notice(self, "sync", "add")
         return {"results": vector_store_result}
 
+    def _buffer_gate(self, session_scope: str, messages) -> tuple:
+        """Relevance-based admission + eviction in ONE LLM call.
+
+        Every ``cache_refresh_interval`` saved messages, ask the LLM two
+        questions in a single pass:
+          1. ADMIT — which of the CURRENT messages belong in the buffer
+          2. KEEP  — which of the BUFFERED messages are still relevant to the
+                     current conversation
+
+        Buffered messages not kept are evicted immediately. Returns
+        ``(admitted, keep_ids)``: ``admitted`` are the current messages the
+        caller should persist, ``keep_ids`` are the buffered ids the gate
+        decided to retain (pass them to ``save_messages`` so its FIFO eviction
+        does not delete them). When refresh is disabled or not due, the
+        original messages are returned with empty ``keep_ids``.
+
+        Failures never block memory writes — on any error the original
+        messages are returned and refresh is skipped.
+        """
+        _gate_fired = False
+        try:
+            # Normalize to a list; single non-list messages are wrapped.
+            gate_messages = list(messages) if isinstance(messages, list) else [messages]
+
+            interval = getattr(self.config, "cache_refresh_interval", 0) or 0
+            if interval <= 0:
+                # Gate disabled: pure time-FIFO fallback.
+                return gate_messages, set()
+
+            if not gate_messages:
+                return [], set()
+
+            delta = len(gate_messages)
+            due = self.db.increment_message_count(session_scope, delta=delta, refresh_interval=interval)
+            if not due:
+                return gate_messages, set()
+            # Interval reached: gate fires (success or LLM failure alike resets
+            # the counter so the next window starts fresh).
+            _gate_fired = True
+
+            buffered = self.db.get_all_messages(session_scope)
+            if not buffered:
+                self.db.reset_message_count(session_scope)
+                return gate_messages, set()
+
+            max_batch = getattr(self.config, "cache_refresh_max_batch", 40) or 40
+            if len(buffered) > max_batch:
+                buffered = buffered[:max_batch]
+
+            from mem0.configs.prompts import build_cache_refresh_prompt
+
+            prompt = build_cache_refresh_prompt(gate_messages, buffered)
+            resp = self.llm.generate_response(
+                messages=[
+                    {"role": "system", "content": "You are a JSON-only conversation buffer curator."},
+                    {"role": "user", "content": prompt},
+                ],
+                response_format={"type": "json_object"},
+            )
+            resp = remove_code_blocks(resp or "")
+            if not resp or not resp.strip():
+                self.db.reset_message_count(session_scope)
+                return gate_messages, set()
+
+            try:
+                payload = json.loads(resp, strict=False)
+            except json.JSONDecodeError:
+                payload = json.loads(extract_json(resp), strict=False)
+
+            # ADMIT — current messages to persist
+            admit_indices = payload.get("admit_indices", []) or []
+            if not isinstance(admit_indices, list):
+                admit_indices = []
+            msg_list = list(gate_messages) if isinstance(gate_messages, list) else [gate_messages]
+            admitted = []
+            for idx in admit_indices:
+                try:
+                    idx = int(idx)
+                except (TypeError, ValueError):
+                    continue
+                if 0 <= idx < len(msg_list):
+                    admitted.append(msg_list[idx])
+
+            # KEEP — buffered messages to retain; evict the rest
+            keep_indices = payload.get("keep_indices", []) or []
+            if not isinstance(keep_indices, list):
+                keep_indices = []
+            keep_ids = set()
+            for idx in keep_indices:
+                try:
+                    idx = int(idx)
+                except (TypeError, ValueError):
+                    continue
+                if 0 <= idx < len(buffered):
+                    keep_ids.add(buffered[idx]["id"])
+
+            deleted = self.db.delete_messages_except(session_scope, keep_ids)
+            logger.info(
+                f"Buffer gate scope={session_scope}: admitted {len(admitted)}/{len(msg_list)} new, "
+                f"kept {len(keep_ids)}/{len(buffered)} buffered, evicted {deleted}"
+            )
+            return admitted, keep_ids
+        except Exception as e:
+            # Never block memory writes on a failed gate.
+            logger.warning(f"Buffer gate skipped for scope={session_scope}: {e}")
+            return (list(messages) if isinstance(messages, list) else messages), set()
+        finally:
+            # Reset the counter ONLY once the interval was reached. Do NOT reset
+            # when not due — that would zero the accumulator before it ever
+            # reaches the interval, so the gate would never fire.
+            # increment_message_count already resets the counter when the
+            # interval IS reached; this covers the LLM-failure path too.
+            if _gate_fired:
+                try:
+                    self.db.reset_message_count(session_scope)
+                except Exception:
+                    pass
+
+
     def _add_to_vector_store(self, messages, metadata, filters, infer, prompt=None):
         if not infer:
             returned_memories = []
@@ -985,7 +1104,8 @@ class Memory(MemoryBase):
 
         if not extracted_memories:
             # Save messages even if nothing extracted
-            self.db.save_messages(messages, session_scope)
+            admitted, _keep_ids = self._buffer_gate(session_scope, messages)
+            self.db.save_messages(admitted, session_scope, keep_ids=_keep_ids)
             return []
 
         # Phase 3: Batch embed all extracted memory texts
@@ -1039,7 +1159,8 @@ class Memory(MemoryBase):
             records.append((memory_id, text, embed_map[text], mem_metadata))
 
         if not records:
-            self.db.save_messages(messages, session_scope)
+            admitted, _keep_ids = self._buffer_gate(session_scope, messages)
+            self.db.save_messages(admitted, session_scope, keep_ids=_keep_ids)
             return []
 
         # Phase 6: Batch persist
@@ -1190,7 +1311,8 @@ class Memory(MemoryBase):
             logger.warning(f"Batch entity linking failed: {e}")
 
         # Phase 8: Save messages + return
-        self.db.save_messages(messages, session_scope)
+        admitted, _keep_ids = self._buffer_gate(session_scope, messages)
+        self.db.save_messages(admitted, session_scope, keep_ids=_keep_ids)
 
         returned_memories = [
             {"id": r[0], "memory": r[1], "event": "ADD"}
@@ -2645,7 +2767,8 @@ class AsyncMemory(MemoryBase):
             extracted_memories = []
 
         if not extracted_memories:
-            await asyncio.to_thread(self.db.save_messages, messages, session_scope)
+            admitted, keep_ids = await asyncio.to_thread(self._buffer_gate, session_scope, messages)
+            await asyncio.to_thread(self.db.save_messages, admitted, session_scope, keep_ids)
             return []
 
         # Phase 3: Batch embed all extracted memory texts
@@ -2697,7 +2820,8 @@ class AsyncMemory(MemoryBase):
             records.append((memory_id, text, embed_map[text], mem_metadata))
 
         if not records:
-            await asyncio.to_thread(self.db.save_messages, messages, session_scope)
+            admitted, keep_ids = await asyncio.to_thread(self._buffer_gate, session_scope, messages)
+            await asyncio.to_thread(self.db.save_messages, admitted, session_scope, keep_ids)
             return []
 
         # Phase 6: Batch persist
@@ -2848,7 +2972,8 @@ class AsyncMemory(MemoryBase):
             logger.warning(f"Batch entity linking failed (async): {e}")
 
         # Phase 8: Save messages + return
-        await asyncio.to_thread(self.db.save_messages, messages, session_scope)
+        admitted, keep_ids = await asyncio.to_thread(self._buffer_gate, session_scope, messages)
+        await asyncio.to_thread(self.db.save_messages, admitted, session_scope, keep_ids)
 
         returned_memories = [
             {"id": r[0], "memory": r[1], "event": "ADD"}

--- a/mem0/memory/storage.py
+++ b/mem0/memory/storage.py
@@ -16,6 +16,9 @@ class SQLiteManager:
         self._migrate_history_table()
         self._create_history_table()
         self._create_messages_table()
+        self._create_message_seq_table()
+
+
 
     def _migrate_history_table(self) -> None:
         """
@@ -147,6 +150,27 @@ class SQLiteManager:
                 logger.error(f"Failed to create messages table: {e}")
                 raise
 
+    def _create_message_seq_table(self) -> None:
+        """Per-scope counter tracking how many messages were saved since the
+        last relevance refresh. Used to trigger periodic cache refreshes
+        (relevance-based eviction) instead of pure time-FIFO eviction."""
+        with self._lock:
+            try:
+                self.connection.execute("BEGIN")
+                self.connection.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS message_seq (
+                        session_scope TEXT PRIMARY KEY,
+                        saved_count INTEGER DEFAULT 0
+                    )
+                    """
+                )
+                self.connection.execute("COMMIT")
+            except Exception as e:
+                self.connection.execute("ROLLBACK")
+                logger.error(f"Failed to create message_seq table: {e}")
+                raise
+
     def add_history(
         self,
         memory_id: str,
@@ -254,9 +278,19 @@ class SQLiteManager:
             for r in rows
         ]
 
-    def save_messages(self, messages: List[Dict[str, Any]], session_scope: str) -> None:
+    def save_messages(
+        self, messages: List[Dict[str, Any]], session_scope: str, keep_ids: Optional[set] = None
+    ) -> None:
+        """Insert messages, then FIFO-evict to the most recent ``window`` rows.
+
+        ``keep_ids`` (set of message ids) are protected from eviction — used by
+        the buffer gate so its KEEP decision is not undone by the plain FIFO
+        trim. Callers of the gate should pass the keep_ids it returned.
+        """
         if not messages:
             return
+        keep_ids = keep_ids or set()
+        window = 10
         with self._lock:
             try:
                 self.connection.execute("BEGIN")
@@ -276,19 +310,41 @@ class SQLiteManager:
                             now,
                         ),
                     )
-                # Evict old messages beyond the most recent 10 for this scope.
-                # Wrapped in a derived table to force SQLite to materialize the
-                # ORDER BY before the outer NOT IN evaluates it.
-                self.connection.execute(
-                    """
-                    DELETE FROM messages WHERE session_scope = ? AND id NOT IN (
-                        SELECT id FROM (
-                            SELECT id FROM messages WHERE session_scope = ? ORDER BY created_at DESC LIMIT 10
+                if keep_ids:
+                    # Keep the most recent `window` rows PLUS any gate-protected ids,
+                    # evicting everything older than the union. Each UNION branch is
+                    # wrapped in a derived table so ORDER BY/LIMIT apply per-branch.
+                    placeholders = ",".join("?" * len(keep_ids))
+                    self.connection.execute(
+                        """
+                        DELETE FROM messages WHERE session_scope = ? AND id NOT IN (
+                            SELECT id FROM (
+                                SELECT id FROM (
+                                    SELECT id FROM messages
+                                    WHERE session_scope = ? ORDER BY created_at DESC LIMIT ?
+                                )
+                                UNION
+                                SELECT id FROM (
+                                    SELECT id FROM messages
+                                    WHERE session_scope = ? AND id IN ({})
+                                )
+                            )
                         )
+                    """.format(placeholders),
+                        (session_scope, session_scope, window, session_scope, *keep_ids),
                     )
-                """,
-                    (session_scope, session_scope),
-                )
+                else:
+                    # Plain FIFO eviction (no protected ids).
+                    self.connection.execute(
+                        """
+                        DELETE FROM messages WHERE session_scope = ? AND id NOT IN (
+                            SELECT id FROM (
+                                SELECT id FROM messages WHERE session_scope = ? ORDER BY created_at DESC LIMIT ?
+                            )
+                        )
+                    """,
+                        (session_scope, session_scope, window),
+                    )
                 self.connection.execute("COMMIT")
             except Exception as e:
                 self.connection.execute("ROLLBACK")
@@ -332,6 +388,113 @@ class SQLiteManager:
                 self.connection.execute("BEGIN")
                 self.connection.execute("DROP TABLE IF EXISTS history")
                 self.connection.execute("DROP TABLE IF EXISTS messages")
+                self.connection.execute("COMMIT")
+            except Exception as e:
+                self.connection.execute("ROLLBACK")
+                logger.error(f"Failed to reset tables: {e}")
+                raise
+
+    def close(self) -> None:
+        if self.connection:
+            self.connection.close()
+            self.connection = None
+
+    def __del__(self):
+        self.close()
+    # ── Relevance-based cache refresh helpers ──────────────────────────────
+
+    def get_all_messages(self, session_scope: str) -> List[Dict[str, Any]]:
+        """Return ALL buffered messages for a scope, newest first, with ids."""
+        with self._lock:
+            cur = self.connection.execute(
+                "SELECT id, role, content, name, created_at FROM messages WHERE session_scope = ? ORDER BY created_at DESC",
+                (session_scope,),
+            )
+            rows = cur.fetchall()
+        return [
+            {"id": r[0], "role": r[1], "content": r[2], "name": r[3], "created_at": r[4]}
+            for r in rows
+        ]
+
+    def delete_messages_except(self, session_scope: str, keep_ids: set) -> int:
+        """Delete messages in a scope whose id is NOT in keep_ids. Returns count deleted.
+
+        An empty keep_ids set means the LLM judged everything irrelevant, so the
+        entire buffer for the scope is cleared (except nothing is kept)."""
+        with self._lock:
+            try:
+                self.connection.execute("BEGIN")
+                if not keep_ids:
+                    cur = self.connection.execute(
+                        "DELETE FROM messages WHERE session_scope = ?", (session_scope,)
+                    )
+                else:
+                    placeholders = ",".join("?" for _ in keep_ids)
+                    cur = self.connection.execute(
+                        f"DELETE FROM messages WHERE session_scope = ? AND id NOT IN ({placeholders})",
+                        (session_scope, *keep_ids),
+                    )
+                deleted = cur.rowcount
+                self.connection.execute("COMMIT")
+                return deleted
+            except Exception as e:
+                self.connection.execute("ROLLBACK")
+                logger.error(f"Failed to delete messages except keep_ids: {e}")
+                raise
+
+    def increment_message_count(self, session_scope: str, delta: int = 1, refresh_interval: int = 0) -> bool:
+            """Increment per-scope saved-message counter. Returns True when interval reached."""
+            if refresh_interval <= 0:
+                return False
+            with self._lock:
+                try:
+                    self.connection.execute("BEGIN")
+                    self.connection.execute(
+                        "INSERT INTO message_seq (session_scope, saved_count) VALUES (?, ?) "
+                        "ON CONFLICT(session_scope) DO UPDATE SET saved_count = saved_count + ?",
+                        (session_scope, delta, delta),
+                    )
+                    cur = self.connection.execute(
+                        "SELECT saved_count FROM message_seq WHERE session_scope = ?", (session_scope,)
+                    )
+                    count = cur.fetchone()[0]
+                    if count >= refresh_interval:
+                        # Reset counter
+                        self.connection.execute(
+                            "UPDATE message_seq SET saved_count = 0 WHERE session_scope = ?", (session_scope,)
+                        )
+                        self.connection.execute("COMMIT")
+                        return True
+                    self.connection.execute("COMMIT")
+                    return False
+                except Exception as e:
+                    self.connection.execute("ROLLBACK")
+                    logger.error(f"Failed to increment message count: {e}")
+                    raise
+
+    def reset_message_count(self, session_scope: str) -> None:
+        with self._lock:
+            try:
+                self.connection.execute("BEGIN")
+                self.connection.execute(
+                    "UPDATE message_seq SET saved_count = 0 WHERE session_scope = ?", (session_scope,)
+                )
+                self.connection.execute("COMMIT")
+            except Exception as e:
+                self.connection.execute("ROLLBACK")
+                logger.error(f"Failed to reset message count: {e}")
+                raise
+
+    def reset(self) -> None:
+        """Drop both tables. Caller is expected to replace this instance."""
+        if not self.connection:
+            raise RuntimeError("Cannot reset a closed SQLiteManager")
+        with self._lock:
+            try:
+                self.connection.execute("BEGIN")
+                self.connection.execute("DROP TABLE IF EXISTS history")
+                self.connection.execute("DROP TABLE IF EXISTS messages")
+                self.connection.execute("DROP TABLE IF EXISTS message_seq")
                 self.connection.execute("COMMIT")
             except Exception as e:
                 self.connection.execute("ROLLBACK")

--- a/tests/test_pr_buffer_gate.py
+++ b/tests/test_pr_buffer_gate.py
@@ -1,0 +1,106 @@
+"""Regression tests for the relevance-based buffer gate (PR version).
+
+Verifies:
+1. Gate fires exactly on schedule (counter not clobbered by finally).
+2. keep_ids passed to save_messages protect retained buffered messages
+   from the FIFO trim (gate's KEEP decision is not undone).
+3. LLM failure falls back without blocking message writes.
+"""
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from mem0.memory.storage import SQLiteManager
+from mem0.memory.main import Memory
+
+
+class FakeLLM:
+    def __init__(self):
+        self.calls = 0
+        self.fail = False
+
+    def generate_response(self, messages, response_format=None):
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("simulated LLM failure")
+        prompt = messages[-1]["content"]
+        cur_text = re.search(r"## Current Conversation Messages[^#]*", prompt).group(0)
+        buf_text = re.search(r"## Buffered Messages[^#]*", prompt).group(0)
+        cur_items = re.findall(r"\[(\d+)\] (user|assistant): (.*)", cur_text)
+        buf_items = re.findall(r"\[(\d+)\] (user|assistant): (.*)", buf_text)
+        admit = [int(i) for i, _, c in cur_items
+                 if any(k in c for k in ("代理池", "窗口", "熔断器", "面板", "字体", "排障", "打野池"))]
+        keep = [int(i) for i, _, c in buf_items
+                if any(k in c for k in ("代理池", "窗口", "熔断器", "面板", "字体", "排障", "打野池"))]
+        return json.dumps({"admit_indices": admit, "keep_indices": keep})
+
+
+class FakeConfig:
+    cache_refresh_interval = 5
+    cache_refresh_max_batch = 40
+
+
+def make_host(db, llm, interval=5):
+    host = object.__new__(Memory)
+    host.config = FakeConfig()
+    host.config.cache_refresh_interval = interval
+    host.db = db
+    host.llm = llm
+    return host
+
+
+def msg(content):
+    return {"role": "user", "content": content}
+
+
+def test_gate_fires_on_schedule():
+    db = SQLiteManager(":memory:")
+    llm = FakeLLM()
+    host = make_host(db, llm, interval=5)
+    m = [msg("代理池监控面板重写了")]
+    for _ in range(4):
+        admitted, keep = host._buffer_gate("s", m)
+        db.save_messages(admitted, "s", keep_ids=keep)
+    assert llm.calls == 0, f"4 batches should not fire LLM, calls={llm.calls}"
+    admitted, keep = host._buffer_gate("s", m)
+    db.save_messages(admitted, "s", keep_ids=keep)
+    assert llm.calls == 1, f"5th batch must fire LLM, calls={llm.calls}"
+    for _ in range(4):
+        admitted, keep = host._buffer_gate("s", m)
+        db.save_messages(admitted, "s", keep_ids=keep)
+    assert llm.calls == 1, f"post-fire batches must not refire, calls={llm.calls}"
+    print("✅ gate 按 interval 精确触发, 计数器不被 finally 误重置")
+
+
+def test_keep_ids_protected_from_fifo():
+    db = SQLiteManager(":memory:")
+    protected = [msg("代理池状态"), msg("窗口自适应")]
+    db.save_messages(protected, "s")
+    prot_ids = {m["id"] for m in db.get_all_messages("s")}
+    db.save_messages([msg(f"新消息 {i}") for i in range(12)], "s", keep_ids=prot_ids)
+    remaining = db.get_all_messages("s")
+    contents = {m["content"] for m in remaining}
+    assert "代理池状态" in contents, "被保护的旧消息被 FIFO 误删"
+    print("✅ keep_ids 保护的消息不被 save_messages FIFO 裁剪")
+
+
+def test_llm_failure_fallback():
+    db = SQLiteManager(":memory:")
+    llm = FakeLLM()
+    host = make_host(db, llm, interval=1)
+    llm.fail = True
+    admitted, keep = host._buffer_gate("s", [msg("代理池状态如何")])
+    assert len(admitted) == 1, "LLM 失败不应阻塞消息写入"
+    db.save_messages(admitted, "s", keep_ids=keep)
+    assert len(db.get_all_messages("s")) == 1
+    print("✅ LLM 失败时消息照常写入")
+
+
+if __name__ == "__main__":
+    test_gate_fires_on_schedule()
+    test_keep_ids_protected_from_fifo()
+    test_llm_failure_fallback()
+    print("\n✅ PR-A 回归测试通过")


### PR DESCRIPTION
Closes #7195

## Problem

The message buffer uses pure time-FIFO eviction. Stale cross-session content stays in the buffer and pollutes the extraction context passed to the LLM — memories get extracted against irrelevant prior conversations.

## Solution

Every `cache_refresh_interval` messages, a single LLM call evaluates ADMIT (which new messages enter the buffer) and KEEP (which buffered messages stay relevant). Irrelevant buffered messages are evicted immediately.

## Configuration
- `cache_refresh_interval`: messages between gate fires (default 20, 0 disables)
- `cache_refresh_max_batch`: safety cap on prompt size (default 40)

## Implementation
- storage.py: `message_seq` counter, get/delete/increment/reset helpers, `keep_ids` param on `save_messages`
- prompts.py: `CACHE_REFRESH_PROMPT` + builder
- main.py: `_buffer_gate` wired into all 6 sync+async save sites; `_gate_fired` flag prevents premature counter reset

Falls back gracefully: LLM failure never blocks memory writes.