### PR TITLE
fix(vector_stores): skip BM25 schema on Milvus servers older than 2.5

### DIFF
--- a/mem0/vector_stores/milvus.py
+++ b/mem0/vector_stores/milvus.py
@@ -63,6 +63,16 @@ class MilvusDB(VectorStoreBase):
             metric_type=self.metric_type,
         )
 
+    def _server_supports_bm25(self) -> bool:
+        """Return True if the Milvus server is >= 2.5 (BM25 full-text search support)."""
+        try:
+            version = self.client.get_server_version()
+            parts = version.lstrip("v").split(".")
+            major, minor = int(parts[0]), int(parts[1])
+            return (major, minor) >= (2, 5)
+        except Exception:
+            return True
+
     def create_col(
         self,
         collection_name: str,
@@ -89,39 +99,50 @@ class MilvusDB(VectorStoreBase):
                     "To enable hybrid search, use a fresh collection."
                 )
         else:
+            use_bm25 = self._server_supports_bm25()
+
             fields = [
                 FieldSchema(name="id", dtype=DataType.VARCHAR, is_primary=True, max_length=512),
                 FieldSchema(name="vectors", dtype=DataType.FLOAT_VECTOR, dim=vector_size),
                 FieldSchema(name="metadata", dtype=DataType.JSON),
-                # Text field for BM25 full-text search (auto-tokenized by Milvus analyzer)
-                FieldSchema(name="text", dtype=DataType.VARCHAR, max_length=65535, enable_analyzer=True),
-                # Sparse vector field populated automatically by the BM25 function below
-                FieldSchema(name="sparse", dtype=DataType.SPARSE_FLOAT_VECTOR),
             ]
+            if use_bm25:
+                fields.extend(
+                    [
+                        FieldSchema(name="text", dtype=DataType.VARCHAR, max_length=65535, enable_analyzer=True),
+                        FieldSchema(name="sparse", dtype=DataType.SPARSE_FLOAT_VECTOR),
+                    ]
+                )
 
             schema = CollectionSchema(fields, enable_dynamic_field=True)
 
-            # Add BM25 function so Milvus auto-generates sparse vectors from the text field
-            bm25_function = Function(
-                name="bm25",
-                input_field_names=["text"],
-                output_field_names=["sparse"],
-                function_type=FunctionType.BM25,
-            )
-            schema.add_function(bm25_function)
+            if use_bm25:
+                bm25_function = Function(
+                    name="bm25",
+                    input_field_names=["text"],
+                    output_field_names=["sparse"],
+                    function_type=FunctionType.BM25,
+                )
+                schema.add_function(bm25_function)
 
             index_params = self.client.prepare_index_params()
             index_params.add_index(
                 field_name="vectors", metric_type=metric_type, index_type="AUTOINDEX", index_name="vector_index"
             )
-            index_params.add_index(
-                field_name="sparse",
-                index_type="SPARSE_INVERTED_INDEX",
-                metric_type="BM25",
-                index_name="sparse_index",
-            )
+            if use_bm25:
+                index_params.add_index(
+                    field_name="sparse",
+                    index_type="SPARSE_INVERTED_INDEX",
+                    metric_type="BM25",
+                    index_name="sparse_index",
+                )
             self.client.create_collection(collection_name=collection_name, schema=schema, index_params=index_params)
-            self._has_bm25_schema = True
+            self._has_bm25_schema = use_bm25
+            if not use_bm25:
+                logger.warning(
+                    "Milvus server version < 2.5 detected. "
+                    "BM25 keyword scoring will be disabled; semantic search works normally."
+                )
 
     def insert(self, ids, vectors, payloads, **kwargs: Optional[dict[str, any]]):
         """Insert vectors into a collection.
@@ -131,6 +152,7 @@ class MilvusDB(VectorStoreBase):
             payloads (List[Dict], optional): List of payloads corresponding to vectors.
             ids (List[str], optional): List of IDs corresponding to vectors.
         """
+
         # Batch insert all records at once for better performance and consistency.
         # Only include the `text` field when the collection's schema has it — legacy
         # collections created pre-v3 reject unknown top-level fields.
@@ -138,7 +160,9 @@ class MilvusDB(VectorStoreBase):
             record = {"id": idx, "vectors": embedding, "metadata": metadata}
             if self._has_bm25_schema:
                 # Populate the text field for BM25 sparse search; prefer lemmatized text, fall back to raw data
