### PR TITLE
fix(memory): don't insert a duplicate entity row when the lookup fails (Python side of #6925)

### DIFF
--- a/mem0/memory/main.py
+++ b/mem0/memory/main.py
@@ -584,12 +584,19 @@ class Memory(MemoryBase):
         return " ".join(value.strip().lower().split())
 
     def _existing_entities_by_text(self, filters):
-        """Return existing entity rows keyed by normalized payload data."""
+        """Return existing entity rows keyed by normalized payload data.
+
+        Returns ``None`` when the exact-match index could not be read. That is
+        not the same as an empty index: treating a failed lookup as "no entity
+        exists" makes the caller fall through to the semantic threshold and
+        insert a duplicate row for an entity that is already stored, splitting
+        ``linked_memory_ids`` across the two rows.
+        """
         try:
             listed = self.entity_store.list(filters=filters, top_k=10000)
         except Exception as e:
-            logger.debug(f"Exact entity lookup failed, falling back to semantic dedup: {e}")
-            return {}
+            logger.warning(f"Exact entity lookup failed; skipping entity upsert to avoid a duplicate row: {e}")
+            return None
 
         rows_by_text = {}
         for row in _vector_store_list_rows(listed):
@@ -607,7 +614,14 @@ class Memory(MemoryBase):
         try:
             entity_embedding = self.embedding_model.embed(entity_text, "add")
             search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-            exact_match = self._existing_entities_by_text(search_filters).get(self._normalize_entity_text(entity_text))
+            existing_by_text = self._existing_entities_by_text(search_filters)
+            if existing_by_text is None:
+                # The exact-match index is unreadable, so "not found" cannot be
+                # distinguished from "not looked up". Inserting here would fork
+                # the entity into a second row; skip instead and let a later
+                # add() link this memory once the store recovers.
+                return
+            exact_match = existing_by_text.get(self._normalize_entity_text(entity_text))
 
             existing = []
             if exact_match is None:
@@ -1128,10 +1142,13 @@ class Memory(MemoryBase):
 
                 # Filter out entities with failed embeddings
                 valid = [(i, k) for i, k in enumerate(ordered_keys) if entity_embeddings[i] is not None]
-                if valid:
+                exact_matches = self._existing_entities_by_text(search_filters) if valid else {}
+                # A failed exact-match lookup cannot be told apart from an empty
+                # index, and inserting on it duplicates entities that already
+                # exist. Skip the batch rather than fork every entity in it.
+                if valid and exact_matches is not None:
                     valid_indices, valid_keys = zip(*valid)
                     valid_vectors = [entity_embeddings[i] for i in valid_indices]
-                    exact_matches = self._existing_entities_by_text(search_filters)
 
                     # 7c: Batch search for existing entities
                     valid_texts = [global_entities[k][1] for k in valid_keys]
@@ -2248,12 +2265,19 @@ class AsyncMemory(MemoryBase):
         return " ".join(value.strip().lower().split())
 
     def _existing_entities_by_text(self, filters):
-        """Return existing entity rows keyed by normalized payload data."""
+        """Return existing entity rows keyed by normalized payload data.
+
+        Returns ``None`` when the exact-match index could not be read. That is
+        not the same as an empty index: treating a failed lookup as "no entity
+        exists" makes the caller fall through to the semantic threshold and
+        insert a duplicate row for an entity that is already stored, splitting
+        ``linked_memory_ids`` across the two rows.
+        """
         try:
             listed = self.entity_store.list(filters=filters, top_k=10000)
         except Exception as e:
-            logger.debug(f"Exact entity lookup failed, falling back to semantic dedup: {e}")
-            return {}
+            logger.warning(f"Exact entity lookup failed; skipping entity upsert to avoid a duplicate row: {e}")
+            return None
 
         rows_by_text = {}
         for row in _vector_store_list_rows(listed):
@@ -2271,9 +2295,12 @@ class AsyncMemory(MemoryBase):
         try:
             entity_embedding = await asyncio.to_thread(self.embedding_model.embed, entity_text, "add")
             search_filters = {k: v for k, v in filters.items() if k in ("user_id", "agent_id", "run_id") and v}
-            exact_match = (
-                await asyncio.to_thread(self._existing_entities_by_text, search_filters)
-            ).get(self._normalize_entity_text(entity_text))
+            existing_by_text = await asyncio.to_thread(self._existing_entities_by_text, search_filters)
+            if existing_by_text is None:
+                # See the sync variant: a failed lookup is not an absent entity,
+                # and inserting on it forks the entity into a second row.
+                return
+            exact_match = existing_by_text.get(self._normalize_entity_text(entity_text))
 
             existing = []
             if exact_match is None:
@@ -2785,10 +2812,14 @@ class AsyncMemory(MemoryBase):
                     entity_embeddings += [None] * (len(ordered_keys) - len(entity_embeddings))
 
                 valid = [(i, k) for i, k in enumerate(ordered_keys) if entity_embeddings[i] is not None]
-                if valid:
+                exact_matches = (
+                    await asyncio.to_thread(self._existing_entities_by_text, search_filters) if valid else {}
+                )
+                # See the sync batch path: a failed lookup would fork every
+                # entity in this batch into a duplicate row.
+                if valid and exact_matches is not None:
                     valid_indices, valid_keys = zip(*valid)
                     valid_vectors = [entity_embeddings[i] for i in valid_indices]
-                    exact_matches = await asyncio.to_thread(self._existing_entities_by_text, search_filters)
 
                     # 7c: Batch search for existing entities
                     valid_texts = [global_entities[k][1] for k in valid_keys]

--- a/tests/memory/test_main.py
+++ b/tests/memory/test_main.py
@@ -1178,3 +1178,132 @@ class TestAddPipelineEntityEmbeddingCountGuard:
         assert any("padding/truncating" in r.message for r in caplog.records), (
             "expected count-mismatch warning was not emitted"
         )
+
+
+class TestEntityLookupFailureDoesNotDuplicate:
+    """A failed exact-match lookup must not be read as "no entity exists".
+
+    `_existing_entities_by_text` used to swallow a failing `entity_store.list()`
+    and return `{}`. `exact_match` was then None, control fell through to the
+    semantic search gated on `score >= 0.95`, and any existing row scoring below
+    that threshold was ignored — so `add()` inserted a second row for an entity
+    that was already stored and split `linked_memory_ids` across the two.
+    """
+
+    @pytest.fixture
+    def mock_memory(self, mocker):
+        _setup_mocks(mocker)
+        return Memory()
+
+    @pytest.fixture
+    def mock_async_memory(self, mocker):
+        _setup_mocks(mocker)
+        return AsyncMemory()
+
+    @staticmethod
+    def _entity_store_with_failing_list(existing_score):
+        """Store whose exact index is down but whose semantic search answers."""
+        store = Mock()
+        store.list = Mock(side_effect=RuntimeError("entity index unavailable"))
+        store.search = Mock(
+            return_value=[
+                SimpleNamespace(
+                    id="entity-1",
+                    score=existing_score,
+                    payload={"data": "alice", "linked_memory_ids": ["mem-1"]},
+                )
+            ]
+        )
+        store.insert = Mock()
+        store.update = Mock()
+        return store
+
+    def test_sync_upsert_does_not_insert_when_exact_lookup_fails(self, mock_memory):
+        # 0.80 is below the 0.95 semantic gate, so the pre-fix code inserted.
+        store = self._entity_store_with_failing_list(existing_score=0.80)
+        mock_memory._entity_store = store
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+        mock_memory._upsert_entity("alice", "person", "mem-2", {"user_id": "u1"})
+
+        store.insert.assert_not_called()
+
+    def test_sync_upsert_warns_when_exact_lookup_fails(self, mock_memory, caplog):
+        store = self._entity_store_with_failing_list(existing_score=0.80)
+        mock_memory._entity_store = store
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+        with caplog.at_level(logging.WARNING):
+            mock_memory._upsert_entity("alice", "person", "mem-2", {"user_id": "u1"})
+
+        assert any("Exact entity lookup failed" in r.message for r in caplog.records), (
+            "a lookup outage that skips the write must not be silent"
+        )
+
+    def test_sync_upsert_still_links_when_lookup_succeeds(self, mock_memory):
+        """The healthy path is unchanged: an exact hit still links."""
+        store = Mock()
+        store.list = Mock(
+            return_value=[
+                SimpleNamespace(
+                    id="entity-1",
+                    score=1.0,
+                    payload={"data": "alice", "linked_memory_ids": ["mem-1"]},
+                )
+            ]
+        )
+        store.insert = Mock()
+        store.update = Mock()
+        mock_memory._entity_store = store
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+        mock_memory._upsert_entity("alice", "person", "mem-2", {"user_id": "u1"})
+
+        store.insert.assert_not_called()
+        store.update.assert_called_once()
+        payload = store.update.call_args.kwargs["payload"]
+        assert payload["linked_memory_ids"] == ["mem-1", "mem-2"]
+
+    def test_sync_upsert_still_inserts_a_genuinely_new_entity(self, mock_memory):
+        """A readable but empty index must still create the entity."""
+        store = Mock()
+        store.list = Mock(return_value=[])
+        store.search = Mock(return_value=[])
+        store.insert = Mock()
+        store.update = Mock()
+        mock_memory._entity_store = store
+        mock_memory.embedding_model = Mock()
+        mock_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+        mock_memory._upsert_entity("alice", "person", "mem-1", {"user_id": "u1"})
+
+        store.insert.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_upsert_does_not_insert_when_exact_lookup_fails(self, mock_async_memory):
+        store = self._entity_store_with_failing_list(existing_score=0.80)
+        mock_async_memory._entity_store = store
+        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+        await mock_async_memory._upsert_entity_async("alice", "person", "mem-2", {"user_id": "u1"})
+
+        store.insert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_upsert_still_inserts_a_genuinely_new_entity(self, mock_async_memory):
+        store = Mock()
+        store.list = Mock(return_value=[])
+        store.search = Mock(return_value=[])
+        store.insert = Mock()
+        store.update = Mock()
+        mock_async_memory._entity_store = store
+        mock_async_memory.embedding_model = Mock()
+        mock_async_memory.embedding_model.embed = Mock(return_value=[0.1, 0.2, 0.3])
+
+        await mock_async_memory._upsert_entity_async("alice", "person", "mem-1", {"user_id": "u1"})
+
+        store.insert.assert_called_once()


