### PR TITLE
fix(llms): preserve words containing assistant in Azure prompts

### DIFF
--- a/mem0/llms/azure_openai.py
+++ b/mem0/llms/azure_openai.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import re
 from typing import Dict, List, Optional, Union
 
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
@@ -80,6 +81,11 @@ class AzureOpenAILLM(LLMBase):
         which makes ``add`` fail (see issue #2636). The rewrite targets that
         trigger without mutating the caller's messages and without assuming the
         content is a string, so multimodal (list) content passes through untouched.
+
+        Matching is case-sensitive and uses word boundaries, preserving words
+        like "assistants" and "nonassistant". Underscores and digits are word
+        characters, so identifiers like "assistant_id", "my_assistant", and
+        "assistant2" are intentionally left unchanged.
         """
         if not messages:
             return messages
@@ -87,7 +93,7 @@ class AzureOpenAILLM(LLMBase):
         messages = copy.deepcopy(messages)
         last_content = messages[-1].get("content")
         if isinstance(last_content, str):
-            messages[-1]["content"] = last_content.replace("assistant", "ai")
+            messages[-1]["content"] = re.sub(r"\bassistant\b", "ai", last_content)
         return messages
 
     def _parse_response(self, response, tools):

--- a/mem0/llms/azure_openai_structured.py
+++ b/mem0/llms/azure_openai_structured.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import re
 from typing import Dict, List, Optional
 
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
@@ -112,6 +113,11 @@ class AzureOpenAIStructuredLLM(LLMBase):
         which makes ``add`` fail (see issue #2636). The rewrite targets that
         trigger without mutating the caller's messages and without assuming the
         content is a string, so multimodal (list) content passes through untouched.
+
+        Matching is case-sensitive and uses word boundaries, preserving words
+        like "assistants" and "nonassistant". Underscores and digits are word
+        characters, so identifiers like "assistant_id", "my_assistant", and
+        "assistant2" are intentionally left unchanged.
         """
         if not messages:
             return messages
@@ -119,7 +125,7 @@ class AzureOpenAIStructuredLLM(LLMBase):
         messages = copy.deepcopy(messages)
         last_content = messages[-1].get("content")
         if isinstance(last_content, str):
-            messages[-1]["content"] = last_content.replace("assistant", "ai")
+            messages[-1]["content"] = re.sub(r"\bassistant\b", "ai", last_content)
         return messages
 
     def _parse_response(self, response, tools):

--- a/tests/llms/test_azure_openai.py
+++ b/tests/llms/test_azure_openai.py
@@ -165,6 +165,46 @@ def test_generate_response_rewrites_assistant_keyword_for_model_only(mock_openai
     assert messages[-1]["content"] == "my assistant helps me"
 
 
+@pytest.mark.parametrize(
+    "content, expected_content",
+    [
+        ("the assistants arrived", "the assistants arrived"),
+        ("nonassistant setups exist", "nonassistant setups exist"),
+        ("assistantship program", "assistantship program"),
+        ("pass the assistant_id along", "pass the assistant_id along"),
+        ("configure my_assistant now", "configure my_assistant now"),
+        ("assistant2 2assistant", "assistant2 2assistant"),
+        ("my assistant helps with assistants", "my ai helps with assistants"),
+        ("Assistant ASSISTANT assistant", "Assistant ASSISTANT ai"),
+        ("assistant", "ai"),
+        ("(assistant), assistant's co-assistant.", "(ai), ai's co-ai."),
+    ],
+)
+def test_generate_response_respects_assistant_word_boundaries(mock_openai_client, content, expected_content):
+    config = AzureOpenAIConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P)
+    llm = AzureOpenAILLM(config)
+    messages = [
+        {"role": "assistant", "content": "I am your assistant."},
+        {"role": "user", "content": content},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="ok"))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    sent_messages = mock_openai_client.chat.completions.create.call_args[1]["messages"]
+    assert sent_messages == [
+        {"role": "assistant", "content": "I am your assistant."},
+        {"role": "user", "content": expected_content},
+    ]
+    assert messages == [
+        {"role": "assistant", "content": "I am your assistant."},
+        {"role": "user", "content": content},
+    ]
+
+
 def test_generate_response_handles_multimodal_content(mock_openai_client):
     config = AzureOpenAIConfig(model=MODEL, temperature=TEMPERATURE, max_tokens=MAX_TOKENS, top_p=TOP_P)
     llm = AzureOpenAILLM(config)

--- a/tests/llms/test_azure_openai_structured.py
+++ b/tests/llms/test_azure_openai_structured.py
@@ -1,6 +1,8 @@
 from unittest import mock
 from unittest.mock import Mock
 
+import pytest
+
 from mem0.llms.azure_openai_structured import SCOPE, AzureOpenAIStructuredLLM
 
 
