### PR TITLE
fix(vector_stores/weaviate): make search score metric-aware

### DIFF
--- a/mem0/configs/vector_stores/weaviate.py
+++ b/mem0/configs/vector_stores/weaviate.py
@@ -10,6 +10,10 @@ class WeaviateConfig(BaseModel):
 
     collection_name: str = Field("mem0", description="Name of the collection")
     embedding_model_dims: int = Field(1536, description="Dimensions of the embedding model")
+    distance: str = Field(
+        "cosine",
+        description="Distance metric for the vector index (cosine, l2-squared, dot, ...)",
+    )
     cluster_url: Optional[str] = Field(None, description="URL for Weaviate server")
     auth_client_secret: Optional[str] = Field(None, description="API key for Weaviate authentication")
     additional_headers: Optional[Dict[str, str]] = Field(None, description="Additional headers for requests")

--- a/mem0/vector_stores/weaviate.py
+++ b/mem0/vector_stores/weaviate.py
@@ -36,6 +36,7 @@ class Weaviate(VectorStoreBase):
         cluster_url: str = None,
         auth_client_secret: str = None,
         additional_headers: dict = None,
+        distance: str = "cosine",
     ):
         """
         Initialize the Weaviate vector store.
@@ -81,6 +82,7 @@ class Weaviate(VectorStoreBase):
 
         self.collection_name = collection_name
         self.embedding_model_dims = embedding_model_dims
+        self.distance = (distance or "cosine").lower()
         self.create_col(embedding_model_dims)
 
     def _parse_output(self, data: Dict) -> List[OutputData]:
@@ -124,6 +126,7 @@ class Weaviate(VectorStoreBase):
             vector_size (int): Size of the vectors to be stored.
             distance (str, optional): Distance metric for vector similarity. Defaults to "cosine".
         """
+        self.distance = (distance or getattr(self, "distance", None) or "cosine").lower()
         if self.client.collections.exists(self.collection_name):
             logger.debug(f"Collection {self.collection_name} already exists. Skipping creation.")
             return
@@ -178,6 +181,17 @@ class Weaviate(VectorStoreBase):
 
                 batch.add_object(collection=self.collection_name, properties=data_object, uuid=object_id, vector=vector)
 
+
+    def _distance_to_score(self, raw_distance):
+        """Convert Weaviate distance to similarity (VectorStoreBase.search contract)."""
+        if raw_distance is None:
+            return None
+        distance = float(raw_distance)
+        metric = (getattr(self, "distance", None) or "cosine").lower().replace("_", "-")
+        if metric in {"l2", "euclidean", "l2-squared", "squaredeuclidean", "squared-euclidean"}:
+            return 1.0 / (1.0 + distance)
+        return max(0.0, 1.0 - distance)
+
     def search(
         self, query: str, vectors: List[float], top_k: int = 5, filters: Optional[Dict] = None
     ) -> List[OutputData]:
@@ -209,7 +223,7 @@ class Weaviate(VectorStoreBase):
 
             payload["id"] = str(obj.uuid).split("'")[0]  # Include the id in the payload
             if obj.metadata.distance is not None:
-                score = 1 - obj.metadata.distance  # Convert distance to similarity score
+                score = self._distance_to_score(obj.metadata.distance)
             elif obj.metadata.score is not None:
                 score = obj.metadata.score
             else:

--- a/tests/vector_stores/test_weaviate.py
+++ b/tests/vector_stores/test_weaviate.py
@@ -267,3 +267,13 @@ class TestWeaviateDB(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+def test_distance_to_score_metric_aware():
+    from mem0.vector_stores.weaviate import Weaviate
+
+    store = Weaviate.__new__(Weaviate)
+    store.distance = "cosine"
+    assert store._distance_to_score(0.25) == 0.75
+    store.distance = "l2-squared"
+    assert store._distance_to_score(4.0) == 0.2
+    assert store._distance_to_score(4.0) > 0.0


### PR DESCRIPTION
## Linked Issue

Closes #7250

## Description

Sibling of #6546/#6547/#7229 for **Weaviate**.

- Add `distance` config/constructor field and persist `create_col` metric
- Replace hardcoded `1 - distance` with metric-aware `_distance_to_score`
- Regression tests for cosine vs l2-squared

## Type of Change

- [x] Bug fix
