### PR TITLE
fix(memory): do not return failed fallback vector inserts as ADD

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -1054,12 +1054,17 @@ class Memory(MemoryBase):
                 payloads=all_payloads,
             )
         except Exception:
-            # Fallback: insert one by one
+            # Fallback: insert one by one. Drop records that still fail so they
+            # are not returned as ADD or passed to history/entity indexing.
+            failed_ids = set()
             for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
                 try:
                     self.vector_store.insert(vectors=[vec], ids=[mid], payloads=[pay])
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid}: {e}")
+                    failed_ids.add(mid)
+            if failed_ids:
+                records = [r for r in records if r[0] not in failed_ids]
 
         # Batch history
         history_records = [
@@ -2713,11 +2718,15 @@ class AsyncMemory(MemoryBase):
                 payloads=all_payloads,
             )
         except Exception:
+            failed_ids = set()
             for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
                 try:
                     await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
                 except Exception as e:
                     logger.error(f"Failed to insert memory {mid} (async): {e}")
+                    failed_ids.add(mid)
+            if failed_ids:
+                records = [r for r in records if r[0] not in failed_ids]
 
         # Batch history
         history_records = [

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -80,6 +80,42 @@ class TestAddToVectorStoreErrors:
         assert mock_memory.llm.generate_response.call_count == 1
         assert result == []  # Should return empty list when no memories processed
 
+    def test_failed_fallback_record_is_not_returned_or_indexed(self, mocker, mock_memory):
+        """If per-record fallback insert fails, do not report that memory as ADD."""
+        mock_memory.llm.generate_response.return_value = (
+            '{"memory": [{"text": "first memory"}, {"text": "second memory"}]}'
+        )
+        mock_memory.embedding_model = MagicMock()
+        mock_memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+        mock_memory.embedding_model.embed_batch.return_value = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        mock_memory._entity_store = MagicMock()
+        mock_memory.db.batch_add_history = MagicMock()
+
+        def fail_batch_and_second_record(*, vectors, ids, payloads):
+            if len(ids) > 1:
+                raise RuntimeError("batch insert failed")
+            if payloads[0]["data"] == "second memory":
+                raise RuntimeError("single insert failed")
+
+        mock_memory.vector_store.insert.side_effect = fail_batch_and_second_record
+        extract_entities = mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+        mocker.patch("mem0.memory.main.capture_event")
+
+        result = mock_memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "remember two facts"}],
+            metadata={},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+        assert len(result) == 1
+        assert result[0]["memory"] == "first memory"
+        history_ids = [h["memory_id"] for h in mock_memory.db.batch_add_history.call_args[0][0]]
+        assert result[0]["id"] in history_ids
+        assert len(history_ids) == 1
+        extract_entities.assert_called_once()
+        assert extract_entities.call_args[0][0] == ["first memory"]
+
     def test_llm_extraction_exception_is_reraised(self, mocker, mock_memory):
         """A provider error during fact extraction must propagate, not be swallowed.
 


### PR DESCRIPTION
## Summary
V3 `Memory.add()` retries vector inserts one-by-one after a batch failure, but a failed fallback row stayed in `records`. Callers then received an ADD event (and history/entity links) for a memory that was never persisted.

Drop failed IDs from `records` on both the sync and async paths.

Fixes #7201

## Test plan
- [x] `tests/memory/test_main.py::TestAddToVectorStoreErrors::test_failed_fallback_record_is_not_returned_or_indexed` — 1 passed


Made with [Cursor](https://cursor.com)