### PR TITLE
fix(vector_stores): metric-aware score conversion for Vertex AI Vector Search

### DIFF
--- a/mem0/configs/vector_stores/vertex_ai_vector_search.py
+++ b/mem0/configs/vector_stores/vertex_ai_vector_search.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class GoogleMatchingEngineConfig(BaseModel):
@@ -14,8 +14,42 @@ class GoogleMatchingEngineConfig(BaseModel):
     credentials_path: Optional[str] = Field(None, description="Path to service account credentials JSON file")
     service_account_json: Optional[Dict] = Field(None, description="Service account credentials as dictionary (alternative to credentials_path)")
     vector_search_api_endpoint: Optional[str] = Field(None, description="Vector search API endpoint")
+    distance_metric: str = Field(
+        "cosine",
+        description=(
+            "Distance measure of the deployed Vertex AI index: 'cosine' (default), "
+            "'dot_product' (aliases: 'dot_product_point', 'inner_product', 'ip'), or "
+            "'squared_l2' (aliases: 'squared_l2_distance', 'euclidean', 'l2'). "
+            "mem0 cannot infer this from the deployed index, so set it to match."
+        ),
+    )
 
     model_config = ConfigDict(extra="forbid")
+
+    @field_validator("distance_metric")
+    @classmethod
+    def _normalize_distance_metric(cls, value: str) -> str:
+        """Canonicalize common spellings of the Vertex AI distance measure types."""
+        aliases = {
+            "cosine": "cosine",
+            "dot_product": "dot_product",
+            "dotproduct": "dot_product",
+            "dot_product_point": "dot_product",
+            "inner_product": "dot_product",
+            "ip": "dot_product",
+            "euclidean": "squared_l2",
+            "l2": "squared_l2",
+            "squared_l2": "squared_l2",
+            "squared_l2_distance": "squared_l2",
+        }
+        normalized = aliases.get(value.strip().lower())
+        if normalized is None:
+            raise ValueError(
+                f"Invalid distance_metric '{value}'. Expected one of: "
+                f"'cosine', 'dot_product' (or 'dot_product_point', 'inner_product', 'ip'), "
+                f"'squared_l2' (or 'squared_l2_distance', 'euclidean', 'l2')."
+            )
+        return normalized
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/mem0/vector_stores/vertex_ai_vector_search.py
+++ b/mem0/vector_stores/vertex_ai_vector_search.py
@@ -60,6 +60,7 @@ class GoogleMatchingEngine(VectorStoreBase):
         self.deployment_index_id = config.deployment_index_id  # The deployment-specific ID
         self.collection_name = config.collection_name
         self.vector_search_api_endpoint = config.vector_search_api_endpoint
+        self.distance_metric = config.distance_metric
 
         logger.debug("Using project=%s, location=%s", self.project_id, self.region)
 
@@ -102,6 +103,23 @@ class GoogleMatchingEngine(VectorStoreBase):
             logger.error("Failed to initialize Matching Engine components: %s", str(e))
             raise ValueError(f"Invalid configuration: {str(e)}")
 
