### PR TITLE
fix(server): forward text instead of deprecated data alias in update …

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -491,7 +491,7 @@ def update_memory(memory_id: str, updated_memory: MemoryUpdate, _auth=Depends(ve
         fields_set = getattr(updated_memory, "model_fields_set", getattr(updated_memory, "__fields_set__", set()))
         params = {"memory_id": memory_id}
         if "text" in fields_set:
-            params["data"] = updated_memory.text
+            params["text"] = updated_memory.text
         if "metadata" in fields_set:
             params["metadata"] = updated_memory.metadata
         if "expiration_date" in fields_set:

--- a/tests/test_server_params.py
+++ b/tests/test_server_params.py
@@ -545,11 +545,20 @@ class TestUpdateMemory:
     """Verify that PUT /memories/{id} extracts text and metadata from the
     request body and forwards them correctly to Memory.update()."""
 
-    def test_text_forwarded_as_data(self, client, mock_memory):
+    def test_text_forwarded_as_text(self, client, mock_memory):
         resp = client.put("/memories/mem-1", json={"text": "Likes tennis"})
         assert resp.status_code == 200
         _, kwargs = mock_memory.update.call_args
-        assert kwargs["data"] == "Likes tennis"
+        assert kwargs["text"] == "Likes tennis"
+        assert "data" not in kwargs
+
+    def test_no_deprecation_warning_on_update(self, client, mock_memory, caplog):
+        """Regression guard for #7245: a server-driven update must not trigger
+        Memory.update()'s deprecated `data` alias warning."""
+        with caplog.at_level("WARNING", logger="mem0"):
+            resp = client.put("/memories/mem-1", json={"text": "Likes tennis"})
+        assert resp.status_code == 200
+        assert not any("is deprecated" in record.message for record in caplog.records)
 
     def test_metadata_forwarded(self, client, mock_memory):
         resp = client.put("/memories/mem-1", json={
@@ -579,12 +588,12 @@ class TestUpdateMemory:
         _, kwargs = mock_memory.update.call_args
         assert kwargs["expiration_date"] is None
 
-    def test_dict_not_passed_as_data(self, client, mock_memory):
-        """Regression test for #3933: the entire dict must NOT be passed as data."""
+    def test_dict_not_passed_as_text(self, client, mock_memory):
+        """Regression test for #3933: the entire dict must NOT be passed as text."""
         resp = client.put("/memories/mem-1", json={"text": "updated content"})
         assert resp.status_code == 200
         _, kwargs = mock_memory.update.call_args
-        assert isinstance(kwargs["data"], str)
+        assert isinstance(kwargs["text"], str)
 
 
 class TestUpdateOpenAPISchema:


### PR DESCRIPTION
Fixes #7245. PUT /memories/{id} forwarded the request body's text field to Memory.update() under the deprecated data= parameter name, logging a deprecation warning on every update and set to raise TypeError -> 502 once data= is removed in the next major release. Now forwards text= directly, matching the endpoint's own MemoryUpdate.text field name.

Also updates the two existing tests that asserted on kwargs['data'] to assert on kwargs['text'] instead, and adds a caplog-based regression test confirming no deprecation warning fires on a server-driven update.

## Linked Issue

Closes #7245

## Description

`server/main.py`'s `update_memory` endpoint built its call to `Memory.update()` using the deprecated `data=` keyword instead of `text=`, even though the endpoint's own request model already names the field `text`. This meant every update logged an unnecessary deprecation warning, and would raise `TypeError` (surfaced as a 502) once `data` is removed per the SDK's own deprecation notice. The fix forwards `text=` directly. Two existing tests that asserted on the old `data` key were updated to assert on `text` instead, preserving their original regression intent, and a new caplog-based test confirms no deprecation warning fires.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [x] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [ ] AI-generated (an agent wrote most or all of this diff)

Used Claude to locate the exact fix site, draft the one-line change, update the two existing tests whose assertions depended on the old key name, and draft the new caplog regression test. I reviewed each change against the actual file contents in my dev environment before applying it, and verified all 69 tests in `tests/test_server_params.py` pass locally with the fix in place.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Ran `PYTHONPATH=server python -m pytest tests/test_server_params.py -v` locally: 69 passed, 0 failed (68 pre-existing tests + 1 new regression test).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed