### PR TITLE
fix(server): rate-limit the three LLM/embedding-calling endpoints

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -338,7 +338,8 @@ def set_config(config: Dict[str, Any], _auth=Depends(require_admin)):
 
 
 @app.post("/generate-instructions", summary="Generate custom instructions from a use case")
-def generate_instructions(req: GenerateInstructionsRequest, _auth=Depends(verify_auth)):
+@limiter.limit("10/minute")
+def generate_instructions(request: Request, req: GenerateInstructionsRequest, _auth=Depends(verify_auth)):
     """Generate custom instructions and a contextual test message tailored to a use case."""
     try:
         llm = get_memory_instance().llm
@@ -365,7 +366,8 @@ def generate_instructions(req: GenerateInstructionsRequest, _auth=Depends(verify
 
 
 @app.post("/memories", summary="Create memories")
-def add_memory(memory_create: MemoryCreate, _auth=Depends(verify_auth)):
+@limiter.limit("30/minute")
+def add_memory(request: Request, memory_create: MemoryCreate, _auth=Depends(verify_auth)):
     """Store new memories."""
     if not any([memory_create.user_id, memory_create.agent_id, memory_create.run_id]):
         raise HTTPException(status_code=400, detail="At least one identifier (user_id, agent_id, run_id) is required.")
@@ -450,7 +452,8 @@ def get_memory(memory_id: str, _auth=Depends(verify_auth)):
 
 
 @app.post("/search", summary="Search memories")
-def search_memories(search_req: SearchRequest, _auth=Depends(verify_auth)):
+@limiter.limit("30/minute")
+def search_memories(request: Request, search_req: SearchRequest, _auth=Depends(verify_auth)):
     """Search for memories based on a query."""
     try:
         filters = search_req.filters or {}


### PR DESCRIPTION
Fixes #7260.

## What

`server/main.py` already wires up `slowapi`'s limiter (`app.state.limiter`, the `RateLimitExceeded` exception handler) and uses `@limiter.limit(...)` on the three auth routes (`register` 5/minute, `login` 10/minute, `refresh` 20/minute, in `server/routers/auth.py`). No route in `server/main.py` itself carried the decorator, so the three endpoints that make a paid LLM/embedding call per request had no cap at all:

- `POST /generate-instructions` — one billed LLM completion per request, no persistence, no other cost gate.
- `POST /memories` — `Memory.add(...)` with `infer` defaulting to `True`, so an LLM fact-extraction pass plus embeddings on every call.
- `POST /search` — embeds the query and, depending on config (reranker, `explain`), can also call the LLM.

All three only require `Depends(verify_auth)`: a per-user API key, a JWT, the legacy `ADMIN_API_KEY`, or nothing when `AUTH_DISABLED=true`. None of those paths capped request volume, so a single valid credential could drive unbounded billed usage against the deployer's own configured OpenAI/Anthropic/Gemini key.

## Fix

The exact same `@limiter.limit(...)` pattern already proven in `server/routers/auth.py`, applied to these three routes (decorator + `request: Request` as the first parameter, matching that file's convention exactly). Limits:

- `10/minute` for `/generate-instructions` — setup-time, LLM-cost-only path, similar order of magnitude to auth's own limits.
- `30/minute` for `/memories` and `/search` — the two endpoints called repeatedly during normal use, generous enough not to bother a legitimate client, but a real ceiling.

Happy to adjust the numbers if maintainers have a different preference — the mechanism is the important part, the exact limits are a starting point.

## How I verified this

Static: the diff is line-for-line the same decorator + parameter pattern already merged and running in `server/routers/auth.py`. `python -m py_compile` confirms the file is still syntactically valid.

Live: built an isolated venv (`pip install -r server/requirements.txt` + local `pip install -e .`), booted `server/main.py` with `AUTH_DISABLED=true` via FastAPI's `TestClient` (no real LLM/Postgres credentials — those endpoints error out downstream, which is irrelevant to this fix since slowapi counts the request before the handler body runs), and hammered each of the three endpoints in a tight loop:

- `/generate-instructions`: first 10 requests reach the handler (and fail downstream on the fake key, as expected), request 11 returns `429`.
- `/search`: requests 1-30 reach the handler, request 31 returns `429`.
- `/memories`: same, `429` on request 31.

All three match their configured limit exactly.

## AI assistance

Written with AI assistance (same as the linked issue). The verification above (decorator pattern comparison, syntax check, and the three live TestClient runs showing the exact 429 boundary) was actually executed, not asserted from reading alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)