### PR TITLE
feat(integrations): add @mem0/eve memory provider

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -26,6 +26,7 @@ Package workflows keep their own push-to-main and manual triggers. Their `pull_r
 | n8n Node | `n8n-nodes-mem0-checks.yml` | Push to main (`integrations/n8n-nodes-mem0/`), manual | ESLint + tsc build on Node 20 |
 | Zapier App | `zapier-mem0-checks.yml` | Push to main (`integrations/zapier-mem0/`), manual | tsc + `zapier validate` + offline unit tests on Node 22 |
 | mem0-strands | `mem0-strands-checks.yml` | Push to main (`integrations/mem0-strands/`), manual | Ruff + mypy + pytest + hatch build on Python 3.10, 3.11, 3.12 |
+| Eve | `eve-checks.yml` | Push to main (`integrations/eve/`), manual | tsc + vitest + tsup on Node 24 |
 | docs llms.txt | `docs-llms-txt-check.yml` | Manual | `docs/llms.txt` coverage |
 | GitHub Scripts | inline in `ci-gate.yml` | none | `node` over every `.github/scripts/*.test.js` |
 
@@ -64,6 +65,7 @@ Requiring `CI Gate` also means fork PRs from first-time contributors cannot merg
 | DeepSeek Harness Plugin | `deepseek-plugin-cd.yml` | `deepseek-plugin-v*` | npm (`@mem0/deepseek-plugin`) |
 | n8n Node | `n8n-nodes-mem0-cd.yml` | `n8n-nodes-mem0-v*` | npm (`@mem0/n8n-nodes-mem0`) |
 | mem0-strands | `mem0-strands-cd.yml` | `mem0-strands-v*` | PyPI (`mem0-strands`) |
+| Eve | `eve-cd.yml` | `eve-v*` | npm (`@mem0/eve`) |
 
 - Package CD workflows are `workflow_dispatch`-only, with `tag` and `prerelease` inputs. They check out and build the given tag.
 - All publishing uses **OIDC trusted publishing**. No tokens, no secrets.

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -46,6 +46,7 @@ jobs:
       n8n_nodes_mem0: ${{ steps.filter.outputs.n8n_nodes_mem0 }}
       zapier_mem0: ${{ steps.filter.outputs.zapier_mem0 }}
       mem0_strands: ${{ steps.filter.outputs.mem0_strands }}
+      eve: ${{ steps.filter.outputs.eve }}
       docs_llms_txt: ${{ steps.filter.outputs.docs_llms_txt }}
       github_scripts: ${{ steps.filter.outputs.github_scripts }}
     steps:
@@ -109,6 +110,10 @@ jobs:
             mem0_strands:
               - 'integrations/mem0-strands/**'
               - '.github/workflows/mem0-strands-checks.yml'
+              - '.github/workflows/ci-gate.yml'
+            eve:
+              - 'integrations/eve/**'
+              - '.github/workflows/eve-checks.yml'
               - '.github/workflows/ci-gate.yml'
             docs_llms_txt:
               - 'docs/**/*.mdx'
@@ -214,6 +219,13 @@ jobs:
     uses: ./.github/workflows/mem0-strands-checks.yml
     secrets: inherit
 
+  eve:
+    name: Eve
+    needs: changes
+    if: needs.changes.outputs.eve == 'true'
+    uses: ./.github/workflows/eve-checks.yml
+    secrets: inherit
+
   docs-llms-txt:
     name: docs llms.txt
     needs: changes
@@ -256,6 +268,7 @@ jobs:
       - n8n-nodes-mem0
       - zapier-mem0
       - mem0-strands
+      - eve
       - docs-llms-txt
       - github-scripts
     if: always()

--- a/.github/workflows/eve-cd.yml
+++ b/.github/workflows/eve-cd.yml
@@ -1,0 +1,57 @@
+name: Publish @mem0/eve 📦 to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build and publish (e.g. eve-v0.1.0)'
+        required: true
+        type: string
+      prerelease:
+        description: 'Publish under the version preid dist-tag instead of latest'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build-n-publish:
+    name: Build and publish @mem0/eve 📦 to npm
+    if: startsWith(inputs.tag, 'eve-v')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    defaults:
+      run:
+        working-directory: integrations/eve
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+          cache-dependency-path: integrations/eve/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish to npm
+        run: |
+          if [ "${{ inputs.prerelease }}" = "true" ]; then
+            PREID=$(node -p "require('./package.json').version.split('-')[1].split('.')[0]")
+            npx npm@latest publish --provenance --access public --tag "$PREID"
+          else
+            npx npm@latest publish --provenance --access public
+          fi