-                record["text"] = (metadata.get("text_lemmatized") or metadata.get("data", ""))[:65535] if metadata else ""
+                record["text"] = (
+                    (metadata.get("text_lemmatized") or metadata.get("data", ""))[:65535] if metadata else ""
+                )
             return record
 
         data = [_build_record(idx, embedding, metadata) for idx, embedding, metadata in zip(ids, vectors, payloads)]
@@ -169,8 +193,7 @@ class MilvusDB(VectorStoreBase):
                 operands.append(f'(metadata["{key}"] == {value})')
             else:
                 raise ValueError(
-                    f"Filter value for {key!r} must be str, int, float, or bool, "
-                    f"got {type(value).__name__}"
+                    f"Filter value for {key!r} must be str, int, float, or bool, got {type(value).__name__}"
                 )
 
         return " and ".join(operands)

--- a/tests/vector_stores/test_milvus.py
+++ b/tests/vector_stores/test_milvus.py
@@ -22,9 +22,10 @@ class TestMilvusDB:
     @pytest.fixture
     def mock_milvus_client(self):
         """Mock MilvusClient to avoid requiring actual Milvus instance."""
-        with patch('mem0.vector_stores.milvus.MilvusClient') as mock_client:
+        with patch("mem0.vector_stores.milvus.MilvusClient") as mock_client:
             mock_instance = MagicMock()
             mock_instance.has_collection.return_value = False
+            mock_instance.get_server_version.return_value = "2.5.0"
             mock_client.return_value = mock_instance
             yield mock_instance
 
@@ -37,7 +38,7 @@ class TestMilvusDB:
             collection_name="test_collection",
             embedding_model_dims=1536,  # Should be int, not str
             metric_type=MetricType.COSINE,
-            db_name="test_db"
+            db_name="test_db",
         )
 
     def test_initialization_with_int_dims(self, mock_milvus_client):
@@ -48,9 +49,9 @@ class TestMilvusDB:
             collection_name="test_collection",
             embedding_model_dims=1536,  # Integer
             metric_type=MetricType.COSINE,
-            db_name="test_db"
+            db_name="test_db",
         )
-        
+
         assert db.embedding_model_dims == 1536
         assert isinstance(db.embedding_model_dims, int)
 
@@ -59,53 +60,53 @@ class TestMilvusDB:
         # Collection was already created in __init__, but let's verify the call
         mock_milvus_client.create_collection.assert_called_once()
         call_args = mock_milvus_client.create_collection.call_args
-        
+
         # Verify schema was created properly
         assert call_args is not None
-        
+
     def test_batch_insert(self, milvus_db, mock_milvus_client):
         """Test that insert uses batch operation instead of loop (performance fix)."""
         ids = ["id1", "id2", "id3"]
         vectors = [[0.1] * 1536, [0.2] * 1536, [0.3] * 1536]
         payloads = [{"user_id": "alice"}, {"user_id": "bob"}, {"user_id": "charlie"}]
-        
+
         milvus_db.insert(ids, vectors, payloads)
-        
+
         # Verify insert was called once with all data (batch), not 3 times
         assert mock_milvus_client.insert.call_count == 1
-        
+
         # Verify the data structure
         call_args = mock_milvus_client.insert.call_args
-        inserted_data = call_args[1]['data']
-        
+        inserted_data = call_args[1]["data"]
+
         assert len(inserted_data) == 3
-        assert inserted_data[0]['id'] == 'id1'
-        assert inserted_data[1]['id'] == 'id2'
-        assert inserted_data[2]['id'] == 'id3'
+        assert inserted_data[0]["id"] == "id1"
+        assert inserted_data[1]["id"] == "id2"
+        assert inserted_data[2]["id"] == "id3"
 
     def test_create_filter_string_value(self, milvus_db):
         """Test filter creation for string metadata values."""
         filters = {"user_id": "alice"}
         filter_str = milvus_db._create_filter(filters)
-        
+
         assert filter_str == '(metadata["user_id"] == "alice")'
 
     def test_create_filter_numeric_value(self, milvus_db):
         """Test filter creation for numeric metadata values."""
         filters = {"age": 25}
         filter_str = milvus_db._create_filter(filters)
-        
+
         assert filter_str == '(metadata["age"] == 25)'
 
     def test_create_filter_multiple_conditions(self, milvus_db):
         """Test filter creation with multiple conditions."""
         filters = {"user_id": "alice", "category": "work"}
         filter_str = milvus_db._create_filter(filters)
-        
+
         # Should join with 'and'
         assert 'metadata["user_id"] == "alice"' in filter_str
         assert 'metadata["category"] == "work"' in filter_str
