### PR TITLE
fix(ts-sdk): restore project instructions if update assertion fails

### DIFF
--- a/mem0-ts/src/client/tests/integration/management.test.ts
+++ b/mem0-ts/src/client/tests/integration/management.test.ts
@@ -75,22 +75,24 @@ describeIntegration("MemoryClient Integration — Users & Project", () => {
     test("updates project custom_instructions via updateProject()", async () => {
       const testInstruction = `integration-test-${randomUUID().slice(0, 8)}`;
 
-      const result = await client.updateProject({
-        customInstructions: testInstruction,
-      });
+      try {
+        const result = await client.updateProject({
+          customInstructions: testInstruction,
+        });
 
-      expect(result).toBeDefined();
+        expect(result).toBeDefined();
 
-      // Verify the update took effect
-      const project = await client.getProject({
-        fields: ["custom_instructions"],
-      });
-      expect(project.customInstructions).toBe(testInstruction);
-
-      // Restore original
-      await client.updateProject({
-        customInstructions: originalInstructions || "",
-      });
+        // Verify the update took effect
+        const project = await client.getProject({
+          fields: ["custom_instructions"],
+        });
+        expect(project.customInstructions).toBe(testInstruction);
+      } finally {
+        // Restore original, even if the update or an assertion above threw
+        await client.updateProject({
+          customInstructions: originalInstructions || "",
+        });
+      }
     });
   });
 


### PR DESCRIPTION
## Linked Issue

Closes #7044

## Description

The integration test `updates project custom_instructions via updateProject()` in `mem0-ts/src/client/tests/integration/management.test.ts` stored the original `customInstructions` and restored it as the last statement of the test body. If `updateProject()`, `getProject()`, or the assertion in between threw, Jest aborted the test before reaching the restore call, leaving the real project's `customInstructions` set to the test value.

This PR wraps the update-and-verify steps in `try` and moves the restore call into a `finally` block, so the original value is always restored regardless of where the test fails.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Written by Claude Code (Anthropic). I reviewed the diff, confirmed it matches the `try/finally` fix suggested in the issue, and verified `npx prettier --check` passes on the changed file.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated integration tests
- [ ] I added/updated unit tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

This changes the control flow of an existing integration test (which requires live API credentials to run); no new test was added since the fix is about guaranteeing cleanup in the existing one.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed

Prepared with AI assistance; reviewed and verified by the author before submission.