--- a/.github/workflows/eve-checks.yml
+++ b/.github/workflows/eve-checks.yml
@@ -1,0 +1,85 @@
+name: eve checks
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/eve/**'
+      - '.github/workflows/eve-checks.yml'
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+          cache-dependency-path: integrations/eve/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: cd integrations/eve && pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: cd integrations/eve && pnpm typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+          cache-dependency-path: integrations/eve/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: cd integrations/eve && pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: cd integrations/eve && pnpm test
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+          cache-dependency-path: integrations/eve/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: cd integrations/eve && pnpm install --frozen-lockfile
+
+      - name: Build
+        run: cd integrations/eve && pnpm build
+
+      - name: Verify dist output exists
+        run: |
+          test -f integrations/eve/dist/index.js || (echo "Build output missing: dist/index.js" && exit 1)
+          test -f integrations/eve/dist/index.d.ts || (echo "Build output missing: dist/index.d.ts" && exit 1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
             deepseek-plugin-v*)  workflow="deepseek-plugin-cd.yml" ;;
             n8n-nodes-mem0-v*) workflow="n8n-nodes-mem0-cd.yml" ;;
             mem0-strands-v*)   workflow="mem0-strands-cd.yml" ;;
+            eve-v*)            workflow="eve-cd.yml" ;;
             v*)           workflow="cd.yml" ;;
             *)
               echo "::error::Release tag '$TAG' does not match any known package prefix — nothing will be published. See the tag prefix table in AGENTS.md."

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -325,6 +325,7 @@
                       "integrations/google-ai-adk",
                       "integrations/mastra",
                       "integrations/vercel-ai-sdk",
+                      "integrations/eve",
                       "integrations/vercel",
                       "integrations/chatdev",
                       "integrations/strands"

--- a/docs/integrations/eve.mdx
+++ b/docs/integrations/eve.mdx
@@ -36,8 +36,8 @@ export default defineMemory({
 ## How it works
 
 1. **Recall.** Before each turn and after compaction, Mem0 searches memories for the locked Eve scope and returns `{ id, content }` messages. Eve injects those as user-role messages attributed to the slot.
-2. **Capture.** After a successful turn, Mem0 adds the user messages from that turn and, when present, the latest assistant reply. By default (`infer: true`) Mem0 extracts durable facts.
-3. **Tools.** The model can call `search`, `remember`, and `forget`. Eve qualifies them as `mem0__search`, `mem0__remember`, and `mem0__forget` when the slot file is `mem0.ts`.
+2. **Capture.** After a successful turn, Mem0 adds the user messages from that turn and, when present, that turn's assistant reply. By default (`infer: true`) Mem0 extracts durable facts. Capture is deduplicated per `operationId` on a best-effort basis (an in-process gate plus a durable `metadata.operation_id` lookup); because that check and the write are not atomic and platform writes are asynchronous, a restart or concurrent worker can occasionally capture a turn twice.
+3. **Tools.** The model can call `search`, `remember`, and `forget`. Eve qualifies them as `mem0__search`, `mem0__remember`, and `mem0__forget` when the slot file is `mem0.ts`. `remember` returns `{ status: "saved" }` on a resolved write or `{ status: "queued" }` when the platform accepts it for asynchronous extraction.
 
 Eve owns namespace, scope, and when recall/capture run. Mem0 owns storage, ranking, and extraction. Search, capture, remember, and forget are partitioned by `memory.scope.key`. Forget deletes by id only after confirming the memory belongs to that key.
 

--- a/docs/integrations/eve.mdx
+++ b/docs/integrations/eve.mdx
@@ -1,0 +1,68 @@
+---
+title: Eve
+description: "Use Mem0 as a first-class memory provider for Vercel Eve agents."
+---
+
+[Eve](https://eve.dev/docs/memory) is Vercel's agent framework. A memory provider sits in the agent loop: Eve recalls context before each turn, captures completed turns, and exposes provider tools. `@mem0/eve` is Mem0's implementation of that contract.
+
+This is not the Mem0 MCP connection. MCP gives the model tools it may or may not call. The memory provider runs automatically.
+
+## Install
+
+```bash
+npm install @mem0/eve
+```
+
+`eve` is a peer dependency. Get an API key from the [Mem0 dashboard](https://app.mem0.ai/dashboard/api-keys).
+
+Create `agent/memory/mem0.ts`:
+
+```ts
+import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
+import { mem0Provider } from "@mem0/eve";
+
+export default defineMemory({
+  description: "Recall and manage durable context for the current user.",
+  provider: mem0Provider({
+    apiKey: process.env.MEM0_API_KEY!,
+  }),
+  scope: byPrincipal,
+});
+```
+
+After Eve lists Mem0 in the official registry, the same slot is created by:
+
+```bash
+eve add memory/mem0
+```
+
+## How it works
+
+1. **Recall.** Before each turn, Mem0 searches memories for the locked Eve scope and returns them as attributed user-role messages.
+2. **Capture.** After a successful turn, Mem0 adds the user and assistant messages and extracts durable facts.
+3. **Tools.** The model can call `search`, `remember`, and `forget`. Eve qualifies them as `mem0__search`, `mem0__remember`, and `mem0__forget` when the slot file is `mem0.ts`.
+
+Eve owns namespace, scope, and when recall/capture run. Mem0 owns storage, ranking, and extraction. Every read and write is partitioned by `memory.scope.key`.
+
+## Options
+
+```ts
+mem0Provider({
+  apiKey: process.env.MEM0_API_KEY!,
+  topK: 5,
+  threshold: 0.1,
+  rerank: false,
+  infer: true,
+  autoSearch: { enabled: true },
+  capture: { enabled: true },
+});
+```
+
+See the [`@mem0/eve` README](https://github.com/mem0ai/mem0/tree/main/integrations/eve) for the full option list.
+
+## Related
+
+- [Eve memory docs](https://eve.dev/docs/memory)
+- [Build a memory provider](https://eve.dev/docs/memory/custom-provider)
+- [Vercel AI SDK](/integrations/vercel-ai-sdk) for `generateText` / `streamText` apps that are not Eve agents

--- a/docs/integrations/eve.mdx
+++ b/docs/integrations/eve.mdx
@@ -5,7 +5,7 @@ description: "Use Mem0 as a first-class memory provider for Vercel Eve agents."
 
 [Eve](https://eve.dev/docs/memory) is Vercel's agent framework. A memory provider sits in the agent loop: Eve recalls context before each turn, captures completed turns, and exposes provider tools. `@mem0/eve` is Mem0's implementation of that contract.
 
-This is not the Mem0 MCP connection. MCP gives the model tools it may or may not call. The memory provider runs automatically.
+This is not the Mem0 MCP connection. MCP gives the model tools it may or may not call. The memory provider runs automatically. The live MCP install is `eve add connection/mem0`.
 
 ## Install
 
@@ -31,19 +31,15 @@ export default defineMemory({
 });
 ```
 
-After Eve lists Mem0 in the official registry, the same slot is created by:
-
-```bash
-eve add memory/mem0
-```
+`eve add memory/mem0` is not in Eve's catalog yet. After Mem0 is listed in the official registry, that command will create the same slot file.
 
 ## How it works
 
-1. **Recall.** Before each turn, Mem0 searches memories for the locked Eve scope and returns them as attributed user-role messages.
-2. **Capture.** After a successful turn, Mem0 adds the user and assistant messages and extracts durable facts.
+1. **Recall.** Before each turn and after compaction, Mem0 searches memories for the locked Eve scope and returns `{ id, content }` messages. Eve injects those as user-role messages attributed to the slot.
+2. **Capture.** After a successful turn, Mem0 adds the user messages from that turn and, when present, the latest assistant reply. By default (`infer: true`) Mem0 extracts durable facts.
 3. **Tools.** The model can call `search`, `remember`, and `forget`. Eve qualifies them as `mem0__search`, `mem0__remember`, and `mem0__forget` when the slot file is `mem0.ts`.
 
-Eve owns namespace, scope, and when recall/capture run. Mem0 owns storage, ranking, and extraction. Every read and write is partitioned by `memory.scope.key`.
+Eve owns namespace, scope, and when recall/capture run. Mem0 owns storage, ranking, and extraction. Search, capture, remember, and forget are partitioned by `memory.scope.key`. Forget deletes by id only after confirming the memory belongs to that key.
 
 ## Options
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -263,7 +263,7 @@ If the user is on a pre-current major (Python < 2, TS < 3, or a Platform call st
 - [Mastra](https://docs.mem0.ai/integrations/mastra) [Platform]: Use when the user is on Mastra (TypeScript).
 - [OpenClaw](https://docs.mem0.ai/integrations/openclaw) [Both]: Use when wiring Mem0 into Claude Code or editors via OpenClaw.
 - [Vercel AI SDK](https://docs.mem0.ai/integrations/vercel-ai-sdk) [Both]: Use when the user is on the Vercel AI SDK.
-- [Eve](https://docs.mem0.ai/integrations/eve) [Platform]: Use when adding Mem0 as a first-class Eve memory provider (`@mem0/eve`, `mem0Provider`, `eve add memory/mem0`). Not the Mem0 MCP connection.
+- [Eve](https://docs.mem0.ai/integrations/eve) [Platform]: Use when adding Mem0 as a first-class Eve memory provider (`@mem0/eve`, `mem0Provider`, hand-written `agent/memory/mem0.ts`). `eve add memory/mem0` is not available yet. Not the Mem0 MCP connection (`eve add connection/mem0`).
 - [Vercel](https://docs.mem0.ai/integrations/vercel) [Platform]: Use when deploying on Vercel and installing Mem0 from the Vercel Marketplace.
 - [Strands Agents](https://docs.mem0.ai/integrations/strands) [Both]: Use when the user is on AWS Strands and wants a native MemoryStore.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -263,6 +263,7 @@ If the user is on a pre-current major (Python < 2, TS < 3, or a Platform call st
 - [Mastra](https://docs.mem0.ai/integrations/mastra) [Platform]: Use when the user is on Mastra (TypeScript).
 - [OpenClaw](https://docs.mem0.ai/integrations/openclaw) [Both]: Use when wiring Mem0 into Claude Code or editors via OpenClaw.
 - [Vercel AI SDK](https://docs.mem0.ai/integrations/vercel-ai-sdk) [Both]: Use when the user is on the Vercel AI SDK.
+- [Eve](https://docs.mem0.ai/integrations/eve) [Platform]: Use when adding Mem0 as a first-class Eve memory provider (`@mem0/eve`, `mem0Provider`, `eve add memory/mem0`). Not the Mem0 MCP connection.
 - [Vercel](https://docs.mem0.ai/integrations/vercel) [Platform]: Use when deploying on Vercel and installing Mem0 from the Vercel Marketplace.
 - [Strands Agents](https://docs.mem0.ai/integrations/strands) [Both]: Use when the user is on AWS Strands and wants a native MemoryStore.
 

--- a/integrations/AGENTS.md
+++ b/integrations/AGENTS.md
@@ -47,7 +47,7 @@ Run the type check after every TypeScript change: `pnpm run typecheck` or `tsc -
 
 ## What each one is
 
-- **`eve/`** is the Eve memory provider (`mem0Provider`). Eve calls recall before each turn and capture after each turn. This is not the Mem0 MCP connection.
+- **`eve/`** is the Eve memory provider (`mem0Provider`). Eve calls recall on `turn.started` and `compaction.completed`, capture on `turn.completed` when enabled, and exposes `search` / `remember` / `forget` tools. This is not the Mem0 MCP connection.
 - **`vercel-ai-sdk/`** wraps the Vercel AI SDK through a `createMem0` provider. Integrations for AI-SDK repos go through this wrapper, not raw `MemoryClient`.
 - **`claude-code-plugin/`** is the Claude Code plugin (v0.3.0, installs as `mem0@mem0-plugins`): local evidence capture via lifecycle hooks, background memory extraction to the Mem0 Platform, a local `search_memories` MCP tool, six `/mem0:*` skills, and the `mem0:sidekick` agent. Pure-stdlib Python — no dependencies to install. Its `core/` + `adapters/claude/` split marks engine vs. harness glue; future per-harness plugins start by copying `core/` and keeping the contract tests verbatim (see its `docs/CONTRACT.md`).
 - **`mem0-plugin/`** connects Cursor, Codex, Kimi, Antigravity, and OpenCode to the MCP server at `mcp.mem0.ai` and installs lifecycle hooks for automatic memory capture. Exposes 9 MCP tools: `add_memory`, `search_memories`, `get_memories`, `get_memory`, `update_memory`, `delete_memory`, `delete_all_memories`, `delete_entities`, `list_entities`. The Claude Code plugin moved to [`claude-code-plugin/`](claude-code-plugin/) in v0.3.0 (installs as `mem0@mem0-plugins`); do not run both at the same time.

--- a/integrations/AGENTS.md
+++ b/integrations/AGENTS.md
@@ -4,6 +4,7 @@ Agent and editor integrations. Each subdirectory is self-contained: its own `pac
 
 | Directory | Package | Build | Lint | Test |
 |-----------|---------|-------|------|------|
+| `eve/` | `@mem0/eve` | tsup (ESM) | none | vitest |
 | `vercel-ai-sdk/` | `@mem0/vercel-ai-provider` | tsup (CJS+ESM) | ESLint + Prettier | jest + vitest (edge/node) |
 | `openclaw/` | `@mem0/openclaw-mem0` | tsup (ESM) | none | vitest |
 | `claude-code-plugin/` | Claude Code plugin, installs as `mem0@mem0-plugins` (v0.3.0) | none | ruff | pytest |
@@ -20,6 +21,12 @@ pnpm everywhere except `.opencode-plugin/` (Bun) and `mem0-strands/` (Python: pi
 ## Commands
 
 ```bash
+cd integrations/eve
+pnpm install
+pnpm run typecheck
+pnpm run test
+pnpm run build
+
 cd integrations/vercel-ai-sdk
 pnpm install
 pnpm run build           # tsup
@@ -40,6 +47,7 @@ Run the type check after every TypeScript change: `pnpm run typecheck` or `tsc -
 
 ## What each one is
 
+- **`eve/`** is the Eve memory provider (`mem0Provider`). Eve calls recall before each turn and capture after each turn. This is not the Mem0 MCP connection.
 - **`vercel-ai-sdk/`** wraps the Vercel AI SDK through a `createMem0` provider. Integrations for AI-SDK repos go through this wrapper, not raw `MemoryClient`.
 - **`claude-code-plugin/`** is the Claude Code plugin (v0.3.0, installs as `mem0@mem0-plugins`): local evidence capture via lifecycle hooks, background memory extraction to the Mem0 Platform, a local `search_memories` MCP tool, six `/mem0:*` skills, and the `mem0:sidekick` agent. Pure-stdlib Python — no dependencies to install. Its `core/` + `adapters/claude/` split marks engine vs. harness glue; future per-harness plugins start by copying `core/` and keeping the contract tests verbatim (see its `docs/CONTRACT.md`).
 - **`mem0-plugin/`** connects Cursor, Codex, Kimi, Antigravity, and OpenCode to the MCP server at `mcp.mem0.ai` and installs lifecycle hooks for automatic memory capture. Exposes 9 MCP tools: `add_memory`, `search_memories`, `get_memories`, `get_memory`, `update_memory`, `delete_memory`, `delete_all_memories`, `delete_entities`, `list_entities`. The Claude Code plugin moved to [`claude-code-plugin/`](claude-code-plugin/) in v0.3.0 (installs as `mem0@mem0-plugins`); do not run both at the same time.

--- a/integrations/eve/.gitignore
+++ b/integrations/eve/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+coverage
+*.tgz

--- a/integrations/eve/LICENSE
+++ b/integrations/eve/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2023] [Taranjeet Singh]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/integrations/eve/README.md
+++ b/integrations/eve/README.md
@@ -36,12 +36,14 @@ The live MCP path today is `eve add connection/mem0`. That is a different integr
 |---|---|
 | `recall["turn.started"]` | Semantic search over memories for the locked scope |
 | `recall["compaction.completed"]` | Same search after Eve compacting history (`turn` may be null) |
-| `capture["turn.completed"]` | Add the completed user turn and, when present, the latest assistant reply |
+| `capture["turn.completed"]` | Add the completed user turn and, when present, this turn's assistant reply |
 | `tools()` | `search`, `remember`, `forget` |
 
 Search, capture, remember, and forget are partitioned by `memory.scope.key`. Forget loads the memory first and deletes only when `userId` matches that key.
 
-Capture uses `operationId` as an idempotency key: an in-process gate plus a durable `metadata.operation_id` lookup so Eve replays after restart do not write twice.
+Capture uses `operationId` for **best-effort** deduplication: an in-process gate plus a durable `metadata.operation_id` lookup. This is not atomic — with `infer: true` a prior write can be a PENDING event whose memory is not yet visible, so a restart during that window (or two concurrent workers) can capture the same turn twice. Eliminating that would require a backend-supported atomic idempotency key.
+
+`remember` returns `{ status: "saved" }` when the write resolves, or `{ status: "queued" }` when the platform accepts it for asynchronous extraction (it becomes searchable a moment later).
 
 If the slot file is named `mem0.ts`, Eve qualifies tools as `mem0__search`, `mem0__remember`, and `mem0__forget`.
 

--- a/integrations/eve/README.md
+++ b/integrations/eve/README.md
@@ -1,0 +1,90 @@
+# @mem0/eve
+
+Mem0 as a first-class [Eve](https://eve.dev/docs/memory) memory provider.
+
+Eve recalls relevant memories before each turn, captures completed turns automatically, and exposes search / remember / forget tools bound to the locked memory scope. Mem0 owns storage, extraction, and retrieval.
+
+```ts
+import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
+import { mem0Provider } from "@mem0/eve";
+
+export default defineMemory({
+  description: "Recall and manage durable context for the current user.",
+  provider: mem0Provider({
+    apiKey: process.env.MEM0_API_KEY!,
+  }),
+  scope: byPrincipal,
+});
+```
+
+## Install
+
+```bash
+npm install @mem0/eve
+```
+
+`eve` is a peer dependency. Get an API key from the [Mem0 dashboard](https://app.mem0.ai/dashboard/api-keys).
+
+Until Eve lists Mem0 in the official registry, add the slot file yourself as `agent/memory/mem0.ts`. After the registry PR lands, this becomes:
+
+```bash
+eve add memory/mem0
+```
+
+## What it does
+
+| Eve hook | Mem0 behavior |
+|---|---|
+| `recall["turn.started"]` | Semantic search over memories for the locked scope |
+| `recall["compaction.completed"]` | Same search after Eve compacting history |
+| `capture["turn.completed"]` | Add the completed user/assistant turn |
+| `tools()` | `search`, `remember`, `forget` |
+
+Every read and write is partitioned by `memory.scope.key`. The model cannot choose another caller. Replay uses `operationId` as an idempotency key.
+
+If the slot file is named `mem0.ts`, Eve qualifies tools as `mem0__search`, `mem0__remember`, and `mem0__forget`.
+
+## Options
+
+```ts
+mem0Provider({
+  apiKey: process.env.MEM0_API_KEY!,
+  host: "https://api.mem0.ai",
+  topK: 5,
+  threshold: 0.1,
+  rerank: false,
+  infer: true,
+  autoSearch: { enabled: true },
+  capture: { enabled: true },
+  metadata: { app: "support-agent" },
+});
+```
+
+| Option | Default | Purpose |
+|---|---|---|
+| `apiKey` | required | String or async getter |
+| `host` | `https://api.mem0.ai` | Mem0 Platform host |
+| `topK` | `5` | Memories recalled per turn |
+| `threshold` | `0.1` | Minimum similarity |
+| `rerank` | `false` | Mem0 reranking |
+| `infer` | `true` | Extract facts on capture |
+| `autoSearch.enabled` | `true` | Recall before each turn |
+| `capture.enabled` | `true` | Write after each successful turn |
+| `metadata` | `{}` | Extra metadata on captured turns |
+
+## Official registry
+
+Eve already listed Mem0 as an MCP connection. This package is the memory-provider path. After `@mem0/eve` is on npm, open a PR against [vercel/eve](https://github.com/vercel/eve) that adds `memory/mem0` using the files in [`registry/`](./registry). See [`registry/README.md`](./registry/README.md).
+
+## Development
+
+Requires Node.js 24+.
+
+```bash
+cd integrations/eve
+pnpm install
+pnpm test
+pnpm typecheck
+pnpm build
+```

--- a/integrations/eve/README.md
+++ b/integrations/eve/README.md
@@ -26,24 +26,26 @@ npm install @mem0/eve
 
 `eve` is a peer dependency. Get an API key from the [Mem0 dashboard](https://app.mem0.ai/dashboard/api-keys).
 
-Until Eve lists Mem0 in the official registry, add the slot file yourself as `agent/memory/mem0.ts`. After the registry PR lands, this becomes:
+Until Eve lists Mem0 in the official registry, add the slot file yourself as `agent/memory/mem0.ts`. `eve add memory/mem0` is not available yet. After the registry PR lands, that command will create the same file.
 
-```bash
-eve add memory/mem0
-```
+The live MCP path today is `eve add connection/mem0`. That is a different integration: tools the model may call, not automatic recall/capture.
 
 ## What it does
 
 | Eve hook | Mem0 behavior |
 |---|---|
 | `recall["turn.started"]` | Semantic search over memories for the locked scope |
-| `recall["compaction.completed"]` | Same search after Eve compacting history |
-| `capture["turn.completed"]` | Add the completed user/assistant turn |
+| `recall["compaction.completed"]` | Same search after Eve compacting history (`turn` may be null) |
+| `capture["turn.completed"]` | Add the completed user turn and, when present, the latest assistant reply |
 | `tools()` | `search`, `remember`, `forget` |
 
-Every read and write is partitioned by `memory.scope.key`. The model cannot choose another caller. Replay uses `operationId` as an idempotency key.
+Search, capture, remember, and forget are partitioned by `memory.scope.key`. Forget loads the memory first and deletes only when `userId` matches that key.
+
+Capture uses `operationId` as an idempotency key: an in-process gate plus a durable `metadata.operation_id` lookup so Eve replays after restart do not write twice.
 
 If the slot file is named `mem0.ts`, Eve qualifies tools as `mem0__search`, `mem0__remember`, and `mem0__forget`.
+
+A throwing `recall` fails the Eve turn. A throwing `capture` is logged by Eve and does not fail the turn. Tool `execute` errors become failed tool results the model can see.
 
 ## Options
 
@@ -63,15 +65,16 @@ mem0Provider({
 
 | Option | Default | Purpose |
 |---|---|---|
-| `apiKey` | required | String or async getter |
-| `host` | `https://api.mem0.ai` | Mem0 Platform host |
-| `topK` | `5` | Memories recalled per turn |
-| `threshold` | `0.1` | Minimum similarity |
-| `rerank` | `false` | Mem0 reranking |
-| `infer` | `true` | Extract facts on capture |
-| `autoSearch.enabled` | `true` | Recall before each turn |
+| `apiKey` | required without `store` | String or async getter. Function keys are validated on first use. |
+| `host` | `https://api.mem0.ai` | Mem0 Platform host (`http:` or `https:` URL) |
+| `topK` | `5` | Result count for automatic recall and the `search` tool |
+| `threshold` | `0.1` | Minimum similarity for automatic recall and the `search` tool |
+| `rerank` | `false` | Mem0 reranking for automatic recall and the `search` tool |
+| `infer` | `true` | Extract facts on capture and on `remember` |
+| `autoSearch.enabled` | `true` | Recall on `turn.started` and `compaction.completed` |
 | `capture.enabled` | `true` | Write after each successful turn |
 | `metadata` | `{}` | Extra metadata on captured turns |
+| `store` | unset | Test / advanced injection. Replaces the Mem0 client and must honor `userId`. |
 
 ## Official registry
 

--- a/integrations/eve/package.json
+++ b/integrations/eve/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@mem0/eve",
+  "version": "0.1.0",
+  "description": "Mem0 memory provider for Eve agents. Recall, capture, and scope-bound tools.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mem0ai/mem0",
+    "directory": "integrations/eve"
+  },
+  "keywords": [
+    "eve",
+    "mem0",
+    "memory",
+    "agents",
+    "vercel"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "mem0ai": "^3.1.0",
+    "zod": "^4.0.0"
+  },
+  "peerDependencies": {
+    "eve": ">=0.47.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "eve": "^0.52.2",
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.7"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/integrations/eve/pnpm-lock.yaml
+++ b/integrations/eve/pnpm-lock.yaml
@@ -1,0 +1,3429 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      mem0ai:
+        specifier: ^3.1.0
+        version: 3.1.8(@cloudflare/workers-types@4.20260702.1)(@types/jest@29.5.14)(@types/pg@8.11.0)(better-sqlite3@12.11.1)(compromise@14.16.0)(mongodb@7.5.0)(natural@8.1.1)(pg@8.11.3)
+      zod:
+        specifier: ^4.0.0
+        version: 4.5.4
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      eve:
+        specifier: ^0.52.2
+        version: 0.52.2(ai@7.0.93(zod@4.5.4))
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(postcss@8.5.28)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.11(@types/node@24.13.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.7))
+
+packages:
+
+  '@ai-sdk/gateway@4.0.75':
+    resolution: {integrity: sha512-HOnhw3oXtBnboBF7kAKipjToCN6+5w6EuukiUKiULcxBitS+vbHRRv9IUBcq+Z1wkXcJjfywKrt5r++I6OYyXg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.36':
+    resolution: {integrity: sha512-MFXBn6XDyf37PNQAge/HTatPJE8Vmg/g/w4WPtjSV53jq8FKAzoaN5+43hsdQa9bqgN+/13jxug9ChvsG+godQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.10':
+    resolution: {integrity: sha512-fX2ENAc7iDpZ+Wp4+Rk06Usn/Ys7dI9uAkGv0jlF6XVrW13NkRWx5Ou+U6lIM2E1fTLkCs16GGrUAaVvroag7A==}
+    engines: {node: '>=22'}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@cloudflare/workers-types@4.20260702.1':
+    resolution: {integrity: sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jest/expect-utils@29.7.0':
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.6.0':
+    resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mongodb-js/saslprep@1.5.2':
+    resolution: {integrity: sha512-UBvCBdPHAmiiDNEpD2ORBGzna4qYr06fLELfGDPW3/KZ9uLK+cGT9npAc/x/6/8SLzdbILMuc3HWFQ0FvJMhCw==}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-project/types@0.148.0':
+    resolution: {integrity: sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==}
+
+  '@redis/bloom@5.12.1':
+    resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/client@5.12.1':
+    resolution: {integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@5.12.1':
+    resolution: {integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/search@5.12.1':
+    resolution: {integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/time-series@5.12.1':
+    resolution: {integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@rolldown/binding-android-arm-eabi@1.2.7':
+    resolution: {integrity: sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.7':
+    resolution: {integrity: sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.7':
+    resolution: {integrity: sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.7':
+    resolution: {integrity: sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.7':
+    resolution: {integrity: sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.7':
+    resolution: {integrity: sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.7':
+    resolution: {integrity: sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.7':
+    resolution: {integrity: sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.7':
+    resolution: {integrity: sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.7':
+    resolution: {integrity: sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.7':
+    resolution: {integrity: sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.2.7':
+    resolution: {integrity: sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.2.7':
+    resolution: {integrity: sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.7':
+    resolution: {integrity: sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.7':
+    resolution: {integrity: sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    resolution: {integrity: sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    resolution: {integrity: sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    resolution: {integrity: sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    resolution: {integrity: sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    resolution: {integrity: sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    resolution: {integrity: sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    resolution: {integrity: sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    resolution: {integrity: sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    resolution: {integrity: sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    resolution: {integrity: sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    resolution: {integrity: sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    resolution: {integrity: sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    resolution: {integrity: sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    resolution: {integrity: sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    resolution: {integrity: sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    resolution: {integrity: sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    resolution: {integrity: sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    resolution: {integrity: sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    resolution: {integrity: sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    resolution: {integrity: sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    resolution: {integrity: sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    resolution: {integrity: sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    resolution: {integrity: sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@sinclair/typebox@0.27.12':
+    resolution: {integrity: sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@29.5.14':
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
+
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  '@types/pg@8.11.0':
+    resolution: {integrity: sha512-sDAlRiBNthGjNFfvt0k6mtotoVYVQ63pA8R4EMWka7crawSR60waVYR0HAgmPRs/e2YaeJTD/43OoZ3PFw80pw==}
+
+  '@types/stack-utils@2.0.3':
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  afinn-165-financialmarketnews@3.0.0:
+    resolution: {integrity: sha512-0g9A1S3ZomFIGDTzZ0t6xmv4AuokBvBmpes8htiyHpH7N4xDmvSQL6UxL/Zcs2ypRb3VwgCscaD8Q3zEawKYhw==}
+
+  afinn-165@2.0.2:
+    resolution: {integrity: sha512-mJ/RLUfpXfQA6bzugv+bBsc/QYkVrKaLYeS8fWBpKbTCsonv4iuV9ET0fgReEunm9vKLkaNgnekuSNlTC3WQ1Q==}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
+  ai@7.0.93:
+    resolution: {integrity: sha512-CJss6zb9mlltk/mCr8qom20NBnqEQxVawkqwtT62tCwsxilZpXfHNRMRwcS3XRpzdP1kEluVuDBUayYWEEd95g==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  apparatus@0.0.10:
+    resolution: {integrity: sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==}
+    engines: {node: '>=0.2.6'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.20.0:
+    resolution: {integrity: sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  bson@7.3.2:
+    resolution: {integrity: sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==}
+    engines: {node: '>=20.19.0'}
+
+  buffer-writer@2.0.0:
+    resolution: {integrity: sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==}
+    engines: {node: '>=4'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  compromise@14.16.0:
+    resolution: {integrity: sha512-4DFYl/Hl7sW4XWUDfx9S5vxqyYKpZDwwqrpXsQv5acdbVP+joKceIcIaLb0lhVWUpDBV0OnExk/o/dnYUwXnhQ==}
+    engines: {node: '>=12.0.0'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  crossws@0.4.12:
+    resolution: {integrity: sha512-aypfsr6t0uNvkqaZc6zvBfXzC6pLI0/sIulpkV6RwCVtZqG5ebBzv4weImKK0VNCj91Wl9F5j7p5WU4MNrybng==}
+    peerDependencies:
+      srvx: '>=0.11.5'
+    peerDependenciesMeta:
+      srvx:
+        optional: true
+
+  db0@0.4.1:
+    resolution: {integrity: sha512-6RBY/bSn42UrqATwsiULj2uYFyEykB3XeA/NLIVQeHNXlYV6D4Idxx3/aa6k5Y45Dwzx7sygeLotnqHWSeURYA==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  efrt@2.7.0:
+    resolution: {integrity: sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==}
+    engines: {node: '>=12.0.0'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  env-runner@0.2.1:
+    resolution: {integrity: sha512-2iDP2DfheAMMAKeXBggEuFmpSq+1Xs6wQoHba1g65pZFXlC3VHD1O6/tgVzS6GQLv+P2koPKZPKgKhXkigNBdg==}
+    hasBin: true
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eve@0.52.2:
+    resolution: {integrity: sha512-FM3aC2A3SCKQxtyhSNR5+CaIVlKJmTGb7rCqcuHEhZShDKo1IXCTt/F7r4toqkLDG6lW7VcStTku77KWiosLfg==}
+    engines: {node: '>=24'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      ai: ^7.0.82
+      braintrust: ^3.0.0
+      just-bash: ^3.1.0
+      microsandbox: ^0.5.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      braintrust:
+        optional: true
+      just-bash:
+        optional: true
+      microsandbox:
+        optional: true
+
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  exsolve@1.1.1:
+    resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  grad-school@0.0.5:
+    resolution: {integrity: sha512-rXunEHF9M9EkMydTBux7+IryYXEZinRk6g8OBOGDBzo/qWJjhTxy86i5q7lQYpCLHN8Sqv1XX3OIOc7ka2gtvQ==}
+    engines: {node: '>=8.0.0'}
+
+  h3@2.0.1-rc.31:
+    resolution: {integrity: sha512-AG7qZzF99a0BSYoXT3evJgIhwSIUKow7R+hwkLRZS06WJ9nbSb7QXUDgs1ByBjp6svTvl++N/GKA7I9YPz9cQQ==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.12
+      ocache: '>=0.3.0'
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+      ocache:
+        optional: true
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  httpxy@0.5.5:
+    resolution: {integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-message-util@29.7.0:
+    resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-util@29.7.0:
+    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  kareem@3.3.0:
+    resolution: {integrity: sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw==}
+    engines: {node: '>=18.0.0'}
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mem0ai@3.1.8:
+    resolution: {integrity: sha512-K6GMfW0Yy7aaOBHPOX8bGO3+vuO3wvNH1SOJWDgK4QkSbPE8RM+XMLY8mNSvBPBggzHlrxBdD2I1Lwz9gCqzFw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@anthropic-ai/sdk': ^0.40.1
+      '@aws-sdk/client-bedrock-runtime': '>=3.0.0 <3.968.0'
+      '@aws-sdk/client-neptune-graph': '>=3.0.0 <3.968.0'
+      '@aws-sdk/client-s3vectors': 3.967.0
+      '@azure/identity': ^4.0.0
+      '@azure/search-documents': ^12.0.0
+      '@cloudflare/workers-types': ^4.20250504.0
+      '@databricks/sql': ^1.16.0
+      '@elastic/elasticsearch': ^9.0.0
+      '@google-cloud/aiplatform': ^6.8.0
+      '@google/genai': ^1.40.0
+      '@huggingface/transformers': ^3.0.0 || ^4.0.0
+      '@langchain/core': ^1.1.47
+      '@mistralai/mistralai': ^1.5.2
+      '@mochow/mochow-sdk-node': ^2.1.5
+      '@opensearch-project/opensearch': ^3.5.1
+      '@pinecone-database/pinecone': ^8.0.0
+      '@qdrant/js-client-rest': ^1.18.0
+      '@supabase/supabase-js': ^2.49.1
+      '@turbopuffer/turbopuffer': ^2.0.0
+      '@types/jest': 29.5.14
+      '@types/pg': 8.11.0
+      '@upstash/vector': ^1.2.3
+      '@zilliz/milvus2-sdk-node': ^2.4.0 || ^3.0.0
+      better-sqlite3: ^12.6.2
+      cassandra-driver: 4.8.0
+      chromadb: ^3.5.0
+      cloudflare: ^4.2.0
+      cohere-ai: ^7.17.0 || ^8.0.0
+      compromise: ^14.0.0
+      fastembed: ^2.1.0
+      groq-sdk: 0.3.0
+      iovalkey: ^0.3.3
+      mongodb: ^7.0.0
+      mysql2: ^3.0.0
+      natural: ^8.0.1
+      ollama: ^0.5.14
+      oracledb: ^6.5.0 || ^7.0.0
+      pg: 8.11.3
+      redis: ^4.6.13
+      weaviate-client: ^3.0.0
+      zeroentropy: ^0.1.0-alpha.10
+    peerDependenciesMeta:
+      '@anthropic-ai/sdk':
+        optional: true
+      '@aws-sdk/client-bedrock-runtime':
+        optional: true
+      '@aws-sdk/client-neptune-graph':
+        optional: true
+      '@aws-sdk/client-s3vectors':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/search-documents':
+        optional: true
+      '@databricks/sql':
+        optional: true
+      '@elastic/elasticsearch':
+        optional: true
+      '@google-cloud/aiplatform':
+        optional: true
+      '@google/genai':
+        optional: true
+      '@huggingface/transformers':
+        optional: true
+      '@langchain/core':
+        optional: true
+      '@mistralai/mistralai':
+        optional: true
+      '@mochow/mochow-sdk-node':
+        optional: true
+      '@opensearch-project/opensearch':
+        optional: true
+      '@pinecone-database/pinecone':
+        optional: true
+      '@qdrant/js-client-rest':
+        optional: true
+      '@supabase/supabase-js':
+        optional: true
+      '@turbopuffer/turbopuffer':
+        optional: true
+      '@upstash/vector':
+        optional: true
+      '@zilliz/milvus2-sdk-node':
+        optional: true
+      cassandra-driver:
+        optional: true
+      chromadb:
+        optional: true
+      cloudflare:
+        optional: true
+      cohere-ai:
+        optional: true
+      fastembed:
+        optional: true
+      groq-sdk:
+        optional: true
+      iovalkey:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      ollama:
+        optional: true
+      oracledb:
+        optional: true
+      redis:
+        optional: true
+      weaviate-client:
+        optional: true
+      zeroentropy:
+        optional: true
+
+  memjs@1.3.2:
+    resolution: {integrity: sha512-qUEg2g8vxPe+zPn09KidjIStHPtoBO8Cttm8bgJFWWabbsjQ9Av9Ky+6UcvKx6ue0LLb/LEhtcyQpRyKfzeXcg==}
+    engines: {node: '>=0.10.0'}
+
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  mongodb-connection-string-url@7.0.2:
+    resolution: {integrity: sha512-ZoS07RoFqpKYQwAk59qmrx8+jJHNHU30UjlU96QktiGn1ltvDr+vCznLX5DiUBLEpMAHatHNWV1nM/74ul66kA==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb@7.5.0:
+    resolution: {integrity: sha512-5FnrEDLnvp6ycUOGLNLLU33BfCx2qmp2mJjGPDwKLruYsVzXVSK5fsGpoDXvsXJwBfBsD7ebMRdawbDxC2814g==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: ^7.2.0
+      snappy: ^7.3.2
+      socks: ^2.8.6
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
+  mongoose@9.9.5:
+    resolution: {integrity: sha512-t/kUoeDjlHmav7yCaq//YKU3wiIgUPaTj4GrluiTHUw4jQ77/CXtdMDSor4f1u3SKLhIK6NgCF+AzzUqU02Aag==}
+    engines: {node: '>=20.19.0'}
+
+  mpath@0.9.0:
+    resolution: {integrity: sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==}
+    engines: {node: '>=4.0.0'}
+
+  mquery@6.0.0:
+    resolution: {integrity: sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==}
+    engines: {node: '>=20.19.0'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  natural@8.1.1:
+    resolution: {integrity: sha512-Ucb+lsUcGxUqu3rn8cwHjT6gJQosO63nIX/aBQXB3+IDkNbFV7PuviysO+Rzz3aKn7PZhPj3bNF4PS9gDVjYCQ==}
+    engines: {node: '>=0.4.10'}
+
+  nf3@0.3.24:
+    resolution: {integrity: sha512-HxLK4bo+5jNsEETZp4w3tJblHOA9MCBY14IN9nZJJV8JDxt9yNIYxuBuLMjTAR5GFa3HL61+8VQDUrXv3/C8fw==}
+
+  nitro@3.0.260903-beta:
+    resolution: {integrity: sha512-54gANPi62O8rfMvepiJUVuIzEIinYfpeHbebywlLxvVTgIYXDwSvpaU9Id+0sJOBjBx0wC1/CVYXJkH7SY+l0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  node-abi@3.96.0:
+    resolution: {integrity: sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==}
+    engines: {node: '>=10'}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  ocache@0.3.0:
+    resolution: {integrity: sha512-RS/9P0zeBb0gDJmadGERLH8lZNXK7xbufTDhclkXGvFGTsj0G4M5/cLk+mizcERH29mLXNnocfB5wjcK70wGJg==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  openai@4.104.0:
+    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  packet-reader@1.0.0:
+    resolution: {integrity: sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg-types@4.1.0:
+    resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
+    engines: {node: '>=10'}
+
+  pg@8.11.3:
+    resolution: {integrity: sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pg@8.23.0:
+    resolution: {integrity: sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  pgpass@1.0.6:
+    resolution: {integrity: sha512-lqIfH7bdgsxHAY/ZnUOwm+aCFKrsHBDhSFuk9O0B9uCqJAIkrKTo/+LQqLPLUS4e04+jCmQVikxE3QipH5chPw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss@8.5.28:
+    resolution: {integrity: sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+
+  postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  redis@5.12.1:
+    resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
+    engines: {node: '>= 18.19.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  rolldown@1.2.7:
+    resolution: {integrity: sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rollup@4.63.1:
+    resolution: {integrity: sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rou3@0.9.2:
+    resolution: {integrity: sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sift@17.1.3:
+    resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  srvx@1.0.4:
+    resolution: {integrity: sha512-eZmYaxUfZSo7/8m8UdsHRJNmTLSCTPPom9d7a60vMmuVeZvwhbvflRR+00/CxTCjMOFa5+H8tgBeNDVZ+w7AAQ==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  stopwords-iso@1.1.0:
+    resolution: {integrity: sha512-I6GPS/E0zyieHehMRPQcqkiBMJKGgLta+1hREixhoLPqEA0AlVFiC43dl8uPpmkkeRdDMzYRWFWk5/l9x7nmNg==}
+    engines: {node: '>=0.10.0'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  suffix-thumb@5.0.2:
+    resolution: {integrity: sha512-I5PWXAFKx3FYnI9a+dQMWNqTxoRt6vdBdb0O+BJ1sxXCWtSoQCusc13E58f+9p4MYx/qCnEMkD5jac6K2j3dgA==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  sylvester@0.0.21:
+    resolution: {integrity: sha512-yUT0ukFkFEt4nb+NY+n2ag51aS/u9UHXoZw+A4jgD77/jzZsBoSDHuqysrVCBC4CYR4TYvUJq54ONpXgDBH8tA==}
+    engines: {node: '>=0.2.6'}
+
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.3.1:
+    resolution: {integrity: sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
+    engines: {node: '>=20.18.1'}
+
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  unstorage@2.0.0-alpha.10:
+    resolution: {integrity: sha512-6h1veZp8gnp4dGllf0tDijoXxDYymJu251IpKKkrSVH+QHL6tXFbwG85KM+CBHSgpkkgtPuIiZ9oLCLP5+1Evw==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
+  uuid@13.0.2:
+    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
+    hasBin: true
+
+  vite@8.2.2:
+    resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0 || ^0.5.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wordnet-db@3.1.14:
+    resolution: {integrity: sha512-zVyFsvE+mq9MCmwXUWHIcpfbrHHClZWZiVOzKSxNJruIcFn2RbY55zkhiAMMxM8zCVSmtNiViq8FsAZSFpMYag==}
+    engines: {node: '>=0.6.0'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
+
+snapshots:
+
+  '@ai-sdk/gateway@4.0.75(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.10
+      '@ai-sdk/provider-utils': 5.0.36(zod@4.5.4)
+      '@vercel/oidc': 3.2.0
+      zod: 4.5.4
+
+  '@ai-sdk/provider-utils@5.0.36(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.10
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.1
+      zod: 4.5.4
+
+  '@ai-sdk/provider@4.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@cloudflare/workers-types@4.20260702.1': {}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@jest/expect-utils@29.7.0':
+    dependencies:
+      jest-get-type: 29.6.3
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.12
+
+  '@jest/types@29.6.3':
+    dependencies:
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 24.13.3
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.6.0
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.6.0': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.6.0
+
+  '@mongodb-js/saslprep@1.5.2':
+    dependencies:
+      sparse-bitfield: 3.0.3
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@oxc-project/types@0.148.0': {}
+
+  '@redis/bloom@5.12.1(@redis/client@5.12.1)':
+    dependencies:
+      '@redis/client': 5.12.1
+
+  '@redis/client@5.12.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+
+  '@redis/json@5.12.1(@redis/client@5.12.1)':
+    dependencies:
+      '@redis/client': 5.12.1
+
+  '@redis/search@5.12.1(@redis/client@5.12.1)':
+    dependencies:
+      '@redis/client': 5.12.1
+
+  '@redis/time-series@5.12.1(@redis/client@5.12.1)':
+    dependencies:
+      '@redis/client': 5.12.1
+
+  '@rolldown/binding-android-arm-eabi@1.2.7':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.2.7':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.7':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.7':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.7':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.7':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.7':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.7':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.7':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    optional: true
+
+  '@sinclair/typebox@0.27.12': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@29.5.14':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
+
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 24.13.3
+      form-data: 4.0.6
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/pg@8.11.0':
+    dependencies:
+      '@types/node': 24.13.3
+      pg-protocol: 1.16.0
+      pg-types: 4.1.0
+
+  '@types/stack-utils@2.0.3': {}
+
+  '@types/webidl-conversions@7.0.3': {}
+
+  '@types/whatwg-url@13.0.0':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
+
+  '@vercel/oidc@3.2.0': {}
+
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.7))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.27.7)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
+  '@workflow/serde@4.1.0': {}
+
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
+  acorn@8.18.0: {}
+
+  afinn-165-financialmarketnews@3.0.0: {}
+
+  afinn-165@2.0.2: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+
+  ai@7.0.93(zod@4.5.4):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.75(zod@4.5.4)
+      '@ai-sdk/provider': 4.0.10
+      '@ai-sdk/provider-utils': 5.0.36(zod@4.5.4)
+      zod: 4.5.4
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  any-promise@1.3.0: {}
+
+  apparatus@0.0.10:
+    dependencies:
+      sylvester: 0.0.21
+
+  assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  axios@1.20.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  base64-js@1.5.1: {}
+
+  better-sqlite3@12.11.1:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  bson@7.3.2: {}
+
+  buffer-writer@2.0.0: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  chai@6.2.2: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  chownr@1.1.4: {}
+
+  ci-info@3.9.0: {}
+
+  cluster-key-slot@1.1.2: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  commander@4.1.1: {}
+
+  compromise@14.16.0:
+    dependencies:
+      efrt: 2.7.0
+      grad-school: 0.0.5
+      suffix-thumb: 5.0.2
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  crossws@0.4.12(srvx@1.0.4):
+    optionalDependencies:
+      srvx: 1.0.4
+
+  db0@0.4.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
+  delayed-stream@1.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  diff-sequences@29.6.3: {}
+
+  dotenv@17.4.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  efrt@2.7.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  env-runner@0.2.1:
+    dependencies:
+      crossws: 0.4.12(srvx@1.0.4)
+      exsolve: 1.1.1
+      httpxy: 0.5.5
+      srvx: 1.0.4
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.2: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  escape-string-regexp@2.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  eve@0.52.2(ai@7.0.93(zod@4.5.4)):
+    dependencies:
+      ai: 7.0.93(zod@4.5.4)
+      nitro: 3.0.260903-beta
+      undici: 8.9.0
+
+  event-target-shim@5.0.1: {}
+
+  eventsource-parser@3.1.1: {}
+
+  expand-template@2.0.3: {}
+
+  expect-type@1.4.0: {}
+
+  expect@29.7.0:
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+
+  exsolve@1.1.1: {}
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
+
+  file-uri-to-path@1.0.0: {}
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.63.1
+
+  follow-redirects@1.16.0: {}
+
+  form-data-encoder@1.7.2: {}
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
+
+  fs-constants@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  github-from-package@0.0.0: {}
+
+  gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  grad-school@0.0.5: {}
+
+  h3@2.0.1-rc.31(crossws@0.4.12(srvx@1.0.4))(ocache@0.3.0):
+    dependencies:
+      rou3: 0.9.2
+      srvx: 1.0.4
+    optionalDependencies:
+      crossws: 0.4.12(srvx@1.0.4)
+      ocache: 0.3.0
+
+  has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hookable@6.1.1: {}
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  httpxy@0.5.5: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
+  is-number@7.0.0: {}
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-message-util@29.7.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@jest/types': 29.6.3
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-util@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 24.13.3
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.2
+
+  joycon@3.1.1: {}
+
+  js-tokens@4.0.0: {}
+
+  json-schema@0.4.0: {}
+
+  kareem@3.3.0: {}
+
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.6.0
+
+  math-intrinsics@1.1.0: {}
+
+  mem0ai@3.1.8(@cloudflare/workers-types@4.20260702.1)(@types/jest@29.5.14)(@types/pg@8.11.0)(better-sqlite3@12.11.1)(compromise@14.16.0)(mongodb@7.5.0)(natural@8.1.1)(pg@8.11.3):
+    dependencies:
+      '@cloudflare/workers-types': 4.20260702.1
+      '@types/jest': 29.5.14
+      '@types/pg': 8.11.0
+      axios: 1.20.0
+      better-sqlite3: 12.11.1
+      compromise: 14.16.0
+      natural: 8.1.1
+      openai: 4.104.0(zod@3.25.76)
+      pg: 8.11.3
+      uuid: 11.1.1
+      zod: 3.25.76
+    optionalDependencies:
+      mongodb: 7.5.0
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - supports-color
+      - ws
+
+  memjs@1.3.2: {}
+
+  memory-pager@1.5.0: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mimic-response@3.1.0: {}
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.18.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
+  mongodb-connection-string-url@7.0.2:
+    dependencies:
+      '@types/whatwg-url': 13.0.0
+      whatwg-url: 14.2.0
+
+  mongodb@7.5.0:
+    dependencies:
+      '@mongodb-js/saslprep': 1.5.2
+      bson: 7.3.2
+      mongodb-connection-string-url: 7.0.2
+
+  mongoose@9.9.5:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      kareem: 3.3.0
+      mongodb: 7.5.0
+      mpath: 0.9.0
+      mquery: 6.0.0
+      ms: 2.1.3
+      sift: 17.1.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
+
+  mpath@0.9.0: {}
+
+  mquery@6.0.0: {}
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.18: {}
+
+  napi-build-utils@2.0.0: {}
+
+  natural@8.1.1:
+    dependencies:
+      afinn-165: 2.0.2
+      afinn-165-financialmarketnews: 3.0.0
+      apparatus: 0.0.10
+      dotenv: 17.4.2
+      memjs: 1.3.2
+      mongoose: 9.9.5
+      pg: 8.23.0
+      redis: 5.12.1
+      safe-stable-stringify: 2.5.0
+      stopwords-iso: 1.1.0
+      sylvester: 0.0.21
+      underscore: 1.13.8
+      uuid: 13.0.2
+      wordnet-db: 3.1.14
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - pg-native
+      - snappy
+      - socks
+
+  nf3@0.3.24: {}
+
+  nitro@3.0.260903-beta:
+    dependencies:
+      consola: 3.4.2
+      crossws: 0.4.12(srvx@1.0.4)
+      db0: 0.4.1
+      env-runner: 0.2.1
+      h3: 2.0.1-rc.31(crossws@0.4.12(srvx@1.0.4))(ocache@0.3.0)
+      hookable: 6.1.1
+      nf3: 0.3.24
+      ocache: 0.3.0
+      rolldown: 1.2.7
+      rou3: 0.9.2
+      srvx: 1.0.4
+      unenv: 2.0.0-rc.24
+      unstorage: 2.0.0-alpha.10
+
+  node-abi@3.96.0:
+    dependencies:
+      semver: 7.8.5
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  object-assign@4.1.1: {}
+
+  obuf@1.1.2: {}
+
+  obug@2.1.4: {}
+
+  ocache@0.3.0: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  openai@4.104.0(zod@3.25.76):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - encoding
+
+  packet-reader@1.0.0: {}
+
+  pathe@2.0.3: {}
+
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-numeric@1.0.2: {}
+
+  pg-pool@3.14.0(pg@8.11.3):
+    dependencies:
+      pg: 8.11.3
+
+  pg-pool@3.14.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+
+  pg-protocol@1.16.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg-types@4.1.0:
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.4
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
+
+  pg@8.11.3:
+    dependencies:
+      buffer-writer: 2.0.0
+      packet-reader: 1.0.0
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.11.3)
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+      pgpass: 1.0.6
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pg@8.23.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  pgpass@1.0.6: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.7: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(postcss@8.5.28):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.28
+
+  postcss@8.5.28:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-array@3.0.4: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-bytea@3.0.0:
+    dependencies:
+      obuf: 1.1.2
+
+  postgres-date@1.0.7: {}
+
+  postgres-date@2.1.0: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  postgres-interval@3.0.0: {}
+
+  postgres-range@1.1.4: {}
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.96.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.5
+      tunnel-agent: 0.6.0
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  proxy-from-env@2.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  punycode@2.3.1: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  react-is@18.3.1: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  readdirp@4.1.2: {}
+
+  redis@5.12.1:
+    dependencies:
+      '@redis/bloom': 5.12.1(@redis/client@5.12.1)
+      '@redis/client': 5.12.1
+      '@redis/json': 5.12.1(@redis/client@5.12.1)
+      '@redis/search': 5.12.1(@redis/client@5.12.1)
+      '@redis/time-series': 5.12.1(@redis/client@5.12.1)
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
+
+  resolve-from@5.0.0: {}
+
+  rolldown@1.2.7:
+    dependencies:
+      '@oxc-project/types': 0.148.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm-eabi': 1.2.7
+      '@rolldown/binding-android-arm64': 1.2.7
+      '@rolldown/binding-darwin-arm64': 1.2.7
+      '@rolldown/binding-darwin-x64': 1.2.7
+      '@rolldown/binding-freebsd-x64': 1.2.7
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.7
+      '@rolldown/binding-linux-arm64-gnu': 1.2.7
+      '@rolldown/binding-linux-arm64-musl': 1.2.7
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.7
+      '@rolldown/binding-linux-s390x-gnu': 1.2.7
+      '@rolldown/binding-linux-x64-gnu': 1.2.7
+      '@rolldown/binding-linux-x64-musl': 1.2.7
+      '@rolldown/binding-openharmony-arm64': 1.2.7
+      '@rolldown/binding-win32-arm64-msvc': 1.2.7
+      '@rolldown/binding-win32-x64-msvc': 1.2.7
+
+  rollup@4.63.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.63.1
+      '@rollup/rollup-android-arm64': 4.63.1
+      '@rollup/rollup-darwin-arm64': 4.63.1
+      '@rollup/rollup-darwin-x64': 4.63.1
+      '@rollup/rollup-freebsd-arm64': 4.63.1
+      '@rollup/rollup-freebsd-x64': 4.63.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.63.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.63.1
+      '@rollup/rollup-linux-arm64-gnu': 4.63.1
+      '@rollup/rollup-linux-arm64-musl': 4.63.1
+      '@rollup/rollup-linux-loong64-gnu': 4.63.1
+      '@rollup/rollup-linux-loong64-musl': 4.63.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.63.1
+      '@rollup/rollup-linux-ppc64-musl': 4.63.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.63.1
+      '@rollup/rollup-linux-riscv64-musl': 4.63.1
+      '@rollup/rollup-linux-s390x-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-musl': 4.63.1
+      '@rollup/rollup-openbsd-x64': 4.63.1
+      '@rollup/rollup-openharmony-arm64': 4.63.1
+      '@rollup/rollup-win32-arm64-msvc': 4.63.1
+      '@rollup/rollup-win32-ia32-msvc': 4.63.1
+      '@rollup/rollup-win32-x64-gnu': 4.63.1
+      '@rollup/rollup-win32-x64-msvc': 4.63.1
+      fsevents: 2.3.3
+
+  rou3@0.9.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  safe-stable-stringify@2.5.0: {}
+
+  semver@7.8.5: {}
+
+  sift@17.1.3: {}
+
+  siginfo@2.0.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  slash@3.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
+
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
+
+  split2@4.2.0: {}
+
+  srvx@1.0.4: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  stopwords-iso@1.1.0: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-json-comments@2.0.1: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
+  suffix-thumb@5.0.2: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  sylvester@0.0.21: {}
+
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyexec@1.3.1: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+
+  tinyrainbow@3.1.1: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(postcss@8.5.28)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.28)
+      resolve-from: 5.0.0
+      rollup: 4.63.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.28
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
+
+  underscore@1.13.8: {}
+
+  undici-types@5.26.5: {}
+
+  undici-types@7.18.2: {}
+
+  undici@7.29.1: {}
+
+  undici@8.9.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
+  unstorage@2.0.0-alpha.10: {}
+
+  util-deprecate@1.0.2: {}
+
+  uuid@11.1.1: {}
+
+  uuid@13.0.2: {}
+
+  vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.7):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.7
+      postcss: 8.5.28
+      rolldown: 1.2.7
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+
+  vitest@4.1.11(@types/node@24.13.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.7)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.7))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.1
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.27.7)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+    transitivePeerDependencies:
+      - msw
+
+  web-streams-polyfill@4.0.0-beta.3: {}
+
+  webidl-conversions@3.0.1: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wordnet-db@3.1.14: {}
+
+  wrappy@1.0.2: {}
+
+  xtend@4.0.2: {}
+
+  zod@3.25.76: {}
+
+  zod@4.5.4: {}

--- a/integrations/eve/registry/README.md
+++ b/integrations/eve/registry/README.md
@@ -1,0 +1,36 @@
+# Eve registry contribution
+
+These files are the Mem0 side of `eve add memory/mem0`. They are not published in the npm tarball. Copy them into a PR against [vercel/eve](https://github.com/vercel/eve) after `@mem0/eve` is on npm.
+
+Supermemory's version of this change is [vercel/eve#2775](https://github.com/vercel/eve/pull/2775). Eve already asked Mem0 to own the package and open that PR.
+
+## What the Eve PR should do
+
+1. Add a `kind: "memory"` catalog item named `mem0`.
+2. Install `@mem0/eve` and declare `MEM0_API_KEY`.
+3. Write `agent/memory/mem0.ts` from [`mem0.ts`](./mem0.ts).
+4. List Mem0 on [eve.dev/docs/memory](https://eve.dev/docs/memory) next to Supermemory and Upstash.
+
+[`item.json`](./item.json) is the shadcn-registry shape Eve uses for `eve add`. Adapt field names to Eve's current catalog schema if it has moved since this was written.
+
+## Suggested install command
+
+```bash
+eve add memory/mem0
+```
+
+## Suggested docs snippet
+
+```ts
+import { mem0Provider } from "@mem0/eve";
+import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
+
+export default defineMemory({
+  description: "Recall and manage durable context for the current user.",
+  provider: mem0Provider({
+    apiKey: process.env.MEM0_API_KEY!,
+  }),
+  scope: byPrincipal,
+});
+```

--- a/integrations/eve/registry/README.md
+++ b/integrations/eve/registry/README.md
@@ -2,7 +2,7 @@
 
 These files are the Mem0 side of `eve add memory/mem0`. They are not published in the npm tarball. Copy them into a PR against [vercel/eve](https://github.com/vercel/eve) after `@mem0/eve` is on npm.
 
-Supermemory's version of this change is [vercel/eve#2775](https://github.com/vercel/eve/pull/2775). Eve already asked Mem0 to own the package and open that PR.
+Supermemory's version of this change is [vercel/eve#2775](https://github.com/vercel/eve/pull/2775). Use that PR as the catalog/shape reference.
 
 ## What the Eve PR should do
 

--- a/integrations/eve/registry/item.json
+++ b/integrations/eve/registry/item.json
@@ -1,0 +1,17 @@
+{
+  "name": "mem0",
+  "type": "registry:item",
+  "title": "Mem0",
+  "description": "Hosted semantic memory for Eve agents. Recalls relevant context before each turn, captures completed turns, and exposes search, remember, and forget tools.",
+  "dependencies": ["@mem0/eve"],
+  "envVars": {
+    "MEM0_API_KEY": ""
+  },
+  "files": [
+    {
+      "path": "registry/mem0.ts",
+      "type": "registry:file",
+      "target": "agent/memory/mem0.ts"
+    }
+  ]
+}

--- a/integrations/eve/registry/mem0.ts
+++ b/integrations/eve/registry/mem0.ts
@@ -1,0 +1,11 @@
+import { mem0Provider } from "@mem0/eve";
+import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
+
+export default defineMemory({
+  description: "Recall and manage durable context for the current user.",
+  provider: mem0Provider({
+    apiKey: process.env.MEM0_API_KEY!,
+  }),
+  scope: byPrincipal,
+});

--- a/integrations/eve/src/capture.ts
+++ b/integrations/eve/src/capture.ts
@@ -10,6 +10,12 @@ export async function captureCompletedTurn(input: {
   messages: readonly ConversationMessage[];
   turnInput: readonly ConversationMessage[];
 }): Promise<boolean> {
+  // Best-effort deduplication, not a guarantee. This lookup + add is not atomic,
+  // and with infer:true the prior write can still be a PENDING event whose
+  // memory is not yet visible here. So a restart during that window, or two
+  // workers that both clear this check before either write, can capture the
+  // same operation twice. The in-process gate in provider.ts narrows the common
+  // case; eliminating it would need a backend-supported atomic idempotency key.
   const existing = await input.store.listByMetadata({
     userId: input.scopeKey,
     metadata: { operation_id: input.operationId },

--- a/integrations/eve/src/capture.ts
+++ b/integrations/eve/src/capture.ts
@@ -1,0 +1,26 @@
+import { completedTurnMessages, type ConversationMessage } from "./messages.js";
+import type { MemoryStore } from "./store.js";
+
+export async function captureCompletedTurn(input: {
+  store: MemoryStore;
+  scopeKey: string;
+  infer: boolean;
+  metadata: Readonly<Record<string, unknown>>;
+  messages: readonly ConversationMessage[];
+  turnInput: readonly ConversationMessage[];
+}): Promise<boolean> {
+  const messages = completedTurnMessages({
+    messages: input.messages,
+    turnInput: input.turnInput,
+  });
+  if (messages.length === 0) {
+    return false;
+  }
+
+  await input.store.add(messages, {
+    userId: input.scopeKey,
+    infer: input.infer,
+    metadata: input.metadata,
+  });
+  return true;
+}

--- a/integrations/eve/src/capture.ts
+++ b/integrations/eve/src/capture.ts
@@ -1,14 +1,23 @@
 import { completedTurnMessages, type ConversationMessage } from "./messages.js";
-import type { MemoryStore } from "./store.js";
+import type { MemoryStore, StoreMetadata } from "./store.js";
 
 export async function captureCompletedTurn(input: {
   store: MemoryStore;
   scopeKey: string;
+  operationId: string;
   infer: boolean;
-  metadata: Readonly<Record<string, unknown>>;
+  metadata: StoreMetadata;
   messages: readonly ConversationMessage[];
   turnInput: readonly ConversationMessage[];
 }): Promise<boolean> {
+  const existing = await input.store.listByMetadata({
+    userId: input.scopeKey,
+    metadata: { operation_id: input.operationId },
+  });
+  if (existing.length > 0) {
+    return false;
+  }
+
   const messages = completedTurnMessages({
     messages: input.messages,
     turnInput: input.turnInput,

--- a/integrations/eve/src/errors.ts
+++ b/integrations/eve/src/errors.ts
@@ -1,3 +1,39 @@
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Unknown Mem0 error";
 }
+
+export function isSetupError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const text = `${error.name} ${error.message}`.toLowerCase();
+  return (
+    text.includes("api key") ||
+    text.includes("cannot be empty") ||
+    text.includes("authentication") ||
+    text.includes("unauthorized") ||
+    text.includes("401") ||
+    text.includes("403")
+  );
+}
+
+export function isNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const text = `${error.name} ${error.message}`.toLowerCase();
+  return text.includes("not found") || text.includes("404");
+}
+
+export function logProviderError(
+  scope: string,
+  error: unknown,
+  extra: Readonly<Record<string, unknown>>,
+): void {
+  console.error(`[@mem0/eve] ${scope}`, {
+    error,
+    name: error instanceof Error ? error.name : undefined,
+    message: errorMessage(error),
+    ...extra,
+  });
+}

--- a/integrations/eve/src/errors.ts
+++ b/integrations/eve/src/errors.ts
@@ -1,0 +1,3 @@
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown Mem0 error";
+}

--- a/integrations/eve/src/idempotency.ts
+++ b/integrations/eve/src/idempotency.ts
@@ -1,5 +1,7 @@
 const DEFAULT_LIMIT = 256;
 
+// In-process fast path only. Durable replay after restart is handled by
+// listing memories with metadata.operation_id before add.
 export function createIdempotencyGate(limit = DEFAULT_LIMIT) {
   const seen = new Map<string, Promise<void>>();
 

--- a/integrations/eve/src/idempotency.ts
+++ b/integrations/eve/src/idempotency.ts
@@ -1,0 +1,26 @@
+const DEFAULT_LIMIT = 256;
+
+export function createIdempotencyGate(limit = DEFAULT_LIMIT) {
+  const seen = new Map<string, Promise<void>>();
+
+  return function once(operationId: string, work: () => Promise<void>): Promise<void> {
+    const existing = seen.get(operationId);
+    if (existing) {
+      return existing;
+    }
+
+    const pending = work().catch((error: unknown) => {
+      seen.delete(operationId);
+      throw error;
+    });
+
+    seen.set(operationId, pending);
+    if (seen.size > limit) {
+      const oldest = seen.keys().next().value;
+      if (oldest && oldest !== operationId) {
+        seen.delete(oldest);
+      }
+    }
+    return pending;
+  };
+}

--- a/integrations/eve/src/index.ts
+++ b/integrations/eve/src/index.ts
@@ -1,0 +1,3 @@
+export { mem0Provider, mem0Provider as default } from "./provider.js";
+export type { Mem0ApiKey, Mem0ProviderOptions } from "./options.js";
+export type { MemoryStore, MemoryMessage, SearchHit } from "./store.js";

--- a/integrations/eve/src/index.ts
+++ b/integrations/eve/src/index.ts
@@ -1,3 +1,8 @@
 export { mem0Provider, mem0Provider as default } from "./provider.js";
-export type { Mem0ApiKey, Mem0ProviderOptions } from "./options.js";
+export type {
+  Mem0ApiKey,
+  Mem0InjectedProviderOptions,
+  Mem0ProviderOptions,
+  Mem0RemoteProviderOptions,
+} from "./options.js";
 export type { MemoryStore, MemoryMessage, SearchHit } from "./store.js";

--- a/integrations/eve/src/messages.ts
+++ b/integrations/eve/src/messages.ts
@@ -9,9 +9,16 @@ function textFromPart(part: unknown): string {
   if (typeof part === "string") {
     return part;
   }
-  if (part && typeof part === "object" && "text" in part) {
-    const text = (part as { text: unknown }).text;
-    return typeof text === "string" ? text : "";
+  if (part && typeof part === "object") {
+    const record = part as { type?: unknown; text?: unknown };
+    // Typed parts must be explicit text. A `reasoning` part also carries a
+    // `text` field, so accepting any object with `text` would leak the model's
+    // private reasoning into long-term memory. Untyped `{ text }` (no `type`
+    // key) stays supported for callers that pass a bare text object.
+    if ("type" in record && record.type !== "text") {
+      return "";
+    }
+    return typeof record.text === "string" ? record.text : "";
   }
   return "";
 }
@@ -72,11 +79,42 @@ export function completedTurnMessages(input: {
     return [];
   }
 
-  // Pair this turn's users with the latest assistant in the settled history.
-  const history = conversationMessages(input.messages);
-  const lastAssistant = [...history]
-    .reverse()
-    .find((message) => message.role === "assistant");
+  // Pair this turn's users with the assistant reply produced *in this turn*
+  // only. The current turn begins at the last user message in the settled
+  // history; any assistant text after it belongs to this turn. Walking the
+  // whole history instead would attach an older answer to the new user input
+  // when this turn is tool-only (no assistant text of its own).
+  let lastUserIndex = -1;
+  for (let index = input.messages.length - 1; index >= 0; index -= 1) {
+    if (input.messages[index]?.role === "user") {
+      lastUserIndex = index;
+      break;
+    }
+  }
 
-  return lastAssistant ? [...users, lastAssistant] : users;
+  // Collect every assistant text segment produced in this turn, in order, so a
+  // text -> tool-call -> text answer is captured whole rather than losing the
+  // pre-tool content.
+  const assistantSegments: string[] = [];
+  if (lastUserIndex >= 0) {
+    for (
+      let index = lastUserIndex + 1;
+      index < input.messages.length;
+      index += 1
+    ) {
+      const message = input.messages[index];
+      if (message?.role !== "assistant") {
+        continue;
+      }
+      const text = extractText(message.content);
+      if (text.length > 0) {
+        assistantSegments.push(text);
+      }
+    }
+  }
+
+  const assistantText = assistantSegments.join("\n");
+  return assistantText
+    ? [...users, { role: "assistant", content: assistantText }]
+    : users;
 }

--- a/integrations/eve/src/messages.ts
+++ b/integrations/eve/src/messages.ts
@@ -5,27 +5,29 @@ export interface ConversationMessage {
   readonly content: unknown;
 }
 
+function textFromPart(part: unknown): string {
+  if (typeof part === "string") {
+    return part;
+  }
+  if (part && typeof part === "object" && "text" in part) {
+    const text = (part as { text: unknown }).text;
+    return typeof text === "string" ? text : "";
+  }
+  return "";
+}
+
 export function extractText(content: unknown): string {
   if (typeof content === "string") {
     return content.trim();
+  }
+  if (content && typeof content === "object" && !Array.isArray(content)) {
+    return textFromPart(content).trim();
   }
   if (!Array.isArray(content)) {
     return "";
   }
 
-  return content
-    .map((part) => {
-      if (typeof part === "string") {
-        return part;
-      }
-      if (part && typeof part === "object" && "text" in part) {
-        const text = (part as { text: unknown }).text;
-        return typeof text === "string" ? text : "";
-      }
-      return "";
-    })
-    .join("\n")
-    .trim();
+  return content.map(textFromPart).join("\n").trim();
 }
 
 export function lastUserText(messages: readonly ConversationMessage[]): string {
@@ -70,6 +72,7 @@ export function completedTurnMessages(input: {
     return [];
   }
 
+  // Pair this turn's users with the latest assistant in the settled history.
   const history = conversationMessages(input.messages);
   const lastAssistant = [...history]
     .reverse()

--- a/integrations/eve/src/messages.ts
+++ b/integrations/eve/src/messages.ts
@@ -1,0 +1,79 @@
+import type { MemoryMessage } from "./store.js";
+
+export interface ConversationMessage {
+  readonly role: string;
+  readonly content: unknown;
+}
+
+export function extractText(content: unknown): string {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      if (part && typeof part === "object" && "text" in part) {
+        const text = (part as { text: unknown }).text;
+        return typeof text === "string" ? text : "";
+      }
+      return "";
+    })
+    .join("\n")
+    .trim();
+}
+
+export function lastUserText(messages: readonly ConversationMessage[]): string {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "user") {
+      continue;
+    }
+    const text = extractText(message.content);
+    if (text.length > 0) {
+      return text;
+    }
+  }
+  return "";
+}
+
+export function conversationMessages(
+  messages: readonly ConversationMessage[],
+): MemoryMessage[] {
+  const result: MemoryMessage[] = [];
+  for (const message of messages) {
+    if (message.role !== "user" && message.role !== "assistant") {
+      continue;
+    }
+    const text = extractText(message.content);
+    if (text.length === 0) {
+      continue;
+    }
+    result.push({ role: message.role, content: text });
+  }
+  return result;
+}
+
+export function completedTurnMessages(input: {
+  readonly messages: readonly ConversationMessage[];
+  readonly turnInput: readonly ConversationMessage[];
+}): MemoryMessage[] {
+  const users = conversationMessages(input.turnInput).filter(
+    (message) => message.role === "user",
+  );
+  if (users.length === 0) {
+    return [];
+  }
+
+  const history = conversationMessages(input.messages);
+  const lastAssistant = [...history]
+    .reverse()
+    .find((message) => message.role === "assistant");
+
+  return lastAssistant ? [...users, lastAssistant] : users;
+}

--- a/integrations/eve/src/options.ts
+++ b/integrations/eve/src/options.ts
@@ -1,0 +1,74 @@
+import type { MemoryStore } from "./store.js";
+
+export type Mem0ApiKey = string | (() => string | Promise<string>);
+
+export interface Mem0ProviderOptions {
+  readonly apiKey: Mem0ApiKey;
+  readonly host?: string;
+  readonly topK?: number;
+  readonly threshold?: number;
+  readonly rerank?: boolean;
+  readonly infer?: boolean;
+  readonly autoSearch?: {
+    readonly enabled?: boolean;
+  };
+  readonly capture?: {
+    readonly enabled?: boolean;
+  };
+  readonly metadata?: Readonly<Record<string, string | number | boolean>>;
+  readonly store?: MemoryStore;
+}
+
+export interface ResolvedMem0ProviderOptions {
+  readonly apiKey: Mem0ApiKey;
+  readonly host: string;
+  readonly topK: number;
+  readonly threshold: number;
+  readonly rerank: boolean;
+  readonly infer: boolean;
+  readonly autoSearch: {
+    readonly enabled: boolean;
+  };
+  readonly capture: {
+    readonly enabled: boolean;
+  };
+  readonly metadata: Readonly<Record<string, string | number | boolean>>;
+  readonly store?: MemoryStore;
+}
+
+export function resolveOptions(options: Mem0ProviderOptions): ResolvedMem0ProviderOptions {
+  const apiKey = options.apiKey;
+  if (typeof apiKey === "string") {
+    const trimmed = apiKey.trim();
+    if (trimmed.length === 0) {
+      throw new Error("Mem0 API key cannot be empty");
+    }
+  }
+
+  const topK = options.topK ?? 5;
+  if (!Number.isInteger(topK) || topK < 1 || topK > 100) {
+    throw new Error("topK must be an integer between 1 and 100");
+  }
+
+  const threshold = options.threshold ?? 0.1;
+  if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+    throw new Error("threshold must be a number between 0 and 1");
+  }
+
+  return {
+    apiKey,
+    host: options.host ?? "https://api.mem0.ai",
+    topK,
+    threshold,
+    rerank: options.rerank ?? false,
+    infer: options.infer ?? true,
+    autoSearch: {
+      enabled: options.autoSearch?.enabled ?? true,
+    },
+    capture: {
+      enabled: options.capture?.enabled ?? true,
+    },
+    metadata: options.metadata ?? {},
+    ...(options.store ? { store: options.store } : {}),
+  };
+}

--- a/integrations/eve/src/options.ts
+++ b/integrations/eve/src/options.ts
@@ -2,9 +2,7 @@ import type { MemoryStore } from "./store.js";
 
 export type Mem0ApiKey = string | (() => string | Promise<string>);
 
-export interface Mem0ProviderOptions {
-  readonly apiKey: Mem0ApiKey;
-  readonly host?: string;
+export interface Mem0SharedProviderOptions {
   readonly topK?: number;
   readonly threshold?: number;
   readonly rerank?: boolean;
@@ -16,11 +14,23 @@ export interface Mem0ProviderOptions {
     readonly enabled?: boolean;
   };
   readonly metadata?: Readonly<Record<string, string | number | boolean>>;
-  readonly store?: MemoryStore;
 }
 
-export interface ResolvedMem0ProviderOptions {
+export interface Mem0RemoteProviderOptions extends Mem0SharedProviderOptions {
   readonly apiKey: Mem0ApiKey;
+  readonly host?: string;
+}
+
+export interface Mem0InjectedProviderOptions extends Mem0SharedProviderOptions {
+  readonly store: MemoryStore;
+  readonly apiKey?: Mem0ApiKey;
+  readonly host?: string;
+}
+
+export type Mem0ProviderOptions = Mem0RemoteProviderOptions | Mem0InjectedProviderOptions;
+
+export interface ResolvedMem0ProviderOptions {
+  readonly apiKey?: Mem0ApiKey;
   readonly host: string;
   readonly topK: number;
   readonly threshold: number;
@@ -36,13 +46,38 @@ export interface ResolvedMem0ProviderOptions {
   readonly store?: MemoryStore;
 }
 
+function validateApiKey(apiKey: Mem0ApiKey): void {
+  if (typeof apiKey === "string" && apiKey.trim().length === 0) {
+    throw new Error("Mem0 API key cannot be empty");
+  }
+}
+
+function resolveHost(host: string | undefined): string {
+  const trimmed = host?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return "https://api.mem0.ai";
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error("host must be an http or https URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("host must be an http or https URL");
+  }
+  return trimmed;
+}
+
 export function resolveOptions(options: Mem0ProviderOptions): ResolvedMem0ProviderOptions {
+  const store = "store" in options ? options.store : undefined;
   const apiKey = options.apiKey;
-  if (typeof apiKey === "string") {
-    const trimmed = apiKey.trim();
-    if (trimmed.length === 0) {
-      throw new Error("Mem0 API key cannot be empty");
-    }
+  if (!store && apiKey === undefined) {
+    throw new Error("apiKey is required unless a store is provided");
+  }
+  if (apiKey !== undefined) {
+    validateApiKey(apiKey);
   }
 
   const topK = options.topK ?? 5;
@@ -56,8 +91,8 @@ export function resolveOptions(options: Mem0ProviderOptions): ResolvedMem0Provid
   }
 
   return {
-    apiKey,
-    host: options.host ?? "https://api.mem0.ai",
+    ...(apiKey !== undefined ? { apiKey } : {}),
+    host: resolveHost(options.host),
     topK,
     threshold,
     rerank: options.rerank ?? false,
@@ -69,6 +104,6 @@ export function resolveOptions(options: Mem0ProviderOptions): ResolvedMem0Provid
       enabled: options.capture?.enabled ?? true,
     },
     metadata: options.metadata ?? {},
-    ...(options.store ? { store: options.store } : {}),
+    ...(store ? { store } : {}),
   };
 }

--- a/integrations/eve/src/provider.ts
+++ b/integrations/eve/src/provider.ts
@@ -1,0 +1,120 @@
+import { defineMemoryProvider, type MemoryProvider } from "eve/memory";
+import { captureCompletedTurn } from "./capture.js";
+import { errorMessage } from "./errors.js";
+import { createIdempotencyGate } from "./idempotency.js";
+import { lastUserText, type ConversationMessage } from "./messages.js";
+import { resolveOptions, type Mem0ProviderOptions } from "./options.js";
+import { recallMemories } from "./recall.js";
+import { createMem0Store, type MemoryStore } from "./store.js";
+import { createMem0Tools } from "./tools.js";
+
+function asConversation(messages: readonly unknown[]): ConversationMessage[] {
+  return messages.filter((message): message is ConversationMessage => {
+    if (message === null || typeof message !== "object") {
+      return false;
+    }
+    return (
+      "role" in message && typeof (message as { role: unknown }).role === "string"
+    );
+  });
+}
+
+export function mem0Provider(options: Mem0ProviderOptions): MemoryProvider {
+  const config = resolveOptions(options);
+  const once = createIdempotencyGate();
+  let storePromise: Promise<MemoryStore> | undefined;
+
+  const getStore = async (): Promise<MemoryStore> => {
+    if (config.store) {
+      return config.store;
+    }
+    storePromise ??= createMem0Store({
+      apiKey: config.apiKey,
+      host: config.host,
+    });
+    return storePromise;
+  };
+
+  const recall = async (context: {
+    abortSignal: AbortSignal;
+    messages: readonly unknown[];
+    session: { id: string };
+    memory: { scope: { key: string } };
+    turn?: { input: readonly unknown[] } | null;
+  }) => {
+    if (!config.autoSearch.enabled) {
+      return null;
+    }
+
+    const querySource = context.turn?.input ?? context.messages;
+    const query = lastUserText(asConversation(querySource));
+
+    try {
+      const store = await getStore();
+      return await recallMemories({
+        store,
+        scopeKey: context.memory.scope.key,
+        query,
+        topK: config.topK,
+        threshold: config.threshold,
+        rerank: config.rerank,
+      });
+    } catch (error) {
+      if (context.abortSignal.aborted) {
+        throw error;
+      }
+      console.error("[@mem0/eve] recall failed", {
+        error: errorMessage(error),
+        sessionId: context.session.id,
+      });
+      return null;
+    }
+  };
+
+  return defineMemoryProvider({
+    recall: {
+      "turn.started": recall,
+      "compaction.completed": recall,
+    },
+    ...(config.capture.enabled
+      ? {
+          capture: {
+            async "turn.completed"(context) {
+              try {
+                const store = await getStore();
+                await once(context.operationId, async () => {
+                  await captureCompletedTurn({
+                    store,
+                    scopeKey: context.memory.scope.key,
+                    infer: config.infer,
+                    metadata: {
+                      ...config.metadata,
+                      source: "eve",
+                      operation_id: context.operationId,
+                      session_id: context.session.id,
+                      slot: context.memory.slot,
+                    },
+                    messages: asConversation(context.messages),
+                    turnInput: asConversation(context.turn.input),
+                  });
+                });
+              } catch (error) {
+                if (context.abortSignal.aborted) {
+                  throw error;
+                }
+                console.error("[@mem0/eve] capture failed", {
+                  error: errorMessage(error),
+                  sessionId: context.session.id,
+                  turnId: context.turn.id,
+                });
+              }
+            },
+          },
+        }
+      : {}),
+    async tools(context) {
+      const store = await getStore();
+      return createMem0Tools(store, context.memory.scope.key);
+    },
+  });
+}

--- a/integrations/eve/src/provider.ts
+++ b/integrations/eve/src/provider.ts
@@ -1,11 +1,11 @@
 import { defineMemoryProvider, type MemoryProvider } from "eve/memory";
 import { captureCompletedTurn } from "./capture.js";
-import { errorMessage } from "./errors.js";
+import { isSetupError, logProviderError } from "./errors.js";
 import { createIdempotencyGate } from "./idempotency.js";
 import { lastUserText, type ConversationMessage } from "./messages.js";
 import { resolveOptions, type Mem0ProviderOptions } from "./options.js";
 import { recallMemories } from "./recall.js";
-import { createMem0Store, type MemoryStore } from "./store.js";
+import { createLazyStore, createMem0Store, type MemoryStore } from "./store.js";
 import { createMem0Tools } from "./tools.js";
 
 function asConversation(messages: readonly unknown[]): ConversationMessage[] {
@@ -14,7 +14,9 @@ function asConversation(messages: readonly unknown[]): ConversationMessage[] {
       return false;
     }
     return (
-      "role" in message && typeof (message as { role: unknown }).role === "string"
+      "role" in message &&
+      typeof (message as { role: unknown }).role === "string" &&
+      "content" in message
     );
   });
 }
@@ -22,17 +24,21 @@ function asConversation(messages: readonly unknown[]): ConversationMessage[] {
 export function mem0Provider(options: Mem0ProviderOptions): MemoryProvider {
   const config = resolveOptions(options);
   const once = createIdempotencyGate();
-  let storePromise: Promise<MemoryStore> | undefined;
+  const loadRemoteStore = createLazyStore(async () => {
+    if (!config.apiKey) {
+      throw new Error("Mem0 API key cannot be empty");
+    }
+    return createMem0Store({
+      apiKey: config.apiKey,
+      host: config.host,
+    });
+  });
 
   const getStore = async (): Promise<MemoryStore> => {
     if (config.store) {
       return config.store;
     }
-    storePromise ??= createMem0Store({
-      apiKey: config.apiKey,
-      host: config.host,
-    });
-    return storePromise;
+    return loadRemoteStore();
   };
 
   const recall = async (context: {
@@ -47,7 +53,13 @@ export function mem0Provider(options: Mem0ProviderOptions): MemoryProvider {
     }
 
     const querySource = context.turn?.input ?? context.messages;
-    const query = lastUserText(asConversation(querySource));
+    const conversation = asConversation(querySource);
+    if (querySource.length > 0 && conversation.length === 0) {
+      console.error("[@mem0/eve] dropped all recall messages; no searchable user text", {
+        sessionId: context.session.id,
+      });
+    }
+    const query = lastUserText(conversation);
 
     try {
       const store = await getStore();
@@ -60,14 +72,13 @@ export function mem0Provider(options: Mem0ProviderOptions): MemoryProvider {
         rerank: config.rerank,
       });
     } catch (error) {
-      if (context.abortSignal.aborted) {
+      if (context.abortSignal.aborted || isSetupError(error)) {
         throw error;
       }
-      console.error("[@mem0/eve] recall failed", {
-        error: errorMessage(error),
+      logProviderError("recall failed", error, {
         sessionId: context.session.id,
       });
-      return null;
+      throw error;
     }
   };
 
@@ -80,41 +91,36 @@ export function mem0Provider(options: Mem0ProviderOptions): MemoryProvider {
       ? {
           capture: {
             async "turn.completed"(context) {
-              try {
-                const store = await getStore();
-                await once(context.operationId, async () => {
-                  await captureCompletedTurn({
-                    store,
-                    scopeKey: context.memory.scope.key,
-                    infer: config.infer,
-                    metadata: {
-                      ...config.metadata,
-                      source: "eve",
-                      operation_id: context.operationId,
-                      session_id: context.session.id,
-                      slot: context.memory.slot,
-                    },
-                    messages: asConversation(context.messages),
-                    turnInput: asConversation(context.turn.input),
-                  });
+              const store = await getStore();
+              await once(context.operationId, async () => {
+                await captureCompletedTurn({
+                  store,
+                  scopeKey: context.memory.scope.key,
+                  operationId: context.operationId,
+                  infer: config.infer,
+                  metadata: {
+                    ...config.metadata,
+                    source: "eve",
+                    operation_id: context.operationId,
+                    session_id: context.session.id,
+                    slot: context.memory.slot,
+                  },
+                  messages: asConversation(context.messages),
+                  turnInput: asConversation(context.turn.input),
                 });
-              } catch (error) {
-                if (context.abortSignal.aborted) {
-                  throw error;
-                }
-                console.error("[@mem0/eve] capture failed", {
-                  error: errorMessage(error),
-                  sessionId: context.session.id,
-                  turnId: context.turn.id,
-                });
-              }
+              });
             },
           },
         }
       : {}),
     async tools(context) {
       const store = await getStore();
-      return createMem0Tools(store, context.memory.scope.key);
+      return createMem0Tools(store, context.memory.scope.key, {
+        topK: config.topK,
+        threshold: config.threshold,
+        rerank: config.rerank,
+        infer: config.infer,
+      });
     },
   });
 }

--- a/integrations/eve/src/recall.ts
+++ b/integrations/eve/src/recall.ts
@@ -1,0 +1,36 @@
+import type { SearchHit, MemoryStore } from "./store.js";
+
+export interface RecallMessage {
+  readonly id: string;
+  readonly content: string;
+}
+
+export function formatRecallMessages(hits: readonly SearchHit[]): RecallMessage[] {
+  return hits.flatMap((hit) => {
+    const content = hit.memory.trim();
+    return content.length > 0 ? [{ id: hit.id, content }] : [];
+  });
+}
+
+export async function recallMemories(input: {
+  store: MemoryStore;
+  scopeKey: string;
+  query: string;
+  topK: number;
+  threshold: number;
+  rerank: boolean;
+}): Promise<{ messages: RecallMessage[] } | null> {
+  const query = input.query.trim();
+  if (query.length === 0) {
+    return null;
+  }
+
+  const { results } = await input.store.search(query, {
+    filters: { user_id: input.scopeKey },
+    topK: input.topK,
+    threshold: input.threshold,
+    rerank: input.rerank,
+  });
+  const messages = formatRecallMessages(results);
+  return messages.length > 0 ? { messages } : null;
+}

--- a/integrations/eve/src/recall.ts
+++ b/integrations/eve/src/recall.ts
@@ -7,8 +7,9 @@ export interface RecallMessage {
 
 export function formatRecallMessages(hits: readonly SearchHit[]): RecallMessage[] {
   return hits.flatMap((hit) => {
+    const id = hit.id.trim();
     const content = hit.memory.trim();
-    return content.length > 0 ? [{ id: hit.id, content }] : [];
+    return id.length > 0 && content.length > 0 ? [{ id, content }] : [];
   });
 }
 
@@ -26,7 +27,7 @@ export async function recallMemories(input: {
   }
 
   const { results } = await input.store.search(query, {
-    filters: { user_id: input.scopeKey },
+    userId: input.scopeKey,
     topK: input.topK,
     threshold: input.threshold,
     rerank: input.rerank,

--- a/integrations/eve/src/store.ts
+++ b/integrations/eve/src/store.ts
@@ -27,6 +27,15 @@ export interface AddMemoryInput {
   readonly metadata: StoreMetadata;
 }
 
+// A hosted-platform write with `infer: true` is asynchronous: Mem0 accepts the
+// request and returns an `event_id` with a PENDING status before extraction has
+// produced (or rejected) any memory. `queued` reflects that accepted-not-yet-
+// stored state; `completed` means the write resolved synchronously.
+export interface AddResult {
+  readonly status: "queued" | "completed";
+  readonly eventId?: string;
+}
+
 export interface SearchMemoryInput {
   readonly userId: string;
   readonly topK: number;
@@ -35,7 +44,10 @@ export interface SearchMemoryInput {
 }
 
 export interface MemoryStore {
-  add(messages: readonly MemoryMessage[], input: AddMemoryInput): Promise<void>;
+  add(
+    messages: readonly MemoryMessage[],
+    input: AddMemoryInput,
+  ): Promise<AddResult>;
   search(query: string, input: SearchMemoryInput): Promise<{ results: readonly SearchHit[] }>;
   get(memoryId: string): Promise<MemoryRecord | null>;
   listByMetadata(input: {
@@ -68,6 +80,35 @@ export function parseSearchHit(item: unknown): SearchHit | null {
     return null;
   }
   return { id, memory };
+}
+
+// Event statuses that mean "accepted, extraction not finished". Only these map
+// to `queued`; a terminal status (SUCCEEDED/FAILED) or an unknown/absent status
+// falls through to `completed`, so a FAILED write is never reported as still
+// pending. (The hosted add path returns PENDING synchronously; FAILED only
+// appears later via event polling.)
+const PENDING_STATUSES = new Set(["PENDING", "RUNNING", "PROCESSING", "QUEUED"]);
+
+export function parseAddResult(response: unknown): AddResult {
+  if (response && typeof response === "object" && !Array.isArray(response)) {
+    const record = response as Record<string, unknown>;
+    const eventIdValue = record.event_id ?? record.eventId;
+    const eventId =
+      typeof eventIdValue === "string" && eventIdValue.length > 0
+        ? eventIdValue
+        : undefined;
+    const status =
+      typeof record.status === "string" ? record.status.toUpperCase() : "";
+    if (eventId && PENDING_STATUSES.has(status)) {
+      return { status: "queued", eventId };
+    }
+    if (eventId) {
+      return { status: "completed", eventId };
+    }
+  }
+  // A memory-results array (or any non-event payload) means the write already
+  // resolved; there is nothing left pending to report.
+  return { status: "completed" };
 }
 
 export function parseMemoryRecord(item: unknown): MemoryRecord | null {
@@ -138,11 +179,12 @@ export async function createMem0Store(input: {
 
   const store: MemoryStore = {
     async add(messages, options) {
-      await client.add([...messages], {
+      const response = await client.add([...messages], {
         userId: options.userId,
         infer: options.infer,
         metadata: { ...options.metadata },
       });
+      return parseAddResult(response);
     },
     async search(query, options) {
       const response = await client.search(query, {

--- a/integrations/eve/src/store.ts
+++ b/integrations/eve/src/store.ts
@@ -1,0 +1,83 @@
+import type { Mem0ApiKey } from "./options.js";
+
+export type MemoryRole = "user" | "assistant";
+
+export interface MemoryMessage {
+  readonly role: MemoryRole;
+  readonly content: string;
+}
+
+export interface SearchHit {
+  readonly id: string;
+  readonly memory: string;
+}
+
+export interface AddMemoryInput {
+  readonly userId: string;
+  readonly infer: boolean;
+  readonly metadata: Readonly<Record<string, unknown>>;
+}
+
+export interface SearchMemoryInput {
+  readonly filters: {
+    readonly user_id: string;
+  };
+  readonly topK: number;
+  readonly threshold: number;
+  readonly rerank: boolean;
+}
+
+export interface MemoryStore {
+  add(messages: readonly MemoryMessage[], input: AddMemoryInput): Promise<unknown>;
+  search(query: string, input: SearchMemoryInput): Promise<{ results: readonly SearchHit[] }>;
+  delete(memoryId: string): Promise<unknown>;
+}
+
+export async function resolveApiKey(apiKey: Mem0ApiKey): Promise<string> {
+  const value = typeof apiKey === "function" ? await apiKey() : apiKey;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Mem0 API key cannot be empty");
+  }
+  return trimmed;
+}
+
+export async function createMem0Store(input: {
+  apiKey: Mem0ApiKey;
+  host: string;
+}): Promise<MemoryStore> {
+  const MemoryClient = (await import("mem0ai")).default;
+  const client = new MemoryClient({
+    apiKey: await resolveApiKey(input.apiKey),
+    host: input.host,
+  });
+
+  return {
+    async add(messages, options) {
+      return client.add([...messages], {
+        userId: options.userId,
+        infer: options.infer,
+        metadata: { ...options.metadata },
+      });
+    },
+    async search(query, options) {
+      const response = await client.search(query, {
+        filters: options.filters,
+        topK: options.topK,
+        threshold: options.threshold,
+        rerank: options.rerank,
+      });
+      const results = Array.isArray(response?.results) ? response.results : [];
+      return {
+        results: results.flatMap((item) => {
+          const id = typeof item.id === "string" ? item.id : "";
+          const memory = typeof item.memory === "string" ? item.memory : "";
+          return id && memory ? [{ id, memory }] : [];
+        }),
+      };
+    },
+    async delete(memoryId) {
+      return client.delete(memoryId);
+    },
+  };
+}

--- a/integrations/eve/src/store.ts
+++ b/integrations/eve/src/store.ts
@@ -1,4 +1,5 @@
 import type { Mem0ApiKey } from "./options.js";
+import { isNotFoundError } from "./errors.js";
 
 export type MemoryRole = "user" | "assistant";
 
@@ -12,25 +13,94 @@ export interface SearchHit {
   readonly memory: string;
 }
 
-export interface AddMemoryInput {
+export interface MemoryRecord {
+  readonly id: string;
   readonly userId: string;
-  readonly infer: boolean;
   readonly metadata: Readonly<Record<string, unknown>>;
 }
 
+export type StoreMetadata = Readonly<Record<string, string | number | boolean>>;
+
+export interface AddMemoryInput {
+  readonly userId: string;
+  readonly infer: boolean;
+  readonly metadata: StoreMetadata;
+}
+
 export interface SearchMemoryInput {
-  readonly filters: {
-    readonly user_id: string;
-  };
+  readonly userId: string;
   readonly topK: number;
   readonly threshold: number;
   readonly rerank: boolean;
 }
 
 export interface MemoryStore {
-  add(messages: readonly MemoryMessage[], input: AddMemoryInput): Promise<unknown>;
+  add(messages: readonly MemoryMessage[], input: AddMemoryInput): Promise<void>;
   search(query: string, input: SearchMemoryInput): Promise<{ results: readonly SearchHit[] }>;
-  delete(memoryId: string): Promise<unknown>;
+  get(memoryId: string): Promise<MemoryRecord | null>;
+  listByMetadata(input: {
+    readonly userId: string;
+    readonly metadata: Readonly<Record<string, string>>;
+  }): Promise<readonly MemoryRecord[]>;
+  delete(memoryId: string, userId: string): Promise<void>;
+}
+
+export function parseSearchHit(item: unknown): SearchHit | null {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+  const record = item as Record<string, unknown>;
+  const nested =
+    record.data && typeof record.data === "object"
+      ? (record.data as Record<string, unknown>)
+      : undefined;
+  const idValue = record.id ?? record.memory_id ?? nested?.id;
+  const id =
+    typeof idValue === "string"
+      ? idValue.trim()
+      : typeof idValue === "number"
+        ? String(idValue)
+        : "";
+  const memoryValue =
+    record.memory ?? record.text ?? nested?.memory ?? nested?.text;
+  const memory = typeof memoryValue === "string" ? memoryValue : "";
+  if (id.length === 0 || memory.trim().length === 0) {
+    return null;
+  }
+  return { id, memory };
+}
+
+export function parseMemoryRecord(item: unknown): MemoryRecord | null {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+  const record = item as Record<string, unknown>;
+  const idValue = record.id ?? record.memory_id;
+  const id = typeof idValue === "string" ? idValue.trim() : "";
+  const userIdValue = record.userId ?? record.user_id;
+  const userId = typeof userIdValue === "string" ? userIdValue : "";
+  if (id.length === 0 || userId.length === 0) {
+    return null;
+  }
+  const metadata =
+    record.metadata && typeof record.metadata === "object"
+      ? (record.metadata as Record<string, unknown>)
+      : {};
+  return { id, userId, metadata };
+}
+
+function asItemList(response: unknown, operation: string): unknown[] {
+  if (Array.isArray(response)) {
+    return response;
+  }
+  if (response && typeof response === "object") {
+    const record = response as Record<string, unknown>;
+    const raw = record.results ?? record.memories;
+    if (Array.isArray(raw)) {
+      return raw;
+    }
+  }
+  throw new Error(`Mem0 ${operation} returned an unexpected response shape`);
 }
 
 export async function resolveApiKey(apiKey: Mem0ApiKey): Promise<string> {
@@ -40,6 +110,20 @@ export async function resolveApiKey(apiKey: Mem0ApiKey): Promise<string> {
     throw new Error("Mem0 API key cannot be empty");
   }
   return trimmed;
+}
+
+export function createLazyStore(factory: () => Promise<MemoryStore>) {
+  let pending: Promise<MemoryStore> | undefined;
+
+  return async (): Promise<MemoryStore> => {
+    if (!pending) {
+      pending = factory().catch((error: unknown) => {
+        pending = undefined;
+        throw error;
+      });
+    }
+    return pending;
+  };
 }
 
 export async function createMem0Store(input: {
@@ -52,9 +136,9 @@ export async function createMem0Store(input: {
     host: input.host,
   });
 
-  return {
+  const store: MemoryStore = {
     async add(messages, options) {
-      return client.add([...messages], {
+      await client.add([...messages], {
         userId: options.userId,
         infer: options.infer,
         metadata: { ...options.metadata },
@@ -62,22 +146,47 @@ export async function createMem0Store(input: {
     },
     async search(query, options) {
       const response = await client.search(query, {
-        filters: options.filters,
+        filters: { user_id: options.userId },
         topK: options.topK,
         threshold: options.threshold,
         rerank: options.rerank,
       });
-      const results = Array.isArray(response?.results) ? response.results : [];
       return {
-        results: results.flatMap((item) => {
-          const id = typeof item.id === "string" ? item.id : "";
-          const memory = typeof item.memory === "string" ? item.memory : "";
-          return id && memory ? [{ id, memory }] : [];
+        results: asItemList(response, "search").flatMap((item) => {
+          const hit = parseSearchHit(item);
+          return hit ? [hit] : [];
         }),
       };
     },
-    async delete(memoryId) {
-      return client.delete(memoryId);
+    async get(memoryId) {
+      try {
+        return parseMemoryRecord(await client.get(memoryId));
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    async listByMetadata({ userId, metadata }) {
+      const response = await client.getAll({
+        filters: {
+          AND: [{ user_id: userId }, { metadata }],
+        },
+        pageSize: 5,
+      });
+      return asItemList(response, "getAll").flatMap((item) => {
+        const record = parseMemoryRecord(item);
+        return record && record.userId === userId ? [record] : [];
+      });
+    },
+    async delete(memoryId, userId) {
+      const record = await store.get(memoryId);
+      if (!record || record.userId !== userId) {
+        throw new Error("Memory not found");
+      }
+      await client.delete(memoryId);
     },
   };
+  return store;
 }

--- a/integrations/eve/src/tools.ts
+++ b/integrations/eve/src/tools.ts
@@ -37,17 +37,29 @@ export function createMem0Tools(
     }),
     remember: defineTool({
       description:
-        "Save one durable fact or preference about the current caller.",
+        "Save one durable fact or preference about the current caller. On the " +
+        "hosted platform the write is queued for extraction and may take a " +
+        "moment to become searchable; a `queued` status means accepted, not yet " +
+        "stored. Do not claim the fact is saved when the status is queued.",
       inputSchema: z.object({
         text: z.string().min(1).max(4000),
       }),
       async execute({ text }) {
-        await store.add([{ role: "user", content: text }], {
+        const result = await store.add([{ role: "user", content: text }], {
           userId: scopeKey,
           infer: options.infer,
           metadata: { source: "eve-tool" },
         });
-        return { saved: true };
+        // Report the true write state. With infer:true the platform returns a
+        // PENDING event, so promising "saved" would let the model tell the user
+        // a fact is stored when only the request was queued. Surface the eventId
+        // so the write can be correlated/confirmed rather than left a dead end.
+        return result.status === "queued"
+          ? {
+              status: "queued" as const,
+              ...(result.eventId ? { eventId: result.eventId } : {}),
+            }
+          : { status: "saved" as const };
       },
     }),
     forget: defineTool({

--- a/integrations/eve/src/tools.ts
+++ b/integrations/eve/src/tools.ts
@@ -1,0 +1,53 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+import type { MemoryStore } from "./store.js";
+
+export function createMem0Tools(store: MemoryStore, scopeKey: string) {
+  return {
+    search: defineTool({
+      description: "Search long-term memories for the current caller.",
+      inputSchema: z.object({
+        query: z.string().min(1).max(2000),
+      }),
+      async execute({ query }) {
+        const { results } = await store.search(query, {
+          filters: { user_id: scopeKey },
+          topK: 8,
+          threshold: 0.1,
+          rerank: false,
+        });
+        return {
+          memories: results.map((hit) => ({
+            id: hit.id,
+            memory: hit.memory,
+          })),
+        };
+      },
+    }),
+    remember: defineTool({
+      description:
+        "Save one durable fact or preference about the current caller.",
+      inputSchema: z.object({
+        text: z.string().min(1).max(4000),
+      }),
+      async execute({ text }) {
+        await store.add([{ role: "user", content: text }], {
+          userId: scopeKey,
+          infer: true,
+          metadata: { source: "eve-tool" },
+        });
+        return { saved: true };
+      },
+    }),
+    forget: defineTool({
+      description: "Delete one memory belonging to the current caller by id.",
+      inputSchema: z.object({
+        id: z.string().min(1),
+      }),
+      async execute({ id }) {
+        await store.delete(id);
+        return { deleted: true };
+      },
+    }),
+  };
+}

--- a/integrations/eve/src/tools.ts
+++ b/integrations/eve/src/tools.ts
@@ -2,7 +2,18 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 import type { MemoryStore } from "./store.js";
 
-export function createMem0Tools(store: MemoryStore, scopeKey: string) {
+export interface Mem0ToolOptions {
+  readonly topK: number;
+  readonly threshold: number;
+  readonly rerank: boolean;
+  readonly infer: boolean;
+}
+
+export function createMem0Tools(
+  store: MemoryStore,
+  scopeKey: string,
+  options: Mem0ToolOptions,
+) {
   return {
     search: defineTool({
       description: "Search long-term memories for the current caller.",
@@ -11,10 +22,10 @@ export function createMem0Tools(store: MemoryStore, scopeKey: string) {
       }),
       async execute({ query }) {
         const { results } = await store.search(query, {
-          filters: { user_id: scopeKey },
-          topK: 8,
-          threshold: 0.1,
-          rerank: false,
+          userId: scopeKey,
+          topK: options.topK,
+          threshold: options.threshold,
+          rerank: options.rerank,
         });
         return {
           memories: results.map((hit) => ({
@@ -33,7 +44,7 @@ export function createMem0Tools(store: MemoryStore, scopeKey: string) {
       async execute({ text }) {
         await store.add([{ role: "user", content: text }], {
           userId: scopeKey,
-          infer: true,
+          infer: options.infer,
           metadata: { source: "eve-tool" },
         });
         return { saved: true };
@@ -45,7 +56,7 @@ export function createMem0Tools(store: MemoryStore, scopeKey: string) {
         id: z.string().min(1),
       }),
       async execute({ id }) {
-        await store.delete(id);
+        await store.delete(id, scopeKey);
         return { deleted: true };
       },
     }),

--- a/integrations/eve/tests/capture.test.ts
+++ b/integrations/eve/tests/capture.test.ts
@@ -47,6 +47,73 @@ describe("captureCompletedTurn", () => {
     expect(store.added).toEqual([]);
   });
 
+  it("dedupes a replay once the prior write is visible", async () => {
+    const store = createFakeStore();
+    const args = {
+      store,
+      scopeKey: "scope_abc",
+      operationId: "op_dedup",
+      infer: true,
+      metadata: { source: "eve", operation_id: "op_dedup" },
+      turnInput: [{ role: "user", content: "I am vegetarian" }],
+      messages: [
+        { role: "user", content: "I am vegetarian" },
+        { role: "assistant", content: "Got it." },
+      ],
+    };
+    // First write is immediately visible (completed), so the replay is deduped.
+    expect(await captureCompletedTurn(args)).toBe(true);
+    expect(await captureCompletedTurn(args)).toBe(false);
+    expect(store.added).toHaveLength(1);
+  });
+
+  it("cannot dedupe while the prior write is still pending (best-effort)", async () => {
+    // Documents the known limitation: with infer:true the first write is a
+    // PENDING event whose memory is not yet visible, so the metadata lookup
+    // finds nothing and a restart replay writes the same operation again.
+    const store = createFakeStore([], { pendingWrites: true });
+    const args = {
+      store,
+      scopeKey: "scope_abc",
+      operationId: "op_pending",
+      infer: true,
+      metadata: { source: "eve", operation_id: "op_pending" },
+      turnInput: [{ role: "user", content: "I am vegetarian" }],
+      messages: [
+        { role: "user", content: "I am vegetarian" },
+        { role: "assistant", content: "Got it." },
+      ],
+    };
+    expect(await captureCompletedTurn(args)).toBe(true);
+    expect(await captureCompletedTurn(args)).toBe(true);
+    expect(store.added).toHaveLength(2);
+  });
+
+  it("does not dedupe concurrent replays that both pass the lookup (best-effort)", async () => {
+    // Two workers on separate provider instances both clear the metadata check
+    // before either write lands, so both capture the same operation.
+    const store = createFakeStore([], { pendingWrites: true });
+    const args = {
+      store,
+      scopeKey: "scope_abc",
+      operationId: "op_concurrent",
+      infer: true,
+      metadata: { source: "eve", operation_id: "op_concurrent" },
+      turnInput: [{ role: "user", content: "I am vegetarian" }],
+      messages: [
+        { role: "user", content: "I am vegetarian" },
+        { role: "assistant", content: "Got it." },
+      ],
+    };
+    const [first, second] = await Promise.all([
+      captureCompletedTurn(args),
+      captureCompletedTurn(args),
+    ]);
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+    expect(store.added).toHaveLength(2);
+  });
+
   it("skips add when the operation id was already captured", async () => {
     const store = createFakeStore([
       {

--- a/integrations/eve/tests/capture.test.ts
+++ b/integrations/eve/tests/capture.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { captureCompletedTurn } from "../src/capture.js";
+import { createFakeStore } from "./helpers.js";
+
+describe("captureCompletedTurn", () => {
+  it("adds the current turn under the locked scope", async () => {
+    const store = createFakeStore();
+    const captured = await captureCompletedTurn({
+      store,
+      scopeKey: "scope_abc",
+      infer: true,
+      metadata: { source: "eve" },
+      turnInput: [{ role: "user", content: "I am vegetarian" }],
+      messages: [
+        { role: "user", content: "I am vegetarian" },
+        { role: "assistant", content: "Got it." },
+      ],
+    });
+
+    expect(captured).toBe(true);
+    expect(store.added).toEqual([
+      {
+        userId: "scope_abc",
+        messages: [
+          { role: "user", content: "I am vegetarian" },
+          { role: "assistant", content: "Got it." },
+        ],
+      },
+    ]);
+  });
+
+  it("does not write when the turn has no user text", async () => {
+    const store = createFakeStore();
+    const captured = await captureCompletedTurn({
+      store,
+      scopeKey: "scope_abc",
+      infer: true,
+      metadata: {},
+      turnInput: [],
+      messages: [],
+    });
+    expect(captured).toBe(false);
+    expect(store.added).toEqual([]);
+  });
+});

--- a/integrations/eve/tests/capture.test.ts
+++ b/integrations/eve/tests/capture.test.ts
@@ -8,8 +8,9 @@ describe("captureCompletedTurn", () => {
     const captured = await captureCompletedTurn({
       store,
       scopeKey: "scope_abc",
-      infer: true,
-      metadata: { source: "eve" },
+      operationId: "op_1",
+      infer: false,
+      metadata: { source: "eve", operation_id: "op_1" },
       turnInput: [{ role: "user", content: "I am vegetarian" }],
       messages: [
         { role: "user", content: "I am vegetarian" },
@@ -21,6 +22,8 @@ describe("captureCompletedTurn", () => {
     expect(store.added).toEqual([
       {
         userId: "scope_abc",
+        infer: false,
+        metadata: { source: "eve", operation_id: "op_1" },
         messages: [
           { role: "user", content: "I am vegetarian" },
           { role: "assistant", content: "Got it." },
@@ -34,11 +37,37 @@ describe("captureCompletedTurn", () => {
     const captured = await captureCompletedTurn({
       store,
       scopeKey: "scope_abc",
+      operationId: "op_1",
       infer: true,
-      metadata: {},
+      metadata: { operation_id: "op_1" },
       turnInput: [],
       messages: [],
     });
+    expect(captured).toBe(false);
+    expect(store.added).toEqual([]);
+  });
+
+  it("skips add when the operation id was already captured", async () => {
+    const store = createFakeStore([
+      {
+        id: "mem_existing",
+        memory: "already stored",
+        metadata: { operation_id: "op_replay" },
+      },
+    ]);
+    const captured = await captureCompletedTurn({
+      store,
+      scopeKey: "scope_abc",
+      operationId: "op_replay",
+      infer: true,
+      metadata: { operation_id: "op_replay" },
+      turnInput: [{ role: "user", content: "I am vegetarian" }],
+      messages: [
+        { role: "user", content: "I am vegetarian" },
+        { role: "assistant", content: "Got it." },
+      ],
+    });
+
     expect(captured).toBe(false);
     expect(store.added).toEqual([]);
   });

--- a/integrations/eve/tests/errors.test.ts
+++ b/integrations/eve/tests/errors.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  errorMessage,
+  isNotFoundError,
+  isSetupError,
+  logProviderError,
+} from "../src/errors.js";
+
+describe("errors", () => {
+  it("classifies setup and not-found errors", () => {
+    expect(isSetupError(new Error("Mem0 API key cannot be empty"))).toBe(true);
+    expect(isSetupError(Object.assign(new Error("denied"), { name: "AuthenticationError" }))).toBe(
+      true,
+    );
+    expect(isSetupError(new Error("mem0 down"))).toBe(false);
+    expect(isNotFoundError(new Error("Memory not found"))).toBe(true);
+    expect(isNotFoundError(new Error("HTTP 404"))).toBe(true);
+    expect(errorMessage("x")).toBe("Unknown Mem0 error");
+  });
+
+  it("logs the original error object", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const failure = Object.assign(new Error("HTTP 401"), {
+      name: "AuthenticationError",
+    });
+    try {
+      logProviderError("recall failed", failure, { sessionId: "sess_1" });
+      expect(error).toHaveBeenCalledWith("[@mem0/eve] recall failed", {
+        error: failure,
+        name: "AuthenticationError",
+        message: "HTTP 401",
+        sessionId: "sess_1",
+      });
+    } finally {
+      error.mockRestore();
+    }
+  });
+});

--- a/integrations/eve/tests/helpers.ts
+++ b/integrations/eve/tests/helpers.ts
@@ -23,7 +23,10 @@ export type FakeSearch = SearchMemoryInput & {
   query: string;
 };
 
-export function createFakeStore(hits: FakeHit[] = []): MemoryStore & {
+export function createFakeStore(
+  hits: FakeHit[] = [],
+  options: { pendingWrites?: boolean } = {},
+): MemoryStore & {
   added: FakeAdd[];
   searched: FakeSearch[];
   deleted: string[];
@@ -50,11 +53,18 @@ export function createFakeStore(hits: FakeHit[] = []): MemoryStore & {
         infer: input.infer,
         metadata: input.metadata,
       });
+      // Model Mem0's async extraction: a pending write is accepted but its
+      // memory is not yet visible to listByMetadata/get, so it cannot dedupe a
+      // replay. A resolved write becomes immediately visible.
+      if (options.pendingWrites) {
+        return { status: "queued" as const, eventId: `evt_${added.length}` };
+      }
       records.push({
         id: `mem_added_${added.length}`,
         userId: input.userId,
         metadata: input.metadata,
       });
+      return { status: "completed" as const };
     },
     async search(query, input) {
       searched.push({ query, ...input });

--- a/integrations/eve/tests/helpers.ts
+++ b/integrations/eve/tests/helpers.ts
@@ -1,0 +1,73 @@
+import type { MemoryMessage, MemoryStore, SearchHit } from "../src/store.js";
+
+export function createFakeStore(hits: SearchHit[] = []): MemoryStore & {
+  added: Array<{ messages: readonly MemoryMessage[]; userId: string }>;
+  searched: Array<{ query: string; userId: string }>;
+  deleted: string[];
+} {
+  const added: Array<{ messages: readonly MemoryMessage[]; userId: string }> = [];
+  const searched: Array<{ query: string; userId: string }> = [];
+  const deleted: string[] = [];
+
+  return {
+    added,
+    searched,
+    deleted,
+    async add(messages, input) {
+      added.push({ messages, userId: input.userId });
+      return { eventId: "evt_1" };
+    },
+    async search(query, input) {
+      searched.push({ query, userId: input.filters.user_id });
+      return { results: hits };
+    },
+    async delete(memoryId) {
+      deleted.push(memoryId);
+      return { message: "ok" };
+    },
+  };
+}
+
+export function memoryContext(input?: {
+  scopeKey?: string;
+  operationId?: string;
+  turnInput?: Array<{ role: string; content: unknown }>;
+  messages?: Array<{ role: string; content: unknown }>;
+}): {
+  abortSignal: AbortSignal;
+  operationId: string;
+  session: { id: string };
+  memory: {
+    scope: { key: string; namespace: string; value: string };
+    slot: string;
+  };
+  messages: Array<{ role: string; content: unknown }>;
+  turn: {
+    id: string;
+    sequence: number;
+    input: Array<{ role: string; content: unknown }>;
+  };
+} {
+  return {
+    abortSignal: new AbortController().signal,
+    operationId: input?.operationId ?? "op_1",
+    session: { id: "sess_1" },
+    memory: {
+      scope: {
+        key: input?.scopeKey ?? "scope_abc",
+        namespace: "default",
+        value: "user_1",
+      },
+      slot: "mem0",
+    },
+    messages: input?.messages ?? [
+      { role: "user", content: "I am vegetarian" },
+      { role: "assistant", content: "I will remember that." },
+    ],
+    turn: {
+      id: "turn_1",
+      sequence: 1,
+      input: input?.turnInput ?? [{ role: "user", content: "I am vegetarian" }],
+    },
+  };
+}

--- a/integrations/eve/tests/helpers.ts
+++ b/integrations/eve/tests/helpers.ts
@@ -1,29 +1,86 @@
-import type { MemoryMessage, MemoryStore, SearchHit } from "../src/store.js";
+import type {
+  AddMemoryInput,
+  MemoryMessage,
+  MemoryRecord,
+  MemoryStore,
+  SearchHit,
+  SearchMemoryInput,
+} from "../src/store.js";
 
-export function createFakeStore(hits: SearchHit[] = []): MemoryStore & {
-  added: Array<{ messages: readonly MemoryMessage[]; userId: string }>;
-  searched: Array<{ query: string; userId: string }>;
+export type FakeHit = SearchHit & {
+  readonly userId?: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+};
+
+export type FakeAdd = {
+  messages: readonly MemoryMessage[];
+  userId: string;
+  infer: boolean;
+  metadata: Readonly<Record<string, unknown>>;
+};
+
+export type FakeSearch = SearchMemoryInput & {
+  query: string;
+};
+
+export function createFakeStore(hits: FakeHit[] = []): MemoryStore & {
+  added: FakeAdd[];
+  searched: FakeSearch[];
   deleted: string[];
+  records: MemoryRecord[];
 } {
-  const added: Array<{ messages: readonly MemoryMessage[]; userId: string }> = [];
-  const searched: Array<{ query: string; userId: string }> = [];
+  const added: FakeAdd[] = [];
+  const searched: FakeSearch[] = [];
   const deleted: string[] = [];
+  const records: MemoryRecord[] = hits.map((hit) => ({
+    id: hit.id,
+    userId: hit.userId ?? "scope_abc",
+    metadata: hit.metadata ?? {},
+  }));
 
   return {
     added,
     searched,
     deleted,
+    records,
     async add(messages, input) {
-      added.push({ messages, userId: input.userId });
-      return { eventId: "evt_1" };
+      added.push({
+        messages,
+        userId: input.userId,
+        infer: input.infer,
+        metadata: input.metadata,
+      });
+      records.push({
+        id: `mem_added_${added.length}`,
+        userId: input.userId,
+        metadata: input.metadata,
+      });
     },
     async search(query, input) {
-      searched.push({ query, userId: input.filters.user_id });
-      return { results: hits };
+      searched.push({ query, ...input });
+      return {
+        results: hits.filter((hit) => (hit.userId ?? "scope_abc") === input.userId),
+      };
     },
-    async delete(memoryId) {
+    async get(memoryId) {
+      return records.find((record) => record.id === memoryId) ?? null;
+    },
+    async listByMetadata({ userId, metadata }) {
+      return records.filter((record) => {
+        if (record.userId !== userId) {
+          return false;
+        }
+        return Object.entries(metadata).every(
+          ([key, value]) => record.metadata[key] === value,
+        );
+      });
+    },
+    async delete(memoryId, userId) {
+      const record = records.find((item) => item.id === memoryId);
+      if (!record || record.userId !== userId) {
+        throw new Error("Memory not found");
+      }
       deleted.push(memoryId);
-      return { message: "ok" };
     },
   };
 }
@@ -31,6 +88,14 @@ export function createFakeStore(hits: SearchHit[] = []): MemoryStore & {
 export function memoryContext(input?: {
   scopeKey?: string;
   operationId?: string;
+  aborted?: boolean;
+  turn?:
+    | {
+        id?: string;
+        sequence?: number;
+        input: Array<{ role: string; content: unknown }>;
+      }
+    | null;
   turnInput?: Array<{ role: string; content: unknown }>;
   messages?: Array<{ role: string; content: unknown }>;
 }): {
@@ -46,10 +111,21 @@ export function memoryContext(input?: {
     id: string;
     sequence: number;
     input: Array<{ role: string; content: unknown }>;
-  };
+  } | null;
 } {
+  const controller = new AbortController();
+  if (input?.aborted) {
+    controller.abort();
+  }
+
+  const turnInput =
+    input?.turn === null
+      ? undefined
+      : (input?.turn?.input ??
+        input?.turnInput ?? [{ role: "user", content: "I am vegetarian" }]);
+
   return {
-    abortSignal: new AbortController().signal,
+    abortSignal: controller.signal,
     operationId: input?.operationId ?? "op_1",
     session: { id: "sess_1" },
     memory: {
@@ -64,10 +140,13 @@ export function memoryContext(input?: {
       { role: "user", content: "I am vegetarian" },
       { role: "assistant", content: "I will remember that." },
     ],
-    turn: {
-      id: "turn_1",
-      sequence: 1,
-      input: input?.turnInput ?? [{ role: "user", content: "I am vegetarian" }],
-    },
+    turn:
+      input?.turn === null
+        ? null
+        : {
+            id: input?.turn?.id ?? "turn_1",
+            sequence: input?.turn?.sequence ?? 1,
+            input: turnInput ?? [{ role: "user", content: "I am vegetarian" }],
+          },
   };
 }

--- a/integrations/eve/tests/idempotency.test.ts
+++ b/integrations/eve/tests/idempotency.test.ts
@@ -29,4 +29,19 @@ describe("createIdempotencyGate", () => {
     await once("op_1", work);
     expect(calls).toBe(2);
   });
+
+  it("evicts the oldest id after the cap", async () => {
+    const once = createIdempotencyGate(2);
+    let calls = 0;
+    const work = async () => {
+      calls += 1;
+    };
+
+    await once("op_1", work);
+    await once("op_2", work);
+    await once("op_3", work);
+    await once("op_1", work);
+
+    expect(calls).toBe(4);
+  });
 });

--- a/integrations/eve/tests/idempotency.test.ts
+++ b/integrations/eve/tests/idempotency.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { createIdempotencyGate } from "../src/idempotency.js";
+
+describe("createIdempotencyGate", () => {
+  it("runs work once per operation id", async () => {
+    const once = createIdempotencyGate();
+    let calls = 0;
+    const work = async () => {
+      calls += 1;
+    };
+
+    await Promise.all([once("op_1", work), once("op_1", work)]);
+    await once("op_1", work);
+
+    expect(calls).toBe(1);
+  });
+
+  it("retries after a failure", async () => {
+    const once = createIdempotencyGate();
+    let calls = 0;
+    const work = async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("nope");
+      }
+    };
+
+    await expect(once("op_1", work)).rejects.toThrow("nope");
+    await once("op_1", work);
+    expect(calls).toBe(2);
+  });
+});

--- a/integrations/eve/tests/messages.test.ts
+++ b/integrations/eve/tests/messages.test.ts
@@ -27,6 +27,19 @@ describe("extractText", () => {
   it("ignores non-text parts", () => {
     expect(extractText([{ type: "image", url: "x" }])).toBe("");
   });
+
+  it("ignores reasoning parts and keeps only the final text", () => {
+    expect(
+      extractText([
+        { type: "reasoning", text: "speculation" },
+        { type: "text", text: "Noted." },
+      ]),
+    ).toBe("Noted.");
+  });
+
+  it("still reads an untyped text object", () => {
+    expect(extractText({ text: "  bare  " })).toBe("bare");
+  });
 });
 
 describe("lastUserText", () => {
@@ -86,5 +99,55 @@ describe("completedTurnMessages", () => {
         messages: [{ role: "assistant", content: "hello" }],
       }),
     ).toEqual([]);
+  });
+
+  it("does not attach a previous turn's answer to a tool-only turn", () => {
+    // Older Q&A, then a new user message whose only assistant output is a
+    // tool call (no text). The stale "older reply" must not be captured.
+    expect(
+      completedTurnMessages({
+        turnInput: [{ role: "user", content: "new question" }],
+        messages: [
+          { role: "user", content: "older question" },
+          { role: "assistant", content: "older reply" },
+          { role: "user", content: "new question" },
+          { role: "assistant", content: [{ type: "tool-call", id: "t1" }] },
+        ],
+      }),
+    ).toEqual([{ role: "user", content: "new question" }]);
+  });
+
+  it("captures all assistant text in a text/tool-call/text turn", () => {
+    expect(
+      completedTurnMessages({
+        turnInput: [{ role: "user", content: "Q" }],
+        messages: [
+          { role: "user", content: "Q" },
+          { role: "assistant", content: "part A" },
+          { role: "assistant", content: [{ type: "tool-call", id: "t1" }] },
+          { role: "assistant", content: "part B" },
+        ],
+      }),
+    ).toEqual([
+      { role: "user", content: "Q" },
+      { role: "assistant", content: "part A\npart B" },
+    ]);
+  });
+
+  it("captures this turn's assistant reply, not an earlier one", () => {
+    expect(
+      completedTurnMessages({
+        turnInput: [{ role: "user", content: "new question" }],
+        messages: [
+          { role: "user", content: "older question" },
+          { role: "assistant", content: "older reply" },
+          { role: "user", content: "new question" },
+          { role: "assistant", content: "new reply" },
+        ],
+      }),
+    ).toEqual([
+      { role: "user", content: "new question" },
+      { role: "assistant", content: "new reply" },
+    ]);
   });
 });

--- a/integrations/eve/tests/messages.test.ts
+++ b/integrations/eve/tests/messages.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  completedTurnMessages,
+  conversationMessages,
+  extractText,
+  lastUserText,
+} from "../src/messages.js";
+
+describe("extractText", () => {
+  it("reads a string", () => {
+    expect(extractText("  hello  ")).toBe("hello");
+  });
+
+  it("joins text parts", () => {
+    expect(
+      extractText([
+        { type: "text", text: "I like" },
+        { type: "text", text: "tea" },
+      ]),
+    ).toBe("I like\ntea");
+  });
+
+  it("ignores non-text parts", () => {
+    expect(extractText([{ type: "image", url: "x" }])).toBe("");
+  });
+});
+
+describe("lastUserText", () => {
+  it("returns the last user message", () => {
+    expect(
+      lastUserText([
+        { role: "user", content: "first" },
+        { role: "assistant", content: "ok" },
+        { role: "user", content: "second" },
+      ]),
+    ).toBe("second");
+  });
+
+  it("returns empty when there is no user text", () => {
+    expect(lastUserText([{ role: "assistant", content: "hi" }])).toBe("");
+  });
+});
+
+describe("conversationMessages", () => {
+  it("keeps user and assistant text only", () => {
+    expect(
+      conversationMessages([
+        { role: "system", content: "ignore" },
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+        { role: "user", content: "" },
+      ]),
+    ).toEqual([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ]);
+  });
+});
+
+describe("completedTurnMessages", () => {
+  it("pairs the current user turn with the latest assistant reply", () => {
+    expect(
+      completedTurnMessages({
+        turnInput: [{ role: "user", content: "I like tea" }],
+        messages: [
+          { role: "user", content: "older" },
+          { role: "assistant", content: "older reply" },
+          { role: "user", content: "I like tea" },
+          { role: "assistant", content: "Noted." },
+        ],
+      }),
+    ).toEqual([
+      { role: "user", content: "I like tea" },
+      { role: "assistant", content: "Noted." },
+    ]);
+  });
+
+  it("skips capture when the turn has no user text", () => {
+    expect(
+      completedTurnMessages({
+        turnInput: [{ role: "assistant", content: "hello" }],
+        messages: [{ role: "assistant", content: "hello" }],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/integrations/eve/tests/messages.test.ts
+++ b/integrations/eve/tests/messages.test.ts
@@ -20,6 +20,10 @@ describe("extractText", () => {
     ).toBe("I like\ntea");
   });
 
+  it("reads a single text object", () => {
+    expect(extractText({ type: "text", text: "  solo  " })).toBe("solo");
+  });
+
   it("ignores non-text parts", () => {
     expect(extractText([{ type: "image", url: "x" }])).toBe("");
   });

--- a/integrations/eve/tests/options.test.ts
+++ b/integrations/eve/tests/options.test.ts
@@ -4,7 +4,8 @@ import { createFakeStore } from "./helpers.js";
 
 describe("resolveOptions", () => {
   it("applies defaults", () => {
-    expect(resolveOptions({ apiKey: "m0-test" })).toMatchObject({
+    expect(resolveOptions({ apiKey: "m0-test" })).toEqual({
+      apiKey: "m0-test",
       host: "https://api.mem0.ai",
       topK: 5,
       threshold: 0.1,
@@ -12,6 +13,7 @@ describe("resolveOptions", () => {
       infer: true,
       autoSearch: { enabled: true },
       capture: { enabled: true },
+      metadata: {},
     });
   });
 
@@ -19,8 +21,56 @@ describe("resolveOptions", () => {
     expect(() => resolveOptions({ apiKey: "   " })).toThrow(/empty/);
   });
 
+  it("requires an api key when no store is provided", () => {
+    expect(() => resolveOptions({} as never)).toThrow(/apiKey is required/);
+  });
+
+  it("allows a store without an api key", () => {
+    const store = createFakeStore();
+    expect(resolveOptions({ store }).store).toBe(store);
+  });
+
+  it("does not invoke a function api key at resolve time", () => {
+    let calls = 0;
+    const apiKey = () => {
+      calls += 1;
+      return "";
+    };
+    expect(() => resolveOptions({ apiKey })).not.toThrow();
+    expect(calls).toBe(0);
+  });
+
   it("rejects an invalid topK", () => {
     expect(() => resolveOptions({ apiKey: "m0-test", topK: 0 })).toThrow(/topK/);
+    expect(() => resolveOptions({ apiKey: "m0-test", topK: 101 })).toThrow(/topK/);
+    expect(() => resolveOptions({ apiKey: "m0-test", topK: 1.5 })).toThrow(/topK/);
+  });
+
+  it("rejects an invalid threshold", () => {
+    expect(() => resolveOptions({ apiKey: "m0-test", threshold: -0.1 })).toThrow(
+      /threshold/,
+    );
+    expect(() => resolveOptions({ apiKey: "m0-test", threshold: 1.1 })).toThrow(
+      /threshold/,
+    );
+    expect(() => resolveOptions({ apiKey: "m0-test", threshold: Number.NaN })).toThrow(
+      /threshold/,
+    );
+  });
+
+  it("rejects a non-http host", () => {
+    expect(() => resolveOptions({ apiKey: "m0-test", host: "localhost" })).toThrow(
+      /host/,
+    );
+    expect(() => resolveOptions({ apiKey: "m0-test", host: "ftp://mem0.ai" })).toThrow(
+      /host/,
+    );
+  });
+
+  it("treats a blank host as the default", () => {
+    expect(resolveOptions({ apiKey: "m0-test", host: "   " }).host).toBe(
+      "https://api.mem0.ai",
+    );
   });
 
   it("keeps an injected store", () => {

--- a/integrations/eve/tests/options.test.ts
+++ b/integrations/eve/tests/options.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { resolveOptions } from "../src/options.js";
+import { createFakeStore } from "./helpers.js";
+
+describe("resolveOptions", () => {
+  it("applies defaults", () => {
+    expect(resolveOptions({ apiKey: "m0-test" })).toMatchObject({
+      host: "https://api.mem0.ai",
+      topK: 5,
+      threshold: 0.1,
+      rerank: false,
+      infer: true,
+      autoSearch: { enabled: true },
+      capture: { enabled: true },
+    });
+  });
+
+  it("rejects an empty api key", () => {
+    expect(() => resolveOptions({ apiKey: "   " })).toThrow(/empty/);
+  });
+
+  it("rejects an invalid topK", () => {
+    expect(() => resolveOptions({ apiKey: "m0-test", topK: 0 })).toThrow(/topK/);
+  });
+
+  it("keeps an injected store", () => {
+    const store = createFakeStore();
+    expect(resolveOptions({ apiKey: "m0-test", store }).store).toBe(store);
+  });
+});

--- a/integrations/eve/tests/provider.test.ts
+++ b/integrations/eve/tests/provider.test.ts
@@ -247,7 +247,7 @@ describe("mem0Provider", () => {
     expect(search).toEqual({
       memories: [{ id: "mem_1", memory: "likes tea" }],
     });
-    expect(remember).toEqual({ saved: true });
+    expect(remember).toEqual({ status: "saved" });
     expect(forget).toEqual({ deleted: true });
     expect(store.searched[0]).toMatchObject({
       userId: "scope_abc",
@@ -262,6 +262,18 @@ describe("mem0Provider", () => {
       messages: [{ role: "user", content: "Allergic to peanuts" }],
     });
     expect(store.deleted).toEqual(["mem_1"]);
+  });
+
+  it("reports remember as queued when the write is still pending", async () => {
+    const store = createFakeStore([], { pendingWrites: true });
+    const provider = mem0Provider({ store, infer: true });
+    const tools = await provider.tools!(toolsContext());
+    const rememberTool = tools?.remember;
+    if (!rememberTool) {
+      throw new Error("expected remember tool");
+    }
+    const remember = await runTool(rememberTool, { text: "Allergic to peanuts" });
+    expect(remember).toEqual({ status: "queued", eventId: "evt_1" });
   });
 
   it("refuses to forget a memory from another scope", async () => {

--- a/integrations/eve/tests/provider.test.ts
+++ b/integrations/eve/tests/provider.test.ts
@@ -1,4 +1,5 @@
 import type {
+  MemoryCompactionCompletedContext,
   MemoryToolsContext,
   MemoryTurnCompletedContext,
   MemoryTurnStartedContext,
@@ -19,6 +20,15 @@ function completedContext(
   return memoryContext(input) as unknown as MemoryTurnCompletedContext;
 }
 
+function compactionContext(
+  input?: Parameters<typeof memoryContext>[0],
+): MemoryCompactionCompletedContext {
+  return memoryContext({
+    ...input,
+    turn: input?.turn === undefined ? null : input.turn,
+  }) as unknown as MemoryCompactionCompletedContext;
+}
+
 function toolsContext(
   input?: Parameters<typeof memoryContext>[0],
 ): MemoryToolsContext {
@@ -32,10 +42,20 @@ async function runTool(
   return tool.execute(input as never, {} as never);
 }
 
+function requireCapture(
+  provider: ReturnType<typeof mem0Provider>,
+): NonNullable<NonNullable<typeof provider.capture>["turn.completed"]> {
+  const capture = provider.capture?.["turn.completed"];
+  if (!capture) {
+    throw new Error("expected turn.completed");
+  }
+  return capture;
+}
+
 describe("mem0Provider", () => {
   it("recalls memories for the locked scope on turn start", async () => {
     const store = createFakeStore([{ id: "mem_1", memory: "User likes tea" }]);
-    const provider = mem0Provider({ apiKey: "m0-test", store });
+    const provider = mem0Provider({ store });
     const result = await provider.recall["turn.started"](
       startedContext({
         turnInput: [{ role: "user", content: "What do I drink?" }],
@@ -43,31 +63,110 @@ describe("mem0Provider", () => {
     );
 
     expect(store.searched).toEqual([
-      { query: "What do I drink?", userId: "scope_abc" },
+      {
+        query: "What do I drink?",
+        userId: "scope_abc",
+        topK: 5,
+        threshold: 0.1,
+        rerank: false,
+      },
     ]);
     expect(result).toEqual({
       messages: [{ id: "mem_1", content: "User likes tea" }],
     });
   });
 
-  it("does not fail the turn when search throws", async () => {
+  it("forwards recall search options", async () => {
+    const store = createFakeStore([{ id: "mem_1", memory: "User likes tea" }]);
+    const provider = mem0Provider({
+      store,
+      topK: 3,
+      threshold: 0.5,
+      rerank: true,
+    });
+    await provider.recall["turn.started"](
+      startedContext({
+        turnInput: [{ role: "user", content: "tea" }],
+      }),
+    );
+    expect(store.searched[0]).toMatchObject({
+      topK: 3,
+      threshold: 0.5,
+      rerank: true,
+    });
+  });
+
+  it("skips search when autoSearch is disabled", async () => {
+    const store = createFakeStore([{ id: "mem_1", memory: "User likes tea" }]);
+    const provider = mem0Provider({ store, autoSearch: { enabled: false } });
+    await expect(
+      provider.recall["turn.started"](startedContext()),
+    ).resolves.toBeNull();
+    expect(store.searched).toEqual([]);
+  });
+
+  it("recalls after compaction when turn is null", async () => {
+    const store = createFakeStore([{ id: "mem_1", memory: "User likes tea" }]);
+    const provider = mem0Provider({ store });
+    const recallAfterCompaction = provider.recall["compaction.completed"];
+    if (!recallAfterCompaction) {
+      throw new Error("expected compaction.completed");
+    }
+    const result = await recallAfterCompaction(
+      compactionContext({
+        messages: [
+          { role: "user", content: "What do I drink?" },
+          { role: "assistant", content: "tea" },
+        ],
+      }),
+    );
+
+    expect(store.searched).toEqual([
+      {
+        query: "What do I drink?",
+        userId: "scope_abc",
+        topK: 5,
+        threshold: 0.1,
+        rerank: false,
+      },
+    ]);
+    expect(result).toEqual({
+      messages: [{ id: "mem_1", content: "User likes tea" }],
+    });
+  });
+
+  it("fails the turn when search throws", async () => {
     const store = createFakeStore();
     store.search = async () => {
       throw new Error("mem0 down");
     };
-    const provider = mem0Provider({ apiKey: "m0-test", store });
+    const provider = mem0Provider({ store });
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    await expect(
-      provider.recall["turn.started"](startedContext()),
-    ).resolves.toBeNull();
+    try {
+      await expect(
+        provider.recall["turn.started"](startedContext()),
+      ).rejects.toThrow("mem0 down");
+    } finally {
+      error.mockRestore();
+    }
+  });
 
-    error.mockRestore();
+  it("rethrows when recall is aborted", async () => {
+    const store = createFakeStore();
+    store.search = async () => {
+      throw new Error("cancelled");
+    };
+    const provider = mem0Provider({ store });
+
+    await expect(
+      provider.recall["turn.started"](startedContext({ aborted: true })),
+    ).rejects.toThrow("cancelled");
   });
 
   it("captures a completed turn once per operation id", async () => {
     const store = createFakeStore();
-    const provider = mem0Provider({ apiKey: "m0-test", store });
+    const provider = mem0Provider({ store });
     const capture = provider.capture?.["turn.completed"];
     expect(capture).toBeTypeOf("function");
 
@@ -76,12 +175,42 @@ describe("mem0Provider", () => {
     await capture!(context);
 
     expect(store.added).toHaveLength(1);
-    expect(store.added[0]?.userId).toBe("scope_abc");
+    expect(store.added[0]).toMatchObject({
+      userId: "scope_abc",
+      infer: true,
+      metadata: {
+        source: "eve",
+        operation_id: "op_replay",
+        session_id: "sess_1",
+        slot: "mem0",
+      },
+    });
+  });
+
+  it("does not recapture after process restart when operation metadata exists", async () => {
+    const store = createFakeStore();
+    const first = requireCapture(mem0Provider({ store }));
+    await first(completedContext({ operationId: "op_replay" }));
+
+    const restarted = requireCapture(mem0Provider({ store }));
+    await restarted(completedContext({ operationId: "op_replay" }));
+
+    expect(store.added).toHaveLength(1);
+  });
+
+  it("surfaces capture store failures", async () => {
+    const store = createFakeStore();
+    store.add = async () => {
+      throw new Error("write failed");
+    };
+
+    await expect(
+      requireCapture(mem0Provider({ store }))(completedContext()),
+    ).rejects.toThrow("write failed");
   });
 
   it("omits capture when it is disabled", () => {
     const provider = mem0Provider({
-      apiKey: "m0-test",
       store: createFakeStore(),
       capture: { enabled: false },
     });
@@ -90,7 +219,13 @@ describe("mem0Provider", () => {
 
   it("binds tools to the locked scope", async () => {
     const store = createFakeStore([{ id: "mem_1", memory: "likes tea" }]);
-    const provider = mem0Provider({ apiKey: "m0-test", store });
+    const provider = mem0Provider({
+      store,
+      topK: 3,
+      threshold: 0.4,
+      rerank: true,
+      infer: false,
+    });
     const tools = await provider.tools!(toolsContext());
     if (!tools) {
       throw new Error("expected tools");
@@ -114,8 +249,52 @@ describe("mem0Provider", () => {
     });
     expect(remember).toEqual({ saved: true });
     expect(forget).toEqual({ deleted: true });
-    expect(store.searched[0]?.userId).toBe("scope_abc");
-    expect(store.added[0]?.userId).toBe("scope_abc");
+    expect(store.searched[0]).toMatchObject({
+      userId: "scope_abc",
+      topK: 3,
+      threshold: 0.4,
+      rerank: true,
+    });
+    expect(store.added[0]).toMatchObject({
+      userId: "scope_abc",
+      infer: false,
+      metadata: { source: "eve-tool" },
+      messages: [{ role: "user", content: "Allergic to peanuts" }],
+    });
     expect(store.deleted).toEqual(["mem_1"]);
+  });
+
+  it("refuses to forget a memory from another scope", async () => {
+    const store = createFakeStore([
+      { id: "mem_other", memory: "secret", userId: "scope_other" },
+    ]);
+    const provider = mem0Provider({ store });
+    const tools = await provider.tools!(toolsContext());
+    const forgetTool = tools?.forget;
+    if (!forgetTool) {
+      throw new Error("expected forget tool");
+    }
+
+    await expect(runTool(forgetTool, { id: "mem_other" })).rejects.toThrow(
+      /Memory not found/,
+    );
+    expect(store.deleted).toEqual([]);
+  });
+
+  it("surfaces tool store failures", async () => {
+    const store = createFakeStore();
+    store.add = async () => {
+      throw new Error("add failed");
+    };
+    const provider = mem0Provider({ store });
+    const tools = await provider.tools!(toolsContext());
+    const rememberTool = tools?.remember;
+    if (!rememberTool) {
+      throw new Error("expected remember tool");
+    }
+
+    await expect(
+      runTool(rememberTool, { text: "remember this" }),
+    ).rejects.toThrow("add failed");
   });
 });

--- a/integrations/eve/tests/provider.test.ts
+++ b/integrations/eve/tests/provider.test.ts
@@ -1,0 +1,121 @@
+import type {
+  MemoryToolsContext,
+  MemoryTurnCompletedContext,
+  MemoryTurnStartedContext,
+} from "eve/memory";
+import { describe, expect, it, vi } from "vitest";
+import { mem0Provider } from "../src/provider.js";
+import { createFakeStore, memoryContext } from "./helpers.js";
+
+function startedContext(
+  input?: Parameters<typeof memoryContext>[0],
+): MemoryTurnStartedContext {
+  return memoryContext(input) as unknown as MemoryTurnStartedContext;
+}
+
+function completedContext(
+  input?: Parameters<typeof memoryContext>[0],
+): MemoryTurnCompletedContext {
+  return memoryContext(input) as unknown as MemoryTurnCompletedContext;
+}
+
+function toolsContext(
+  input?: Parameters<typeof memoryContext>[0],
+): MemoryToolsContext {
+  return memoryContext(input) as unknown as MemoryToolsContext;
+}
+
+async function runTool(
+  tool: { execute: (input: never, context: never) => unknown },
+  input: object,
+): Promise<unknown> {
+  return tool.execute(input as never, {} as never);
+}
+
+describe("mem0Provider", () => {
+  it("recalls memories for the locked scope on turn start", async () => {
+    const store = createFakeStore([{ id: "mem_1", memory: "User likes tea" }]);
+    const provider = mem0Provider({ apiKey: "m0-test", store });
+    const result = await provider.recall["turn.started"](
+      startedContext({
+        turnInput: [{ role: "user", content: "What do I drink?" }],
+      }),
+    );
+
+    expect(store.searched).toEqual([
+      { query: "What do I drink?", userId: "scope_abc" },
+    ]);
+    expect(result).toEqual({
+      messages: [{ id: "mem_1", content: "User likes tea" }],
+    });
+  });
+
+  it("does not fail the turn when search throws", async () => {
+    const store = createFakeStore();
+    store.search = async () => {
+      throw new Error("mem0 down");
+    };
+    const provider = mem0Provider({ apiKey: "m0-test", store });
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      provider.recall["turn.started"](startedContext()),
+    ).resolves.toBeNull();
+
+    error.mockRestore();
+  });
+
+  it("captures a completed turn once per operation id", async () => {
+    const store = createFakeStore();
+    const provider = mem0Provider({ apiKey: "m0-test", store });
+    const capture = provider.capture?.["turn.completed"];
+    expect(capture).toBeTypeOf("function");
+
+    const context = completedContext({ operationId: "op_replay" });
+    await capture!(context);
+    await capture!(context);
+
+    expect(store.added).toHaveLength(1);
+    expect(store.added[0]?.userId).toBe("scope_abc");
+  });
+
+  it("omits capture when it is disabled", () => {
+    const provider = mem0Provider({
+      apiKey: "m0-test",
+      store: createFakeStore(),
+      capture: { enabled: false },
+    });
+    expect(provider.capture).toBeUndefined();
+  });
+
+  it("binds tools to the locked scope", async () => {
+    const store = createFakeStore([{ id: "mem_1", memory: "likes tea" }]);
+    const provider = mem0Provider({ apiKey: "m0-test", store });
+    const tools = await provider.tools!(toolsContext());
+    if (!tools) {
+      throw new Error("expected tools");
+    }
+
+    const searchTool = tools.search;
+    const rememberTool = tools.remember;
+    const forgetTool = tools.forget;
+    if (!searchTool || !rememberTool || !forgetTool) {
+      throw new Error("expected search, remember, and forget tools");
+    }
+
+    const search = await runTool(searchTool, { query: "drinks" });
+    const remember = await runTool(rememberTool, {
+      text: "Allergic to peanuts",
+    });
+    const forget = await runTool(forgetTool, { id: "mem_1" });
+
+    expect(search).toEqual({
+      memories: [{ id: "mem_1", memory: "likes tea" }],
+    });
+    expect(remember).toEqual({ saved: true });
+    expect(forget).toEqual({ deleted: true });
+    expect(store.searched[0]?.userId).toBe("scope_abc");
+    expect(store.added[0]?.userId).toBe("scope_abc");
+    expect(store.deleted).toEqual(["mem_1"]);
+  });
+});

--- a/integrations/eve/tests/recall.test.ts
+++ b/integrations/eve/tests/recall.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { formatRecallMessages, recallMemories } from "../src/recall.js";
+import { createFakeStore } from "./helpers.js";
+
+describe("formatRecallMessages", () => {
+  it("drops empty memories", () => {
+    expect(
+      formatRecallMessages([
+        { id: "1", memory: " likes tea " },
+        { id: "2", memory: "   " },
+      ]),
+    ).toEqual([{ id: "1", content: "likes tea" }]);
+  });
+});
+
+describe("recallMemories", () => {
+  it("searches inside the locked scope and returns keyed messages", async () => {
+    const store = createFakeStore([{ id: "mem_1", memory: "User likes tea" }]);
+    const result = await recallMemories({
+      store,
+      scopeKey: "scope_abc",
+      query: "What does the user drink?",
+      topK: 5,
+      threshold: 0.1,
+      rerank: false,
+    });
+
+    expect(store.searched).toEqual([
+      { query: "What does the user drink?", userId: "scope_abc" },
+    ]);
+    expect(result).toEqual({
+      messages: [{ id: "mem_1", content: "User likes tea" }],
+    });
+  });
+
+  it("returns null for an empty query", async () => {
+    const store = createFakeStore([{ id: "mem_1", memory: "x" }]);
+    await expect(
+      recallMemories({
+        store,
+        scopeKey: "scope_abc",
+        query: "   ",
+        topK: 5,
+        threshold: 0.1,
+        rerank: false,
+      }),
+    ).resolves.toBeNull();
+    expect(store.searched).toEqual([]);
+  });
+});

--- a/integrations/eve/tests/recall.test.ts
+++ b/integrations/eve/tests/recall.test.ts
@@ -3,11 +3,12 @@ import { formatRecallMessages, recallMemories } from "../src/recall.js";
 import { createFakeStore } from "./helpers.js";
 
 describe("formatRecallMessages", () => {
-  it("drops empty memories", () => {
+  it("drops empty memories and empty ids", () => {
     expect(
       formatRecallMessages([
         { id: "1", memory: " likes tea " },
         { id: "2", memory: "   " },
+        { id: "  ", memory: "kept text" },
       ]),
     ).toEqual([{ id: "1", content: "likes tea" }]);
   });
@@ -20,13 +21,19 @@ describe("recallMemories", () => {
       store,
       scopeKey: "scope_abc",
       query: "What does the user drink?",
-      topK: 5,
-      threshold: 0.1,
-      rerank: false,
+      topK: 3,
+      threshold: 0.5,
+      rerank: true,
     });
 
     expect(store.searched).toEqual([
-      { query: "What does the user drink?", userId: "scope_abc" },
+      {
+        query: "What does the user drink?",
+        userId: "scope_abc",
+        topK: 3,
+        threshold: 0.5,
+        rerank: true,
+      },
     ]);
     expect(result).toEqual({
       messages: [{ id: "mem_1", content: "User likes tea" }],
@@ -46,5 +53,19 @@ describe("recallMemories", () => {
       }),
     ).resolves.toBeNull();
     expect(store.searched).toEqual([]);
+  });
+
+  it("returns null when search has no usable hits", async () => {
+    const store = createFakeStore([{ id: "  ", memory: "   " }]);
+    await expect(
+      recallMemories({
+        store,
+        scopeKey: "scope_abc",
+        query: "tea",
+        topK: 5,
+        threshold: 0.1,
+        rerank: false,
+      }),
+    ).resolves.toBeNull();
   });
 });

--- a/integrations/eve/tests/store.test.ts
+++ b/integrations/eve/tests/store.test.ts
@@ -25,10 +25,47 @@ vi.mock("mem0ai", () => ({
 import {
   createLazyStore,
   createMem0Store,
+  parseAddResult,
   parseMemoryRecord,
   parseSearchHit,
   resolveApiKey,
 } from "../src/store.js";
+
+describe("parseAddResult", () => {
+  it("reports a pending event as queued", () => {
+    expect(parseAddResult({ event_id: "evt_1", status: "PENDING" })).toEqual({
+      status: "queued",
+      eventId: "evt_1",
+    });
+  });
+
+  it("reports a succeeded event as completed", () => {
+    expect(parseAddResult({ event_id: "evt_1", status: "SUCCEEDED" })).toEqual({
+      status: "completed",
+      eventId: "evt_1",
+    });
+  });
+
+  it("treats a memory-results array as completed", () => {
+    expect(parseAddResult([{ id: "m1", memory: "tea" }])).toEqual({
+      status: "completed",
+    });
+  });
+
+  it("does not report a failed event as queued", () => {
+    expect(parseAddResult({ event_id: "evt_1", status: "FAILED" })).toEqual({
+      status: "completed",
+      eventId: "evt_1",
+    });
+  });
+
+  it("does not report an event with no status as queued", () => {
+    expect(parseAddResult({ event_id: "evt_1" })).toEqual({
+      status: "completed",
+      eventId: "evt_1",
+    });
+  });
+});
 
 describe("parseSearchHit", () => {
   it("accepts id, memory_id, nested text, and numeric ids", () => {
@@ -122,18 +159,19 @@ describe("createMem0Store", () => {
     getAll.mockResolvedValue({
       results: [{ id: "m9", userId: "scope_abc", metadata: { operation_id: "op_1" } }],
     });
-    add.mockResolvedValue({ eventId: "evt_1" });
+    add.mockResolvedValue({ event_id: "evt_1", status: "SUCCEEDED" });
 
     const store = await createMem0Store({
       apiKey: "m0-test",
       host: "https://api.mem0.ai",
     });
 
-    await store.add([{ role: "user", content: "I like tea" }], {
+    const addResult = await store.add([{ role: "user", content: "I like tea" }], {
       userId: "scope_abc",
       infer: false,
       metadata: { source: "eve", operation_id: "op_1" },
     });
+    expect(addResult).toEqual({ status: "completed", eventId: "evt_1" });
     const found = await store.search("tea", {
       userId: "scope_abc",
       topK: 3,
@@ -167,6 +205,21 @@ describe("createMem0Store", () => {
         metadata: { operation_id: "op_1" },
       },
     ]);
+  });
+
+  it("surfaces a pending platform write as queued", async () => {
+    const store = await createMem0Store({
+      apiKey: "m0-test",
+      host: "https://api.mem0.ai",
+    });
+    add.mockResolvedValueOnce({ event_id: "evt_9", status: "PENDING" });
+    await expect(
+      store.add([{ role: "user", content: "I like tea" }], {
+        userId: "scope_abc",
+        infer: true,
+        metadata: { source: "eve" },
+      }),
+    ).resolves.toEqual({ status: "queued", eventId: "evt_9" });
   });
 
   it("accepts a bare search array and rejects unknown envelopes", async () => {

--- a/integrations/eve/tests/store.test.ts
+++ b/integrations/eve/tests/store.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { MemoryClient, add, search, get, getAll, del } = vi.hoisted(() => {
+  const add = vi.fn();
+  const search = vi.fn();
+  const get = vi.fn();
+  const getAll = vi.fn();
+  const del = vi.fn();
+  const MemoryClient = vi.fn(
+    class {
+      add = add;
+      search = search;
+      get = get;
+      getAll = getAll;
+      delete = del;
+    },
+  );
+  return { MemoryClient, add, search, get, getAll, del };
+});
+
+vi.mock("mem0ai", () => ({
+  default: MemoryClient,
+}));
+
+import {
+  createLazyStore,
+  createMem0Store,
+  parseMemoryRecord,
+  parseSearchHit,
+  resolveApiKey,
+} from "../src/store.js";
+
+describe("parseSearchHit", () => {
+  it("accepts id, memory_id, nested text, and numeric ids", () => {
+    expect(parseSearchHit({ id: 12, memory: "tea" })).toEqual({
+      id: "12",
+      memory: "tea",
+    });
+    expect(
+      parseSearchHit({ memory_id: "m1", data: { memory: "nested" } }),
+    ).toEqual({ id: "m1", memory: "nested" });
+    expect(parseSearchHit({ id: "m2", text: "plain" })).toEqual({
+      id: "m2",
+      memory: "plain",
+    });
+    expect(parseSearchHit({ id: "", memory: "x" })).toBeNull();
+  });
+});
+
+describe("parseMemoryRecord", () => {
+  it("requires id and userId", () => {
+    expect(
+      parseMemoryRecord({
+        id: "m1",
+        user_id: "scope_abc",
+        metadata: { source: "eve" },
+      }),
+    ).toEqual({
+      id: "m1",
+      userId: "scope_abc",
+      metadata: { source: "eve" },
+    });
+    expect(parseMemoryRecord({ id: "m1" })).toBeNull();
+  });
+});
+
+describe("resolveApiKey", () => {
+  it("trims string keys and rejects empty values", async () => {
+    await expect(resolveApiKey("  token  ")).resolves.toBe("token");
+    await expect(resolveApiKey("   ")).rejects.toThrow(/empty/);
+  });
+
+  it("resolves async getters", async () => {
+    await expect(resolveApiKey(async () => "  secret  ")).resolves.toBe("secret");
+    await expect(resolveApiKey(async () => "")).rejects.toThrow(/empty/);
+  });
+});
+
+describe("createLazyStore", () => {
+  it("retries after a failed factory call", async () => {
+    let calls = 0;
+    const load = createLazyStore(async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("unavailable");
+      }
+      return { name: "store" } as never;
+    });
+
+    await expect(load()).rejects.toThrow("unavailable");
+    await expect(load()).resolves.toEqual({ name: "store" });
+    expect(calls).toBe(2);
+  });
+});
+
+describe("createMem0Store", () => {
+  beforeEach(() => {
+    add.mockReset();
+    search.mockReset();
+    get.mockReset();
+    getAll.mockReset();
+    del.mockReset();
+    MemoryClient.mockClear();
+  });
+
+  it("constructs the client with a resolved key and host", async () => {
+    const store = await createMem0Store({
+      apiKey: async () => "  m0-live  ",
+      host: "https://api.mem0.ai",
+    });
+    expect(store).toBeTruthy();
+    expect(MemoryClient).toHaveBeenCalledWith({
+      apiKey: "m0-live",
+      host: "https://api.mem0.ai",
+    });
+  });
+
+  it("forwards add, search, and metadata filters", async () => {
+    search.mockResolvedValue({
+      results: [{ id: "m1", memory: "likes tea" }, { id: 2, memory: "" }],
+    });
+    getAll.mockResolvedValue({
+      results: [{ id: "m9", userId: "scope_abc", metadata: { operation_id: "op_1" } }],
+    });
+    add.mockResolvedValue({ eventId: "evt_1" });
+
+    const store = await createMem0Store({
+      apiKey: "m0-test",
+      host: "https://api.mem0.ai",
+    });
+
+    await store.add([{ role: "user", content: "I like tea" }], {
+      userId: "scope_abc",
+      infer: false,
+      metadata: { source: "eve", operation_id: "op_1" },
+    });
+    const found = await store.search("tea", {
+      userId: "scope_abc",
+      topK: 3,
+      threshold: 0.5,
+      rerank: true,
+    });
+    const existing = await store.listByMetadata({
+      userId: "scope_abc",
+      metadata: { operation_id: "op_1" },
+    });
+
+    expect(add).toHaveBeenCalledWith(
+      [{ role: "user", content: "I like tea" }],
+      {
+        userId: "scope_abc",
+        infer: false,
+        metadata: { source: "eve", operation_id: "op_1" },
+      },
+    );
+    expect(search).toHaveBeenCalledWith("tea", {
+      filters: { user_id: "scope_abc" },
+      topK: 3,
+      threshold: 0.5,
+      rerank: true,
+    });
+    expect(found.results).toEqual([{ id: "m1", memory: "likes tea" }]);
+    expect(existing).toEqual([
+      {
+        id: "m9",
+        userId: "scope_abc",
+        metadata: { operation_id: "op_1" },
+      },
+    ]);
+  });
+
+  it("accepts a bare search array and rejects unknown envelopes", async () => {
+    const store = await createMem0Store({
+      apiKey: "m0-test",
+      host: "https://api.mem0.ai",
+    });
+    search.mockResolvedValueOnce([{ id: "m1", memory: "tea" }]);
+    await expect(
+      store.search("tea", {
+        userId: "scope_abc",
+        topK: 5,
+        threshold: 0.1,
+        rerank: false,
+      }),
+    ).resolves.toEqual({ results: [{ id: "m1", memory: "tea" }] });
+
+    search.mockResolvedValueOnce({ memories: "nope" });
+    await expect(
+      store.search("tea", {
+        userId: "scope_abc",
+        topK: 5,
+        threshold: 0.1,
+        rerank: false,
+      }),
+    ).rejects.toThrow(/unexpected response shape/);
+  });
+
+  it("deletes only when the memory belongs to the scope", async () => {
+    const store = await createMem0Store({
+      apiKey: "m0-test",
+      host: "https://api.mem0.ai",
+    });
+
+    get.mockResolvedValueOnce({ id: "m1", userId: "scope_abc" });
+    await store.delete("m1", "scope_abc");
+    expect(del).toHaveBeenCalledWith("m1");
+
+    get.mockResolvedValueOnce({ id: "m2", user_id: "other" });
+    await expect(store.delete("m2", "scope_abc")).rejects.toThrow(/Memory not found/);
+    expect(del).toHaveBeenCalledTimes(1);
+
+    get.mockRejectedValueOnce(new Error("Memory not found"));
+    await expect(store.delete("missing", "scope_abc")).rejects.toThrow(
+      /Memory not found/,
+    );
+  });
+});

--- a/integrations/eve/tsconfig.json
+++ b/integrations/eve/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/integrations/eve/tsup.config.ts
+++ b/integrations/eve/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  external: ["eve", "eve/memory", "eve/tools", "mem0ai", "zod"],
+});

--- a/integrations/eve/vitest.config.ts
+++ b/integrations/eve/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

`@mem0/eve` — Eve memory provider at `integrations/eve`. Public API is `mem0Provider()` from `src/index.ts`.

## Code

**`src/provider.ts`** — `defineMemoryProvider` wiring.

- `recall["turn.started"]` and `recall["compaction.completed"]` share one handler. Query is `lastUserText(turn.input ?? messages)`.
- `capture["turn.completed"]` is omitted when `capture.enabled` is false.
- `tools()` returns `search` / `remember` / `forget` from `createMem0Tools`, locked to `context.memory.scope.key`.
- Store is lazy via `createLazyStore`. A rejected init is not cached.
- Recall throws (setup errors and Mem0 failures). Capture has no try/catch — Eve logs it.

**`src/store.ts`** — `mem0ai` adapter (`MemoryStore`).

- `add` / `search` pass `userId` / `filters.user_id` = scope key.
- `search` accepts `{ results }` or a bare array; anything else throws.
- `delete(id, userId)` calls `get` first; deletes only when `userId` matches. Otherwise `Memory not found`.
- `listByMetadata` is `getAll` with `{ user_id, metadata }` (used for capture replay).

**`src/recall.ts` / `src/capture.ts` / `src/tools.ts`**

- Recall: trim query, search, map hits to `{ id, content }`, return `null` if empty.
- Capture: skip if `metadata.operation_id` already exists for the scope, then `add` the current user turn + latest assistant (`infer` + metadata including `operation_id`).
- Tools: same `topK` / `threshold` / `rerank` / `infer` as the provider. Forget goes through scoped `delete`.

**`src/messages.ts` / `src/options.ts` / `src/idempotency.ts` / `src/errors.ts`**

- Message helpers: string / text-part / single `{ text }` content → Mem0 `{ role, content }`.
- Options: `apiKey` required unless `store` is injected; `host` must be `http:`/`https:`; `topK` 1–100; `threshold` 0–1.
- In-process `operationId` gate (cap 256) in front of the durable metadata check.
- `isSetupError` / `logProviderError` keep the original error object on logs.

**Tests** — `tests/*.test.ts` (53). Fake `MemoryStore` for provider/recall/capture; mocked `mem0ai` in `store.test.ts` for the real client mapping.

**Repo wiring**

- Docs: `docs/integrations/eve.mdx`, package README, `docs/llms.txt`
- CI: `eve-checks.yml` (typecheck / test / build), path filter + call job in `ci-gate.yml`
- Release: `eve-cd.yml`, `eve-v*` in `release.yml`
- `integrations/eve/registry/` — files for a later `vercel/eve` PR (`eve add memory/mem0` is not live yet)

## Package layout

```mermaid
flowchart TB
    index["index.ts\nmem0Provider, types"] --> provider["provider.ts"]
    provider --> options["options.ts\nresolveOptions"]
    provider --> recall["recall.ts"]
    provider --> capture["capture.ts"]
    provider --> tools["tools.ts\nsearch / remember / forget"]
    provider --> lazy["store.ts\ncreateLazyStore"]
    provider --> once["idempotency.ts\nin-process operationId"]
    provider --> messages["messages.ts\nEve messages → text"]
    provider --> errors["errors.ts"]

    recall --> store["store.ts\nMemoryStore"]
    capture --> store
    tools --> store
    once --> capture
    capture --> meta["listByMetadata\noperation_id"]
    lazy --> create["createMem0Store"]
    create --> client["mem0ai MemoryClient"]
    store --> client
```

## Test plan

- [x] `cd integrations/eve && pnpm test` (53)
- [x] `pnpm typecheck` and `pnpm build`
- [ ] CI `eve-checks` on this PR
- [ ] After merge: publish `@mem0/eve@0.1.0` (`eve-v0.1.0`), then Eve registry PR

## Review

@kartik-mem0