-        assert ' and ' in filter_str
+        assert " and " in filter_str
 
     def test_create_filter_wildcard_conditions(self, milvus_db):
         """Test filter creation with wildcard conditions."""
@@ -118,24 +119,19 @@ class TestMilvusDB:
     def test_search_with_filters(self, milvus_db, mock_milvus_client):
         """Test search with metadata filters (reproduces user's bug scenario)."""
         # Setup mock return value
-        mock_milvus_client.search.return_value = [[
-            {"id": "mem1", "distance": 0.8, "entity": {"metadata": {"user_id": "alice"}}}
-        ]]
-        
+        mock_milvus_client.search.return_value = [
+            [{"id": "mem1", "distance": 0.8, "entity": {"metadata": {"user_id": "alice"}}}]
+        ]
+
         query_vector = [0.1] * 1536
         filters = {"user_id": "alice"}
-        
-        results = milvus_db.search(
-            query="test query",
-            vectors=query_vector,
-            top_k=5,
-            filters=filters
-        )
-        
+
+        results = milvus_db.search(query="test query", vectors=query_vector, top_k=5, filters=filters)
+
         # Verify search was called with correct filter
         call_args = mock_milvus_client.search.call_args
-        assert call_args[1]['filter'] == '(metadata["user_id"] == "alice")'
-        
+        assert call_args[1]["filter"] == '(metadata["user_id"] == "alice")'
+
         # Verify results are parsed correctly
         assert len(results) == 1
         assert results[0].id == "mem1"
@@ -144,20 +140,20 @@ class TestMilvusDB:
     def test_search_different_user_ids(self, milvus_db, mock_milvus_client):
         """Test that search works with different user_ids (reproduces reported bug)."""
         # This test validates the fix for: "Error with different user_ids"
-        
+
         # Mock return for first user
-        mock_milvus_client.search.return_value = [[
-            {"id": "mem1", "distance": 0.9, "entity": {"metadata": {"user_id": "milvus_user"}}}
-        ]]
-        
+        mock_milvus_client.search.return_value = [
+            [{"id": "mem1", "distance": 0.9, "entity": {"metadata": {"user_id": "milvus_user"}}}]
+        ]
+
         results1 = milvus_db.search("test", [0.1] * 1536, filters={"user_id": "milvus_user"})
         assert len(results1) == 1
-        
+
         # Mock return for second user
-        mock_milvus_client.search.return_value = [[
-            {"id": "mem2", "distance": 0.85, "entity": {"metadata": {"user_id": "bob"}}}
-        ]]
-        
+        mock_milvus_client.search.return_value = [
+            [{"id": "mem2", "distance": 0.85, "entity": {"metadata": {"user_id": "bob"}}}]
+        ]
+
         # This should not raise "Unsupported Field type: 0" error
         results2 = milvus_db.search("test", [0.2] * 1536, filters={"user_id": "bob"})
         assert len(results2) == 1
@@ -167,35 +163,30 @@ class TestMilvusDB:
         vector_id = "test_id"
         vector = [0.1] * 1536
         payload = {"user_id": "alice", "data": "Updated memory"}
-        
+
         milvus_db.update(vector_id=vector_id, vector=vector, payload=payload)
-        
+
         # Verify upsert was called (not delete+insert)
         mock_milvus_client.upsert.assert_called_once()
-        
+
         call_args = mock_milvus_client.upsert.call_args
-        assert call_args[1]['collection_name'] == "test_collection"
-        assert call_args[1]['data']['id'] == vector_id
-        assert call_args[1]['data']['vectors'] == vector
-        assert call_args[1]['data']['metadata'] == payload
+        assert call_args[1]["collection_name"] == "test_collection"
+        assert call_args[1]["data"]["id"] == vector_id
+        assert call_args[1]["data"]["vectors"] == vector
+        assert call_args[1]["data"]["metadata"] == payload
 
     def test_delete(self, milvus_db, mock_milvus_client):
         """Test vector deletion."""
         vector_id = "test_id"
         milvus_db.delete(vector_id)
-        
-        mock_milvus_client.delete.assert_called_once_with(
-            collection_name="test_collection",
-            ids=[vector_id]
-        )
+
+        mock_milvus_client.delete.assert_called_once_with(collection_name="test_collection", ids=[vector_id])
 
     def test_get(self, milvus_db, mock_milvus_client):
         """Test retrieving a vector by ID."""
         vector_id = "test_id"
-        mock_milvus_client.get.return_value = [
-            {"id": vector_id, "metadata": {"user_id": "alice"}}
-        ]
-        
+        mock_milvus_client.get.return_value = [{"id": vector_id, "metadata": {"user_id": "alice"}}]
+
         result = milvus_db.get(vector_id)
 
         assert result.id == vector_id
@@ -212,36 +203,28 @@ class TestMilvusDB:
         """Test listing memories with filters."""
         mock_milvus_client.query.return_value = [
             {"id": "mem1", "metadata": {"user_id": "alice"}},
-            {"id": "mem2", "metadata": {"user_id": "alice"}}
+            {"id": "mem2", "metadata": {"user_id": "alice"}},
         ]
-        
+
         results = milvus_db.list(filters={"user_id": "alice"}, top_k=10)
-        
+
         # Verify query was called with filter
         call_args = mock_milvus_client.query.call_args
-        assert call_args[1]['filter'] == '(metadata["user_id"] == "alice")'
-        assert call_args[1]['limit'] == 10
-        
+        assert call_args[1]["filter"] == '(metadata["user_id"] == "alice")'
+        assert call_args[1]["limit"] == 10
+
         # Verify results
         assert len(results[0]) == 2
 
     def test_parse_output(self, milvus_db):
         """Test output data parsing."""
         raw_data = [
-            {
-                "id": "mem1",
-                "distance": 0.9,
-                "entity": {"metadata": {"user_id": "alice"}}
-            },
-            {
-                "id": "mem2",
-                "distance": 0.85,
-                "entity": {"metadata": {"user_id": "bob"}}
-            }
+            {"id": "mem1", "distance": 0.9, "entity": {"metadata": {"user_id": "alice"}}},
+            {"id": "mem2", "distance": 0.85, "entity": {"metadata": {"user_id": "bob"}}},
         ]
-        
+
         parsed = milvus_db._parse_output(raw_data)
-        
+
         assert len(parsed) == 2
         assert parsed[0].id == "mem1"
         assert parsed[0].score == 0.9
@@ -261,12 +244,10 @@ class TestMilvusDB:
 
         milvus_db.update(vector_id=vector_id, vector=None, payload=payload)
 
-        mock_milvus_client.get.assert_called_once_with(
-            collection_name="test_collection", ids=vector_id
-        )
+        mock_milvus_client.get.assert_called_once_with(collection_name="test_collection", ids=vector_id)
         call_args = mock_milvus_client.upsert.call_args
-        assert call_args[1]['data']['vectors'] == existing_vector
-        assert call_args[1]['data']['metadata'] == payload
+        assert call_args[1]["data"]["vectors"] == existing_vector
+        assert call_args[1]["data"]["metadata"] == payload
 
     def test_update_with_none_payload_fetches_existing(self, milvus_db, mock_milvus_client):
         """Test that update with payload=None fetches the existing metadata."""
@@ -281,8 +262,8 @@ class TestMilvusDB:
         milvus_db.update(vector_id=vector_id, vector=vector, payload=None)
 
         call_args = mock_milvus_client.upsert.call_args
-        assert call_args[1]['data']['vectors'] == vector
-        assert call_args[1]['data']['metadata'] == existing_metadata
+        assert call_args[1]["data"]["vectors"] == vector
+        assert call_args[1]["data"]["metadata"] == existing_metadata
 
     def test_update_with_both_none_fetches_existing(self, milvus_db, mock_milvus_client):
         """Test that update with both vector=None and payload=None fetches existing data."""
@@ -299,8 +280,8 @@ class TestMilvusDB:
         # Should only call get once even though both are None
         assert mock_milvus_client.get.call_count == 1
         call_args = mock_milvus_client.upsert.call_args
-        assert call_args[1]['data']['vectors'] == existing_vector
-        assert call_args[1]['data']['metadata'] == existing_metadata
+        assert call_args[1]["data"]["vectors"] == existing_vector
+        assert call_args[1]["data"]["metadata"] == existing_metadata
 
     def test_update_with_none_vector_raises_on_missing_record(self, milvus_db, mock_milvus_client):
         """Test that update raises ValueError when the record doesn't exist."""
@@ -311,9 +292,7 @@ class TestMilvusDB:
 
     def test_update_with_none_vector_raises_on_missing_vector_data(self, milvus_db, mock_milvus_client):
         """Test that update raises ValueError when existing record has no vector."""
-        mock_milvus_client.get.return_value = [
-            {"id": "test_id", "vectors": None, "metadata": {"user_id": "alice"}}
-        ]
+        mock_milvus_client.get.return_value = [{"id": "test_id", "vectors": None, "metadata": {"user_id": "alice"}}]
 
         with pytest.raises(ValueError, match="no vector data"):
             milvus_db.update(vector_id="test_id", vector=None, payload={"data": "test"})