@@ -302,6 +304,39 @@ def test_generate_response_rewrites_assistant_keyword_for_model_only(mock_azure_
     sent_messages = mock_client.chat.completions.create.call_args[1]["messages"]
     assert sent_messages[-1]["content"] == "my ai helps me"
     assert messages[-1]["content"] == "my assistant helps me"
+
+
+@pytest.mark.parametrize(
+    "content, expected_content",
+    [
+        ("the assistants arrived", "the assistants arrived"),
+        ("nonassistant setups exist", "nonassistant setups exist"),
+        ("assistantship program", "assistantship program"),
+        ("pass the assistant_id along", "pass the assistant_id along"),
+        ("configure my_assistant now", "configure my_assistant now"),
+        ("assistant2 2assistant", "assistant2 2assistant"),
+        ("my assistant helps with assistants", "my ai helps with assistants"),
+        ("Assistant ASSISTANT assistant", "Assistant ASSISTANT ai"),
+        ("assistant", "ai"),
+        ("(assistant), assistant's co-assistant.", "(ai), ai's co-ai."),
+    ],
+)
+def test_rewrite_assistant_keyword_respects_word_boundaries(content, expected_content):
+    messages = [
+        {"role": "assistant", "content": "I am your assistant."},
+        {"role": "user", "content": content},
+    ]
+
+    rewritten_messages = AzureOpenAIStructuredLLM._rewrite_assistant_keyword(messages)
+
+    assert rewritten_messages == [
+        {"role": "assistant", "content": "I am your assistant."},
+        {"role": "user", "content": expected_content},
+    ]
+    assert messages == [
+        {"role": "assistant", "content": "I am your assistant."},
+        {"role": "user", "content": content},
+    ]
 
 
 @mock.patch("mem0.llms.azure_openai_structured.AzureOpenAI")


### PR DESCRIPTION
## Linked Issue

Closes #6036

## Description

<!-- What does this PR do? Why is it needed? -->

Both Azure providers currently rewrite `assistant` inside larger words and identifiers in the final message: `the assistants arrived` becomes `the ais arrived`, and `assistant_id` becomes `ai_id`.

Use `re.sub(r"\bassistant\b", "ai", last_content)` in both providers and document the word-boundary behavior. Matching remains case-sensitive: standalone lowercase `assistant` is rewritten, while `Assistant` and `ASSISTANT` retain their existing behavior. Words such as `assistants` and identifiers such as `assistant_id`, `my_assistant`, and `assistant2` are intentionally preserved. Caller messages, earlier messages, roles, and multimodal content retain their existing handling.

This follows Bartok9's fix in #6042 and the approach confirmed in [kartik-mem0's final review](https://github.com/mem0ai/mem0/pull/6042#pullrequestreview-4855376338), with parameterized regression and compatibility coverage. #6042 was closed without merging; its public comments do not explain the closure. Related #6509 added no regression tests and was [closed by its author while clearing their backlog](https://github.com/mem0ai/mem0/pull/6509#issuecomment-5633980353), with an offer to reopen if requested. The shared `LLMBase` helper remains the non-blocking follow-up identified in the review.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

<!-- This is about the code, not this description. Writing the description with AI is fine. -->

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

<!-- If you ticked either AI box, name the tool and what you checked yourself. -->

Codex wrote the implementation and tests and executed the local validation. I reviewed and understand every line of the diff, including the case-sensitive word boundaries, identifier handling, caller immutability, and the tests' use of the real provider paths with a mocked Azure SDK.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and the migration path. Delete this section if not applicable. -->

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

<!-- Describe how you tested this, or link to CI results. -->

Executed locally on Windows with Python 3.12.10 in a Hatch-created environment. The two Azure test files were run before changing either implementation and again after applying the fix. The test invocation used the environment's Python executable, with JUnit and cache output options, for:

```text
python -B -m pytest tests/llms/test_azure_openai.py tests/llms/test_azure_openai_structured.py -q --tb=short
```

| Implementation | Actual result |
| --- | --- |
| Original `str.replace` with the new tests | `14 failed, 39 passed in 3.58s` |
| Fixed implementation with the same tests | `53 passed in 3.17s` |

All 14 failures were the new corruption regressions, seven per provider. For example, the original implementation sent `the ais arrived` instead of `the assistants arrived`, and `pass the ai_id along` instead of `pass the assistant_id along`. There were no collection errors or skips in these runs. The other six new parameter cases preserve existing standalone-word, capitalization, and punctuation behavior; the 33 existing tests also pass.

Ruff 0.16.0 (`check --no-cache`), isort (`--check-only`), and `git diff --check` passed for the four changed files. Both helpers have matching documentation of the intentional identifier behavior.

Validation covers the focused Azure unit suites with the SDK mocked. The full repository suite, other Python versions, and live Azure content-filter behavior were not tested locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed
