### PR TITLE
fix(vector_stores/valkey): make search score metric-aware

### DIFF
--- a/mem0/configs/vector_stores/valkey.py
+++ b/mem0/configs/vector_stores/valkey.py
@@ -15,6 +15,10 @@ class ValkeyConfig(BaseModel):
     hnsw_ef_construction: int = Field(200, description="HNSW: search width during index construction")
     hnsw_ef_runtime: int = Field(10, description="HNSW: search width during queries")
     cluster_mode: bool = Field(False, description="Enable cluster mode for Valkey cluster (CME) deployments")
+    distance: str = Field(
+        "COSINE",
+        description="Distance metric for the vector index: COSINE, L2, or IP",
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/mem0/vector_stores/valkey.py
+++ b/mem0/vector_stores/valkey.py
@@ -66,6 +66,7 @@ class ValkeyDB(VectorStoreBase):
         hnsw_ef_construction: int = 200,
         hnsw_ef_runtime: int = 10,
         cluster_mode: bool = False,
+        distance: str = "COSINE",
     ):
         """
         Initialize the Valkey vector store.
@@ -80,6 +81,7 @@ class ValkeyDB(VectorStoreBase):
             hnsw_ef_construction (int, optional): HNSW ef_construction parameter. Defaults to 200.
             hnsw_ef_runtime (int, optional): HNSW ef_runtime parameter. Defaults to 10.
             cluster_mode (bool, optional): Enable cluster mode for Valkey cluster (CME) deployments. Defaults to False.
+            distance (str, optional): Distance metric for the vector index ('COSINE', 'L2', or 'IP'). Defaults to "COSINE".
         """
         self.embedding_model_dims = embedding_model_dims
         self.collection_name = collection_name
@@ -90,6 +92,7 @@ class ValkeyDB(VectorStoreBase):
         self.hnsw_ef_construction = hnsw_ef_construction
         self.hnsw_ef_runtime = hnsw_ef_runtime
         self.cluster_mode = cluster_mode
+        self.distance = (distance or "COSINE").upper()
 
         # Validate index type
         if self.index_type not in ["hnsw", "flat"]:
@@ -231,7 +234,7 @@ class ValkeyDB(VectorStoreBase):
         cmd = self._build_index_schema(
             self.collection_name,
             embedding_model_dims,
-            "COSINE",  # Fixed distance metric for initialization
+            self.distance,
             self.prefix,
         )
 
@@ -257,7 +260,7 @@ class ValkeyDB(VectorStoreBase):
         # Use provided parameters or fall back to instance attributes
         collection_name = name or self.collection_name
         embedding_dims = vector_size or self.embedding_model_dims
-        distance_metric = distance or "COSINE"
+        distance_metric = (distance or self.distance or "COSINE").upper()
         prefix = f"mem0:{collection_name}"
 
         # Try to drop the index if it exists (cleanup before creation)
@@ -279,6 +282,7 @@ class ValkeyDB(VectorStoreBase):
             if name:
                 self.collection_name = collection_name
                 self.prefix = prefix
+            self.distance = distance_metric
 
             return self.client.ft(collection_name)
         except Exception as e:
@@ -389,6 +393,25 @@ class ValkeyDB(VectorStoreBase):
             logger.error(f"Search failed with query '{query}': {e}")
             raise
 
+    def _distance_to_score(self, raw_distance):
+        """Convert Valkey/Redis vector distance into a similarity-style score.
+
+        Mirrors the metric-aware conversion used by S3 Vectors (#6547):
+        - COSINE: distance in [0, 2] -> ``max(0, 1 - distance)``
+        - L2: unbounded Euclidean distance -> ``1 / (1 + distance)``
+        - IP: Redis/Valkey KNN already exposes ``1 / (1 + inner_product)``
+          (lower is closer), so ``1 - distance`` recovers similarity
+        """
+        if raw_distance is None:
+            return None
+        metric = (self.distance or "COSINE").upper()
+        distance = float(raw_distance)
+        # Euclidean / L2 distance is unbounded, so 1 - distance collapses
+        # almost every hit with distance > 1 to 0.
+        if metric in ("L2", "EUCLIDEAN"):
+            return 1.0 / (1.0 + distance)
+        return max(0.0, 1.0 - distance)
+
     def _process_search_results(self, results):
         """
         Process search results into OutputData objects.
@@ -402,7 +425,7 @@ class ValkeyDB(VectorStoreBase):
         memory_results = []
         for doc in results.docs:
             raw_distance = float(doc.vector_score) if hasattr(doc, "vector_score") else None
-            score = max(0.0, 1.0 - raw_distance) if raw_distance is not None else None
+            score = self._distance_to_score(raw_distance)
 
             # Create the payload
             payload = {

--- a/tests/vector_stores/test_valkey.py
+++ b/tests/vector_stores/test_valkey.py
@@ -1066,3 +1066,76 @@ def test_escape_tag_value_normal_strings(valkey_db):
 def test_escape_tag_value_hyphenated_user_id(valkey_db):
     """Hyphenated user IDs must have the hyphen escaped for exact-match."""
     assert valkey_db._escape_tag_value("user-123") == r"user\-123"
+
+def test_search_score_cosine_uses_one_minus_distance(valkey_db, mock_valkey_client):
+    """Cosine metric keeps the 1 - distance similarity mapping."""
+    mock_doc = MagicMock()
+    mock_doc.memory_id = "id1"
+    mock_doc.hash = "h1"
+    mock_doc.memory = "near"
+    mock_doc.created_at = str(int(datetime.now().timestamp()))
+    mock_doc.metadata = json.dumps({})
+    mock_doc.vector_score = "0.25"
+
+    mock_results = MagicMock()
+    mock_results.docs = [mock_doc]
+    mock_valkey_client.ft.return_value.search.return_value = mock_results
+
+    valkey_db.distance = "COSINE"
+    results = valkey_db.search(query="test", vectors=np.random.rand(1536).tolist(), top_k=1)
+
+    assert results[0].score == pytest.approx(0.75)
+
+
+def test_search_score_l2_uses_bounded_map(valkey_db, mock_valkey_client):
+    """L2 distance is unbounded; scores must not collapse to 0."""
+    near = MagicMock()
+    near.memory_id = "near"
+    near.hash = "h1"
+    near.memory = "near"
+    near.created_at = str(int(datetime.now().timestamp()))
+    near.metadata = json.dumps({})
+    near.vector_score = "0.5"
+
+    far = MagicMock()
+    far.memory_id = "far"
+    far.hash = "h2"
+    far.memory = "far"
+    far.created_at = str(int(datetime.now().timestamp()))
+    far.metadata = json.dumps({})
+    far.vector_score = "4.0"
+
+    mock_results = MagicMock()
+    mock_results.docs = [near, far]
+    mock_valkey_client.ft.return_value.search.return_value = mock_results
+
+    valkey_db.distance = "L2"
+    results = valkey_db.search(query="test", vectors=np.random.rand(1536).tolist(), top_k=2)
+
+    # 1 / (1 + d): a distance > 1 would give a negative (clamped 0) score under
+    # the old cosine-only formula; the bounded map keeps ranking intact.
+    assert results[0].score == pytest.approx(1.0 / 1.5)
+    assert results[1].score == pytest.approx(1.0 / 5.0)
+    assert results[0].score > results[1].score > 0.0
+
+
+def test_create_col_persists_distance_for_scoring(valkey_db, mock_valkey_client):
+    """create_col(distance=...) must update scoring, not only FT.CREATE."""
+    valkey_db.create_col(name="l2_collection", vector_size=768, distance="L2")
+    assert valkey_db.distance == "L2"
+
+    mock_doc = MagicMock()
+    mock_doc.memory_id = "id1"
+    mock_doc.hash = "h1"
+    mock_doc.memory = "x"
+    mock_doc.created_at = str(int(datetime.now().timestamp()))
+    mock_doc.metadata = json.dumps({})
+    mock_doc.vector_score = "4.0"
+
+    mock_results = MagicMock()
+    mock_results.docs = [mock_doc]
+    mock_valkey_client.ft.return_value.search.return_value = mock_results
+
+    results = valkey_db.search(query="test", vectors=np.random.rand(768).tolist(), top_k=1)
+    assert results[0].score == pytest.approx(1.0 / 5.0)
+


### PR DESCRIPTION
## Linked Issue

Closes #7229

## Description

Sibling of #6546 / #6547 for the **Valkey** store.

Search scoring hardcoded `max(0.0, 1.0 - raw_distance)`, which is only correct for cosine. With L2 (already accepted by `create_col(distance=...)`), unbounded distances collapse almost every hit with `d > 1` to `0.0`.

This PR:

- Adds `distance` to `ValkeyConfig` / `ValkeyDB` (default `COSINE`)
- Uses `self.distance` in `_create_index` (was hardcoded `COSINE`)
- Persists `create_col(..., distance=...)` onto `self.distance` for scoring
- Adds `_distance_to_score` mirroring #6547:
  - COSINE / IP → `max(0, 1 - d)`
  - L2 → `1 / (1 + d)`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Breaking Changes

N/A. Cosine (the default) is unchanged; only L2 scoring is corrected, and index init now respects the configured metric.

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added regression tests in `tests/vector_stores/test_valkey.py`:
- cosine keeps `1 - d`
- L2 uses the bounded map and does not collapse `d=4.0` to `0`
- `create_col(distance="L2")` updates scoring, not only `FT.CREATE`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed
