### PR TITLE
fix(memory): salvage completed memory objects from truncated extraction JSON

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -57,6 +57,7 @@ from mem0.memory.utils import (
     parse_vision_messages,
     process_telemetry_filters,
     remove_code_blocks,
+    salvage_memory_objects,
 )
 from mem0.utils.entity_extraction import extract_entities, extract_entities_batch
 from mem0.utils.factory import (
@@ -976,9 +977,18 @@ class Memory(MemoryBase):
             else:
                 try:
                     extracted_memories = json.loads(response, strict=False).get("memory", [])
-                except json.JSONDecodeError:
-                    extracted_json = extract_json(response)
-                    extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
+                except (json.JSONDecodeError, AttributeError):
+                    try:
+                        extracted_json = extract_json(response)
+                        extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
+                    except (json.JSONDecodeError, AttributeError):
+                        extracted_memories = salvage_memory_objects(response)
+                        if extracted_memories:
+                            logger.warning(
+                                f"Extraction response was truncated; salvaged {len(extracted_memories)} memory objects"
+                            )
+                        else:
+                            raise
         except Exception as e:
             logger.error(f"Error parsing extraction response: {e}")
             extracted_memories = []
@@ -2637,9 +2647,18 @@ class AsyncMemory(MemoryBase):
             else:
                 try:
                     extracted_memories = json.loads(response, strict=False).get("memory", [])
-                except json.JSONDecodeError:
-                    extracted_json = extract_json(response)
-                    extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
+                except (json.JSONDecodeError, AttributeError):
+                    try:
+                        extracted_json = extract_json(response)
+                        extracted_memories = json.loads(extracted_json, strict=False).get("memory", [])
+                    except (json.JSONDecodeError, AttributeError):
+                        extracted_memories = salvage_memory_objects(response)
+                        if extracted_memories:
+                            logger.warning(
+                                f"Extraction response was truncated; salvaged {len(extracted_memories)} memory objects (async)"
+                            )
+                        else:
+                            raise
         except Exception as e:
             logger.error(f"Error parsing extraction response (async): {e}")
             extracted_memories = []

--- a/mem0/memory/utils.py
+++ b/mem0/memory/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import re
 from typing import Any, Dict, List
@@ -156,6 +157,83 @@ def extract_json(text):
         else:
             json_str = text
     return json_str
+
+
+def salvage_memory_objects(text: str) -> List[Dict[str, Any]]:
+    """
+    Salvages completed memory objects from a truncated or malformed LLM JSON response.
+
+    When max_tokens causes the LLM to cut off generation mid-JSON, standard json.loads()
+    and extract_json() fail on the incomplete syntax. This function locates the memory
+    array and uses incremental JSON decoding to extract all complete objects that preceded
+    the cutoff point, preventing silent data loss.
+
+    Args:
+        text: Raw response string from the LLM.
+
+    Returns:
+        List of decoded memory dictionaries that were fully formed before the cutoff.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return []
+
+    # Locate the start of the memory array.
+    # Matches keys: "memory", "memories", "facts", "data", "items", "results" followed by '['
+    match = re.search(r'"(?:memory|memories|facts|data|items|results)"\s*:\s*\[', text)
+    idx = -1
+    if match:
+        idx = match.end()
+    else:
+        # Check if text is a raw top-level JSON array: first '[' before any '{'
+        first_bracket = text.find("[")
+        first_brace = text.find("{")
+        if first_bracket != -1 and (first_brace == -1 or first_bracket < first_brace):
+            idx = first_bracket + 1
+
+    if idx == -1:
+        return []
+
+    decoder = json.JSONDecoder()
+    salvaged: List[Dict[str, Any]] = []
+
+    while idx < len(text):
+        # Skip whitespace and array element delimiters
+        while idx < len(text) and text[idx] in " \t\r\n,":
+            idx += 1
+        if idx >= len(text):
+            break
+        if text[idx] == "]":
+            break
+        if text[idx] != "{":
+            # If the item is a string literal (e.g. in facts lists), parse it as well
+            if text[idx] == '"':
+                try:
+                    str_val, end_idx = decoder.raw_decode(text, idx)
+                    if isinstance(str_val, str) and str_val.strip():
+                        salvaged.append({"text": str_val})
+                    idx = end_idx
+                    continue
+                except json.JSONDecodeError:
+                    break
+            # Any other character indicates malformed or truncated array content
+            break
+        try:
+            obj, end_idx = decoder.raw_decode(text, idx)
+            if isinstance(obj, dict):
+                # Ensure text field is populated if fact or statement was used
+                if "text" not in obj:
+                    for alt_key in ("fact", "memory", "statement", "content"):
+                        if alt_key in obj and isinstance(obj[alt_key], str):
+                            obj["text"] = obj[alt_key]
+                            break
+                if obj.get("text"):
+                    salvaged.append(obj)
+            idx = end_idx
+        except json.JSONDecodeError:
+            # Cutoff encountered mid-object; stop and return preceding items
+            break
+
+    return salvaged
 
 
 def get_image_description(image_obj, llm, vision_details):

--- a/tests/memory/test_truncation_salvage.py
+++ b/tests/memory/test_truncation_salvage.py
@@ -1,0 +1,199 @@
+import logging
+from unittest.mock import MagicMock
+import pytest
+
+from mem0.memory.main import AsyncMemory, Memory
+from mem0.memory.utils import salvage_memory_objects
+
+
+class TestSalvageMemoryObjects:
+    """Unit tests for salvage_memory_objects utility function."""
+
+    def test_clean_json_array(self):
+        text = '{"memory": [{"id": "0", "text": "Likes coffee", "attributed_to": "user"}]}'
+        result = salvage_memory_objects(text)
+        assert len(result) == 1
+        assert result[0]["text"] == "Likes coffee"
+        assert result[0]["attributed_to"] == "user"
+
+    def test_truncated_mid_second_object(self):
+        text = (
+            '{"memory": ['
+            '{"id": "0", "text": "Likes coffee", "attributed_to": "user"}, '
+            '{"id": "1", "text": "Works at Google", "attributed_to": "us'
+        )
+        result = salvage_memory_objects(text)
+        assert len(result) == 1
+        assert result[0]["text"] == "Likes coffee"
+
+    def test_truncated_at_comma_after_objects(self):
+        text = '{"memory": [{"id": "0", "text": "Fact 1"}, {"id": "1", "text": "Fact 2"}, '
+        result = salvage_memory_objects(text)
+        assert len(result) == 2
+        assert result[0]["text"] == "Fact 1"
+        assert result[1]["text"] == "Fact 2"
+
+    def test_truncated_at_opening_brace_of_third_object(self):
+        text = '{"memory": [{"id": "0", "text": "Fact 1"}, {"id": "1", "text": "Fact 2"}, {"id": "2", '
+        result = salvage_memory_objects(text)
+        assert len(result) == 2
+        assert result[0]["text"] == "Fact 1"
+        assert result[1]["text"] == "Fact 2"
+
+    def test_truncated_inside_markdown_and_think_block(self):
+        text = """<think>Extracting facts from the conversation...</think>
+```json
+{
+  "memory": [
+    {
+      "id": "0",
+      "text": "User lives in Seattle",
+      "attributed_to": "user"
+    },
+    {
+      "id": "1",
+      "text": "User drives an electric car",
+      "attributed_to": "user"
+    },
+    {
+      "id": "2",
+      "text": "User visited Vancouver in
+"""
+        result = salvage_memory_objects(text)
+        assert len(result) == 2
+        assert result[0]["text"] == "User lives in Seattle"
+        assert result[1]["text"] == "User drives an electric car"
+
+    def test_facts_key_salvage(self):
+        text = '{"facts": [{"text": "Alpha"}, {"text": "Beta"}, {"text": "Trun'
+        result = salvage_memory_objects(text)
+        assert len(result) == 2
+        assert result[0]["text"] == "Alpha"
+        assert result[1]["text"] == "Beta"
+
+    def test_string_facts_salvage(self):
+        text = '{"facts": ["User is an engineer", "User likes tea", "User plans to tr'
+        result = salvage_memory_objects(text)
+        assert len(result) == 2
+        assert result[0]["text"] == "User is an engineer"
+        assert result[1]["text"] == "User likes tea"
+
+    def test_top_level_array_salvage(self):
+        text = '[{"text": "Fact A"}, {"text": "Fact B"}, {"text": "Fact C trun'
+        result = salvage_memory_objects(text)
+        assert len(result) == 2
+        assert result[0]["text"] == "Fact A"
+        assert result[1]["text"] == "Fact B"
+
+    def test_alternative_fact_keys_normalized(self):
+        text = '{"memory": [{"fact": "Loves hiking"}, {"statement": "Reads sci-fi"}]}'
+        result = salvage_memory_objects(text)
+        assert len(result) == 2
+        assert result[0]["text"] == "Loves hiking"
+        assert result[1]["text"] == "Reads sci-fi"
+
+    def test_empty_and_whitespace_input(self):
+        assert salvage_memory_objects("") == []
+        assert salvage_memory_objects("   \n\t ") == []
+        assert salvage_memory_objects(None) == []
+
+    def test_completely_invalid_json(self):
+        assert salvage_memory_objects("This is a conversational reply with no JSON.") == []
+
+
+def _setup_mocks_for_salvage(mocker):
+    mock_embedder = mocker.MagicMock()
+    mock_embedder.return_value.embed.return_value = [0.1, 0.2, 0.3]
+    mock_embedder.return_value.embed_batch.return_value = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    mocker.patch("mem0.utils.factory.EmbedderFactory.create", mock_embedder)
+
+    mock_vector_store = mocker.MagicMock()
+    mock_vector_store.return_value.search.return_value = []
+    mock_vector_store.return_value.insert = mocker.MagicMock()
+    mocker.patch(
+        "mem0.utils.factory.VectorStoreFactory.create", side_effect=[mock_vector_store.return_value, mocker.MagicMock()]
+    )
+
+    mock_llm = mocker.MagicMock()
+    mocker.patch("mem0.utils.factory.LlmFactory.create", mock_llm)
+    mocker.patch("mem0.memory.storage.SQLiteManager", mocker.MagicMock())
+    mocker.patch("mem0.memory.main.capture_event")
+
+    return mock_llm, mock_vector_store
+
+
+class TestTruncationEndToEnd:
+    """End-to-end tests for sync and async memory extraction with truncation."""
+
+    def test_sync_add_to_vector_store_salvages_truncated_output(self, mocker, caplog):
+        mock_llm, _ = _setup_mocks_for_salvage(mocker)
+
+        memory = Memory()
+        memory.config = mocker.MagicMock()
+        memory.config.custom_instructions = None
+        memory.config.custom_update_memory_prompt = None
+        memory.custom_instructions = None
+        memory.api_version = "v1.1"
+        memory.db.get_last_messages = MagicMock(return_value=[])
+        memory.db.save_messages = MagicMock()
+
+        # Simulate max_tokens cutoff mid-generation on the 2nd item
+        truncated_response = (
+            '{"memory": ['
+            '{"id": "0", "text": "User is named Alice", "attributed_to": "user"}, '
+            '{"id": "1", "text": "Alice is a software dev'
+        )
+        memory.llm.generate_response.return_value = truncated_response
+
+        with caplog.at_level(logging.WARNING):
+            result = memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "I am Alice and work as a software dev"}],
+                metadata={},
+                filters={},
+                infer=True,
+            )
+
+        # Confirm salvaged memory was persisted rather than silently dropped
+        assert len(result) == 1
+        assert result[0]["memory"] == "User is named Alice"
+        assert any(
+            "Extraction response was truncated; salvaged 1 memory objects" in record.message
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_add_to_vector_store_salvages_truncated_output(self, mocker, caplog):
+        mock_llm, _ = _setup_mocks_for_salvage(mocker)
+
+        async_memory = AsyncMemory()
+        async_memory.config = mocker.MagicMock()
+        async_memory.config.custom_instructions = None
+        async_memory.config.custom_update_memory_prompt = None
+        async_memory.custom_instructions = None
+        async_memory.api_version = "v1.1"
+        async_memory.db.get_last_messages = MagicMock(return_value=[])
+        async_memory.db.save_messages = MagicMock()
+
+        truncated_response = (
+            '{"memory": ['
+            '{"id": "0", "text": "User is named Bob", "attributed_to": "user"}, '
+            '{"id": "1", "text": "Bob has two dogs", "attributed_to": "user"}, '
+            '{"id": "2", "text": "One dog is named Ch'
+        )
+        async_memory.llm.generate_response.return_value = truncated_response
+
+        with caplog.at_level(logging.WARNING):
+            result = await async_memory._add_to_vector_store(
+                messages=[{"role": "user", "content": "I am Bob and have two dogs"}],
+                metadata={},
+                effective_filters={},
+                infer=True,
+            )
+
+        assert len(result) == 2
+        assert result[0]["memory"] == "User is named Bob"
+        assert result[1]["memory"] == "Bob has two dogs"
+        assert any(
+            "Extraction response was truncated; salvaged 2 memory objects (async)" in record.message
+            for record in caplog.records
+        )


### PR DESCRIPTION
## Linked Issue

Closes #5428

## Description

### Root Cause
When extraction output is cut off prematurely (e.g. hitting `max_tokens` mid-stream), the LLM emits an unterminated JSON array:
```json
{"memory": [{"id": "0", "text": "Alice is an engineer"}, {"id": "1", "text": "Alice enjoys hiki
```
Previously, `_add_to_vector_store` in both synchronous and asynchronous paths attempted `json.loads(response)` followed by `json.loads(extract_json(response))`. Because the closing brackets and braces are missing, both attempts raised `json.JSONDecodeError`. The outer `except Exception:` block reset `extracted_memories = []`, causing silent data loss for all completed memories that were already generated in that batch.

### Fix
1. Added `salvage_memory_objects` in `mem0/memory/utils.py`:
   - Scans for the start of the memory array (`"memory"`, `"memories"`, `"facts"`, or top-level `[`).
   - Iterates using `json.JSONDecoder().raw_decode` across array items to decode every fully formed memory object preceding the cutoff.
   - Stops gracefully at the point of truncation without raising exceptions.
   - Handles both dictionaries and string literal arrays, normalizing alternative keys (`fact`, `statement`, `content`) into standard `text`.
2. Updated `_add_to_vector_store` in `mem0/memory/main.py` (both sync and async):
   - Integrates `salvage_memory_objects` into the parsing fallback chain.
   - If truncation occurred but valid memories exist, logs a warning with the count of salvaged items and continues downstream embedding and persistence.
   - If input is completely invalid (no recoverable memories), re-raises `JSONDecodeError` to preserve existing error-handling behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [x] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [ ] AI-generated (an agent wrote most or all of this diff)

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [x] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

Added `tests/memory/test_truncation_salvage.py` covering:
- Clean complete JSON.
- Truncation mid-second object.
- Truncation at trailing comma.
- Truncation at unclosed `{`.
- Truncation within markdown code fences and `<think>` reasoning blocks.
- Arrays using `"facts"` key or raw top-level lists.
- Alternative memory item keys (`fact`, `statement`, `content`).
- Empty, whitespace, and non-JSON string inputs.
- Synchronous and asynchronous end-to-end extraction and vector store persistence.

All 13 new tests passed. All 86 existing memory and parser tests passed. `ruff check mem0/ tests/` passed with 0 errors.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
