### PR TITLE
docs(upstash): correct the default collection namespace

### DIFF
--- a/docs/components/vectordbs/dbs/upstash-vector.mdx
+++ b/docs/components/vectordbs/dbs/upstash-vector.mdx
@@ -102,7 +102,7 @@ Here are the parameters available for configuring Upstash Vector:
 | `url`               | URL for the Upstash Vector index   | `None`        |
 | `token`             | Token for the Upstash Vector index | `None`        |
 | `client`            | An `upstash_vector.Index` instance | `None`        |
-| `collection_name`   | The default namespace used         | `""`          |
+| `collection_name`   | The default namespace used         | `"mem0"`      |
 | `enable_embeddings` | Whether to use Upstash embeddings  | `False`       |
 
 <Note>


### PR DESCRIPTION
## Linked Issue

Closes #7286

## Description

Correct the documented collection_name default from an empty string
to "mem0", matching UpstashVectorConfig and the original review
decision in PR #2493.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [x] Documentation update

## AI Assistance

<!-- This is about the code, not this description. Writing the description with AI is fine. -->

- [ ] No AI assistance
- [x] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [ ] AI-generated (an agent wrote most or all of this diff)

<!-- If you ticked either AI box, name the tool and what you checked yourself. -->

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A — documentation-only correction.

## Test Coverage

- [ ] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [x] No tests needed (explain why)

This change corrects one documented default value and does not change
runtime behavior.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed
