### PR TITLE
fix(gcp): read service account JSON as UTF-8 when extracting project_id

### DIFF
--- a/mem0/utils/gcp_auth.py
+++ b/mem0/utils/gcp_auth.py
@@ -57,7 +57,7 @@ class GCPAuthenticator:
                 credentials_path, scopes=scopes
             )
             # Extract project_id from the file
-            with open(credentials_path, 'r') as f:
+            with open(credentials_path, 'r', encoding='utf-8') as f:
                 cred_data = json.load(f)
                 project_id = cred_data.get("project_id")
 
@@ -69,7 +69,7 @@ class GCPAuthenticator:
                     env_path, scopes=scopes
                 )
                 # Extract project_id from the file
-                with open(env_path, 'r') as f:
+                with open(env_path, 'r', encoding='utf-8') as f:
                     cred_data = json.load(f)
                     project_id = cred_data.get("project_id")
 

--- a/tests/utils/test_gcp_auth.py
+++ b/tests/utils/test_gcp_auth.py
@@ -1,0 +1,50 @@
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+pytest.importorskip("google.auth")
+
+from mem0.utils.gcp_auth import GCPAuthenticator
+
+# A project_id with non-ASCII characters; the file must be read as UTF-8 for it to survive.
+NON_ASCII_PROJECT_ID = "proyecto-niño"
+
+
+@pytest.fixture
+def credentials_file(tmp_path):
+    """Write a UTF-8 encoded service account JSON with a non-ASCII project_id."""
+    path = tmp_path / "service_account.json"
+    payload = {
+        "type": "service_account",
+        "project_id": NON_ASCII_PROJECT_ID,
+        "client_email": "svc@example.iam.gserviceaccount.com",
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    return str(path)
+
+
+def test_get_credentials_reads_credentials_path_as_utf8(credentials_file):
+    with patch(
+        "mem0.utils.gcp_auth.service_account.Credentials.from_service_account_file",
+        return_value=Mock(),
+    ) as mock_loader:
+        credentials, project_id = GCPAuthenticator.get_credentials(credentials_path=credentials_file)
+
+    mock_loader.assert_called_once_with(credentials_file, scopes=None)
+    assert credentials is mock_loader.return_value
+    assert project_id == NON_ASCII_PROJECT_ID
+
+
+def test_get_credentials_reads_env_credentials_as_utf8(credentials_file, monkeypatch):
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", credentials_file)
+
+    with patch(
+        "mem0.utils.gcp_auth.service_account.Credentials.from_service_account_file",
+        return_value=Mock(),
+    ) as mock_loader:
+        credentials, project_id = GCPAuthenticator.get_credentials()
+
+    mock_loader.assert_called_once_with(credentials_file, scopes=None)
+    assert credentials is mock_loader.return_value
+    assert project_id == NON_ASCII_PROJECT_ID


### PR DESCRIPTION
## Linked Issue

Closes #7209

## Description

`GCPAuthenticator.get_credentials()` re-reads the service account JSON file (both the `credentials_path` branch and the `GOOGLE_APPLICATION_CREDENTIALS` branch) to extract `project_id`, but opened the file without an explicit encoding. The read therefore depended on the platform default text encoding: on a non-UTF-8 locale (e.g. cp1252 on Windows), a `project_id` containing non-ASCII characters was mojibaked or raised `UnicodeDecodeError`, while the google-auth loader itself reads the same file as UTF-8.

This PR passes `encoding="utf-8"` to both `open()` calls in `mem0/utils/gcp_auth.py`, matching JSON/GCP credential file expectations, and adds regression tests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `tests/utils/test_gcp_auth.py` with regression tests for both the direct `credentials_path` path and the `GOOGLE_APPLICATION_CREDENTIALS` path, using a UTF-8 service account JSON whose `project_id` is `proyecto-niño`. Ran `python -m pytest tests/utils/test_gcp_auth.py -q` on Windows (locale preferred encoding cp1252): both tests fail without the fix (the `project_id` comes back mojibaked) and pass with it. `ruff check` passes on both changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