+    def _distance_to_similarity(self, raw_distance: Optional[float]) -> Optional[float]:
+        """Convert a Vertex AI raw distance into a similarity score.
+
+        Follows the conversion contract documented on ``VectorStoreBase.search``:
+
+        - cosine distance: ``max(0.0, 1.0 - distance)``
+        - squared L2 distance: ``1.0 / (1.0 + distance)`` (bounded, monotone)
+        - dot product: returned as-is (already higher-is-better)
+        """
+        if raw_distance is None:
+            return None
+        if self.distance_metric == "squared_l2":
+            return 1.0 / (1.0 + raw_distance)
+        if self.distance_metric == "dot_product":
+            return float(raw_distance)
+        return max(0.0, 1.0 - raw_distance)
+
     def _parse_output(self, data: Dict) -> List[OutputData]:
         """
         Parse the output data.
@@ -114,7 +132,7 @@ class GoogleMatchingEngine(VectorStoreBase):
         output_data = []
         for result in results:
             raw_distance = result.get("distance")
-            score = max(0.0, 1.0 - raw_distance) if raw_distance is not None else None
+            score = self._distance_to_similarity(raw_distance)
             output_data.append(
                 OutputData(
                     id=result.get("datapoint").get("datapointId"),
@@ -265,7 +283,7 @@ class GoogleMatchingEngine(VectorStoreBase):
                             logger.debug("Adding %s: %s", restrict.name, restrict.allow_tokens[0])
                             payload[restrict.name] = restrict.allow_tokens[0]
 
-                score = max(0.0, 1.0 - neighbor.distance) if neighbor.distance is not None else None
+                score = self._distance_to_similarity(neighbor.distance)
                 output_data = OutputData(id=neighbor.id, score=score, payload=payload)
                 results.append(output_data)
 
@@ -415,7 +433,7 @@ class GoogleMatchingEngine(VectorStoreBase):
                                 if restrict.allow_list:
                                     payload[restrict.namespace] = restrict.allow_list[0]
 
-                        score = max(0.0, 1.0 - neighbor.distance) if neighbor.distance is not None else None
+                        score = self._distance_to_similarity(neighbor.distance)
                         return OutputData(id=neighbor.datapoint.datapoint_id, score=score, payload=payload)
 
                 logger.debug("No results found")

--- a/tests/vector_stores/test_vertex_ai_vector_search.py
+++ b/tests/vector_stores/test_vertex_ai_vector_search.py
@@ -165,3 +165,67 @@ def test_error_handling(vector_store, mock_vertex_ai):
 
     assert isinstance(exc_info.value, exceptions.InvalidArgument)
     assert "Invalid request" in str(exc_info.value)
+
+
+class TestDistanceMetric:
+    """Metric-aware distance-to-similarity conversion (issue #7232)."""
+
+    def _config(self, **overrides):
+        base = dict(
+            project_id="test-project",
+            project_number="123456789",
+            region="us-central1",
+            endpoint_id="test-endpoint",
+            index_id="test-index",
+            deployment_index_id="test-deployment",
+            collection_name="test-collection",
+            vector_search_api_endpoint="test.vertexai.goog",
+        )
+        base.update(overrides)
+        return GoogleMatchingEngineConfig(**base)
+
+    def _store(self, config, mock_vertex_ai):
+        mock_vertex_ai["index_class"].return_value = mock_vertex_ai["index"]
+        mock_vertex_ai["endpoint_class"].return_value = mock_vertex_ai["endpoint"]
+        return GoogleMatchingEngine(**config.model_dump())
+
+    def test_default_metric_is_cosine(self):
+        assert self._config().distance_metric == "cosine"
+
+    def test_metric_aliases_are_canonicalized(self):
+        assert self._config(distance_metric="SQUARED_L2_DISTANCE").distance_metric == "squared_l2"
+        assert self._config(distance_metric="dot_product_point").distance_metric == "dot_product"
+        assert self._config(distance_metric="euclidean").distance_metric == "squared_l2"
+
+    def test_invalid_metric_is_rejected(self):
+        with pytest.raises(Exception):
+            self._config(distance_metric="manhattan")
+
+    def test_metric_reaches_the_store(self, mock_vertex_ai):
+        store = self._store(self._config(distance_metric="squared_l2"), mock_vertex_ai)
+        assert store.distance_metric == "squared_l2"
+
+    def test_cosine_conversion_unchanged(self, mock_vertex_ai):
+        store = self._store(self._config(), mock_vertex_ai)
+        assert store._distance_to_similarity(0.2) == pytest.approx(0.8)
+        assert store._distance_to_similarity(2.0) == 0.0
+        assert store._distance_to_similarity(None) is None
+
+    def test_squared_l2_conversion_is_bounded(self, mock_vertex_ai):
+        store = self._store(self._config(distance_metric="squared_l2"), mock_vertex_ai)
+        assert store._distance_to_similarity(2.0) == pytest.approx(1.0 / 3.0)
+        assert 0.0 < store._distance_to_similarity(2.0) < 1.0
+
+    def test_dot_product_passes_through(self, mock_vertex_ai):
+        store = self._store(self._config(distance_metric="dot_product"), mock_vertex_ai)
+        assert store._distance_to_similarity(2.0) == pytest.approx(2.0)
+
+    def test_parse_output_respects_metric(self, mock_vertex_ai):
+        """Regression: _parse_output must not hardcode the cosine conversion."""
+        data = {"nearestNeighbors": {"neighbors": [{"datapoint": {"datapointId": "d1", "metadata": {}}, "distance": 2.0}]}}
+
+        cosine_store = self._store(self._config(), mock_vertex_ai)
+        assert cosine_store._parse_output(data)[0].score == 0.0
+
+        l2_store = self._store(self._config(distance_metric="squared_l2"), mock_vertex_ai)
+        assert l2_store._parse_output(data)[0].score == pytest.approx(1.0 / 3.0)


### PR DESCRIPTION
Fixes #7232

## Problem

`GoogleMatchingEngine` hardcoded the cosine-style score conversion (`max(0.0, 1.0 - raw_distance)`) in `_parse_output`, `search`, and `get`. Vertex Matching Engine indexes can be deployed with `DOT_PRODUCT_POINT` or `SQUARED_L2_DISTANCE` in addition to `COSINE`; with an L2-style index, unbounded distances make `1 - distance` collapse nearly every hit to `0.0`, destroying ranking and any score thresholds.

## Fix

- **`GoogleMatchingEngineConfig.distance_metric`** (default `cosine`) tells mem0 which measure the deployed index uses — mem0 cannot infer it from the index (matching the issue's observation that `create_col(..., distance=...)` is documented as ignored). A `field_validator` canonicalizes the Vertex spellings (`squared_l2_distance`, `dot_product_point`, `euclidean`, `l2`, `ip`, `inner_product`) and rejects unknown values, so typos fail at config time instead of silently degrading to cosine.
- **`_distance_to_similarity`** converts per the contract documented on `VectorStoreBase.search`: cosine `max(0, 1-d)`, squared L2 `1/(1+d)` (bounded, monotone), dot product passed through as already similarity-like.
- All three call sites (`_parse_output`, `search`, `get`) now use the converter.

## Tests

`tests/vector_stores/test_vertex_ai_vector_search.py::TestDistanceMetric` (8 cases): default metric, alias canonicalization, invalid-metric rejection, config-to-store propagation, the three conversions, and a `_parse_output` regression case (cosine vs squared-L2 on the same input). 7 of the 8 fail on `main` and all 15 tests in the file pass with this change; `ruff check` clean.

Mirrors the `distance_metric` knob pattern of #6547 (S3 Vectors).