### PR TITLE
fix(memory): run entity-index cleanup in processes that never wrote entities

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -657,16 +657,19 @@ class Memory(MemoryBase):
           - otherwise re-embed the entity text and update the payload
             (the vector store's update() requires a vector).
 
-        No-op if the entity store has never been initialized in this process.
+        The entity store is resolved through the lazy `entity_store` property,
+        matching the write path, so cleanup also runs in processes that have
+        not written entities themselves (worker pools, cleanup jobs); a store
+        that cannot be initialized degrades to a warning instead of skipping
+        the cleanup silently.
         Errors on individual entities are swallowed at debug level; outer
         failures are swallowed at warning level so the primary delete/update
         path is never broken by entity cleanup.
         """
-        if self._entity_store is None:
-            return
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         try:
-            listed = self.entity_store.list(filters=search_filters, top_k=10000)
+            entity_store = self.entity_store
+            listed = entity_store.list(filters=search_filters, top_k=10000)
             rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
             for row in rows or []:
                 try:
@@ -677,7 +680,7 @@ class Memory(MemoryBase):
                     remaining = [mid for mid in linked if mid != memory_id]
                     if not remaining:
                         try:
-                            self.entity_store.delete(vector_id=row.id)
+                            entity_store.delete(vector_id=row.id)
                         except Exception as e:
                             logger.debug(f"Entity delete failed for id={row.id}: {e}")
                     else:
@@ -692,7 +695,7 @@ class Memory(MemoryBase):
                             continue
                         new_payload = {**payload, "linked_memory_ids": remaining}
                         try:
-                            self.entity_store.update(
+                            entity_store.update(
                                 vector_id=row.id,
                                 vector=vec,
                                 payload=new_payload,
@@ -2338,12 +2341,17 @@ class AsyncMemory(MemoryBase):
             logger.warning(f"Bulk entity store cleanup failed: {e}")
 
     async def _remove_memory_from_entity_store(self, memory_id, filters):
-        """Async variant of `Memory._remove_memory_from_entity_store`."""
-        if self._entity_store is None:
-            return
+        """Async variant of `Memory._remove_memory_from_entity_store`.
+
+        Like the sync variant, resolves the store through the lazy
+        `entity_store` property so cleanup also runs in processes that have not
+        written entities themselves; an uninitialized store no longer skips
+        the cleanup silently.
+        """
         search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
         try:
-            listed = await asyncio.to_thread(self.entity_store.list, filters=search_filters, top_k=10000)
+            entity_store = self.entity_store
+            listed = await asyncio.to_thread(entity_store.list, filters=search_filters, top_k=10000)
             rows = listed[0] if isinstance(listed, (list, tuple)) and listed and isinstance(listed[0], list) else listed
             for row in rows or []:
                 try:
@@ -2354,7 +2362,7 @@ class AsyncMemory(MemoryBase):
                     remaining = [mid for mid in linked if mid != memory_id]
                     if not remaining:
                         try:
-                            await asyncio.to_thread(self.entity_store.delete, vector_id=row.id)
+                            await asyncio.to_thread(entity_store.delete, vector_id=row.id)
                         except Exception as e:
                             logger.debug(f"Entity delete failed for id={row.id} (async): {e}")
                     else:
@@ -2370,7 +2378,7 @@ class AsyncMemory(MemoryBase):
                         new_payload = {**payload, "linked_memory_ids": remaining}
                         try:
                             await asyncio.to_thread(
-                                self.entity_store.update,
+                                entity_store.update,
                                 vector_id=row.id,
                                 vector=vec,
                                 payload=new_payload,

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -2,7 +2,7 @@ import logging
 import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 import pytest
 
@@ -1177,4 +1177,85 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         )
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
+        )
+
+
+class TestEntityStoreCleanupOnFreshProcess:
+    """Regression (issue #7226): entity cleanup must also run in processes that
+    never wrote entities themselves. The delete paths resolve the store through
+    the lazy `entity_store` property (like the write path) instead of skipping
+    when the private `_entity_store` attribute is still unset."""
+
+    @staticmethod
+    def _fake_store():
+        store = MagicMock()
+        row = SimpleNamespace(id="e1", payload={"data": "Paris", "linked_memory_ids": ["mem-1"]})
+        store.list.return_value = [row]
+        return store
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = Memory()
+        memory._entity_store = None
+        return memory
+
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        _setup_mocks(mocker)
+        memory = AsyncMemory()
+        memory._entity_store = None
+        return memory
+
+    def test_sync_cleanup_runs_in_fresh_process(self, mock_memory, mocker):
+        store = self._fake_store()
+        mocker.patch.object(Memory, "entity_store", new_callable=PropertyMock, return_value=store)
+
+        mock_memory._remove_memory_from_entity_store("mem-1", {"user_id": "alice"})
+
+        store.list.assert_called_once()
+        store.delete.assert_called_once_with(vector_id="e1")
+
+    @pytest.mark.asyncio
+    async def test_async_cleanup_runs_in_fresh_process(self, mock_async_memory, mocker):
+        store = self._fake_store()
+        mocker.patch.object(AsyncMemory, "entity_store", new_callable=PropertyMock, return_value=store)
+
+        await mock_async_memory._remove_memory_from_entity_store("mem-1", {"user_id": "alice"})
+
+        store.list.assert_called_once()
+        store.delete.assert_called_once_with(vector_id="e1")
+
+    def test_cleanup_still_uses_already_initialized_store(self, mock_memory):
+        store = self._fake_store()
+        mock_memory._entity_store = store
+
+        mock_memory._remove_memory_from_entity_store("mem-1", {"user_id": "alice"})
+
+        store.list.assert_called_once()
+        store.delete.assert_called_once_with(vector_id="e1")
+
+    def test_sync_cleanup_survives_store_initialization_failure(self, mock_memory, mocker, caplog):
+        mocker.patch.object(
+            Memory, "entity_store", new_callable=PropertyMock, side_effect=RuntimeError("store down")
+        )
+
+        with caplog.at_level(logging.WARNING):
+            mock_memory._remove_memory_from_entity_store("mem-1", {"user_id": "alice"})
+
+        assert any("Entity store cleanup failed" in r.message for r in caplog.records), (
+            "expected store-initialization failure to degrade to a warning"
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_cleanup_survives_store_initialization_failure(self, mock_async_memory, mocker, caplog):
+        mocker.patch.object(
+            AsyncMemory, "entity_store", new_callable=PropertyMock, side_effect=RuntimeError("store down")
+        )
+
+        with caplog.at_level(logging.WARNING):
+            await mock_async_memory._remove_memory_from_entity_store("mem-1", {"user_id": "alice"})
+
+        assert any("Entity store cleanup failed" in r.message for r in caplog.records), (
+            "expected store-initialization failure to degrade to a warning"
         )


### PR DESCRIPTION
Fixes #7226

## Problem

`Memory._remove_memory_from_entity_store` and its async variant early-returned when the private `_entity_store` attribute was still unset. The write path reaches the store through the lazy `entity_store` property (which creates it from config on first use), but the delete paths read the private attribute directly — so any process that has only ever deleted (worker pools, scheduled cleanup, GDPR erasure scripts, a restarted server deleting before its first write) silently skipped entity cleanup.

Consequences (from the issue): stale `linked_memory_ids` survive forever, the entity record is never deleted even when its link list should empty out, and the entity boost weight degrades quadratically as stale links accumulate (`1 / (1 + 0.001 * (num_linked - 1)^2)` — −91% boost at 100 stale links).

## Fix

Both delete paths now resolve the store through the same lazy `entity_store` property used by the write path (same pattern already used by `_compute_entity_boosts`). A store that cannot be initialized degrades to the method's existing warning-level contract (`Entity store cleanup failed ...`) instead of silently skipping, so the primary delete/update path is never broken by entity cleanup.

Docstrings updated accordingly (`No-op if the entity store has never been initialized in this process` is no longer true).

## Tests

`tests/memory/test_main.py::TestEntityStoreCleanupOnFreshProcess` (5 cases):

- sync + async cleanup runs on a fresh process (`_entity_store` unset) — both **fail on main, pass with this fix**;
- the already-initialized path is unchanged;
- sync + async initialization failures degrade to a warning without raising.

All 57 tests in `tests/memory/test_main.py` pass; `ruff check` clean on both changed files. (I did not run `ruff format`: the file carries pre-existing formatter drift on `main` and reformatting would drown this diff.)

## Scope note

`_bulk_clear_entity_store` (the `delete_all` path) has the same per-process guard, but its callers additionally gate on `self._entity_store is not None`, so fixing it properly also touches `delete_all` semantics. I left it out of this focused fix — happy to follow up if maintainers want it.