### PR TITLE
fix(memory): don't return failed fallback inserts as successful memories (V3 add)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -23,6 +23,7 @@ from mem0.configs.prompts import (
     generate_additive_extraction_prompt,
 )
 from mem0.exceptions import LLMError
+from mem0.exceptions import VectorStoreError
 from mem0.exceptions import ValidationError as Mem0ValidationError
 from mem0.memory.base import MemoryBase
 from mem0.memory.notices import (
@@ -1053,13 +1054,30 @@ class Memory(MemoryBase):
                 ids=all_ids,
                 payloads=all_payloads,
             )
+            persisted_records = records
         except Exception:
-            # Fallback: insert one by one
-            for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
+            # Fallback: insert one by one, keeping only the records that
+            # actually persist. A record whose individual insert fails must
+            # not be reported as an ADD or indexed (history/entities), or
+            # callers would hold an ID that the vector store never stored.
+            persisted_records = []
+            last_insert_error = None
+            for record in records:
+                mid, vec, pay = record[0], record[2], record[3]
                 try:
                     self.vector_store.insert(vectors=[vec], ids=[mid], payloads=[pay])
+                    persisted_records.append(record)
                 except Exception as e:
+                    last_insert_error = e
                     logger.error(f"Failed to insert memory {mid}: {e}")
+            if not persisted_records:
+                raise VectorStoreError(
+                    message="All vector store inserts failed; no memories were persisted",
+                    error_code="VECTOR_002",
+                    details={"attempted_ids": all_ids},
+                    suggestion="Check the vector store connection and capacity, then retry",
+                ) from last_insert_error
+        records = persisted_records
 
         # Batch history
         history_records = [
@@ -2712,12 +2730,30 @@ class AsyncMemory(MemoryBase):
                 ids=all_ids,
                 payloads=all_payloads,
             )
+            persisted_records = records
         except Exception:
-            for mid, vec, pay in zip(all_ids, all_vectors, all_payloads):
+            # Fallback: insert one by one, keeping only the records that
+            # actually persist. A record whose individual insert fails must
+            # not be reported as an ADD or indexed (history/entities), or
+            # callers would hold an ID that the vector store never stored.
+            persisted_records = []
+            last_insert_error = None
+            for record in records:
+                mid, vec, pay = record[0], record[2], record[3]
                 try:
                     await asyncio.to_thread(self.vector_store.insert, vectors=[vec], ids=[mid], payloads=[pay])
+                    persisted_records.append(record)
                 except Exception as e:
+                    last_insert_error = e
                     logger.error(f"Failed to insert memory {mid} (async): {e}")
