### PR TITLE
fix(cli): read config json as utf-8

### DIFF
--- a/cli/python/src/mem0_cli/config.py
+++ b/cli/python/src/mem0_cli/config.py
@@ -90,7 +90,7 @@ def load_config() -> Mem0Config:
     config = Mem0Config()
 
     if CONFIG_FILE.exists():
-        with open(CONFIG_FILE) as f:
+        with open(CONFIG_FILE, encoding="utf-8") as f:
             data = json.load(f)
 
         config.version = data.get("version", CONFIG_VERSION)
@@ -174,7 +174,7 @@ def save_config(config: Mem0Config) -> None:
         },
     }
 
-    with open(CONFIG_FILE, "w") as f:
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 
     os.chmod(CONFIG_FILE, stat.S_IRUSR | stat.S_IWUSR)  # 0600

--- a/cli/python/tests/test_config.py
+++ b/cli/python/tests/test_config.py
@@ -59,6 +59,30 @@ class TestConfig:
         config = load_config()
         assert config.platform.api_key == ""
 
+    def test_load_config_reads_utf8_json(self, isolate_config):
+        import json
+
+        from mem0_cli.config import CONFIG_FILE, ensure_config_dir
+
+        ensure_config_dir()
+        CONFIG_FILE.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "platform": {
+                        "api_key": "m0-test",
+                        "base_url": "https://api.mem0.ai",
+                        "user_email": "用户@example.com",
+                    },
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        loaded = load_config()
+        assert loaded.platform.user_email == "用户@example.com"
+
     def test_config_file_permissions(self, isolate_config):
         config = Mem0Config()
         config.platform.api_key = "secret"


### PR DESCRIPTION
## Problem

Closes #7227.

The Python CLI reads and writes `~/.mem0/config.json` using the platform default text encoding. That is usually invisible on UTF-8 machines, but can make config loading locale-dependent on Windows or other non-UTF-8 environments when config values contain non-ASCII text.

## Before / after

Before:
- `load_config()` opened `config.json` without an explicit encoding
- `save_config()` wrote `config.json` without an explicit encoding

After:
- config reads and writes use `encoding="utf-8"`
- a focused regression test covers loading raw UTF-8 JSON containing non-ASCII text

## Verification

From `cli/python`:

```console
$env:PYTHONPATH='src'; uv run pytest tests/test_config.py
```

Result: `25 passed`.