### PR TITLE
fix(vector_stores/faiss): reset index on load failure to prevent silent memory corruption

### DIFF
--- a/mem0/vector_stores/faiss.py
+++ b/mem0/vector_stores/faiss.py
@@ -168,6 +168,8 @@ class FAISS(VectorStoreBase):
             if os.path.exists(index_path) and (os.path.exists(json_docstore_path) or os.path.exists(pkl_docstore_path)):
                 # _load will prefer JSON over pickle and auto-migrate
                 self._load(index_path, pkl_docstore_path)
+                if self.index is None:
+                    self.create_col(collection_name)
             else:
                 self.create_col(collection_name)
 
@@ -221,6 +223,7 @@ class FAISS(VectorStoreBase):
             raise ValueError(f"Failed to load FAISS docstore: potentially malicious pickle file. {e}") from e
         except Exception as e:
             logger.warning(f"Failed to load FAISS index: {e}")
+            self.index = None
             self.docstore = {}
             self.index_to_id = {}
 


### PR DESCRIPTION
## Summary

Fixes #7117.

When the FAISS vector store's `_load()` fails to parse the docstore
(e.g. truncated JSON after an OOM kill), the `except Exception` block
clears `self.docstore` and `self.index_to_id` but leaves `self.index`
intact. The next `insert()` computes `starting_idx = len(self.index_to_id)`
(= 0) while FAISS appends vectors at the existing index position N,
permanently desynchronizing the mapping. Search silently returns the wrong
memory with a perfect score.

## Reproduction

```python
import shutil, numpy as np
from mem0.vector_stores.faiss import FAISS

DIMS, PATH = 8, "/tmp/faiss-repro"
shutil.rmtree(PATH, ignore_errors=True)
store = FAISS(collection_name="repro", path=PATH, embedding_model_dims=DIMS)
store.insert([np.zeros(DIMS)], payloads=[{"data": "apple"}], ids=["id-apple"])

# Simulate crash mid-save: truncate the JSON
import json
with open(f"{PATH}/repro.json", "r+", encoding="utf-8") as f:
    content = f.read(); f.seek(0); f.truncate(); f.write(content[:len(content)//2])

store2 = FAISS(collection_name="repro", path=PATH, embedding_model_dims=DIMS)
store2.insert([np.zeros(DIMS)], payloads=[{"data": "cherry"}], ids=["id-cherry"])

# Before fix: search for apple returns cherry at score 1.0
# After fix:  fresh store, no corruption
```

## Root Cause

In `_load()`, the broad `except Exception` handler resets the dicts but
not `self.index`. When the FAISS index file loads successfully but the
JSON docstore is corrupted, the index retains N stale vectors while the
mapping claims the index is empty.

## Fix

Two changes (3 lines):
1. Add `self.index = None` in the `_load()` except block so the store
   enters a consistent (empty) state on any load failure.
2. In `__init__`, call `create_col()` after `_load()` returns with
   `self.index is None`, so the store starts fresh with a clean index.

## Changes

- `mem0/vector_stores/faiss.py`: 3 insertions