+            if not persisted_records:
+                raise VectorStoreError(
+                    message="All vector store inserts failed; no memories were persisted",
+                    error_code="VECTOR_002",
+                    details={"attempted_ids": all_ids},
+                    suggestion="Check the vector store connection and capacity, then retry",
+                ) from last_insert_error
+        records = persisted_records
 
         # Batch history
         history_records = [

--- a/tests/memory/test_vector_fallback_repro.py
+++ b/tests/memory/test_vector_fallback_repro.py
@@ -1,0 +1,112 @@
+"""Regression tests for #7201: V3 add() returns failed fallback vector
+inserts as successful memories, and passes them to history/entity indexing."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from mem0.exceptions import VectorStoreError
+from mem0.memory.main import Memory, AsyncMemory
+
+
+def _build_memory(mocker, cls=Memory):
+    """Wire a Memory/AsyncMemory with mocked LLM/embeddings/vector store; the
+    vector store fails the batch insert and the second individual fallback
+    insert. AsyncMemory routes its sync calls through asyncio.to_thread, so
+    the same MagicMock wiring works for both classes."""
+    memory = cls.__new__(cls)
+    memory.api_version = "v1.1"
+    memory.custom_instructions = None
+    memory.db = MagicMock()
+    memory.db.get_last_messages.return_value = []
+    memory.embedding_model = MagicMock()
+    memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+    memory.embedding_model.embed_batch.return_value = [
+        [0.1, 0.2, 0.3],
+        [0.4, 0.5, 0.6],
+    ]
+    memory.llm = MagicMock()
+    memory.llm.generate_response.return_value = '{"memory": [{"text": "first memory"}, {"text": "second memory"}]}'
+    memory.vector_store = MagicMock()
+    memory._entity_store = MagicMock()
+
+    def fail_batch_and_second_record(*, vectors, ids, payloads):
+        if len(ids) > 1:
+            raise RuntimeError("batch insert failed")
+        if payloads[0]["data"] == "second memory":
+            raise RuntimeError("single insert failed")
+
+    memory.vector_store.insert.side_effect = fail_batch_and_second_record
+    extract_entities = mocker.patch(
+        "mem0.memory.main.extract_entities_batch",
+        return_value=[[]],
+    )
+    mocker.patch("mem0.memory.main.capture_event")
+    return memory, extract_entities
+
+
+def test_failed_fallback_record_is_not_returned_or_indexed(mocker):
+    memory, extract_entities = _build_memory(mocker)
+
+    result = memory._add_to_vector_store(
+        messages=[{"role": "user", "content": "remember two facts"}],
+        metadata={},
+        filters={"user_id": "u1"},
+        infer=True,
+    )
+
+    assert [item["memory"] for item in result] == ["first memory"]
+    history_records = memory.db.batch_add_history.call_args.args[0]
+    assert [record["new_memory"] for record in history_records] == ["first memory"]
+    extract_entities.assert_called_once_with(["first memory"])
+
+
+def test_failed_fallback_record_is_not_indexed_async(mocker):
+    """The async path (AsyncMemory) has the identical bug; it must be fixed
+    in lockstep."""
+    memory, _ = _build_memory(mocker, cls=AsyncMemory)
+
+    result = asyncio.run(
+        memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "remember two facts"}],
+            metadata={},
+            effective_filters={"user_id": "u1"},
+            infer=True,
+        )
+    )
+
+    assert [item["memory"] for item in result] == ["first memory"]
+    history_records = memory.db.batch_add_history.call_args.args[0]
+    assert [record["new_memory"] for record in history_records] == ["first memory"]
+
+
+def test_all_fallback_inserts_failing_raises(mocker):
+    """If no fallback insert succeeds, the write must raise an explicit
+    vector-store error instead of reporting success with zero memories."""
+    memory = Memory.__new__(Memory)
+    memory.api_version = "v1.1"
+    memory.custom_instructions = None
+    memory.db = MagicMock()
+    memory.db.get_last_messages.return_value = []
+    memory.embedding_model = MagicMock()
+    memory.embedding_model.embed.return_value = [0.1, 0.2, 0.3]
+    memory.embedding_model.embed_batch.return_value = [[0.1, 0.2, 0.3]]
+    memory.llm = MagicMock()
+    memory.llm.generate_response.return_value = '{"memory": [{"text": "one memory"}]}'
+    memory.vector_store = MagicMock()
+    memory.vector_store.insert.side_effect = RuntimeError("vector store down")
+    memory._entity_store = MagicMock()
+    mocker.patch("mem0.memory.main.extract_entities_batch", return_value=[[]])
+    mocker.patch("mem0.memory.main.capture_event")
+
+    with pytest.raises(VectorStoreError) as exc_info:
+        memory._add_to_vector_store(
+            messages=[{"role": "user", "content": "remember one fact"}],
+            metadata={},
+            filters={"user_id": "u1"},
+            infer=True,
+        )
+
+    assert "vector store" in str(exc_info.value).lower()
+    memory.db.batch_add_history.assert_not_called()


### PR DESCRIPTION
##  Bug / Issue Fix

Fixes #7201

In `Memory.add()` / `AsyncMemory.add()` (V3), when the batch `vector_store.insert()` in Phase 6 of `_add_to_vector_store` fails, the code falls back to inserting records one by one. The current fallback loop only logs each individual failure — the failed records stay in `records` and are:

1. returned to the caller as `ADD` results (callers hold IDs the vector store never stored),
2. passed to `db.batch_add_history()` as history entries,
3. passed to `extract_entities_batch()` for entity linking.

So a partially-failed write looks like a full success, and the history/entity indexes gain ghost references to memories that don't exist in the vector store.

## 📝 Description of Changes

- Sync `_add_to_vector_store` (`Memory`): the fallback loop now collects only the records whose individual insert succeeds into `persisted_records`; `records` is reassigned from it, so the return value, history batch, and entity indexing all see only persisted memories.
- Async `_add_to_vector_store` (`AsyncMemory`): same fix, applied in lockstep to the async path (which routes the same calls through `asyncio.to_thread`).
- If **no** fallback insert succeeds, raise `VectorStoreError` (`VECTOR_002`) with the attempted IDs and a retry suggestion, instead of returning an empty-but-"successful" result.
- Added `tests/memory/test_vector_fallback_repro.py` (3 tests): the failed record is excluded from the return value / history / entity indexing (sync + async), and total failure raises `VectorStoreError` with no history written.

## 🧪 Testing

```
$ python -m pytest tests/memory/test_vector_fallback_repro.py -v
3 passed

$ python -m pytest tests/memory/ -q
387 passed
```

Existing failures in the full test suite (missing optional deps: boto3, groq, litellm, ...) reproduce on a clean baseline and are unrelated to this change.