### PR TITLE
fix(proxy): repair broken MemoryClient search path

### DIFF
--- a/mem0/proxy/main.py
+++ b/mem0/proxy/main.py
@@ -161,15 +161,17 @@ class Completions:
         threading.Thread(target=add_task, daemon=True).start()
 
     def _fetch_relevant_memories(self, messages, user_id, agent_id, run_id, filters, top_k):
-        # Currently, only pass the last 6 messages to the search API to prevent long query
         message_input = [f"{message['role']}: {message['content']}" for message in messages][-6:]
-        # TODO: Make it better by summarizing the past conversation
+        search_filters = dict(filters) if filters else {}
+        if user_id:
+            search_filters["user_id"] = user_id
+        if agent_id:
+            search_filters["agent_id"] = agent_id
+        if run_id:
+            search_filters["run_id"] = run_id
         return self.mem0_client.search(
             query="\n".join(message_input),
-            user_id=user_id,
-            agent_id=agent_id,
-            run_id=run_id,
-            filters=filters,
+            filters=search_filters,
             top_k=top_k,
         )
 
@@ -182,5 +184,7 @@ class Completions:
             if relevant_memories.get("relations"):
                 entities = [entity for entity in relevant_memories["relations"]]
         elif isinstance(self.mem0_client, mem0.client.main.MemoryClient):
-            memories_text = "\n".join(memory["memory"] for memory in relevant_memories)
+            memories_text = "\n".join(memory["memory"] for memory in relevant_memories["results"])
+            if relevant_memories.get("relations"):
+                entities = [entity for entity in relevant_memories["relations"]]
         return f"- Relevant Memories/Facts: {memories_text}\n\n- Entities: {entities}\n\n- User Question: {messages[-1]['content']}"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -68,11 +68,13 @@ def test_completions_create(mock_memory_client, mock_litellm):
     completions = Completions(mock_memory_client)
 
     messages = [{"role": "user", "content": "Hello, how are you?"}]
-    mock_memory_client.search.return_value = [{"memory": "Some relevant memory"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "Some relevant memory"}]}
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
     mock_litellm.supports_function_calling.return_value = True
 
-    response = completions.create(model="gpt-4.1-nano-2025-04-14", messages=messages, user_id="test_user", temperature=0.7)
+    response = completions.create(
+        model="gpt-4.1-nano-2025-04-14", messages=messages, user_id="test_user", temperature=0.7
+    )
 
     mock_memory_client.add.assert_called_once()
     mock_memory_client.search.assert_called_once()
@@ -93,7 +95,7 @@ def test_completions_create_with_system_message(mock_memory_client, mock_litellm
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hello, how are you?"},
     ]
-    mock_memory_client.search.return_value = [{"memory": "Some relevant memory"}]
+    mock_memory_client.search.return_value = {"results": [{"memory": "Some relevant memory"}]}
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "I'm doing well, thank you!"}}]}
     mock_litellm.supports_function_calling.return_value = True
 
@@ -118,7 +120,7 @@ def test_completions_create_messages_default_does_not_leak_between_calls(mock_me
     completions = Completions(mock_memory_client)
     mock_litellm.supports_function_calling.return_value = True
     mock_litellm.completion.return_value = {"choices": [{"message": {"content": "ok"}}]}
-    mock_memory_client.search.return_value = []
+    mock_memory_client.search.return_value = {"results": []}
 
     # Each call passes a fresh list — confirms the public happy path stays green.
     completions.create(
@@ -141,6 +143,61 @@ def test_completions_create_messages_default_does_not_leak_between_calls(mock_me
         f"Completions.create(messages=...) must default to None to avoid the "
         f"B006 shared-default-list bug; got {messages_default!r}."
     )
+
+
+def test_fetch_relevant_memories_passes_entity_params_in_filters(mock_memory_client):
+    """Regression test for #4907 bug 1: entity params must go inside filters, not as top-level kwargs."""
+    completions = Completions(mock_memory_client)
+    mock_memory_client.search.return_value = {"results": []}
+
+    completions._fetch_relevant_memories(
+        messages=[{"role": "user", "content": "hi"}],
+        user_id="u1",
+        agent_id="a1",
+        run_id=None,
+        filters=None,
+        top_k=5,
+    )
+
+    mock_memory_client.search.assert_called_once()
+    call_kwargs = mock_memory_client.search.call_args[1]
+    assert "user_id" not in call_kwargs, "user_id must not be a top-level kwarg"
+    assert "agent_id" not in call_kwargs, "agent_id must not be a top-level kwarg"
+    assert call_kwargs["filters"] == {"user_id": "u1", "agent_id": "a1"}
+    assert call_kwargs["top_k"] == 5
+
+
+def test_fetch_relevant_memories_merges_caller_filters(mock_memory_client):
+    """Regression test for #4907: explicit entity params merge into caller-provided filters."""
+    completions = Completions(mock_memory_client)
+    mock_memory_client.search.return_value = {"results": []}
+    caller_filters = {"category": "work"}
+
+    completions._fetch_relevant_memories(
+        messages=[{"role": "user", "content": "hi"}],
+        user_id="u1",
+        agent_id=None,
+        run_id=None,
+        filters=caller_filters,
+        top_k=10,
+    )
+
+    call_kwargs = mock_memory_client.search.call_args[1]
+    assert call_kwargs["filters"] == {"category": "work", "user_id": "u1"}
+    assert caller_filters == {"category": "work"}, "caller's dict must not be mutated"
+
+
+def test_format_query_with_memories_memoryclient_uses_results_key(mock_memory_client):
+    """Regression test for #4907 bug 2: MemoryClient branch must unwrap ['results']."""
+    completions = Completions(mock_memory_client)
+    messages = [{"role": "user", "content": "What do I like?"}]
+    search_response = {"results": [{"memory": "likes pizza"}, {"memory": "likes hiking"}]}
+
+    result = completions._format_query_with_memories(messages, search_response)
+
+    assert "likes pizza" in result
+    assert "likes hiking" in result
+    assert "What do I like?" in result
 
 
 def test_missing_litellm_raises_actionable_import_error(monkeypatch):


### PR DESCRIPTION
## Linked Issue

Closes #4907

## Description

The proxy chat path (`mem0/proxy/main.py`) is completely broken when using `MemoryClient` (hosted platform). Two bugs prevent any chat completion from succeeding:

**Bug 1 — `_fetch_relevant_memories` passes entity params as top-level kwargs**

Both `Memory.search()` and `MemoryClient.search()` reject `user_id`, `agent_id`, `run_id` as top-level kwargs with `ValueError`. They must be passed inside a `filters` dict. The fix merges entity params into a copy of the caller-provided `filters` dict before calling `search()`.

**Bug 2 — `_format_query_with_memories` iterates dict keys in MemoryClient branch**

`MemoryClient.search()` returns `{"results": [...]}` (v1.1 format). The MemoryClient branch iterated the dict directly (`for memory in relevant_memories`), yielding keys like `"results"` instead of memory objects, raising `TypeError: string indices must be integers`. The fix unwraps `["results"]` to match the Memory branch.

**Not in scope:** The related `_async_add_to_memory` bug (#6819) has active PRs and is intentionally excluded.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## AI Assistance

- [ ] No AI assistance
- [ ] AI-assisted (autocomplete, or I asked a model questions while writing this)
- [x] AI-generated (an agent wrote most or all of this diff)

Claude Code (Opus 4.6) was used for codebase exploration, implementation, and testing. Every line was reviewed and the fix was verified with red-green regression tests.

- [x] **I can explain every line of this diff and how it interacts with the rest of the codebase, without asking an AI tool.**

## Breaking Changes

N/A

## Test Coverage

- [x] I added/updated unit tests
- [ ] I added/updated integration tests
- [ ] I tested manually (describe below)
- [ ] No tests needed (explain why)

**Red-green verified:** All 3 regression tests fail on `main` (before fix) and pass after fix:
- `test_fetch_relevant_memories_passes_entity_params_in_filters` — asserts entity params go in `filters`, not as top-level kwargs
- `test_fetch_relevant_memories_merges_caller_filters` — asserts caller `filters` are merged with entity params without mutation
- `test_format_query_with_memories_memoryclient_uses_results_key` — asserts MemoryClient branch unwraps `["results"]`

Existing 3 test mocks fixed from flat list to `{"results": [...]}` to match actual API format.

```
pytest tests/test_proxy.py -v  →  11 passed
ruff check                     →  All checks passed
ruff format --check            →  2 files already formatted
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)