### PR TITLE
fix(vector-stores): surface Azure AI Search indexing failures

### DIFF
--- a/mem0/vector_stores/azure_ai_search.py
+++ b/mem0/vector_stores/azure_ai_search.py
@@ -169,6 +169,40 @@ class AzureAISearch(VectorStoreBase):
                 document[field] = payload[field]
         return document
 
+    def _validate_indexing_results(self, response, operation: str, default_id: str = None):
+        """Raise when Azure indexing reports a per-document failure.
+
+        Azure SDK returns ``IndexingResult`` objects with ``succeeded`` /
+        ``status_code`` attributes. Older code paths and some mocks yield dicts.
+        The previous ``not hasattr(doc, "status_code") and doc.get(...)`` check
+        short-circuited to False for real SDK objects, silently swallowing errors.
+        """
+        for doc in response:
+            if isinstance(doc, dict):
+                succeeded = doc.get("succeeded", doc.get("status"))
+                status_code = doc.get("status_code")
+                doc_id = doc.get("key", doc.get("id", default_id))
+                error_message = doc.get("error_message", doc.get("errorMessage"))
+            else:
+                succeeded = getattr(doc, "succeeded", None)
+                status_code = getattr(doc, "status_code", None)
+                doc_id = getattr(doc, "key", getattr(doc, "id", default_id))
+                error_message = getattr(doc, "error_message", getattr(doc, "errorMessage", None))
+
+            is_success = True
+            if succeeded is not None:
+                is_success = bool(succeeded)
+            elif status_code is not None:
+                is_success = status_code in (200, 201)
+
+            if not is_success:
+                msg = f"{operation} failed for document {doc_id}"
+                if error_message:
+                    msg += f": {error_message}"
+                else:
+                    msg += f": {doc}"
+                raise Exception(msg)
+
     # Note: Explicit "insert" calls may later be decoupled from memory management decisions.
     def insert(self, vectors, payloads=None, ids=None):
         """
@@ -184,9 +218,7 @@ class AzureAISearch(VectorStoreBase):
             self._generate_document(vector, payload, id) for id, vector, payload in zip(ids, vectors, payloads)
         ]
         response = self.search_client.upload_documents(documents)
-        for doc in response:
-            if not hasattr(doc, "status_code") and doc.get("status_code") != 201:
-                raise Exception(f"Insert failed for document {doc.get('id')}: {doc}")
+        self._validate_indexing_results(response, "Insert")
         return response
 
     def _sanitize_key(self, key: str) -> str:
@@ -289,9 +321,7 @@ class AzureAISearch(VectorStoreBase):
             vector_id (str): ID of the vector to delete.
         """
         response = self.search_client.delete_documents(documents=[{"id": vector_id}])
-        for doc in response:
-            if not hasattr(doc, "status_code") and doc.get("status_code") != 200:
-                raise Exception(f"Delete failed for document {vector_id}: {doc}")
+        self._validate_indexing_results(response, "Delete", default_id=vector_id)
         logger.info(f"Deleted document with ID '{vector_id}' from index '{self.index_name}'.")
         return response
 
@@ -313,9 +343,7 @@ class AzureAISearch(VectorStoreBase):
             for field in ["user_id", "run_id", "agent_id"]:
                 document[field] = payload.get(field)
         response = self.search_client.merge_or_upload_documents(documents=[document])
-        for doc in response:
-            if not hasattr(doc, "status_code") and doc.get("status_code") != 200:
-                raise Exception(f"Update failed for document {vector_id}: {doc}")
+        self._validate_indexing_results(response, "Update", default_id=vector_id)
         return response
 
     def get(self, vector_id) -> OutputData:

--- a/tests/vector_stores/test_azure_ai_search.py
+++ b/tests/vector_stores/test_azure_ai_search.py
@@ -535,6 +535,60 @@ def test_update_allows_empty_vector(azure_ai_search_instance):
     mock_search_client.merge_or_upload_documents.assert_called_once_with(documents=[{"id": "doc1", "vector": []}])
 
 
+def test_insert_with_indexing_result_object(azure_ai_search_instance):
+    """Test insert with IndexingResult-like objects for success and failure."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+
+    class MockIndexingResult:
+        def __init__(self, key, status_code, succeeded, error_message=None):
+            self.key = key
+            self.status_code = status_code
+            self.succeeded = succeeded
+            self.error_message = error_message
+
+    mock_search_client.upload_documents.return_value = [
+        MockIndexingResult(key="doc1", status_code=500, succeeded=False, error_message="Document upload failed")
+    ]
+
+    with pytest.raises(Exception) as exc_info:
+        instance.insert([[0.1, 0.2, 0.3]], [{"user_id": "user1"}], ["doc1"])
+
+    assert "Insert failed for document doc1: Document upload failed" in str(exc_info.value)
+
+    mock_search_client.upload_documents.return_value = [
+        MockIndexingResult(key="doc1", status_code=201, succeeded=True)
+    ]
+    response = instance.insert([[0.1, 0.2, 0.3]], [{"user_id": "user1"}], ["doc1"])
+    assert len(response) == 1
+    assert response[0].succeeded is True
+
+
+def test_update_and_delete_with_indexing_result_object(azure_ai_search_instance):
+    """Update/delete must raise on IndexingResult failures, not swallow them."""
+    instance, mock_search_client, _ = azure_ai_search_instance
+
+    class MockIndexingResult:
+        def __init__(self, key, status_code, succeeded, error_message=None):
+            self.key = key
+            self.status_code = status_code
+            self.succeeded = succeeded
+            self.error_message = error_message
+
+    mock_search_client.merge_or_upload_documents.return_value = [
+        MockIndexingResult(key="doc1", status_code=400, succeeded=False, error_message="merge failed")
+    ]
+    with pytest.raises(Exception) as exc_info:
+        instance.update("doc1", vector=[0.1, 0.2, 0.3])
+    assert "Update failed for document doc1: merge failed" in str(exc_info.value)
+
+    mock_search_client.delete_documents.return_value = [
+        MockIndexingResult(key="doc1", status_code=404, succeeded=False, error_message="not found")
+    ]
+    with pytest.raises(Exception) as exc_info:
+        instance.delete("doc1")
+    assert "Delete failed for document doc1: not found" in str(exc_info.value)
+
+
 # --- Tests for search method ---
 
 


### PR DESCRIPTION
## Linked Issue

Closes #7211

## Description

Azure SDK `IndexingResult` objects expose `status_code`, so the previous check:

```python
if not hasattr(doc, "status_code") and doc.get("status_code") != 201:
```

always short-circuited to `False` for real SDK objects and silently swallowed failed uploads/updates/deletes.

Add `_validate_indexing_results()` that handles both SDK objects (`succeeded` / `status_code` / `error_message`) and dicts, and use it from `insert`, `update`, and `delete`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## AI Assistance

- [x] AI-generated (an agent wrote most or all of this diff)

Tool: Cursor agent. I reviewed the validator logic against the issue repro and ran the focused Azure AI Search unit tests.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests

```bash
pytest tests/vector_stores/test_azure_ai_search.py::test_insert_with_indexing_result_object \
  tests/vector_stores/test_azure_ai_search.py::test_update_and_delete_with_indexing_result_object -q
```

2 passed.

Made with [Cursor](https://cursor.com)