### PR TITLE
fix(vector_stores/faiss): reject empty payload in client-side filters

### DIFF
--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -427,8 +427,13 @@ class FAISS(VectorStoreBase):
         Returns:
             bool: True if payload passes filters, False otherwise.
         """
-        if not filters or not payload:
+        if not filters:
             return True
+        # Empty / missing payload must fail scoped filters (tenancy boundary).
+        # Previously `if not filters or not payload: return True` let `{}` pass
+        # every user_id/agent_id/run_id check.
+        if not payload:
+            return False
 
         for key, value in filters.items():
             if key not in payload:

--- a/tests/vector_stores/test_faiss.py
+++ b/tests/vector_stores/test_faiss.py
@@ -285,6 +285,16 @@ def test_list(faiss_instance):
         assert result.payload["category"] == "A"
 
 
+def test_apply_filters_rejects_empty_payload(faiss_instance):
+    """Regression for #7256: empty payload must not satisfy scoped filters."""
+    assert faiss_instance._apply_filters({}, {"user_id": "alice"}) is False
+    assert faiss_instance._apply_filters(None, {"user_id": "alice"}) is False
+    assert faiss_instance._apply_filters({"user_id": "alice"}, {"user_id": "alice"}) is True
+    assert faiss_instance._apply_filters({"user_id": "bob"}, {"user_id": "alice"}) is False
+    assert faiss_instance._apply_filters({}, {}) is True
+    assert faiss_instance._apply_filters({"user_id": "alice"}, None) is True
+
+
 def test_list_uninitialized_index_returns_nested_list(faiss_instance):
     # Regression for the List[List[OutputData]] contract: callers (e.g.
     # Memory.delete_all) do `vector_store.list(filters=...)[0]`, so an


### PR DESCRIPTION
## Summary
- `_apply_filters` no longer treats a falsy/empty payload as a filter pass.
- Non-empty filters + empty/`None` payload now return `False` (tenancy-safe).
- Adds regression unit test for #7256.

Closes #7256.

## Test plan
- [x] Unit coverage for empty/`None`/matching/mismatching payloads
- [ ] CI `tests/vector_stores/test_faiss.py`