@@ -389,13 +368,73 @@ class TestMilvusDB:
             collection_name="existing_collection",
             embedding_model_dims=1536,
             metric_type=MetricType.L2,
-            db_name="test_db"
+            db_name="test_db",
         )
 
         # create_collection should not be called
         mock_milvus_client.create_collection.assert_not_called()
 
+    def test_create_col_omits_bm25_on_old_server(self, mock_milvus_client):
+        """Regression test for #6183: Milvus < 2.5 must not get BM25 schema fields."""
+        mock_milvus_client.has_collection.return_value = False
+        mock_milvus_client.get_server_version.return_value = "2.4.1"
+
+        db = MilvusDB(
+            url="http://localhost:19530",
+            token="test_token",
+            collection_name="test_collection",
+            embedding_model_dims=1536,
+            metric_type=MetricType.COSINE,
+            db_name="test_db",
+        )
+
+        assert db._has_bm25_schema is False
+        schema = mock_milvus_client.create_collection.call_args[1]["schema"]
+        field_names = {f.name for f in schema.fields}
+        assert "text" not in field_names
+        assert "sparse" not in field_names
+        assert schema.functions == []
+
+    def test_create_col_includes_bm25_on_new_server(self, mock_milvus_client):
+        """Regression test for #6183: Milvus >= 2.5 must include BM25 schema fields."""
+        mock_milvus_client.has_collection.return_value = False
+        mock_milvus_client.get_server_version.return_value = "2.5.0"
+
+        db = MilvusDB(
+            url="http://localhost:19530",
+            token="test_token",
+            collection_name="test_collection",
+            embedding_model_dims=1536,
+            metric_type=MetricType.COSINE,
+            db_name="test_db",
+        )
+
+        assert db._has_bm25_schema is True
+        schema = mock_milvus_client.create_collection.call_args[1]["schema"]
+        field_names = {f.name for f in schema.fields}
+        assert "text" in field_names
+        assert "sparse" in field_names
+
+    def test_create_col_assumes_bm25_on_version_error(self, mock_milvus_client):
+        """Regression test for #6183: version detection failure should default to BM25 enabled."""
+        mock_milvus_client.has_collection.return_value = False
+        mock_milvus_client.get_server_version.side_effect = RuntimeError("connection error")
+
+        db = MilvusDB(
+            url="http://localhost:19530",
+            token="test_token",
+            collection_name="test_collection",
+            embedding_model_dims=1536,
+            metric_type=MetricType.COSINE,
+            db_name="test_db",
+        )
+
+        assert db._has_bm25_schema is True
+        schema = mock_milvus_client.create_collection.call_args[1]["schema"]
+        field_names = {f.name for f in schema.fields}
+        assert "text" in field_names
+        assert "sparse" in field_names
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-


### PR DESCRIPTION
## Linked Issue

Closes #6183

## Description

`MilvusDB.create_col` unconditionally creates BM25 schema fields (`text` VARCHAR with `enable_analyzer=True`, `sparse` SPARSE_FLOAT_VECTOR) and a BM25 function when creating new collections. These features require Milvus 2.5+ — users on older servers (2.4.x and below) get errors during initialization.

**Fix:** Add `_server_supports_bm25()` helper that detects the server version via `MilvusClient.get_server_version()`. For servers < 2.5, create a dense-only schema (id, vectors, metadata) without text/sparse fields or BM25 functions. The existing `_has_bm25_schema` flag already correctly gates all downstream operations (insert, search, keyword_search, update), so no other code changes are needed.

**Fail-open behavior:** If version detection fails (e.g. network error), BM25 is assumed supported — preserving current behavior for unaffected users.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

- [x] Added 3 regression tests:
  - `test_create_col_omits_bm25_on_old_server` — version "2.4.1" creates dense-only schema
  - `test_create_col_includes_bm25_on_new_server` — version "2.5.0" creates full BM25 schema
  - `test_create_col_assumes_bm25_on_version_error` — detection failure defaults to BM25 enabled
- [x] Updated test fixture to provide explicit server version (MagicMock's `__int__` returning 0 was silently breaking version comparison)
- [x] All 28 existing tests continue to pass

## Checklist

- [x] My code follows the style guidelines of this project (ruff check + format)
- [x] I have performed a self-review of my code
- [x] I have added/updated tests that prove my fix works
- [x] New and existing tests pass with my changes

> [!NOTE]
> I used AI assistance (Claude) for this PR. I can explain every line of the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)