### PR DESCRIPTION
Fixes #6925 (Python side).

#6925 reports this failure shape in the TypeScript OSS SDK. The Python OSS SDK
has the same one, so a fix scoped to `mem0-ts/` would leave it in place. I
raised this on the issue first; opening the Python half here.

## The bug

`_existing_entities_by_text` swallowed a failing `entity_store.list()` and
returned `{}` — indistinguishable from "this scope has no entities"
(`mem0/memory/main.py:586-592`, async duplicate at `:2265-2271`):

```python
try:
    listed = self.entity_store.list(filters=filters, top_k=10000)
except Exception as e:
    logger.debug(f"Exact entity lookup failed, falling back to semantic dedup: {e}")
    return {}
```

`exact_match` is then `None`, so `_upsert_entity` falls through to the semantic
search gated on `score >= 0.95`.

The Python path fails one step earlier than the TS one: what goes down is the
exact index, and what silently stands in for it is a similarity threshold.

## Impact

Tracing the control flow with the store's two lookups toggled independently:

| `list()` | semantic `search()` | result |
|---|---|---|
| ok | ok | LINK |
| **fails** | returns the row at 1.00 | LINK (masked) |
| **fails** | returns the row at 0.80 | **INSERT_DUPLICATE** |

Whenever the existing row scores below 0.95 — real for entities that are exact
string matches but embed imprecisely — `add()` forks the entity into a second
row, and the two rows split `linked_memory_ids` between them. Later lookups
find only one, so the links held by the other are effectively lost. The only
trace is a single `logger.debug` line.

The entity store is a separate vector store and can fail on its own: a network
blip, a rate limit, a briefly unavailable collection.

## The change

Return `None` from the helper to distinguish "could not read the index" from
"the index is empty", and skip the upsert on `None` instead of inserting. A
later `add()` links the memory once the store recovers — that loses a link,
which is recoverable, rather than forking the entity, which is not.

The log moves from `debug` to `warning`, since a skipped write should not be
silent.

All four call sites are covered — the per-entity path and the phase 7 batch
path, in both `Memory` and `AsyncMemory` (`:619`, `:1145` and `:2296`, `:2816`).
The batch paths skip the batch rather than fork every entity in it.

The healthy path is deliberately unchanged: an exact hit still links, and a
readable-but-empty index still inserts. Two of the tests below pin exactly that.

## Tests

`TestEntityLookupFailureDoesNotDuplicate` in `tests/memory/test_main.py`, six
cases across sync and async:

- a failed lookup does not insert (sync + async) — the store's semantic search
  returns the existing row at **0.80**, below the 0.95 gate, which is precisely
  the case the old code got wrong
- the skip is logged at WARNING
- a successful lookup still links, and `linked_memory_ids` becomes
  `["mem-1", "mem-2"]`
- a readable but empty index still inserts (sync + async)

Reverting `main.py` alone turns 3 red — the two "does not insert" cases and the
warning. The other 3 pass either way by design, since they pin the healthy path
that must not change.

## Verification

- `pytest tests/memory/ tests/test_main.py` — **434 passed**
- `ruff check` on both changed files — **All checks passed**
- `ruff format` — both files have pre-existing formatting drift on `main`
  (identical before and after this change); the lines this PR adds are
  format-clean, confirmed via `ruff format --diff`.

## AI disclosure

This pull request was prepared with AI assistance. The change was reviewed,
tested, and verified locally by the contributor.
