### PR TITLE
fix(llms): use _get_supported_params in LiteLLM to support reasoning models

### DIFF
--- a/mem0/llms/litellm.py
+++ b/mem0/llms/litellm.py
@@ -72,16 +72,9 @@ class LiteLLM(LLMBase):
         if tools and not litellm.supports_function_calling(self.config.model):
             raise ValueError(f"Model '{self.config.model}' in litellm does not support function calling.")
 
-        params = {
-            "model": self.config.model,
-            "messages": messages,
-            "temperature": self.config.temperature,
-            "top_p": self.config.top_p,
-        }
-        if self._uses_max_completion_tokens(self.config.model):
-            params["max_completion_tokens"] = self.config.max_tokens
-        else:
-            params["max_tokens"] = self.config.max_tokens
+        params = self._get_supported_params(messages=messages)
+        params["model"] = self.config.model
+        params["messages"] = messages
         if response_format:
             params["response_format"] = response_format
         if tools:  # TODO: Remove tools if no issues found with new memory addition logic

--- a/tests/llms/test_litellm.py
+++ b/tests/llms/test_litellm.py
@@ -134,10 +134,51 @@ def test_generate_response_with_tools(mock_litellm):
     response = llm.generate_response(messages, tools=tools)
 
     mock_litellm.completion.assert_called_once_with(
-        model="gpt-4.1-nano-2025-04-14", messages=messages, temperature=0.7, max_tokens=100, top_p=1, tools=tools, tool_choice="auto"
+        model="gpt-4.1-nano-2025-04-14",
+        messages=messages,
+        temperature=0.7,
+        max_tokens=100,
+        top_p=1,
+        tools=tools,
+        tool_choice="auto",
     )
 
     assert response["content"] == "I've added the memory for you."
     assert len(response["tool_calls"]) == 1
     assert response["tool_calls"][0]["name"] == "add_memory"
     assert response["tool_calls"][0]["arguments"] == {"data": "Today is a sunny day."}
+
+
+def test_generate_response_reasoning_model_omits_temperature(mock_litellm):
+    """Regression test for #6241: reasoning models must not receive temperature or top_p."""
+    config = BaseLlmConfig(model="o3-mini", temperature=0.7, max_tokens=100, top_p=1)
+    llm = litellm.LiteLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi"))]
+    mock_litellm.completion.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    _, kwargs = mock_litellm.completion.call_args
+    assert "temperature" not in kwargs, "temperature must not be sent to reasoning models"
+    assert "top_p" not in kwargs, "top_p must not be sent to reasoning models"
+    assert kwargs["model"] == "o3-mini"
+
+
+def test_generate_response_reasoning_model_passes_reasoning_effort(mock_litellm):
+    """Regression test for #6241: reasoning_effort config must be forwarded for reasoning models."""
+    config = BaseLlmConfig(model="o3", temperature=0.7, max_tokens=100, top_p=1, reasoning_effort="medium")
+    llm = litellm.LiteLLM(config)
+    messages = [{"role": "user", "content": "Hello"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi"))]
+    mock_litellm.completion.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    _, kwargs = mock_litellm.completion.call_args
+    assert kwargs["reasoning_effort"] == "medium"
+    assert "temperature" not in kwargs


### PR DESCRIPTION
## Linked Issue

Closes #6241

## Description

`LiteLLM.generate_response` hardcodes `temperature` and `top_p` unconditionally in the params dict, breaking reasoning models (o1, o3-mini, o3) that reject these parameters with API errors.

The fix delegates to `_get_supported_params()` from the base class — the same approach the OpenAI provider already uses at `mem0/llms/openai.py:106`. This helper:
- Filters out `temperature`/`top_p` for reasoning models via `_is_reasoning_model()`
- Routes `max_tokens` vs `max_completion_tokens` via `_get_common_params()`
- Forwards `reasoning_effort` when configured

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

- [x] Added 2 regression tests that fail on old code and pass with fix:
  - `test_generate_response_reasoning_model_omits_temperature` — verifies o3-mini calls omit temperature/top_p
  - `test_generate_response_reasoning_model_passes_reasoning_effort` — verifies reasoning_effort is forwarded
- [x] All 6 existing tests continue to pass (non-reasoning model behavior unchanged)

## Checklist

- [x] My code follows the style guidelines of this project (ruff check + format)
- [x] I have performed a self-review of my code
- [x] I have added/updated tests that prove my fix works
- [x] New and existing tests pass with my changes

> [!NOTE]
> I used AI assistance (Claude) for this PR. I can explain every line of the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)