### PR TITLE
docs: add optional AtMem delivery evidence

### DIFF
--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -491,6 +491,24 @@ export MEM0_TELEMETRY=false
 
 The plugin injects memory-related instructions into the agent's system context via OpenClaw's `prependSystemContext` mechanism. This includes the memory triage protocol and recalled memories. This is the standard OpenClaw plugin SDK pattern for memory backends. No user-facing prompts are modified.
 
+### Optional Delivery Evidence with AtMem
+
+Mem0 search results show which memories were retrieved, but operators with audit
+requirements may also need evidence of which context reached the model-input
+boundary. [AtMem](https://github.com/aetna000/atmem) provides an optional Mem0
+adapter for that deployment model. Mem0 remains the context-selection authority;
+AtMem verifies a scoped inject or withhold decision, delivers the exact context
+once, and records the authorization separately from the host's delivery
+observation.
+
+This is an alternative OpenClaw memory integration, because OpenClaw has one
+memory-plugin slot. Do not enable the Mem0 and AtMem OpenClaw plugins in that
+slot at the same time. Follow AtMem's
+[Mem0 adapter setup](https://github.com/aetna000/atmem/blob/v2.2.6/docs/context-provider-adapters.md#mem0)
+for installation, identity and scope registration, explicit activation,
+verification, and rollback. Delivery evidence proves what context was presented;
+it does not prove that the model used or followed it.
+
 <CardGroup cols={2}>
   <Card title="OpenAI Agents SDK" icon="/images/provider-icons/openai.svg" href="/integrations/openai-agents-sdk">
     Build agents with OpenAI's SDK and Mem0


### PR DESCRIPTION
## Linked Issue

Closes #7273

## Description

Mem0 retrieval identifies which memories were found, while operators with audit requirements may also need evidence of what reached the model-input boundary.

This adds a concise optional section to the existing OpenClaw integration guide. It explains that Mem0 remains the context-selection authority in AtMem's delegated topology, distinguishes authorization from observed delivery, links to the complete scoped setup, and states both the single-memory-slot constraint and the limit of what delivery evidence proves.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Codex drafted the documentation change and checked its claims against Mem0's current OpenClaw guide and AtMem's tagged v2.2.6 adapter documentation. The linked setup page and anchor were also verified.

- [ ] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [x] I tested manually (describe below)
- [x] No tests needed (documentation-only change)

Validation performed:

- `python scripts/check-llms-txt-coverage.py`
- `mintlify validate`
- `mintlify broken-links`
- `git diff --check`
- `pre-commit run --files docs/integrations/openclaw.mdx`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
